### PR TITLE
fix: Predictor not shareable comment [DHIS2-11553]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -62,6 +62,8 @@
       <many-to-many class="org.hisp.dhis.predictor.PredictorGroup" column="predictorgroupid" />
     </set>
 
+    <!-- Sharing is intentionally excluded. No known use case.  -->
+
   </class>
 
 </hibernate-mapping>


### PR DESCRIPTION
[Discussed](https://dhis2.slack.com/archives/G4513PWGY/p1724399823926379) whether `Predictor` is intentionally not shareable or not. Seems that it was designed to not be shareable.

Adding comment in the `.hbm` file advising of this so it's clear for future viewers of this file.