### PR TITLE
fix: only run generic search query if no result list present yet [DHIS2-17952] (2.40)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -544,7 +544,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
     query.setDefaultOrder();
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       return Lists.newArrayList(
           manager.filter(getEntityClass(), options.getOptions().get("query")));
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -120,7 +120,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     }
 
     List<Interpretation> entityList;
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -187,7 +187,7 @@ public class MessageConversationController
       throws QueryParserException {
     List<org.hisp.dhis.message.MessageConversation> messageConversations;
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       messageConversations =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -86,7 +86,7 @@ public class ProgramController extends AbstractCrudController<Program> {
     query.setDefaultOrder();
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -130,7 +130,7 @@ public class MapViewController extends AbstractCrudController<MapView> {
     query.setDefaultOrder();
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {


### PR DESCRIPTION
based on cherry-pick from #18442 and manual merge conflict resolve. 

I opted to simply not backport the test scenario added as a lot of setup has changed around tests which makes it hard to backport tests.