### PR TITLE
fix: only run generic search query if no result list present yet [DHIS2-17952] (2.41.1)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -202,6 +202,14 @@ class OrganisationUnitControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void testGetLevelAndQuery() {
+    // just to show what the result without level filter looks like
+    assertListOfOrganisationUnits(GET("/organisationUnits?query=x").content(), "L1x", "L2x", "L3x");
+    // now the filter of level and query combined only L2x matches x and level 3
+    assertListOfOrganisationUnits(GET("/organisationUnits?level=3&query=x").content(), "L2x");
+  }
+
+  @Test
   void testGetMaxLevel() {
     assertListOfOrganisationUnits(
         GET("/organisationUnits?maxLevel=2").content(), "L0", "L1", "L1x");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -554,7 +554,9 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
     query.setObjects(objects);
 
-    if (options.getOptions().containsKey("query")) {
+    // Note: objects being null means no query had been running whereas empty means a query did run
+    // with no result
+    if (objects == null && options.getOptions().containsKey("query")) {
       return getEntityListPostProcess(
           options,
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query"))));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -126,7 +126,7 @@ public class InterpretationController extends AbstractCrudController<Interpretat
     }
 
     List<Interpretation> entityList;
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -182,7 +182,7 @@ public class MessageConversationController
       throws QueryParserException {
     List<org.hisp.dhis.message.MessageConversation> messageConversations;
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       messageConversations =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -103,7 +103,7 @@ public class ProgramController extends AbstractCrudController<Program> {
     query.setDefaultOrder();
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -134,7 +134,7 @@ public class MapViewController extends AbstractCrudController<MapView> {
     query.setDefaultOrder();
     query.setDefaults(Defaults.valueOf(options.get("defaults", DEFAULTS)));
 
-    if (options.getOptions().containsKey("query")) {
+    if (objects == null && options.getOptions().containsKey("query")) {
       entityList =
           Lists.newArrayList(manager.filter(getEntityClass(), options.getOptions().get("query")));
     } else {


### PR DESCRIPTION
cherry-pick backport of #18442