### PR TITLE
fix(DHIS2-13294): return app details from Apps install endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -147,9 +147,9 @@ public interface AppManager {
    *
    * @param file the app file.
    * @param fileName the name of the app file.
-   * @return outcome of the installation
+   * @return the installed app instance
    */
-  AppStatus installApp(File file, String fileName);
+  App installApp(File file, String fileName);
 
   /**
    * Installs an app from the AppHub with the given ID.
@@ -157,7 +157,7 @@ public interface AppManager {
    * @param appHubId A unqiue ID for a specific app version
    * @return outcome of the installation
    */
-  AppStatus installApp(UUID appHubId);
+  App installApp(UUID appHubId);
 
   /**
    * Indicates whether the app with the given name exist.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -294,6 +294,7 @@ public class DefaultAppManager implements AppManager {
     App installedApp = new App();
     if (appHubId == null) {
       installedApp.setAppState(AppStatus.NOT_FOUND);
+      return installedApp;
     }
 
     try {
@@ -301,6 +302,7 @@ public class DefaultAppManager implements AppManager {
       if (versionJson == null || versionJson.isEmpty()) {
         log.info(String.format("No version found for id %s", appHubId));
         installedApp.setAppState(AppStatus.NOT_FOUND);
+        return installedApp;
       }
       JsonString downloadUrlNode = JsonMixed.of(versionJson).getString("downloadUrl");
       if (downloadUrlNode.isUndefined()) {
@@ -308,6 +310,7 @@ public class DefaultAppManager implements AppManager {
             String.format(
                 "No download URL property found in response for id %s: %s", appHubId, versionJson));
         installedApp.setAppState(AppStatus.NOT_FOUND);
+        return installedApp;
       }
       String downloadUrl = downloadUrlNode.string();
       URL url = new URL(downloadUrl);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -273,35 +273,41 @@ public class DefaultAppManager implements AppManager {
   }
 
   @Override
-  public AppStatus installApp(File file, String fileName) {
+  public App installApp(File file, String fileName) {
     App app = jCloudsAppStorageService.installApp(file, fileName, appCache);
+
+    log.info(
+        String.format(
+            "Installed App with ID %s (status: %s)", app.getAppHubId(), app.getAppState()));
 
     if (app.getAppState().ok()) {
       appCache.put(app.getKey(), app);
       registerDatastoreProtection(app);
     }
 
-    return app.getAppState();
+    return app;
   }
 
   @Override
-  public AppStatus installApp(UUID appHubId) {
+  public App installApp(UUID appHubId) {
+
+    App installedApp = new App();
     if (appHubId == null) {
-      return AppStatus.NOT_FOUND;
+      installedApp.setAppState(AppStatus.NOT_FOUND);
     }
 
     try {
       String versionJson = appHubService.getAppHubApiResponse("v2", "appVersions/" + appHubId);
       if (versionJson == null || versionJson.isEmpty()) {
         log.info(String.format("No version found for id %s", appHubId));
-        return AppStatus.NOT_FOUND;
+        installedApp.setAppState(AppStatus.NOT_FOUND);
       }
       JsonString downloadUrlNode = JsonMixed.of(versionJson).getString("downloadUrl");
       if (downloadUrlNode.isUndefined()) {
         log.info(
             String.format(
                 "No download URL property found in response for id %s: %s", appHubId, versionJson));
-        return AppStatus.NOT_FOUND;
+        installedApp.setAppState(AppStatus.NOT_FOUND);
       }
       String downloadUrl = downloadUrlNode.string();
       URL url = new URL(downloadUrl);
@@ -312,11 +318,13 @@ public class DefaultAppManager implements AppManager {
 
     } catch (IOException ex) {
       log.info(String.format("No version found for id %s", appHubId));
-      return AppStatus.NOT_FOUND;
+      installedApp.setAppState(AppStatus.NOT_FOUND);
     } catch (ConflictException | URISyntaxException e) {
       log.error("Failed to install app with id " + appHubId, e);
-      return AppStatus.INSTALLATION_FAILED;
+      installedApp.setAppState(AppStatus.INSTALLATION_FAILED);
     }
+
+    return installedApp;
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
@@ -64,22 +64,24 @@ class AppManagerTest extends PostgresIntegrationTestBase {
   @DisplayName("Can install and then update an App using MinIO storage")
   void canUpdateAppUsingMinIoTest() throws IOException {
     // install an app for the 1st time (version 1)
-    AppStatus appStatus =
+    App installedApp =
         appManager.installApp(
             new ClassPathResource("app/test-app-minio-v1.zip").getFile(), "test-app-minio-v1.zip");
+
+    AppStatus appStatus = installedApp.getAppState();
 
     assertTrue(appStatus.ok());
     assertEquals("ok", appStatus.getMessage());
 
     // install version 2 of the same app
-    AppStatus update =
+    App updatedApp =
         assertDoesNotThrow(
             () ->
                 appManager.installApp(
                     new ClassPathResource("app/test-app-minio-v2.zip").getFile(),
                     "test-app-minio-v2.zip"));
 
-    assertTrue(update.ok());
+    assertTrue(updatedApp.getAppState().ok());
     assertEquals("ok", appStatus.getMessage());
 
     // get app version & index.html

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppControllerTest.java
@@ -100,6 +100,19 @@ class AppControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
+  void testInstallReturnsAppInfo() throws IOException {
+    var result =
+        appManager.installApp(
+            new ClassPathResource("app/test-app-with-index-html.zip").getFile(),
+            "test-app-with-index-html.zip");
+
+    assertEquals(
+        "31.0.0",
+        result.getVersion(),
+        "the version returned should match the version in the installed zip file");
+  }
+
+  @Test
   void testGetApps() {
     HttpResponse response = GET("/apps");
     JsonArray apps = response.content(HttpStatus.OK);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
@@ -28,11 +28,13 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
@@ -68,5 +70,21 @@ class AppHubControllerTest extends H2ControllerIntegrationTestBase {
         "ERROR",
         "404 Not Found: \"{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Not Found\"}\"",
         GET("/appHub/v37/test").content(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void testAppHubInstallResponseContainsAppInfo() {
+    JsonArray apps = GET("/appHub").content();
+    JsonObject firstApp = apps.getObject(0).getArray("versions").getObject(0);
+
+    String versionId = firstApp.getString("id").string();
+    String version = firstApp.getString("version").string();
+
+    JsonObject result = POST("/appHub/" + versionId).content();
+
+    assertEquals(
+        version,
+        result.getString("version").string(),
+        "an object should be returned containing the version of the app");
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
@@ -80,8 +80,11 @@ class AppHubControllerTest extends H2ControllerIntegrationTestBase {
     String versionId = firstApp.getString("id").string();
     String version = firstApp.getString("version").string();
 
-    JsonObject result = POST("/appHub/" + versionId).content();
+    HttpResponse response = POST("/appHub/" + versionId);
 
+    assertEquals(201, response.status().code());
+
+    JsonObject result = response.content();
     assertEquals(
         version,
         result.getString("version").string(),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppAdditionalNamespacesTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppAdditionalNamespacesTest.java
@@ -55,9 +55,11 @@ class DatastoreControllerAppAdditionalNamespacesTest extends H2ControllerIntegra
   void setUp() throws IOException {
     assertEquals(
         AppStatus.OK,
-        appManager.installApp(
-            new ClassPathResource("app/test-app-with-additional-ns.zip").getFile(),
-            "test-app-with-additional-ns.zip"));
+        appManager
+            .installApp(
+                new ClassPathResource("app/test-app-with-additional-ns.zip").getFile(),
+                "test-app-with-additional-ns.zip")
+            .getAppState());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppTest.java
@@ -68,7 +68,9 @@ class DatastoreControllerAppTest extends H2ControllerIntegrationTestBase {
   void setUp() throws IOException {
     assertEquals(
         AppStatus.OK,
-        appManager.installApp(new ClassPathResource("app/test-app.zip").getFile(), "test-app.zip"));
+        appManager
+            .installApp(new ClassPathResource("app/test-app.zip").getFile(), "test-app.zip")
+            .getAppState());
     // by default we are an app manager
     switchToNewUser("app-admin", Authorities.M_DHIS_WEB_APP_MANAGEMENT.toString());
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
@@ -90,7 +90,9 @@ class DatastoreControllerIntegrationTest extends PostgresControllerIntegrationTe
   void testUpdateKeyJsonValue_App() throws IOException {
     assertEquals(
         AppStatus.OK,
-        appManager.installApp(new ClassPathResource("app/test-app.zip").getFile(), "test-app.zip"));
+        appManager
+            .installApp(new ClassPathResource("app/test-app.zip").getFile(), "test-app.zip")
+            .getAppState());
     // by default we are an app manager
     switchToNewUser("app-admin", Authorities.M_DHIS_WEB_APP_MANAGEMENT.toString());
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -169,7 +169,7 @@ public class AppController {
       throw new WebMessageException(conflict(message));
     }
 
-    return ResponseEntity.ok(installedApp);
+    return new ResponseEntity<>(installedApp, HttpStatus.CREATED);
   }
 
   @PutMapping

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -153,21 +153,23 @@ public class AppController {
     return ResponseEntity.ok(apps);
   }
 
-  @PostMapping
+  @PostMapping(produces = ContextUtils.CONTENT_TYPE_JSON)
   @RequiresAuthority(anyOf = M_DHIS_WEB_APP_MANAGEMENT)
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void installApp(@RequestParam("file") MultipartFile file)
+  public ResponseEntity<App> installApp(@RequestParam("file") MultipartFile file)
       throws IOException, WebMessageException {
     File tempFile = File.createTempFile("IMPORT_", "_ZIP");
     file.transferTo(tempFile);
 
-    AppStatus status = appManager.installApp(tempFile, file.getOriginalFilename());
+    App installedApp = appManager.installApp(tempFile, file.getOriginalFilename());
+    AppStatus appStatus = installedApp.getAppState();
 
-    if (!status.ok()) {
-      String message = i18nManager.getI18n().getString(status.getMessage());
+    if (!appStatus.ok()) {
+      String message = i18nManager.getI18n().getString(installedApp.getAppState().getMessage());
 
       throw new WebMessageException(conflict(message));
     }
+
+    return ResponseEntity.ok(installedApp);
   }
 
   @PutMapping

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -45,12 +45,11 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -81,16 +80,19 @@ public class AppHubController {
     return appHubService.getAppHubApiResponse(apiVersion, query);
   }
 
-  @PostMapping(value = "/{versionId}")
+  @PostMapping(value = "/{versionId}", produces = APPLICATION_JSON_VALUE)
   @RequiresAuthority(anyOf = M_DHIS_WEB_APP_MANAGEMENT)
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void installAppFromAppHub(@PathVariable UUID versionId) throws ConflictException {
-    AppStatus status = appManager.installApp(versionId);
+  public ResponseEntity<App> installAppFromAppHub(@PathVariable UUID versionId)
+      throws ConflictException {
+    App app = appManager.installApp(versionId);
+    AppStatus status = app.getAppState();
 
     if (!status.ok()) {
       String message = i18nManager.getI18n().getString(status.getMessage());
 
       throw new ConflictException(message);
     }
+
+    return ResponseEntity.ok(app);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -93,6 +94,6 @@ public class AppHubController {
       throw new ConflictException(message);
     }
 
-    return ResponseEntity.ok(app);
+    return new ResponseEntity<>(app, HttpStatus.CREATED);
   }
 }


### PR DESCRIPTION
implements [DHIS2-18027](https://dhis2.atlassian.net/browse/DHIS2-18027). 
needed for the fix for [DHIS2-13294](https://dhis2.atlassian.net/browse/DHIS2-13294) 

After manually installing an app (`POST /apps`), we wanted to be able to redirect the user to the app just installed. But since the API only returned an empty 204, the FE had no way to know the ID and other info of the installed App. This backend change exposes this information for the frontend return a 200 with the App object.

The ticket is relevant mainly when manually installing, but I also updated the install from AppHub to return the App object for consistency (and because we can make use of that info to avoid having an extra call to get the list of apps as we do now)



[DHIS2-13294]: https://dhis2.atlassian.net/browse/DHIS2-13294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-18027]: https://dhis2.atlassian.net/browse/DHIS2-18027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ