### PR TITLE
refactor: no attribute property in attributevalues JSONB objects [DHIS2-17482]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_12__Remove_attribute_from_attributeValues.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_12__Remove_attribute_from_attributeValues.sql
@@ -1,0 +1,21 @@
+-- a loop over all tables that have a attributevalues column
+-- and for each of such tables and each attribute
+-- we update each row and remove the "attribute" property
+--
+-- unfortunately when removing properties form a JSON(B) column value
+-- the exact path needs to be specified which is why this has 2nd loop level
+DO
+$do$
+    DECLARE
+        t varchar;
+        a varchar;
+    BEGIN
+        FOR t IN SELECT t.table_name FROM information_schema.tables t
+                INNER JOIN information_schema.columns c ON c.table_name = t.table_name AND c.table_schema = t.table_schema
+                WHERE c.column_name = 'attributevalues' AND c.data_type = 'jsonb' AND t.table_type = 'BASE TABLE' LOOP
+            FOR a IN SELECT DISTINCT uid FROM attribute LOOP
+                EXECUTE format('update %I set attributevalues = attributevalues #- ''{%s,attribute}'' ', t,a);
+            END LOOP;
+        END LOOP;
+    END;
+$do$

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -31,6 +31,10 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-commons</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
 
     <!-- Hibernate -->
 


### PR DESCRIPTION
### Summary 
Eliminates the unnecessary repetition of the shallow attribute within each attribute value.

From
```json
{"<attrid1>": {"value": "<val>", "attribute": {"id":"<attrid1>"}}
```
To
```json
{"<attrid1>": {"value": "<val>"}}
```

I also considered taking it one step further to 
```json
{"<attrid1>": "<val>"}
```
but this would need adjustments in all SQL queries related to this which feels quite risky to identify all of them.

I also decided to use `json-tree` for the object - JSON conversion to be more lenient without having to pay for any additional content in the JSON that isn't mapped. In addition this mapping should perform better as it creates very few intermediate objects. 
