### PR TITLE
fix: broken OpenID value update with linked accounts (#18353)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
@@ -121,7 +121,7 @@
 
     <property name="externalAuth" column="externalauth" />
 
-    <property name="openId" column="openid" unique="true" type="text" />
+    <property name="openId" column="openid" type="text" />
 
     <property name="ldapId" column="ldapid" unique="true" type="text" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -112,8 +113,11 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
 
     User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
-    if (existingUserWithMatchingOpenID != null
-        && !existingUserWithMatchingOpenID.getUid().equals(user.getUid())) {
+    boolean linkedAccountsDisabled =
+        dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED);
+    if (linkedAccountsDisabled
+        && (existingUserWithMatchingOpenID != null
+            && !existingUserWithMatchingOpenID.getUid().equals(user.getUid()))) {
       addReports.accept(
           new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
               .setErrorProperty(USERNAME));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -200,6 +200,9 @@ class AccountControllerTest extends DhisControllerIntegrationTest {
 
   @Test
   void testGetLinkedAccounts() {
+    createUserWithAuth("usera");
+    createUserWithAuth("userb");
+
     String openId = "email@provider.com";
     List<User> allUsers = userService.getAllUsers();
     for (User user : allUsers) {
@@ -209,7 +212,7 @@ class AccountControllerTest extends DhisControllerIntegrationTest {
 
     JsonMixed response = GET("/account/linkedAccounts").content(HttpStatus.OK);
     JsonList<JsonObject> users = response.getList("users", JsonObject.class);
-    assertEquals(2, users.size());
+    assertEquals(3, users.size());
   }
 
   private static void assertMessage(String key, String value, String message, JsonMixed response) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptySet;
+import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
 import static org.hisp.dhis.web.HttpStatus.Series.SUCCESSFUL;
 import static org.hisp.dhis.web.WebClient.Accept;
 import static org.hisp.dhis.web.WebClient.Body;
@@ -51,6 +52,7 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonBoolean;
@@ -69,7 +71,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
-import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.web.HttpStatus;
@@ -100,11 +101,11 @@ class UserControllerTest extends DhisControllerConvenienceTest {
 
   @Autowired private SessionRegistry sessionRegistry;
 
-  @Autowired private UserService userService;
+  @Autowired ObjectMapper objectMapper;
+
+  @Autowired private DhisConfigurationProvider config;
 
   private User peter;
-
-  @Autowired ObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {
@@ -221,8 +222,7 @@ class UserControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  @DisplayName(
-      "Make sure an update after first setting OpenID works, has special handling logic in UserObjectBundleHook.")
+  @DisplayName("Check updates after setting an OpenID value works")
   void testSetOpenIdThenUpdate() {
     assertStatus(
         HttpStatus.OK,
@@ -240,6 +240,60 @@ class UserControllerTest extends DhisControllerConvenienceTest {
             "/users/{id}",
             peter.getUid() + "?importReportMode=ERRORS",
             Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
+  }
+
+  @Test
+  @DisplayName(
+      "Check you can set same OpenID value on multiple accounts when linked accounts are enabled")
+  void testSetOpenIdThenUpdateWithLinkedAccountsEnabled() {
+    config.getProperties().put(LINKED_ACCOUNTS_ENABLED.getKey(), "on");
+
+    User wendy = createUserWithAuth("wendy");
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            wendy.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+  }
+
+  @Test
+  @DisplayName(
+      "Check you can't set same OpenID value on multiple accounts when linked accounts are disabled")
+  void testSetOpenIdThenUpdateWithLinkedAccountsDisabled() {
+    config.getProperties().put(LINKED_ACCOUNTS_ENABLED.getKey(), "off");
+
+    User wendy = createUserWithAuth("wendy");
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+
+    JsonImportSummary response =
+        PATCH(
+                "/users/{id}",
+                wendy.getUid() + "?importReportMode=ERRORS",
+                Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]"))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    assertEquals(
+        "Property `OIDC mapping value` already exists, was given `peter@mail.org`.",
+        response
+            .find(JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4054)
+            .getMessage());
   }
 
   /**


### PR DESCRIPTION
(cherry picked from commit 8ca70a35974d0e43204a43fde2ebb7e0b9e25a24)