### PR TITLE
fix: broken OpenID value update with linked accounts (#18353)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
@@ -121,7 +121,7 @@
 
     <property name="externalAuth" column="externalauth" />
 
-    <property name="openId" column="openid" unique="true" type="text" />
+    <property name="openId" column="openid" type="text" />
 
     <property name="ldapId" column="ldapid" unique="true" type="text" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -108,8 +109,11 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
 
     User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
-    if (existingUserWithMatchingOpenID != null
-        && !existingUserWithMatchingOpenID.getUid().equals(user.getUid())) {
+    boolean linkedAccountsDisabled =
+        dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED);
+    if (linkedAccountsDisabled
+        && (existingUserWithMatchingOpenID != null
+            && !existingUserWithMatchingOpenID.getUid().equals(user.getUid()))) {
       addReports.accept(
           new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
               .setErrorProperty(USERNAME));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -30,9 +30,12 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -178,6 +181,23 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
         "error",
         "Password must have at least 8, and at most 60 characters",
         POST("/account/validatePassword?password=xyz").content(HttpStatus.OK));
+  }
+
+  @Test
+  void testGetLinkedAccounts() {
+    createUserWithAuth("usera");
+    createUserWithAuth("userb");
+
+    String openId = "email@provider.com";
+    List<User> allUsers = userService.getAllUsers();
+    for (User user : allUsers) {
+      user.setOpenId(openId);
+      userService.updateUser(user);
+    }
+
+    JsonResponse response = GET("/account/linkedAccounts").content(HttpStatus.OK);
+    JsonList<JsonObject> users = response.getList("users", JsonObject.class);
+    assertEquals(3, users.size());
   }
 
   private static void assertMessage(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -35,13 +35,13 @@ import java.util.Set;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -196,8 +196,8 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
     }
 
     JsonResponse response = GET("/account/linkedAccounts").content(HttpStatus.OK);
-    JsonList<JsonObject> users = response.getList("users", JsonObject.class);
-    assertEquals(3, users.size());
+    JsonList<JsonUser> list = response.asList(JsonUser.class);
+    assertEquals(3, list.size());
   }
 
   private static void assertMessage(


### PR DESCRIPTION
(cherry picked from commit 8ca70a35974d0e43204a43fde2ebb7e0b9e25a24)