### PR TITLE
chore: fix broken tests from DHIS2-17906

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceImportTest.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
+import static org.hisp.dhis.test.TestBase.createDataElement;
+import static org.hisp.dhis.test.TestBase.createDataSet;
+import static org.hisp.dhis.test.TestBase.injectSecurityContext;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +71,7 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.notification.Notifier;
-import org.hisp.dhis.test.TestBase;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserService;
 import org.hisp.quick.BatchHandlerFactory;
 import org.junit.jupiter.api.Test;
@@ -80,7 +83,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
 
 @ExtendWith(MockitoExtension.class)
-class DataValueSetServiceImportTest extends TestBase {
+class DataValueSetServiceImportTest {
 
   @Mock private IdentifiableObjectManager identifiableObjectManager;
 
@@ -128,6 +131,9 @@ class DataValueSetServiceImportTest extends TestBase {
 
   @Test
   void testImportDataValuesUpdatedSkipNoChange() {
+    SystemUser user = new SystemUser();
+    injectSecurityContext(user);
+
     Calendar calendar = mock(Calendar.class);
     when(calendarService.getSystemCalendar()).thenReturn(calendar);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.jobs;
 
+import static org.hisp.dhis.test.TestBase.injectSecurityContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +43,8 @@ import org.hisp.dhis.scheduling.JobStatus;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.RecordingJobProgress;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.SystemUser;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +57,12 @@ class MetadataSyncJobTest {
   @Mock private SystemSettingManager systemSettingManager;
   @Mock private MetadataVersionService metadataVersionService;
   @Mock private MetadataVersionDelegate metadataVersionDelegate;
+
+  @BeforeAll
+  static void setUp() {
+    SystemUser user = new SystemUser();
+    injectSecurityContext(user);
+  }
 
   @Test
   @DisplayName(


### PR DESCRIPTION
## Summary
Attempts to fix tests that broke after merge of https://github.com/dhis2/dhis2-core/pull/18362
The errors showed up after merge, hence GitHub actions pipeline did not catch them. However Jenkins did.

[DHIS2-17906]: https://dhis2.atlassian.net/browse/DHIS2-17906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ