### PR TITLE
fix: order of headers in TE analytics endpoint - Improve Data Visualizer with fixed period "Weekly (Start Sunday)" labels [DHIS2-17974]  [2.42-DHIS2-17955]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.calendar.DateTimeUnit;
+import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.period.BiMonthlyPeriodType;
 import org.hisp.dhis.period.BiWeeklyAbstractPeriodType;
 import org.hisp.dhis.period.FinancialPeriodType;
@@ -254,7 +255,19 @@ public class I18nFormat {
    *
    * @param period the value to format.
    */
-  public String formatPeriod(Period period) {
+  public String formatPeriod(Period period){
+    return formatPeriod(period, false);
+  }
+
+
+  /**
+   * Formats a period. Returns null if value is null. Returns INVALID_DATE if formatting string is
+   * invalid.
+   *
+   * @param period the value to format.
+   * @param shortVersion the format for a Name or a shortName.
+   */
+  public String formatPeriod(Period period, boolean shortVersion) {
     if (period == null) {
       return null;
     }
@@ -282,7 +295,7 @@ public class I18nFormat {
 
       if (isWeeklyPeriodType(periodType)) {
         return String.format(
-            "Week %s %d-%02d-%02d - %d-%02d-%02d",
+            shortVersion ? "W%s %d-%02d-%02d - %d-%02d-%02d": "Week %s %d-%02d-%02d - %d-%02d-%02d",
             week,
             startDate.getYear(),
             startDate.getMonth().getValue(),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.ResourceBundle;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.calendar.DateTimeUnit;
-import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.period.BiMonthlyPeriodType;
 import org.hisp.dhis.period.BiWeeklyAbstractPeriodType;
 import org.hisp.dhis.period.FinancialPeriodType;
@@ -255,10 +254,9 @@ public class I18nFormat {
    *
    * @param period the value to format.
    */
-  public String formatPeriod(Period period){
+  public String formatPeriod(Period period) {
     return formatPeriod(period, false);
   }
-
 
   /**
    * Formats a period. Returns null if value is null. Returns INVALID_DATE if formatting string is
@@ -295,7 +293,9 @@ public class I18nFormat {
 
       if (isWeeklyPeriodType(periodType)) {
         return String.format(
-            shortVersion ? "W%s %d-%02d-%02d - %d-%02d-%02d": "Week %s %d-%02d-%02d - %d-%02d-%02d",
+            shortVersion
+                ? "W%s %d-%02d-%02d - %d-%02d-%02d"
+                : "Week %s %d-%02d-%02d - %d-%02d-%02d",
             week,
             startDate.getYear(),
             startDate.getMonth().getValue(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonRequestParamsParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonRequestParamsParser.java
@@ -123,8 +123,8 @@ public class CommonRequestParamsParser implements Parser<CommonRequestParams, Co
     // Adds all program attributes from all applicable programs as dimensions.
     request
         .getInternal()
-        .setProgramAttributes(
-            getProgramAttributes(programs).map(IdentifiableObject::getUid).collect(toSet()));
+        .getProgramAttributes()
+        .addAll(getProgramAttributes(programs).map(IdentifiableObject::getUid).toList());
 
     return CommonParsedParams.builder()
         .programs(programs)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -73,7 +73,6 @@ import static org.hisp.dhis.organisationunit.OrganisationUnit.getSortedGrandChil
 import static org.hisp.dhis.period.PeriodType.getCalendar;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 import static org.hisp.dhis.period.RelativePeriods.getRelativePeriodsFromEnum;
-import static org.hisp.dhis.period.WeeklyPeriodType.NAME;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_FINANCIAL_YEAR_START;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -337,12 +337,10 @@ public class DimensionalObjectProducer {
 
     for (Period period : periods) {
       String name = format != null ? format.formatPeriod(period) : null;
-
-      if (!period.getPeriodType().getName().contains(NAME)) {
-        period.setShortName(name);
-      }
+      String shortName = format != null ? format.formatPeriod(period, true) : null;
 
       period.setName(name);
+      period.setShortName(shortName);
 
       if (!calendar.isIso8601()) {
         period.setUid(getLocalPeriodIdentifier(period, calendar));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryRequestMapper.java
@@ -83,10 +83,9 @@ public class TrackedEntityQueryRequestMapper {
     // Adding tracked entity type attributes to the list of dimensions.
     requestParams
         .getInternal()
-        .setEntityTypeAttributes(
-            getTrackedEntityAttributes(trackedEntityType)
-                .map(IdentifiableObject::getUid)
-                .collect(toSet()));
+        .getEntityTypeAttributes()
+        .addAll(
+            getTrackedEntityAttributes(trackedEntityType).map(IdentifiableObject::getUid).toList());
 
     return TrackedEntityQueryParams.builder().trackedEntityType(trackedEntityType).build();
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
@@ -81,7 +81,8 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsAggregateActions.get(params);
 
     // Then
-    assertNoAnalyticsTableResponse(response, "ERROR: relation \"analytics\" does not exist\n  Position: 68");
+    assertNoAnalyticsTableResponse(
+        response, "ERROR: relation \"analytics\" does not exist\n  Position: 68");
   }
 
   @Test
@@ -96,7 +97,9 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsEventActions.query().get("eBAyeGv0exc", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response, "ERROR: relation \"analytics_event_ebayegv0exc\" does not exist\n  Position: 263");
+    assertNoAnalyticsTableResponse(
+        response,
+        "ERROR: relation \"analytics_event_ebayegv0exc\" does not exist\n  Position: 263");
   }
 
   @Test
@@ -109,7 +112,9 @@ public class NoAnalyticsTablesErrorsScenariosTest {
         analyticsEnrollmentsActions.query().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_enrollment_iphinat79uw\" does not exist\n  Position: 241");
+    assertNoAnalyticsTableResponse(
+        response,
+        "ERROR: relation \"analytics_enrollment_iphinat79uw\" does not exist\n  Position: 241");
   }
 
   @Test
@@ -124,7 +129,8 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsEventActions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_event_iphinat79uw\" does not exist\n  Position: 68");
+    assertNoAnalyticsTableResponse(
+        response, "ERROR: relation \"analytics_event_iphinat79uw\" does not exist\n  Position: 68");
   }
 
   @Test
@@ -140,7 +146,8 @@ public class NoAnalyticsTablesErrorsScenariosTest {
         analyticsTrackedEntityActions.query().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_te_neenwmsyuep\" does not exist\n  Position: 1955");
+    assertNoAnalyticsTableResponse(
+        response, "ERROR: relation \"analytics_te_neenwmsyuep\" does not exist\n  Position: 1955");
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
@@ -81,7 +81,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsAggregateActions.get(params);
 
     // Then
-    assertNoAnalyticsTableResponse(response);
+    assertNoAnalyticsTableResponse(response, "ERROR: relation \"analytics\" does not exist\n  Position: 68");
   }
 
   @Test
@@ -96,7 +96,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsEventActions.query().get("eBAyeGv0exc", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response);
+    assertNoAnalyticsTableResponse(response, "ERROR: relation \"analytics_event_ebayegv0exc\" does not exist\n  Position: 263");
   }
 
   @Test
@@ -109,7 +109,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
         analyticsEnrollmentsActions.query().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response);
+    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_enrollment_iphinat79uw\" does not exist\n  Position: 241");
   }
 
   @Test
@@ -124,7 +124,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
     ApiResponse response = analyticsEventActions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response);
+    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_event_iphinat79uw\" does not exist\n  Position: 68");
   }
 
   @Test
@@ -140,7 +140,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
         analyticsTrackedEntityActions.query().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
-    assertNoAnalyticsTableResponse(response);
+    assertNoAnalyticsTableResponse(response,"ERROR: relation \"analytics_te_neenwmsyuep\" does not exist\n  Position: 1955");
   }
 
   @Test
@@ -170,7 +170,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
         .body("errorCode", equalTo("E7180"));
   }
 
-  private void assertNoAnalyticsTableResponse(ApiResponse response) {
+  private void assertNoAnalyticsTableResponse(ApiResponse response, String expectedMessage) {
     response
         .validate()
         .statusCode(409)
@@ -180,6 +180,6 @@ public class NoAnalyticsTablesErrorsScenariosTest {
             equalTo(
                 "Query failed because a referenced table does not exist. Please ensure analytics job was run (SqlState: 42P01)"))
         .body("errorCode", equalTo("E7144"))
-        .body("devMessage", equalTo("SqlState: 42P01"));
+        .body("devMessage", equalTo(expectedMessage));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv13AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv13AutoTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.aggregate;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.test.e2e.actions.RestApiActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** Groups e2e tests for "/analytics" aggregate endpoint. */
+public class AnalyticsQueryDv13AutoTest extends AnalyticsApiTest {
+  private RestApiActions actions;
+
+  @BeforeAll
+  public void setup() {
+    actions = new RestApiActions("analytics");
+  }
+
+  @Test
+  public void weeklyShortNameLabel() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:USER_ORGUNIT")
+            .add("skipData=false")
+            .add("includeNumDen=true")
+            .add("displayProperty=SHORTNAME")
+            .add("skipMeta=false")
+            .add("dimension=dx:fbfJHSPpUQD,pe:2021SunW52");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(8)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(8))
+        .body("headerWidth", equalTo(8));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"dx\":{\"name\":\"Data\"},\"pq2XI5kz2BY\":{\"name\":\"Fixed\"},\"pe\":{\"name\":\"Period\"},\"ou\":{\"name\":\"Organisation unit\"},\"PT59n8BQbqM\":{\"name\":\"Outreach\"},\"2021SunW52\":{\"name\":\"W52 2021-12-26 - 2022-01-01\"},\"fbfJHSPpUQD\":{\"name\":\"ANC 1st visit\"}},\"dimensions\":{\"dx\":[\"fbfJHSPpUQD\"],\"pe\":[\"2021SunW52\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[\"pq2XI5kz2BY\",\"PT59n8BQbqM\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 3, "numerator", "Numerator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 4, "denominator", "Denominator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 5, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 6, "multiplier", "Multiplier", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 7, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(response, List.of("fbfJHSPpUQD", "2021SunW52", "462", "", "", "", "", ""));
+  }
+
+  @Test
+  public void weeklyNameLabel() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:USER_ORGUNIT")
+            .add("skipData=false")
+            .add("includeNumDen=true")
+            .add("displayProperty=NAME")
+            .add("skipMeta=false")
+            .add("dimension=dx:fbfJHSPpUQD,pe:2021SunW52");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(8)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(8))
+        .body("headerWidth", equalTo(8));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"dx\":{\"name\":\"Data\"},\"pq2XI5kz2BY\":{\"name\":\"Fixed\"},\"pe\":{\"name\":\"Period\"},\"ou\":{\"name\":\"Organisation unit\"},\"PT59n8BQbqM\":{\"name\":\"Outreach\"},\"2021SunW52\":{\"name\":\"Week 52 2021-12-26 - 2022-01-01\"},\"fbfJHSPpUQD\":{\"name\":\"ANC 1st visit\"}},\"dimensions\":{\"dx\":[\"fbfJHSPpUQD\"],\"pe\":[\"2021SunW52\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[\"pq2XI5kz2BY\",\"PT59n8BQbqM\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 3, "numerator", "Numerator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 4, "denominator", "Denominator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 5, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 6, "multiplier", "Multiplier", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 7, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(response, List.of("fbfJHSPpUQD", "2021SunW52", "462", "", "", "", "", ""));
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
@@ -48,6 +48,20 @@
       "version": {
         "min": 42
       }
+    },
+    {
+      "name": "weeklyShortNameLabel",
+      "query": "/api/42/analytics?dimension=dx%3AfbfJHSPpUQD,pe%3A2021SunW52&filter=ou%3AUSER_ORGUNIT&displayProperty=SHORTNAME&includeNumDen=true&skipMeta=false&skipData=false",
+      "version": {
+        "min": 42
+      }
+    },
+    {
+      "name": "weeklyNameLabel",
+      "query": "/api/42/analytics?dimension=dx%3AfbfJHSPpUQD,pe%3A2021SunW52&filter=ou%3AUSER_ORGUNIT&displayProperty=NAME&includeNumDen=true&skipMeta=false&skipData=false",
+      "version": {
+        "min": 42
+      }
     }
   ]
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
@@ -51,14 +51,14 @@
     },
     {
       "name": "weeklyShortNameLabel",
-      "query": "/api/42/analytics?dimension=dx%3AfbfJHSPpUQD,pe%3A2021SunW52&filter=ou%3AUSER_ORGUNIT&displayProperty=SHORTNAME&includeNumDen=true&skipMeta=false&skipData=false",
+      "query": "/api/42/analytics?dimension=dx:fbfJHSPpUQD,pe:2021SunW52&filter=ou:USER_ORGUNIT&displayProperty=SHORTNAME&includeNumDen=true&skipMeta=false&skipData=false",
       "version": {
         "min": 42
       }
     },
     {
       "name": "weeklyNameLabel",
-      "query": "/api/42/analytics?dimension=dx%3AfbfJHSPpUQD,pe%3A2021SunW52&filter=ou%3AUSER_ORGUNIT&displayProperty=NAME&includeNumDen=true&skipMeta=false&skipData=false",
+      "query": "/api/42/analytics?dimension=dx:fbfJHSPpUQD,pe:2021SunW52&filter=ou:USER_ORGUNIT&displayProperty=NAME&includeNumDen=true&skipMeta=false&skipData=false\n",
       "version": {
         "min": 42
       }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery1AutoTest.java
@@ -122,13 +122,13 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
         "java.lang.String",
         false,
         true);
+    validateHeader(response, 12, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 12, "w75KJ2mc4zz", "First name", "TEXT", "java.lang.String", false, true);
+        response, 13, "lZGmxYbs97q", "Unique ID", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 13, "zDhUuAYrxNC", "Last name", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 14, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+        response, 14, "w75KJ2mc4zz", "First name", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 15, "lZGmxYbs97q", "Unique ID", "TEXT", "java.lang.String", false, true);
+        response, 15, "zDhUuAYrxNC", "Last name", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response,
         16,
@@ -168,10 +168,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Sharon",
-            "Johnson",
             "Female",
             "",
+            "Sharon",
+            "Johnson",
             "36282.0",
             "3.0"));
     validateRow(
@@ -190,10 +190,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
             "Female",
             "",
+            "Filona",
+            "Ryder",
             "4322.0",
             ""));
     validateRow(
@@ -212,10 +212,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Jack",
-            "Dean",
             "Male",
             "",
+            "Jack",
+            "Dean",
             "4210.0",
             "10.0"));
     validateRow(
@@ -233,10 +233,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Tim",
-            "Johnson",
             "Male",
             "",
+            "Tim",
+            "Johnson",
             "4201.0",
             "8.0"));
     validateRow(
@@ -254,10 +254,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Lily",
-            "Matthews",
             "Female",
             "",
+            "Lily",
+            "Matthews",
             "4201.0",
             "5.0"));
     validateRow(
@@ -275,10 +275,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Konjo MCHP",
             "OU_222670",
             "Sierra Leone / Kenema / Lower Bambara / Konjo MCHP",
-            "Bobby",
-            "Foster",
             "Male",
             "",
+            "Bobby",
+            "Foster",
             "3999.0",
             "2.0"));
   }
@@ -423,13 +423,13 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
         "java.lang.String",
         false,
         true);
+    validateHeader(response, 12, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 12, "w75KJ2mc4zz", "First name", "TEXT", "java.lang.String", false, true);
+        response, 13, "lZGmxYbs97q", "Unique ID", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 13, "zDhUuAYrxNC", "Last name", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 14, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+        response, 14, "w75KJ2mc4zz", "First name", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 15, "lZGmxYbs97q", "Unique ID", "TEXT", "java.lang.String", false, true);
+        response, 15, "zDhUuAYrxNC", "Last name", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response,
         16,
@@ -469,10 +469,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
             "Female",
             "",
+            "Filona",
+            "Ryder",
             "4322.0",
             ""));
     validateRow(
@@ -491,10 +491,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Frank",
-            "Fjordsen",
             "Male",
             "",
+            "Frank",
+            "Fjordsen",
             "3444.0",
             "5.0"));
     validateRow(
@@ -513,10 +513,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Gertrude",
-            "Fjordsen",
             "Female",
             "",
+            "Gertrude",
+            "Fjordsen",
             "3320.0",
             "5.0"));
     validateRow(
@@ -535,10 +535,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Mapailleh MCHP",
             "OU_247072",
             "Sierra Leone / Moyamba / Kargboro / Mapailleh MCHP",
-            "Paula",
-            "Walker",
             "Female",
             "",
+            "Paula",
+            "Walker",
             "3444.0",
             "1.0"));
     validateRow(
@@ -557,10 +557,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "John",
-            "Kelly",
             "Male",
             "",
+            "John",
+            "Kelly",
             "",
             ""));
     validateRow(
@@ -579,10 +579,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Anna",
-            "Jones",
             "Female",
             "",
+            "Anna",
+            "Jones",
             "3243.0",
             "10.0"));
     validateRow(
@@ -601,10 +601,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Gelehun MCHP",
             "OU_222626",
             "Sierra Leone / Kenema / Small Bo / Gelehun MCHP",
-            "Eric",
-            "Robertson",
             "Male",
             "",
+            "Eric",
+            "Robertson",
             "3706.0",
             "2.0"));
     validateRow(
@@ -623,10 +623,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Masoko MCHP",
             "OU_268158",
             "Sierra Leone / Tonkolili / Kholifa Rowalla / Masoko MCHP",
-            "Diane",
-            "Bryant",
             "Female",
             "",
+            "Diane",
+            "Bryant",
             "3779.0",
             "0.0"));
     validateRow(
@@ -645,10 +645,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Tonko Maternity Clinic",
             "OU_193214",
             "Sierra Leone / Bombali / Bombali Sebora / Tonko Maternity Clinic",
-            "Mark",
-            "Coleman",
             "Male",
             "",
+            "Mark",
+            "Coleman",
             "3297.0",
             "0.0"));
     validateRow(
@@ -667,10 +667,10 @@ public class TrackedEntityQuery1AutoTest extends AnalyticsApiTest {
             "Banka Makuloh MCHP",
             "OU_211259",
             "Sierra Leone / Kambia / Masungbala / Banka Makuloh MCHP",
-            "Deborah",
-            "James",
             "Female",
             "",
+            "Deborah",
+            "James",
             "2579.0",
             "0.0"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
@@ -242,11 +242,20 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // Assert headers.
-    validateHeader(
-        response, 0, "trackedentity", "Tracked entity", "TEXT", "java.lang.String", false, true);
+    int headerIndex = 0;
+
     validateHeader(
         response,
-        1,
+        (headerIndex++),
+        "trackedentity",
+        "Tracked entity",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
         "lastupdated",
         "Last updated",
         "DATETIME",
@@ -255,7 +264,7 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
         true);
     validateHeader(
         response,
-        2,
+        (headerIndex++),
         "lastupdatedbydisplayname",
         "Last updated by",
         "TEXT",
@@ -263,21 +272,73 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 3, "created", "Created", "DATETIME", "java.time.LocalDateTime", false, true);
-    validateHeader(
-        response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 5, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 6, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 7, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
-    validateHeader(response, 8, "latitude", "Latitude", "NUMBER", "java.lang.Double", false, true);
-    validateHeader(
-        response, 9, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 10, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true);
+        response,
+        (headerIndex++),
+        "created",
+        "Created",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response,
-        11,
+        (headerIndex++),
+        "createdbydisplayname",
+        "Created by",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "storedby",
+        "Stored by",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response, (headerIndex++), "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "longitude",
+        "Longitude",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "latitude",
+        "Latitude",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "oucode",
+        "Organisation unit code",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
         "ounamehierarchy",
         "Organisation unit hierarchy",
         "TEXT",
@@ -285,28 +346,167 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 12, "w75KJ2mc4zz", "First name", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 13, "zDhUuAYrxNC", "Last name", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 14, "NDXw0cluzSw", "Email", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 15, "iESIqZ0R0R0", "Date of birth", "DATE", "java.time.LocalDate", false, true);
-    validateHeader(response, 16, "VqEFza8wbwA", "Address", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 17, "OvY4VVhSDeJ", "Weight in kg", "NUMBER", "java.lang.Double", false, true);
-    validateHeader(
-        response, 18, "lw1SqmMlnfh", "Height in cm", "NUMBER", "java.lang.Double", false, true);
-    validateHeader(response, 19, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 20, "xs8A6tQJY0s", "TB identifier", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 21, "spFvx9FndA4", "Age", "AGE", "java.util.Date", false, true);
-    validateHeader(response, 22, "FO4sWYJ64LQ", "City", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 23, "GUOBQt5K2WI", "State", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 24, "n9nUvfpTsxQ", "Zip code", "NUMBER", "java.lang.Double", false, true);
+        response,
+        (headerIndex++),
+        "A4xFHyieXys",
+        "Occupation",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeader(
         response,
-        25,
+        (headerIndex++),
+        "Agywv2JGwuq",
+        "Mobile number",
+        "PHONE_NUMBER",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "AuPLng5hLbE",
+        "National identifier",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "cejWyOfXge6",
+        "Gender",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "ciq2USN94oJ",
+        "Civil status",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "DODgdr5Oo2v",
+        "Provider ID",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response, (headerIndex++), "FO4sWYJ64LQ", "City", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "G7vUx908SwP",
+        "Residence location",
+        "COORDINATE",
+        "org.opengis.geometry.primitive.Point",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "gHGyrwKPzej",
+        "Birth date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+    validateHeader(
+        response, (headerIndex++), "GUOBQt5K2WI", "State", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "H9IlTX2X6SL",
+        "Blood type",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "iESIqZ0R0R0",
+        "Date of birth",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "KmEUg2hHEtx",
+        "Email address",
+        "EMAIL",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "kyIzQsj96BD",
+        "Company",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "lw1SqmMlnfh",
+        "Height in cm",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "lZGmxYbs97q",
+        "Unique ID",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "n9nUvfpTsxQ",
+        "Zip code",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response, (headerIndex++), "NDXw0cluzSw", "Email", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "o9odfev2Ty5",
+        "Mother maiden name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "OvY4VVhSDeJ",
+        "Weight in kg",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
         "P2cwLGskgxn",
         "Phone number",
         "PHONE_NUMBER",
@@ -315,60 +515,90 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
         true);
     validateHeader(
         response,
-        26,
-        "G7vUx908SwP",
-        "Residence location",
-        "COORDINATE",
-        "org.opengis.geometry.primitive.Point",
-        false,
-        true);
-    validateHeader(
-        response, 27, "o9odfev2Ty5", "Mother maiden name", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response,
-        28,
-        "AuPLng5hLbE",
-        "National identifier",
+        (headerIndex++),
+        "Qo571yj6Zcn",
+        "Latitude",
         "TEXT",
         "java.lang.String",
         false,
         true);
     validateHeader(
-        response, 29, "A4xFHyieXys", "Occupation", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 30, "kyIzQsj96BD", "Company", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 31, "ruQQnf6rswq", "TB number", "TEXT", "java.lang.String", false, true);
-    validateHeader(response, 32, "VHfUeXpawmE", "Vehicle", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 33, "H9IlTX2X6SL", "Blood type", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 34, "Qo571yj6Zcn", "Latitude", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 35, "RG7uGl4w5Jq", "Longitude", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 36, "lZGmxYbs97q", "Unique ID", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 37, "DODgdr5Oo2v", "Provider ID", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response, 38, "ZcBPrXKahq2", "Postal code", "TEXT", "java.lang.String", false, true);
-    validateHeader(
         response,
-        39,
-        "Agywv2JGwuq",
-        "Mobile number",
-        "PHONE_NUMBER",
+        (headerIndex++),
+        "RG7uGl4w5Jq",
+        "Longitude",
+        "TEXT",
         "java.lang.String",
         false,
         true);
     validateHeader(
-        response, 40, "KmEUg2hHEtx", "Email address", "EMAIL", "java.lang.String", false, true);
+        response,
+        (headerIndex++),
+        "ruQQnf6rswq",
+        "TB number",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeader(
-        response, 41, "gHGyrwKPzej", "Birth date", "DATE", "java.time.LocalDate", false, true);
-    validateHeader(
-        response, 42, "ciq2USN94oJ", "Civil status", "TEXT", "java.lang.String", false, true);
+        response, (headerIndex++), "spFvx9FndA4", "Age", "AGE", "java.util.Date", false, true);
     validateHeader(
         response,
-        43,
+        (headerIndex++),
+        "VHfUeXpawmE",
+        "Vehicle",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "VqEFza8wbwA",
+        "Address",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "w75KJ2mc4zz",
+        "First name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "xs8A6tQJY0s",
+        "TB identifier",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "ZcBPrXKahq2",
+        "Postal code",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
+        "zDhUuAYrxNC",
+        "Last name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        (headerIndex++),
         "IpHINAT79UW.A03MvHHogjR.bx6fsa0t90x",
         "MCH BCG dose, Child Programme, Birth",
         "BOOLEAN",
@@ -377,7 +607,7 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
         true);
     validateHeader(
         response,
-        44,
+        (headerIndex++),
         "IpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6",
         "MCH Apgar Score, Child Programme, Birth",
         "NUMBER",
@@ -402,10 +632,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
-            "",
-            "",
             "",
             "",
             "",
@@ -433,6 +659,10 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "",
             "",
+            "Filona",
+            "",
+            "",
+            "Ryder",
             "",
             ""));
     validateRow(
@@ -451,24 +681,15 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Ava",
-            "Didriksson",
             "",
             "",
             "",
             "",
+            "Married (conjugal cohabitation)",
             "",
             "",
             "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
+            "1985-10-01 00:00:00.0",
             "",
             "",
             "",
@@ -480,8 +701,17 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "",
             "",
-            "1985-10-01 00:00:00.0",
-            "Married (conjugal cohabitation)",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Ava",
+            "",
+            "",
+            "Didriksson",
             "",
             ""));
     validateRow(
@@ -500,27 +730,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Blamawo MCHP",
             "OU_73727",
             "Sierra Leone / Bo / Baoma / Blamawo MCHP",
-            "Rose",
-            "Hudson",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -531,6 +740,27 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "1986-07-04 00:00:00.0",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Rose",
+            "",
+            "",
+            "Hudson",
             "",
             ""));
     validateRow(
@@ -549,27 +779,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Petifu Mayepoh MCHP",
             "OU_268211",
             "Sierra Leone / Tonkolili / Gbonkonlenken / Petifu Mayepoh MCHP",
-            "Beverly",
-            "Boyd",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -581,7 +790,29 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "1972-05-03 00:00:00.0",
             "",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Beverly",
+            "",
+            "",
+            "Boyd",
+            "",
             ""));
+
     validateRow(
         response,
         5,
@@ -598,27 +829,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Kondewakoro CHP",
             "OU_233315",
             "Sierra Leone / Kono / Toli / Kondewakoro CHP",
-            "Sandra",
-            "Ferguson",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -629,6 +839,27 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "1982-03-04 00:00:00.0",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Sandra",
+            "",
+            "",
+            "Ferguson",
             "",
             ""));
     validateRow(
@@ -647,27 +878,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Mathen MCHP",
             "OU_254990",
             "Sierra Leone / Port Loko / Lokomasama / Mathen MCHP",
-            "Heather",
-            "Hughes",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -679,7 +889,29 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "1987-01-28 00:00:00.0",
             "",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Heather",
+            "",
+            "",
+            "Hughes",
+            "",
             ""));
+
     validateRow(
         response,
         7,
@@ -696,27 +928,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Mbokie CHP",
             "OU_197401",
             "Sierra Leone / Bonthe / Sittia / Mbokie CHP",
-            "Melissa",
-            "Fuller",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -728,7 +939,29 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "1981-03-21 00:00:00.0",
             "",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Melissa",
+            "",
+            "",
+            "Fuller",
+            "",
             ""));
+
     validateRow(
         response,
         8,
@@ -745,27 +978,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Kolisokor MCHP",
             "OU_193259",
             "Sierra Leone / Bombali / Makari Gbanti / Kolisokor MCHP",
-            "Irene",
-            "Jacobs",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -776,6 +988,27 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "1988-01-18 00:00:00.0",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Irene",
+            "",
+            "",
+            "Jacobs",
             "",
             ""));
     validateRow(
@@ -794,27 +1027,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "Grey Bush CHC",
             "OU_651068",
             "Sierra Leone / Western Area / Freetown / Grey Bush CHC",
-            "Lillian",
-            "Butler",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "",
             "",
             "",
@@ -825,6 +1037,27 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
             "",
             "1985-03-17 00:00:00.0",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Lillian",
+            "",
+            "",
+            "Butler",
             "",
             ""));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
@@ -207,7 +207,6 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  @Disabled("Disabled temporary, will be enabled after the fix of the header sorting")
   public void sortByEventDateWithOffsetsDesc() throws JSONException {
     // Given
     QueryParamsBuilder params =

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Groups e2e tests for "/trackedEntities/query" endpoint. */
@@ -206,6 +207,7 @@ public class TrackedEntityQuery4AutoTest extends AnalyticsApiTest {
   }
 
   @Test
+  @Disabled("Disabled temporary, will be enabled after the fix of the header sorting")
   public void sortByEventDateWithOffsetsDesc() throws JSONException {
     // Given
     QueryParamsBuilder params =

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQuery4AutoTest.java
@@ -41,7 +41,6 @@ import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Groups e2e tests for "/trackedEntities/query" endpoint. */

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryTest.java
@@ -1247,10 +1247,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Angela",
-            "Wright",
             "Female",
             "",
+            "Angela",
+            "Wright",
             "BV4IomHvri4"));
 
     validateRow(
@@ -1269,10 +1269,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Brenda",
-            "Morgan",
             "Female",
             "",
+            "Brenda",
+            "Morgan",
             "BV4IomHvri4"));
 
     validateRow(
@@ -1291,10 +1291,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Edward",
-            "Murray",
             "Male",
             "",
+            "Edward",
+            "Murray",
             "BV4IomHvri4"));
   }
 
@@ -1342,10 +1342,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Angela",
-            "Wright",
             "Female",
             "",
+            "Angela",
+            "Wright",
             "BV4IomHvri4"));
 
     validateRow(
@@ -1364,10 +1364,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Brenda",
-            "Morgan",
             "Female",
             "",
+            "Brenda",
+            "Morgan",
             "BV4IomHvri4"));
 
     validateRow(
@@ -1386,10 +1386,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
-            "Edward",
-            "Murray",
             "Male",
             "",
+            "Edward",
+            "Murray",
             "BV4IomHvri4"));
   }
 
@@ -1737,10 +1737,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+            "",
+            "",
             "Tom",
             "Johson",
-            "",
-            "",
             "12.0"));
   }
 
@@ -1927,10 +1927,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Plantain Island MCHP",
             "OU_247071",
             "Sierra Leone / Moyamba / Kargboro / Plantain Island MCHP",
-            "Willie",
-            "Wallace",
             "Male",
             "",
+            "Willie",
+            "Wallace",
             "Negative-Conf"));
 
     validateRow(
@@ -1949,10 +1949,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Yankasa MCHP",
             "OU_193257",
             "Sierra Leone / Bombali / Makari Gbanti / Yankasa MCHP",
-            "Willie",
-            "Stewart",
             "Male",
             "",
+            "Willie",
+            "Stewart",
             "Negative-Conf"));
 
     validateRow(
@@ -1971,10 +1971,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Bumpeh Perri CHC",
             "OU_260423",
             "Sierra Leone / Pujehun / Galliness Perri / Bumpeh Perri CHC",
-            "Willie",
-            "Stevens",
             "Male",
             "",
+            "Willie",
+            "Stevens",
             "Negative-Conf"));
   }
 
@@ -2028,10 +2028,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Plantain Island MCHP",
             "OU_247071",
             "Sierra Leone / Moyamba / Kargboro / Plantain Island MCHP",
-            "Willie",
-            "Wallace",
             "Male",
             "",
+            "Willie",
+            "Wallace",
             "Negative (Confirmed)"));
 
     validateRow(
@@ -2050,10 +2050,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Yankasa MCHP",
             "OU_193257",
             "Sierra Leone / Bombali / Makari Gbanti / Yankasa MCHP",
-            "Willie",
-            "Stewart",
             "Male",
             "",
+            "Willie",
+            "Stewart",
             "Negative (Confirmed)"));
 
     validateRow(
@@ -2072,10 +2072,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Bumpeh Perri CHC",
             "OU_260423",
             "Sierra Leone / Pujehun / Galliness Perri / Bumpeh Perri CHC",
-            "Willie",
-            "Stevens",
             "Male",
             "",
+            "Willie",
+            "Stevens",
             "Negative (Confirmed)"));
   }
 
@@ -2128,16 +2128,16 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "ABC123456",
-            "PID0001",
             "Johnson",
-            "Sarah",
+            "30",
             "1988-07-10 00:00:00.0",
             "",
-            "30",
             "FEMALE",
-            "",
+            "ABC123456",
+            "PID0001",
             "FR",
+            "Sarah",
+            "",
             ""));
 
     validateRow(
@@ -2156,15 +2156,15 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "LBO315445",
-            "7hdjdj",
             "Martin",
-            "Steve",
+            "43",
             "1976-02-03 00:00:00.0",
             "",
-            "43",
             "FEMALE",
+            "LBO315445",
+            "7hdjdj",
             "",
+            "Steve",
             "",
             ""));
 
@@ -2184,17 +2184,17 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+            "",
+            "21",
+            "1998-02-04 00:00:00.0",
+            "",
+            "",
             "YOH335093",
             "",
             "",
             "",
-            "1998-02-04 00:00:00.0",
-            "",
-            "21",
-            "",
-            "",
-            "",
-            "SRID=4326;POINT(40.41441 -3.71542)"));
+            "SRID=4326;POINT(40.41441 -3.71542)",
+            ""));
   }
 
   @Test
@@ -2246,16 +2246,16 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "ABC123456",
-            "PID0001",
             "Johnson",
-            "Sarah",
+            "30",
             "1988-07-10 00:00:00.0",
             "",
-            "30",
             "FEMALE",
-            "",
+            "ABC123456",
+            "PID0001",
             "FR",
+            "Sarah",
+            "",
             ""));
 
     validateRow(
@@ -2274,15 +2274,15 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "LBO315445",
-            "7hdjdj",
             "Martin",
-            "Steve",
+            "43",
             "1976-02-03 00:00:00.0",
             "",
-            "43",
             "FEMALE",
+            "LBO315445",
+            "7hdjdj",
             "",
+            "Steve",
             "",
             ""));
 
@@ -2302,17 +2302,17 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+            "",
+            "21",
+            "1998-02-04 00:00:00.0",
+            "",
+            "",
             "YOH335093",
             "",
             "",
             "",
-            "1998-02-04 00:00:00.0",
-            "",
-            "21",
-            "",
-            "",
-            "",
-            "SRID=4326;POINT(40.41441 -3.71542)"));
+            "SRID=4326;POINT(40.41441 -3.71542)",
+            ""));
   }
 
   @Test
@@ -2367,10 +2367,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Jangalor MCHP",
             "OU_543020",
             "Sierra Leone / Bonthe / Imperi / Jangalor MCHP",
-            "Antonio",
-            "Ruiz",
             "Male",
             "",
+            "Antonio",
+            "Ruiz",
             "3681.0",
             "Positive"));
 
@@ -2390,10 +2390,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Mattru Jong MCHP",
             "OU_197389",
             "Sierra Leone / Bonthe / Jong / Mattru Jong MCHP",
-            "Julia",
-            "Gardner",
             "Female",
             "",
+            "Julia",
+            "Gardner",
             "3945.0",
             "Positive"));
 
@@ -2413,10 +2413,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngaiya MCHP",
             "OU_233404",
             "Sierra Leone / Kono / Nimikoro / Ngaiya MCHP",
-            "Beverly",
-            "Hart",
             "Female",
             "",
+            "Beverly",
+            "Hart",
             "3104.0",
             "Positive"));
   }
@@ -2473,10 +2473,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Jangalor MCHP",
             "OU_543020",
             "Sierra Leone / Bonthe / Imperi / Jangalor MCHP",
-            "Antonio",
-            "Ruiz",
             "rBvjJYbMCVx",
             "",
+            "Antonio",
+            "Ruiz",
             "3681.0",
             "fWI0UiNZgMy"));
 
@@ -2496,10 +2496,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Mattru Jong MCHP",
             "OU_197389",
             "Sierra Leone / Bonthe / Jong / Mattru Jong MCHP",
-            "Julia",
-            "Gardner",
             "Mnp3oXrpAbK",
             "",
+            "Julia",
+            "Gardner",
             "3945.0",
             "fWI0UiNZgMy"));
 
@@ -2519,10 +2519,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngaiya MCHP",
             "OU_233404",
             "Sierra Leone / Kono / Nimikoro / Ngaiya MCHP",
-            "Beverly",
-            "Hart",
             "Mnp3oXrpAbK",
             "",
+            "Beverly",
+            "Hart",
             "3104.0",
             "fWI0UiNZgMy"));
   }
@@ -2577,10 +2577,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
             "Female",
             "",
+            "Filona",
+            "Ryder",
             "COMPLETED"));
   }
 
@@ -2634,10 +2634,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
             "Female",
             "",
+            "Filona",
+            "Ryder",
             "COMPLETED"));
   }
 
@@ -2691,10 +2691,10 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "Ngelehun CHC",
             "OU_559",
             "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-            "Filona",
-            "Ryder",
             "Female",
             "",
+            "Filona",
+            "Ryder",
             "COMPLETED"));
   }
 


### PR DESCRIPTION
This PR makes sure the order of TE headers is deterministic, especially when no `headers` param is passed.