### PR TITLE
feat: Improve Data Visualizer with fixed period "Weekly (Start Sunday)" labels [2.40-DHIS2-17955-backport]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
@@ -255,6 +255,16 @@ public class I18nFormat {
    * @param period the value to format.
    */
   public String formatPeriod(Period period) {
+    return formatPeriod(period, false);
+  }
+
+  /**
+   * Formats a period. Returns null if value is null. Returns INVALID_DATE if formatting string is
+   * invalid.
+   *
+   * @param period the value to format.
+   */
+  public String formatPeriod(Period period, boolean shortVersion) {
     if (period == null) {
       return null;
     }
@@ -282,7 +292,9 @@ public class I18nFormat {
 
       if (isWeeklyPeriodType(periodType)) {
         return String.format(
-            "Week %s %d-%02d-%02d - %d-%02d-%02d",
+            shortVersion
+                ? "W%s %d-%02d-%02d - %d-%02d-%02d"
+                : "Week %s %d-%02d-%02d - %d-%02d-%02d",
             week,
             startDate.getYear(),
             startDate.getMonth().getValue(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -69,7 +69,6 @@ import static org.hisp.dhis.organisationunit.OrganisationUnit.getSortedGrandChil
 import static org.hisp.dhis.period.PeriodType.getCalendar;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 import static org.hisp.dhis.period.RelativePeriods.getRelativePeriodsFromEnum;
-import static org.hisp.dhis.period.WeeklyPeriodType.NAME;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_FINANCIAL_YEAR_START;
 
 import java.util.ArrayList;
@@ -338,12 +337,10 @@ public class DimensionalObjectProducer {
 
     for (Period period : periods) {
       String name = format != null ? format.formatPeriod(period) : null;
-
-      if (!period.getPeriodType().getName().contains(NAME)) {
-        period.setShortName(name);
-      }
+      String shortName = format != null ? format.formatPeriod(period, true) : null;
 
       period.setName(name);
+      period.setShortName(shortName);
 
       if (!calendar.isIso8601()) {
         period.setUid(getLocalPeriodIdentifier(period, calendar));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv11AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv11AutoTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.aggregate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** Groups e2e tests for "/analytics" aggregate endpoint. */
+public class AnalyticsQueryDv11AutoTest extends AnalyticsApiTest {
+  private RestApiActions actions;
+
+  @BeforeAll
+  public void setup() {
+    actions = new RestApiActions("analytics");
+  }
+
+  @Test
+  public void weeklyShortNameLabel() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:USER_ORGUNIT")
+            .add("skipData=false")
+            .add("includeNumDen=true")
+            .add("displayProperty=SHORTNAME")
+            .add("skipMeta=false")
+            .add("dimension=dx:fbfJHSPpUQD,pe:2021SunW52");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(8)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(8))
+        .body("headerWidth", equalTo(8));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"dx\":{\"name\":\"Data\"},\"pq2XI5kz2BY\":{\"name\":\"Fixed\"},\"pe\":{\"name\":\"Period\"},\"ou\":{\"name\":\"Organisation unit\"},\"PT59n8BQbqM\":{\"name\":\"Outreach\"},\"2021SunW52\":{\"name\":\"W52 2021-12-26 - 2022-01-01\"},\"fbfJHSPpUQD\":{\"name\":\"ANC 1st visit\"}},\"dimensions\":{\"dx\":[\"fbfJHSPpUQD\"],\"pe\":[\"2021SunW52\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[\"pq2XI5kz2BY\",\"PT59n8BQbqM\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 3, "numerator", "Numerator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 4, "denominator", "Denominator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 5, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 6, "multiplier", "Multiplier", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 7, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+  }
+
+  @Test
+  public void weeklyNameLabel() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:USER_ORGUNIT")
+            .add("skipData=false")
+            .add("includeNumDen=true")
+            .add("displayProperty=NAME")
+            .add("skipMeta=false")
+            .add("dimension=dx:fbfJHSPpUQD,pe:2021SunW52");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(8)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(8))
+        .body("headerWidth", equalTo(8));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"dx\":{\"name\":\"Data\"},\"pq2XI5kz2BY\":{\"name\":\"Fixed\"},\"pe\":{\"name\":\"Period\"},\"ou\":{\"name\":\"Organisation unit\"},\"PT59n8BQbqM\":{\"name\":\"Outreach\"},\"2021SunW52\":{\"name\":\"Week 52 2021-12-26 - 2022-01-01\"},\"fbfJHSPpUQD\":{\"name\":\"ANC 1st visit\"}},\"dimensions\":{\"dx\":[\"fbfJHSPpUQD\"],\"pe\":[\"2021SunW52\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[\"pq2XI5kz2BY\",\"PT59n8BQbqM\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 3, "numerator", "Numerator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 4, "denominator", "Denominator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 5, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 6, "multiplier", "Multiplier", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 7, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(response, List.of("fbfJHSPpUQD", "2021SunW52", "462", "", "", "", "", ""));
+  }
+}


### PR DESCRIPTION
**BACKPORT**
For the short names of the weekly period dimension, we were displaying a less meaningful version, such as "2024SunW1." To improve clarity, we are now updating the short name format to "W1 2023-12-31 - 2024-01-06" when the DHIS2 instance is set to display short names.