### PR TITLE
feat: Improve Data Visualizer with fixed period "Weekly (Start Sunday)" labels [2.39-DHIS2-17955-backport]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/i18n/I18nFormat.java
@@ -255,6 +255,16 @@ public class I18nFormat {
    * @param period the value to format.
    */
   public String formatPeriod(Period period) {
+    return formatPeriod(period, false);
+  }
+
+  /**
+   * Formats a period. Returns null if value is null. Returns INVALID_DATE if formatting string is
+   * invalid.
+   *
+   * @param period the value to format.
+   */
+  public String formatPeriod(Period period, boolean shortVersion) {
     if (period == null) {
       return null;
     }
@@ -282,7 +292,9 @@ public class I18nFormat {
 
       if (isWeeklyPeriodType(periodType)) {
         return String.format(
-            "Week %s %d-%02d-%02d - %d-%02d-%02d",
+            shortVersion
+                ? "W%s %d-%02d-%02d - %d-%02d-%02d"
+                : "Week %s %d-%02d-%02d - %d-%02d-%02d",
             week,
             startDate.getYear(),
             startDate.getMonth().getValue(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -119,7 +119,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.period.RelativePeriods;
-import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.period.comparator.AscendingPeriodComparator;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SettingKey;
@@ -537,12 +536,10 @@ public class DefaultDataQueryService implements DataQueryService {
 
       for (Period period : periods) {
         String name = format != null ? format.formatPeriod(period) : null;
-
-        if (!period.getPeriodType().getName().contains(WeeklyPeriodType.NAME)) {
-          period.setShortName(name);
-        }
+        String shortName = format != null ? format.formatPeriod(period, true) : null;
 
         period.setName(name);
+        period.setShortName(shortName);
 
         if (!calendar.isIso8601()) {
           period.setUid(getLocalPeriodIdentifier(period, calendar));


### PR DESCRIPTION
**BACKPORT**
For the short names of the weekly period dimension, we were displaying a less meaningful version, such as "2024SunW1." To improve clarity, we are now updating the short name format to "W1 2023-12-31 - 2024-01-06" when the DHIS2 instance is set to display short names.