### PR TITLE
fix: Metadata versions endpoint should return valid data [DHIS2-17973]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMetadataVersion.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMetadataVersion.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.webapi.json.domain;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Web API equivalent of a {@link org.hisp.dhis.metadata.version.MetadataVersion}.
+ *
+ * @author David Mackessy
+ */
+public interface JsonMetadataVersion extends JsonObject {
+
+  default String getName() {
+    return getString("name").string();
+  }
+
+  default String getType() {
+    return getString("type").string();
+  }
+
+  default String getCreated() {
+    return getString("created").string();
+  }
+
+  default String getId() {
+    return getString("id").string();
+  }
+
+  default String getHashCode() {
+    return getString("hashCode").string();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataVersionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataVersionControllerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonMetadataVersion;
+import org.hisp.dhis.util.DateUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MetadataVersionControllerTest extends H2ControllerIntegrationTestBase {
+
+  @Test
+  @DisplayName("A valid metadata version should be returned from the versions endpoint")
+  void getMetadataVersionsTest() {
+    // given
+    POST("/systemSettings/keyVersionEnabled?value=true").success();
+    POST("/metadata/version/create?type=ATOMIC").success();
+
+    // when
+    JsonObject response = GET("/metadata/versions").content().as(JsonObject.class);
+    JsonMetadataVersion metadataVersion =
+        response.getArray("metadataversions").get(0, JsonMetadataVersion.class);
+
+    // then
+    assertEquals("Version_1", metadataVersion.getName());
+    assertTrue(CodeGenerator.isValidUid(metadataVersion.getId()), "id is valid UID");
+    assertTrue(DateUtils.dateIsValid(metadataVersion.getCreated()), "date is valid date");
+    assertEquals("ATOMIC", metadataVersion.getType());
+    assertNotNull(metadataVersion.getHashCode());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -75,7 +75,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @OpenApi.Document(domain = MetadataVersion.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@RequestMapping("/api/metadata/version")
+@RequestMapping("/api/metadata")
 public class MetadataVersionController {
   @Autowired private SystemSettingManager systemSettingManager;
 
@@ -84,7 +84,7 @@ public class MetadataVersionController {
   @Autowired private ContextUtils contextUtils;
 
   // Gets the version by versionName or latest system version
-  @GetMapping(produces = ContextUtils.CONTENT_TYPE_JSON)
+  @GetMapping(value = "/version", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody MetadataVersion getMetaDataVersion(
       @RequestParam(value = "versionName", required = false) String versionName)
       throws MetadataVersionException, BadRequestException {
@@ -127,7 +127,7 @@ public class MetadataVersionController {
 
   // Gets the list of all versions in between the passed version name and
   // latest system version
-  @GetMapping(value = "/history", produces = ContextUtils.CONTENT_TYPE_JSON)
+  @GetMapping(value = "/version/history", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody RootNode getMetaDataVersionHistory(
       @RequestParam(value = "baseline", required = false) String versionName)
       throws MetadataVersionException, BadRequestException {
@@ -187,7 +187,7 @@ public class MetadataVersionController {
   }
 
   // Gets the list of all versions
-  @GetMapping(value = "/metadata/versions", produces = ContextUtils.CONTENT_TYPE_JSON)
+  @GetMapping(value = "/versions", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody RootNode getAllVersion()
       throws MetadataVersionException, BadRequestException {
     boolean enabled = isMetadataVersioningEnabled();
@@ -209,7 +209,7 @@ public class MetadataVersionController {
   // Creates version in versioning table, exports the metadata and saves the
   // snapshot in datastore
   @RequiresAuthority(anyOf = F_METADATA_MANAGE)
-  @PostMapping(value = "/create", produces = ContextUtils.CONTENT_TYPE_JSON)
+  @PostMapping(value = "/version/create", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody MetadataVersion createSystemVersion(
       @RequestParam(value = "type") VersionType versionType)
       throws MetadataVersionException, BadRequestException {
@@ -234,7 +234,7 @@ public class MetadataVersionController {
 
   // endpoint to download metadata
   @RequiresAuthority(anyOf = F_METADATA_MANAGE)
-  @GetMapping(value = "/{versionName}/data", produces = APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/version/{versionName}/data", produces = APPLICATION_JSON_VALUE)
   public @ResponseBody String downloadVersion(@PathVariable("versionName") String versionName)
       throws MetadataVersionException, BadRequestException {
     boolean enabled = isMetadataVersioningEnabled();
@@ -259,7 +259,7 @@ public class MetadataVersionController {
 
   // endpoint to download metadata in gzip format
   @RequiresAuthority(anyOf = F_METADATA_MANAGE)
-  @GetMapping(value = "/{versionName}/data.gz", produces = "*/*")
+  @GetMapping(value = "/version/{versionName}/data.gz", produces = "*/*")
   public void downloadGZipVersion(
       @PathVariable("versionName") String versionName, HttpServletResponse response)
       throws MetadataVersionException, IOException, BadRequestException {


### PR DESCRIPTION
# Issue
Endpoint `/api/metadata/versions` broken, returning `404`

# Cause
During some web context mapping feature [here](https://github.com/dhis2/dhis2-core/pull/17122/files#diff-342cc97cf1e3e0f776113d93e2631ef08affdf66a0df902fd2cc5a147fd1e91cR78), the mapping `/metadata/version` was put at the class level. The `versions` endpoint was missed, leaving the endpoint available on `/api/metadata/version/metadata/versions`

# Fix 
- Strip back the top-level path mapping from `/metadata/version` to just `/metadata`
- fix broken endpoint
- ensure other endpoints have the appropriate mapping

# Tests
## Automated
There were no specific tests for any of these endpoints it seems
Added a test for each of the endpoints:
- `/api/metadata/versions`
- `/api/metadata/version`
- `/api/metadata/version?versionName={versionName}`
- `/api/metadata/version/history`
- `/api/metadata/version/history?versionName={versionName}`
- `/api/metadata/version/create`
- `/api/metadata/version/{versionName}/data`
- `/api/metadata/version/{versionName}/data.gz`