### PR TITLE
test: schema based tests as individual tests

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
@@ -94,8 +94,8 @@ public class Section extends BaseIdentifiableObject implements MetadataObject {
     return !getCategoryCombos().isEmpty();
   }
 
-  @JsonProperty
-  @JsonSerialize(as = BaseIdentifiableObject.class)
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Set<CategoryCombo> getCategoryCombos() {
     Set<CategoryCombo> categoryCombos = new HashSet<>();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -33,10 +33,17 @@ import static org.hisp.dhis.test.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
@@ -46,7 +53,9 @@ import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonGenerator;
 import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.test.webapi.json.domain.JsonSchema;
-import org.junit.jupiter.api.Test;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.http.MediaType;
 
 /**
@@ -89,70 +98,132 @@ class SchemaBasedControllerTest extends PostgresControllerIntegrationTestBase {
    */
   private static final Set<String> IGNORED_GIST_ENDPOINTS = Set.of("reportTable", "chart");
 
-  @Test
-  void testCreateAndDeleteSchemaObjects() {
+  private final Map<String, String> createdObjectIds = new ConcurrentHashMap<>();
+
+  @TestFactory
+  Stream<DynamicNode> generateSchemaBasedTests() {
     JsonList<JsonSchema> schemas = GET("/schemas").content().getList("schemas", JsonSchema.class);
     JsonGenerator generator = new JsonGenerator(schemas);
-    int testedSchemas = 0;
+    List<DynamicNode> tests = new ArrayList<>();
     for (JsonSchema schema : schemas) {
       if (!isExcludedFromTest(schema)) {
-        testedSchemas++;
-        Map<String, String> objects = generator.generateObjects(schema);
-        String uid = "";
-        String endpoint = "";
-        // create needed object(s)
-        // last created is the one we want to test for schema
-        // those before might be objects it depends upon that
-        // need to be created first
-        for (Entry<String, String> entry : objects.entrySet()) {
-          endpoint = entry.getKey();
-          uid = assertStatus(HttpStatus.CREATED, POST(endpoint, entry.getValue()));
-        }
-        // run other tests that depend upon having an existing object
-        testWithSchema(schema, uid);
-        // delete the last created object
-        // (the one belonging to the tested schema)
-        assertStatus(HttpStatus.OK, DELETE(endpoint + "/" + uid));
+        tests.add(
+            dynamicContainer(
+                schema.getRelativeApiEndpoint(), generatorTestsForSchema(schema, generator)));
       }
     }
-
-    assertTrue(testedSchemas >= 56, "make sure we actually test schemas");
+    assertTrue(tests.size() > 50, "There should be around 50 schemas");
+    return tests.stream();
   }
 
-  /** Uses the created instance to test the {@code /gist} endpoint list. */
-  private void testWithSchema(JsonSchema schema, String uid) {
-    String endpoint = schema.getRelativeApiEndpoint();
-    if (endpoint != null) {
-      testGistAPI(schema, uid);
-      testCanHaveAttributes(schema, uid);
-    }
+  private List<DynamicNode> generatorTestsForSchema(JsonSchema schema, JsonGenerator generator) {
+    return List.of(
+        dynamicTest("create object", () -> runCreateObject(schema, generator)),
+        dynamicTest("patch object", () -> runPatchObject(schema)),
+        dynamicTest("query object", () -> runQueryObject(schema)),
+        dynamicTest("query object list", () -> runQueryObjectList(schema)),
+        dynamicTest("query object Gist", () -> runQueryObjectGist(schema)),
+        dynamicTest("query object list Gist", () -> runQueryObjectListGist(schema)),
+        dynamicTest("update object attribute value", () -> runUpdateAttributeValue(schema)),
+        dynamicTest("delete object", () -> runDeleteObject(schema)));
   }
 
-  private void testGistAPI(JsonSchema schema, String uid) {
-    if (IGNORED_GIST_ENDPOINTS.contains(schema.getName())) {
-      return;
+  private void runCreateObject(JsonSchema schema, JsonGenerator generator) {
+    Map<String, String> objects = generator.generateObjects(schema);
+    String uid = "";
+    // create needed object(s)
+    // last created is the one we want to test for schema
+    // those before might be objects it depends upon that
+    // need to be created first
+    for (Entry<String, String> entry : objects.entrySet()) {
+      uid = assertStatus(HttpStatus.CREATED, POST(entry.getKey(), entry.getValue()));
     }
     String endpoint = schema.getRelativeApiEndpoint();
+    createdObjectIds.put(endpoint, uid);
+  }
+
+  private void runPatchObject(JsonSchema schema) {
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+    @Language("json")
+    String json = """
+    [{ "op": "add", "path": "/name", "value": "new_name_patch" }]""";
+    assertStatus(HttpStatus.OK, PATCH(endpoint + "/" + uid, json));
+  }
+
+  private void runDeleteObject(JsonSchema schema) {
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+    assertStatus(HttpStatus.OK, DELETE(endpoint + "/" + uid));
+  }
+
+  private void runQueryObjectListGist(JsonSchema schema) {
+    String name = schema.getName();
+    assumeFalse(
+        IGNORED_GIST_ENDPOINTS.contains(schema.getName()), name + " ignores Gist API for reasons");
+
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+
     // test gist list of object for the schema
     JsonObject gist = GET(endpoint + "/gist").content();
     assertTrue(gist.getObject("pager").exists());
     JsonArray list = gist.getArray(schema.getPlural());
     assertFalse(list.isEmpty());
-    // only if there is only one we are sure its the one we created
+    // only if there is only one we are sure it is the one we created
     if (list.size() == 1) {
       assertEquals(uid, list.getObject(0).getString("id").string());
     }
-    // test the single object gist as well
+  }
+
+  private void runQueryObjectGist(JsonSchema schema) {
+    String name = schema.getName();
+    assumeFalse(
+        IGNORED_GIST_ENDPOINTS.contains(schema.getName()), name + " ignores Gist API for reasons");
+
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+
     JsonObject object = GET(endpoint + "/" + uid + "/gist").content();
     assertTrue(object.exists());
     assertEquals(uid, object.getString("id").string());
   }
 
-  private void testCanHaveAttributes(JsonSchema schema, String uid) {
-    ObjectType type = ObjectType.valueOf(schema.getKlass());
-    if (type == null || type == ObjectType.MAP) {
-      return;
+  private void runQueryObject(JsonSchema schema) {
+    String name = schema.getName();
+    assumeFalse(
+        IGNORED_GIST_ENDPOINTS.contains(schema.getName()), name + " ignores Gist API for reasons");
+
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+
+    JsonObject object = GET(endpoint + "/" + uid).content();
+    assertTrue(object.exists());
+    assertEquals(uid, object.getString("id").string());
+  }
+
+  private void runQueryObjectList(JsonSchema schema) {
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+
+    // test list of object for the schema
+    JsonObject gist = GET(endpoint).content();
+    assertTrue(gist.getObject("pager").exists());
+    JsonArray list = gist.getArray(schema.getPlural());
+    assertFalse(list.isEmpty());
+    // only if there is only one we are sure it is the one we created
+    if (list.size() == 1) {
+      assertEquals(uid, list.getObject(0).getString("id").string());
     }
+  }
+
+  private void runUpdateAttributeValue(JsonSchema schema) {
+    ObjectType type = ObjectType.valueOf(schema.getKlass());
+    if (type == null || type == ObjectType.MAP) return;
+
+    String endpoint = schema.getRelativeApiEndpoint();
+    String uid = createdObjectIds.get(endpoint);
+
     String attrId =
         assertStatus(
             HttpStatus.CREATED,
@@ -163,7 +234,7 @@ class SchemaBasedControllerTest extends PostgresControllerIntegrationTestBase {
                     + "', 'valueType':'INTEGER','"
                     + type.getPropertyName()
                     + "':true}"));
-    String endpoint = schema.getRelativeApiEndpoint();
+
     JsonObject object = GET(endpoint + "/" + uid).content();
     assertStatus(
         HttpStatus.OK,
@@ -173,7 +244,7 @@ class SchemaBasedControllerTest extends PostgresControllerIntegrationTestBase {
                 object
                     .getObject("attributeValues")
                     .node()
-                    .replaceWith("[{\"value\":42, \"attribute\":{\"id\":\"" + attrId + "\"}}]")
+                    .replaceWith("[{\"value\":\"42\", \"attribute\":{\"id\":\"" + attrId + "\"}}]")
                     .getDeclaration()),
             ContentType(MediaType.APPLICATION_JSON)));
     assertEquals(


### PR DESCRIPTION
refactors the schema based controller tests so that the one test case that was testing it all now became 448 dynamically generated tests.

![schema-tests](https://github.com/user-attachments/assets/cf0a1247-18ac-4b14-a378-0834688398b8)

I added some more tests as well, for each schema we now also test:
* patching an object `PATCH /api/{object-type}/{id}`
* reading the object (single) metadata API, `GET /api/{object-type}/{id}`
* reading the object list metadata API `GET /api/{object-type}/`

That found a bug in the JSON mapping that I fixed.