### PR TITLE
fix: runStage null to non-null or cancel via exception (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
@@ -66,7 +66,8 @@ public class ImportCompleteDataSetRegistrationsJob implements Job {
 
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(jobConfig.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getFileResource(jobConfig.getUid())));
 
     progress.startingStage("Loading file content");
     try (InputStream input =

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -66,7 +66,8 @@ public class DataValueSetImportJob implements Job {
     ImportOptions options = (ImportOptions) jobId.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(jobId.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getFileResource(jobId.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -83,17 +83,21 @@ public class DefaultTrackerImportService implements TrackerImportService {
 
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
-        jobProgress.runStage(() -> trackerBundleService.create(params, trackerObjects, user));
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> trackerBundleService.create(params, trackerObjects, user)));
 
     jobProgress.startingStage("Calculating Payload Size");
     Map<TrackerType, Integer> bundleSize =
-        jobProgress.runStage(() -> calculatePayloadSize(trackerBundle));
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> calculatePayloadSize(trackerBundle)));
 
     jobProgress.startingStage("Running PreProcess");
     jobProgress.runStage(() -> trackerPreprocessService.preprocess(trackerBundle));
 
     jobProgress.startingStage("Running Validation");
-    ValidationResult validationResult = jobProgress.runStage(() -> validateBundle(trackerBundle));
+    ValidationResult validationResult =
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> validateBundle(trackerBundle)));
 
     ValidationReport validationReport = ValidationReport.fromResult(validationResult);
 
@@ -103,7 +107,8 @@ public class DefaultTrackerImportService implements TrackerImportService {
 
       jobProgress.startingStage("Running Rule Engine Validation");
       ValidationResult result =
-          jobProgress.runStage(() -> validationService.validateRuleEngine(trackerBundle));
+          jobProgress.nonNullStagePostCondition(
+              jobProgress.runStage(() -> validationService.validateRuleEngine(trackerBundle)));
       trackerBundle.setTrackedEntities(result.getTrackedEntities());
       trackerBundle.setEnrollments(result.getEnrollments());
       trackerBundle.setEvents(result.getEvents());
@@ -118,7 +123,9 @@ public class DefaultTrackerImportService implements TrackerImportService {
     }
 
     jobProgress.startingStage("Commit Transaction");
-    PersistenceReport persistenceReport = jobProgress.runStage(() -> commit(params, trackerBundle));
+    PersistenceReport persistenceReport =
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> commit(params, trackerBundle)));
 
     jobProgress.startingStage("PostCommit");
     jobProgress.runStage(() -> trackerBundleService.postCommit(trackerBundle));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
@@ -82,7 +82,8 @@ public class MetadataImportJob implements Job {
     MetadataImportParams params = (MetadataImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
@@ -69,7 +69,8 @@ public class TrackerImportJob implements Job {
     TrackerImportParams params = (TrackerImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {


### PR DESCRIPTION
backport based on cherry-pick of #17846 followed by checkout of `JobProgress` and `RecordingJobProgress` from `master`.