### PR TITLE
test: clear fake message sender to isolate tests DHIS2-17729

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessage;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -48,6 +47,7 @@ import org.hisp.dhis.test.message.FakeMessageSender;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -58,7 +58,12 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class AccountControllerTest extends PostgresControllerIntegrationTestBase {
   @Autowired private SystemSettingManager systemSettingManager;
-  @Autowired private MessageSender messageSender;
+  @Autowired private FakeMessageSender messageSender;
+
+  @AfterEach
+  void afterEach() {
+    messageSender.clearMessages();
+  }
 
   @Test
   void testRecoverAccount_NotEnabled() {
@@ -331,8 +336,7 @@ class AccountControllerTest extends PostgresControllerIntegrationTestBase {
   }
 
   private OutboundMessage assertMessageSendTo(String email) {
-    List<OutboundMessage> messagesByEmail =
-        ((FakeMessageSender) messageSender).getMessagesByEmail(email);
+    List<OutboundMessage> messagesByEmail = messageSender.getMessagesByEmail(email);
     assertFalse(messagesByEmail.isEmpty());
     return messagesByEmail.get(0);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessage;
@@ -74,6 +73,7 @@ import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.jboss.aerogear.security.otp.api.Base32;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,7 +86,7 @@ import org.springframework.security.core.session.SessionRegistry;
  * @author Jan Bernitt
  */
 class UserControllerTest extends H2ControllerIntegrationTestBase {
-  @Autowired private MessageSender messageSender;
+  @Autowired private FakeMessageSender messageSender;
 
   @Autowired private SystemSettingManager systemSettingManager;
 
@@ -119,6 +119,11 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
     User user = userService.getUser(peter.getUid());
     assertEquals("peter@pan.net", user.getEmail());
+  }
+
+  @AfterEach
+  void afterEach() {
+    messageSender.clearMessages();
   }
 
   @Test


### PR DESCRIPTION
The FakeMessageSender (and any other Spring component) will be shared by tests that share the same ApplicationContext https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/caching.html So we have to cleanup any state produced by tests. Otherwise, a change in order will cause tests to fail only on Jenkins, GitHub, ...