### PR TITLE
chore: remove config system settins [DHIS2-18024]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.common.DigitGroupSeparator;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.common.cache.Cacheability;
-import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.fileresource.FileResourceRetentionStrategy;
 import org.hisp.dhis.i18n.locale.LocaleManager;
 import org.hisp.dhis.period.RelativePeriodEnum;
@@ -96,7 +95,6 @@ public enum SettingKey {
       AnalyticsFinancialYearStartKey.class),
   PHONE_NUMBER_AREA_CODE("phoneNumberAreaCode"),
   MULTI_ORGANISATION_UNIT_FORMS("multiOrganisationUnitForms", Boolean.FALSE, Boolean.class),
-  CONFIGURATION("keyConfig", Configuration.class),
   ACCOUNT_RECOVERY("keyAccountRecovery", Boolean.FALSE, Boolean.class),
   LOCK_MULTIPLE_FAILED_LOGINS("keyLockMultipleFailedLogins", Boolean.FALSE, Boolean.class),
   GOOGLE_ANALYTICS_UA("googleAnalyticsUA"),

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_16__Remove_config_setting_row.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_16__Remove_config_setting_row.sql
@@ -1,0 +1,2 @@
+-- keyConfig is no longer a setting
+delete from systemsetting s where s.name = 'keyConfig';


### PR DESCRIPTION
### Summary
Removes the `Configuration` as a system setting.

Reasons
* `Configuration` type is not a system setting but the system configuration that has its own API
* it is one of currently two settings with a complex value (which both are not proper settings; settings contract should be simplified to always be about simple values)
* it is not actually used in the code, which should mean it is never written or updated and thus should always be undefined (default)

As settings map to enum `SettingKey` a potentially existing row needs to be removed via script. 

### Docs
https://github.com/dhis2/dhis2-docs/pull/1430