### PR TITLE
fix: Route API endpoint ambiguity

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -68,11 +68,11 @@ public class RouteController extends AbstractCrudController<Route> {
   @RequestMapping(
       value = "/{id}/run",
       method = {
-          RequestMethod.GET,
-          RequestMethod.POST,
-          RequestMethod.PUT,
-          RequestMethod.DELETE,
-          RequestMethod.PATCH
+        RequestMethod.GET,
+        RequestMethod.POST,
+        RequestMethod.PUT,
+        RequestMethod.DELETE,
+        RequestMethod.PATCH
       })
   public ResponseEntity<String> run(
       @PathVariable("id") String id,
@@ -85,11 +85,11 @@ public class RouteController extends AbstractCrudController<Route> {
   @RequestMapping(
       value = "/{id}/run/**",
       method = {
-          RequestMethod.GET,
-          RequestMethod.POST,
-          RequestMethod.PUT,
-          RequestMethod.DELETE,
-          RequestMethod.PATCH
+        RequestMethod.GET,
+        RequestMethod.POST,
+        RequestMethod.PUT,
+        RequestMethod.DELETE,
+        RequestMethod.PATCH
       })
   public ResponseEntity<String> runWithSubpath(
       @PathVariable("id") String id,
@@ -139,8 +139,8 @@ public class RouteController extends AbstractCrudController<Route> {
   @Override
   @PostMapping(value = "/deleteCollectionItem__disabled")
   @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-  public WebMessage deleteCollectionItem(String pvUid, String pvProperty, String pvItemId,
-      HttpServletResponse response)
+  public WebMessage deleteCollectionItem(
+      String pvUid, String pvProperty, String pvItemId, HttpServletResponse response)
       throws NotFoundException, ForbiddenException, ConflictException, BadRequestException {
     throw new NotFoundException("Method Not Allowed");
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -30,10 +30,13 @@ package org.hisp.dhis.webapi.controller;
 import java.io.IOException;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.route.Route;
@@ -42,9 +45,13 @@ import org.hisp.dhis.schema.descriptors.RouteSchemaDescriptor;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -58,7 +65,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class RouteController extends AbstractCrudController<Route> {
   private final RouteService routeService;
 
-  @RequestMapping(value = "/{id}/run")
+  @RequestMapping(
+      value = "/{id}/run",
+      method = {
+          RequestMethod.GET,
+          RequestMethod.POST,
+          RequestMethod.PUT,
+          RequestMethod.DELETE,
+          RequestMethod.PATCH
+      })
   public ResponseEntity<String> run(
       @PathVariable("id") String id,
       @CurrentUser UserDetails currentUser,
@@ -67,7 +82,15 @@ public class RouteController extends AbstractCrudController<Route> {
     return runWithSubpath(id, currentUser, request);
   }
 
-  @RequestMapping(value = "/{id}/run/**")
+  @RequestMapping(
+      value = "/{id}/run/**",
+      method = {
+          RequestMethod.GET,
+          RequestMethod.POST,
+          RequestMethod.PUT,
+          RequestMethod.DELETE,
+          RequestMethod.PATCH
+      })
   public ResponseEntity<String> runWithSubpath(
       @PathVariable("id") String id,
       @CurrentUser UserDetails currentUser,
@@ -99,5 +122,26 @@ public class RouteController extends AbstractCrudController<Route> {
     }
 
     return Optional.empty();
+  }
+
+  /**
+   * Disable the Collection API for /api/routes endpoint. This conflicts with sub-path based routes
+   * and is not supported by the Route API (no id object collections).
+   */
+  @Override
+  @PostMapping(value = "/addCollectionItem__disabled")
+  @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+  public WebMessage addCollectionItem(String pvUid, String pvProperty, String pvItemId)
+      throws NotFoundException, ConflictException, ForbiddenException, BadRequestException {
+    throw new NotFoundException("Method Not Allowed");
+  }
+
+  @Override
+  @PostMapping(value = "/deleteCollectionItem__disabled")
+  @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+  public WebMessage deleteCollectionItem(String pvUid, String pvProperty, String pvItemId,
+      HttpServletResponse response)
+      throws NotFoundException, ForbiddenException, ConflictException, BadRequestException {
+    throw new NotFoundException("Method Not Allowed");
   }
 }


### PR DESCRIPTION
Fixes a endpoint ambiguity issue with the Collection API and Route API. Since the Route API does not support Collection API anyways this fix will disable the endpoint mapping that is causing the issue.

[DHIS2-17593](https://dhis2.atlassian.net/browse/DHIS2-17593)

[DHIS2-17593]: https://dhis2.atlassian.net/browse/DHIS2-17593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ