### PR TITLE
refactor: sms gateway configuration stored in protected datastore ns [DHIS2-18025]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
@@ -38,7 +38,9 @@ import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Datastore is a key-value store with namespaces to isolate different collections of key-value
@@ -142,6 +144,9 @@ public interface DatastoreService {
    * @throws AccessDeniedException when user lacks authority for namespace
    */
   DatastoreEntry getEntry(String namespace, String key) throws ForbiddenException;
+
+  @Transactional(readOnly = true)
+  DatastoreEntry getEntry(String namespace, String key, UserDetails user) throws ForbiddenException;
 
   /**
    * Adds a new entry.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GatewayAdministrationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GatewayAdministrationService.java
@@ -28,16 +28,21 @@
 package org.hisp.dhis.sms.config;
 
 import javax.annotation.CheckForNull;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 
 /**
  * @author Zubair <rajazubair.asghar@gmail.com>
  */
 public interface GatewayAdministrationService {
-  void setDefaultGateway(SmsGatewayConfig config);
 
-  boolean removeGatewayByUid(String uid);
+  void setDefaultGateway(SmsGatewayConfig config)
+      throws ForbiddenException, ConflictException, BadRequestException;
+
+  boolean removeGatewayByUid(String uid)
+      throws ForbiddenException, ConflictException, BadRequestException;
 
   boolean hasGateways();
 
@@ -47,9 +52,10 @@ public interface GatewayAdministrationService {
 
   SmsGatewayConfig getByUid(String uid);
 
-  boolean addGateway(SmsGatewayConfig config);
+  boolean addGateway(SmsGatewayConfig config)
+      throws ForbiddenException, ConflictException, BadRequestException;
 
   void updateGateway(
       @CheckForNull SmsGatewayConfig persisted, @CheckForNull SmsGatewayConfig updatedConfig)
-      throws NotFoundException, ConflictException;
+      throws NotFoundException, ConflictException, ForbiddenException, BadRequestException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsConfigurationManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsConfigurationManager.java
@@ -27,9 +27,14 @@
  */
 package org.hisp.dhis.sms.config;
 
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ForbiddenException;
+
 /** Zubair <rajazubair.asghar@gmail.com> */
 public interface SmsConfigurationManager {
   SmsConfiguration getSmsConfiguration();
 
-  void updateSmsConfiguration(SmsConfiguration config);
+  void updateSmsConfiguration(SmsConfiguration config)
+      throws ConflictException, ForbiddenException, BadRequestException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsConfigurationManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsConfigurationManager.java
@@ -27,14 +27,17 @@
  */
 package org.hisp.dhis.sms.config;
 
+import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
 public interface SmsConfigurationManager {
+
+  @Nonnull
   SmsConfiguration getSmsConfiguration();
 
-  void updateSmsConfiguration(SmsConfiguration config)
+  void updateSmsConfiguration(@Nonnull SmsConfiguration config)
       throws ConflictException, ForbiddenException, BadRequestException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
@@ -41,7 +41,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IndirectTransactional;
 import org.hisp.dhis.common.NonTransactional;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -54,7 +56,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @RequiredArgsConstructor
-@Service("org.hisp.dhis.sms.config.GatewayAdministrationService")
+@Service
 public class DefaultGatewayAdministrationService implements GatewayAdministrationService {
 
   private final AtomicBoolean hasGateways = new AtomicBoolean();
@@ -75,7 +77,8 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
 
   @Override
   @IndirectTransactional
-  public void setDefaultGateway(SmsGatewayConfig config) {
+  public void setDefaultGateway(SmsGatewayConfig config)
+      throws ForbiddenException, ConflictException, BadRequestException {
     SmsConfiguration configuration = getSmsConfiguration();
 
     configuration
@@ -88,7 +91,8 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
 
   @Override
   @IndirectTransactional
-  public boolean addGateway(SmsGatewayConfig config) {
+  public boolean addGateway(SmsGatewayConfig config)
+      throws ForbiddenException, ConflictException, BadRequestException {
     if (config == null) {
       return false;
     }
@@ -122,7 +126,7 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
   @IndirectTransactional
   public void updateGateway(
       @CheckForNull SmsGatewayConfig persisted, @CheckForNull SmsGatewayConfig updated)
-      throws NotFoundException, ConflictException {
+      throws NotFoundException, ConflictException, ForbiddenException, BadRequestException {
     if (updated == null) throw new ConflictException("Gateway configuration cannot be null");
     if (persisted == null) throw new NotFoundException(SmsGatewayConfig.class, updated.getUid());
     if (persisted.getClass() != updated.getClass())
@@ -180,7 +184,8 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
 
   @Override
   @IndirectTransactional
-  public boolean removeGatewayByUid(String uid) {
+  public boolean removeGatewayByUid(String uid)
+      throws ForbiddenException, ConflictException, BadRequestException {
     SmsConfiguration smsConfiguration = getSmsConfiguration();
 
     List<SmsGatewayConfig> gateways = smsConfiguration.getGateways();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
@@ -66,10 +66,6 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
   @Qualifier("tripleDesStringEncryptor")
   private final PBEStringEncryptor pbeStringEncryptor;
 
-  // -------------------------------------------------------------------------
-  // GatewayAdministrationService implementation
-  // -------------------------------------------------------------------------
-
   @EventListener
   public void handleContextRefresh(ContextRefreshedEvent event) {
     updateHasGatewaysState();
@@ -233,40 +229,13 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
     return hasGateways.get();
   }
 
-  // -------------------------------------------------------------------------
-  // Supportive methods
-  // -------------------------------------------------------------------------
-
   private SmsConfiguration getSmsConfiguration() {
-    SmsConfiguration smsConfiguration = smsConfigurationManager.getSmsConfiguration();
-
-    if (smsConfiguration != null) {
-      return smsConfiguration;
-    }
-
-    return new SmsConfiguration();
+    return smsConfigurationManager.getSmsConfiguration();
   }
 
   private void updateHasGatewaysState() {
-    SmsConfiguration smsConfiguration = smsConfigurationManager.getSmsConfiguration();
-
-    if (smsConfiguration == null) {
-      log.info("SMS configuration not found");
-      hasGateways.set(false);
-      return;
-    }
-
-    List<SmsGatewayConfig> gatewayList = smsConfiguration.getGateways();
-
-    if (gatewayList == null || gatewayList.isEmpty()) {
-      log.info("No Gateway configuration found");
-
-      hasGateways.set(false);
-      return;
-    }
-
-    log.info("Gateway configuration found: " + gatewayList);
-
-    hasGateways.set(true);
+    SmsConfiguration config = smsConfigurationManager.getSmsConfiguration();
+    List<SmsGatewayConfig> gateways = config.getGateways();
+    hasGateways.set(gateways != null && !gateways.isEmpty());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultSmsConfigurationManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultSmsConfigurationManager.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionTyp
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +67,7 @@ public class DefaultSmsConfigurationManager implements SmsConfigurationManager {
             "sms-config", RESTRICTED, RESTRICTED, Authorities.F_MOBILE_SENDSMS.toString()));
   }
 
+  @Nonnull
   @Override
   @IndirectTransactional
   public SmsConfiguration getSmsConfiguration() {
@@ -73,20 +75,20 @@ public class DefaultSmsConfigurationManager implements SmsConfigurationManager {
     try {
       entry = datastore.getEntry("sms-config", "config", new SystemUser());
     } catch (ForbiddenException e) {
-      return null;
+      return new SmsConfiguration();
     }
-    if (entry == null) return null;
+    if (entry == null) return new SmsConfiguration();
     try {
       return jsonMapper.readValue(entry.getValue(), SmsConfiguration.class);
     } catch (JsonProcessingException e) {
       log.error("Failed to parse SMS configuration", e);
-      return null;
+      return new SmsConfiguration();
     }
   }
 
   @Override
   @IndirectTransactional
-  public void updateSmsConfiguration(SmsConfiguration config)
+  public void updateSmsConfiguration(@Nonnull SmsConfiguration config)
       throws ConflictException, ForbiddenException, BadRequestException {
     DatastoreEntry entry = new DatastoreEntry();
     entry.setNamespace("sms-config");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -77,7 +77,7 @@ class GatewayAdministrationServiceTest {
   private DefaultGatewayAdministrationService subject;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
 
     subject = new DefaultGatewayAdministrationService(smsConfigurationManager, pbeStringEncryptor);
 
@@ -290,7 +290,7 @@ class GatewayAdministrationServiceTest {
     assertEquals(expectedNumberOfGateways, spyConfiguration.getGateways().size());
   }
 
-  private SmsGatewayConfig getConfigByClassName(String name) throws Exception {
+  private SmsGatewayConfig getConfigByClassName(String name) {
     return smsConfigurationManager.getSmsConfiguration().getGateways().stream()
         .filter(gateway -> gateway.getClass().getName().equals(name))
         .findFirst()

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -281,7 +281,7 @@ class GatewayAdministrationServiceTest {
     assertGateway(BULKSMS, gateway -> assertEquals("bulksms2", gateway.getName()));
   }
 
-  private void assertGateway(String name, Consumer<SmsGatewayConfig> test) throws Exception {
+  private void assertGateway(String name, Consumer<SmsGatewayConfig> test) {
     SmsGatewayConfig config = getConfigByClassName(name);
     test.accept(config);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -77,7 +77,7 @@ class GatewayAdministrationServiceTest {
   private DefaultGatewayAdministrationService subject;
 
   @BeforeEach
-  public void setUp() {
+  public void setUp() throws Exception {
 
     subject = new DefaultGatewayAdministrationService(smsConfigurationManager, pbeStringEncryptor);
 
@@ -99,7 +99,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testGetByUid() {
+  void testGetByUid() throws Exception {
     subject.addGateway(bulkConfig);
     String uid = subject.getDefaultGateway().getUid();
 
@@ -116,7 +116,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testSetDefaultGateway() {
+  void testSetDefaultGateway() throws Exception {
     subject.addGateway(bulkConfig);
     subject.addGateway(clickatellConfig);
 
@@ -129,7 +129,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testAddGateway() {
+  void testAddGateway() throws Exception {
     boolean isAdded = subject.addGateway(bulkConfig);
 
     assertTrue(isAdded);
@@ -198,7 +198,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testSecondGatewayIsSetToFalse() {
+  void testSecondGatewayIsSetToFalse() throws Exception {
     when(smsConfigurationManager.getSmsConfiguration()).thenReturn(spyConfiguration);
 
     subject.addGateway(bulkConfig);
@@ -215,7 +215,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testRemoveDefaultGateway() {
+  void testRemoveDefaultGateway() throws Exception {
     subject.addGateway(bulkConfig);
     subject.addGateway(clickatellConfig);
 
@@ -233,7 +233,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testRemoveGateway() {
+  void testRemoveGateway() throws Exception {
     subject.addGateway(bulkConfig);
     subject.addGateway(clickatellConfig);
 
@@ -249,7 +249,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testRemoveSingleGateway() {
+  void testRemoveSingleGateway() throws Exception {
     subject.addGateway(bulkConfig);
 
     String bulkId = getConfigByClassName(BULKSMS).getUid();
@@ -261,7 +261,7 @@ class GatewayAdministrationServiceTest {
   }
 
   @Test
-  void testReturnFalseIfConfigIsNull() {
+  void testReturnFalseIfConfigIsNull() throws Exception {
     assertFalse(subject.addGateway(null));
   }
 
@@ -281,7 +281,7 @@ class GatewayAdministrationServiceTest {
     assertGateway(BULKSMS, gateway -> assertEquals("bulksms2", gateway.getName()));
   }
 
-  private void assertGateway(String name, Consumer<SmsGatewayConfig> test) {
+  private void assertGateway(String name, Consumer<SmsGatewayConfig> test) throws Exception {
     SmsGatewayConfig config = getConfigByClassName(name);
     test.accept(config);
   }
@@ -290,7 +290,7 @@ class GatewayAdministrationServiceTest {
     assertEquals(expectedNumberOfGateways, spyConfiguration.getGateways().size());
   }
 
-  private SmsGatewayConfig getConfigByClassName(String name) {
+  private SmsGatewayConfig getConfigByClassName(String name) throws Exception {
     return smsConfigurationManager.getSmsConfiguration().getGateways().stream()
         .filter(gateway -> gateway.getClass().getName().equals(name))
         .findFirst()

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.i18n.locale.LocaleManager;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.security.LoginPageLayout;
-import org.hisp.dhis.sms.config.SmsConfiguration;
 
 /**
  * @author Lars Helge Overland
@@ -86,7 +85,6 @@ public enum SettingKey {
   EMAIL_PASSWORD("keyEmailPassword", "", String.class, true, false),
   MIN_PASSWORD_LENGTH("minPasswordLength", 8, Integer.class),
   MAX_PASSWORD_LENGTH("maxPasswordLength", 72, Integer.class),
-  SMS_CONFIG("keySmsSetting", new SmsConfiguration(), SmsConfiguration.class),
   SMS_MAX_LENGTH("keySmsMaxLength", 1071, Integer.class),
   CACHE_STRATEGY("keyCacheStrategy", CacheStrategy.CACHE_1_MINUTE, CacheStrategy.class),
   CACHEABILITY("keyCacheability", Cacheability.PUBLIC, Cacheability.class),

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_17__Move_sms_config_to_datastore.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_17__Move_sms_config_to_datastore.sql
@@ -1,0 +1,7 @@
+-- insert a new entry with empty object value
+insert into keyjsonvalue (keyjsonvalueid, uid, code, created, lastupdated, namespace, namespacekey, encrypted_value, encrypted, lastupdatedby, userid, publicaccess, jbvalue)
+    (select nextval('hibernate_sequence'), generate_uid(), null, now(), now(), 'sms-config', 'config', null, false, u.userinfoid, u.userinfoid, null, '{}'::jsonb from userinfo u where u.username = 'admin');
+-- copy the value from settings to the new entry (if it exists)
+update keyjsonvalue set jbvalue = COALESCE((select s.value from systemsetting s where s.name = 'keySmsSetting'), '{}')::jsonb where namespace = 'sms-config' and namespacekey = 'config';
+-- delete the setting
+delete from systemsetting where name = 'keySmsSetting';

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
@@ -98,8 +97,8 @@ public class SmsGatewayController {
       })
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonRoot> getGateways(@RequestParam(defaultValue = "*") List<String> fields)
-      throws ForbiddenException, ConflictException {
+  public ResponseEntity<JsonRoot> getGateways(
+      @RequestParam(defaultValue = "*") List<String> fields) {
     SmsConfiguration config = smsConfigurationManager.getSmsConfiguration();
     FieldFilterParams<?> params = FieldFilterParams.of(config.getGateways(), fields);
 
@@ -161,7 +160,7 @@ public class SmsGatewayController {
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @PostMapping
   @ResponseBody
-  public WebMessage addGateway(HttpServletRequest request, HttpServletResponse response)
+  public WebMessage addGateway(HttpServletRequest request)
       throws IOException, ConflictException, ForbiddenException, BadRequestException {
     SmsGatewayConfig config =
         renderService.fromJson(request.getInputStream(), SmsGatewayConfig.class);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -41,7 +41,9 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.commons.jackson.domain.JsonRoot;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
@@ -96,8 +98,8 @@ public class SmsGatewayController {
       })
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonRoot> getGateways(
-      @RequestParam(defaultValue = "*") List<String> fields) {
+  public ResponseEntity<JsonRoot> getGateways(@RequestParam(defaultValue = "*") List<String> fields)
+      throws ForbiddenException, ConflictException {
     SmsConfiguration config = smsConfigurationManager.getSmsConfiguration();
     FieldFilterParams<?> params = FieldFilterParams.of(config.getGateways(), fields);
 
@@ -122,7 +124,8 @@ public class SmsGatewayController {
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @PutMapping("/default/{uid}")
   @ResponseBody
-  public WebMessage setDefault(@PathVariable String uid) throws NotFoundException {
+  public WebMessage setDefault(@PathVariable String uid)
+      throws NotFoundException, ForbiddenException, ConflictException, BadRequestException {
     SmsGatewayConfig gateway = getExistingConfig(uid);
 
     gatewayAdminService.setDefaultGateway(gateway);
@@ -133,7 +136,11 @@ public class SmsGatewayController {
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @PutMapping("/{uid}")
   public WebMessage updateGateway(@PathVariable String uid, HttpServletRequest request)
-      throws IOException, NotFoundException, ConflictException {
+      throws IOException,
+          NotFoundException,
+          ConflictException,
+          ForbiddenException,
+          BadRequestException {
     SmsGatewayConfig config = getExistingConfig(uid);
 
     SmsGatewayConfig updatedConfig =
@@ -155,7 +162,7 @@ public class SmsGatewayController {
   @PostMapping
   @ResponseBody
   public WebMessage addGateway(HttpServletRequest request, HttpServletResponse response)
-      throws IOException, ConflictException {
+      throws IOException, ConflictException, ForbiddenException, BadRequestException {
     SmsGatewayConfig config =
         renderService.fromJson(request.getInputStream(), SmsGatewayConfig.class);
 
@@ -175,7 +182,8 @@ public class SmsGatewayController {
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @DeleteMapping("/{uid}")
   @ResponseBody
-  public WebMessage removeGateway(@PathVariable String uid) throws NotFoundException {
+  public WebMessage removeGateway(@PathVariable String uid)
+      throws NotFoundException, ForbiddenException, ConflictException, BadRequestException {
     getExistingConfig(uid);
 
     gatewayAdminService.removeGatewayByUid(uid);


### PR DESCRIPTION
### Summary
Changes the persistence of the SMS gateway configuration to use the datastore.
To be safe a new protected namespace `sms-config` is used.
Both reads and writes are protected with the existing authority `F_MOBILE_SENDSMS` that was already checked for most related controller methods.

A flyway script moves any existing configuration into the datastore.

The system setting `keySmsSetting` got removed.

### Automatic Testing
Existing controller and component tests were adjusted slightly.

### Manual Testing
Testing the migration:
* create a environment with a server version before this change that has a SMS gateway configuration
* save the DB
* create a new environment with a server version containing this change that uses the saved DB
* after server startup goto SMS configuration app and check the old configuration is shown

Testing edit (after migration):
* goto SMS configuration app
* edit an existing configuration
* create some new gateways and check the change is persisted

Testing the configuration is not directly accessible in the datastore
* try accessing `/api/dataStore/sms-config/config` with a user that does not have `F_MOBILE_SENDSMS`
* verify the user neither can read nor write to the entry