### PR TITLE
fix: Test nullable org unit code for new rule-engine version [DHIS2-17715]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -94,7 +94,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @RequiredArgsConstructor
-@Service("org.hisp.dhis.tracker.imports.programrule.engine.ProgramRuleEntityMapperService")
+@Service
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService {
   private final ProgramRuleVariableService programRuleVariableService;
 
@@ -104,7 +104,10 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
 
   @Override
   public List<Rule> toMappedProgramRules(List<ProgramRule> programRules) {
-    return programRules.stream().map(this::toRule).filter(Objects::nonNull).toList();
+    return programRules.stream()
+        .map(this::toRule)
+        .filter(rule -> !rule.getActions().isEmpty())
+        .toList();
   }
 
   @Override
@@ -121,7 +124,6 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     return programRuleVariables.stream()
         .filter(Objects::nonNull)
         .map(this::toRuleVariable)
-        .filter(Objects::nonNull)
         .toList();
   }
 
@@ -166,11 +168,8 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
 
   @Override
   public RuleEnrollment toMappedRuleEnrollment(
-      Enrollment enrollment, List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
-    if (enrollment == null) {
-      return null;
-    }
-
+      @Nonnull Enrollment enrollment,
+      List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
     String orgUnit = "";
     String orgUnitCode = "";
 
@@ -207,15 +206,11 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
 
   @Override
   public List<RuleEvent> toMappedRuleEvents(Set<Event> events) {
-    return events.stream().filter(Objects::nonNull).map(this::toMappedRuleEvent).toList();
+    return events.stream().map(this::toMappedRuleEvent).toList();
   }
 
   @Override
-  public RuleEvent toMappedRuleEvent(Event eventToEvaluate) {
-    if (eventToEvaluate == null) {
-      return null;
-    }
-
+  public RuleEvent toMappedRuleEvent(@Nonnull Event eventToEvaluate) {
     String orgUnit = getOrgUnit(eventToEvaluate);
     String orgUnitCode = getOrgUnitCode(eventToEvaluate);
 
@@ -278,21 +273,13 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     return "";
   }
 
-  private Rule toRule(ProgramRule programRule) {
-    if (programRule == null) {
-      return null;
-    }
-
+  private Rule toRule(@Nonnull ProgramRule programRule) {
     try {
       List<RuleAction> ruleActions =
           programRule.getProgramRuleActions().stream()
               .map(this::toRuleAction)
               .filter(Objects::nonNull)
               .toList();
-
-      if (ruleActions.isEmpty()) {
-        return null;
-      }
 
       return new Rule(
           programRule.getCondition(),
@@ -310,7 +297,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     }
   }
 
-  private RuleAction toRuleAction(ProgramRuleAction pra) {
+  private RuleAction toRuleAction(@Nonnull ProgramRuleAction pra) {
     return switch (pra.getProgramRuleActionType()) {
       case ASSIGN ->
           new RuleAction(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -94,7 +94,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @RequiredArgsConstructor
-@Service
+@Service("org.hisp.dhis.tracker.imports.programrule.engine.ProgramRuleEntityMapperService")
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService {
   private final ProgramRuleVariableService programRuleVariableService;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -27,8 +27,22 @@
  */
 package org.hisp.dhis.tracker.imports.programrule.engine;
 
+import static org.hisp.dhis.programrule.ProgramRuleActionType.ASSIGN;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.DISPLAYTEXT;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.ERRORONCOMPLETE;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SCHEDULEMESSAGE;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SENDMESSAGE;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SETMANDATORYFIELD;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SHOWERROR;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SHOWWARNING;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.WARNINGONCOMPLETE;
+import static org.hisp.dhis.tracker.imports.programrule.engine.RuleActionKey.ATTRIBUTE_TYPE;
+import static org.hisp.dhis.tracker.imports.programrule.engine.RuleActionKey.CONTENT;
+import static org.hisp.dhis.tracker.imports.programrule.engine.RuleActionKey.FIELD;
+import static org.hisp.dhis.tracker.imports.programrule.engine.RuleActionKey.NOTIFICATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,7 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import kotlinx.datetime.Instant;
-import kotlinx.datetime.LocalDateTime;
+import kotlinx.datetime.LocalDate;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
@@ -62,15 +77,16 @@ import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
-import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
 import org.hisp.dhis.rules.api.DataItem;
+import org.hisp.dhis.rules.models.AttributeType;
+import org.hisp.dhis.rules.models.Rule;
+import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleDataValue;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
-import org.hisp.dhis.rules.models.RuleEventStatus;
 import org.hisp.dhis.rules.models.RuleVariable;
 import org.hisp.dhis.rules.models.RuleVariableAttribute;
 import org.hisp.dhis.rules.models.RuleVariableCalculatedValue;
@@ -83,75 +99,42 @@ import org.hisp.dhis.util.ObjectUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Zubair Asghar.
  */
-@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+@ExtendWith(MockitoExtension.class)
 class ProgramRuleEntityMapperServiceTest extends TestBase {
 
   private static final String SAMPLE_VALUE_A = "textValueA";
 
-  private static final String SAMPLE_VALUE_B = "textValueB";
+  private static final Date NOW = new Date();
+  private static final Date TOMORROW = DateUtils.addDays(NOW, 1);
+  private static final Date YESTERDAY = DateUtils.addDays(NOW, -1);
+  private static final Date AFTER_TOMORROW = DateUtils.addDays(NOW, 2);
 
   private List<ProgramRule> programRules = new ArrayList<>();
 
-  private List<ProgramRuleVariable> programRuleVariables = new ArrayList<>();
+  private final List<ProgramRuleVariable> programRuleVariables = new ArrayList<>();
 
   private Program program;
 
   private ProgramStage programStage;
 
-  private ProgramRule programRuleA = null;
+  private ProgramRuleVariable programRuleVariableA;
 
-  private ProgramRule programRuleB = null;
+  private ProgramRuleVariable programRuleVariableB;
 
-  private ProgramRule programRuleC = null;
-
-  private ProgramRule programRuleD = null;
-
-  private ProgramRuleAction assignAction = null;
-
-  private ProgramRuleAction sendMessageAction = null;
-
-  private ProgramRuleAction displayText = null;
-
-  private ProgramRuleVariable programRuleVariableA = null;
-
-  private ProgramRuleVariable programRuleVariableB = null;
-
-  private ProgramRuleVariable programRuleVariableC = null;
-
-  private ProgramRuleVariable programRuleVariableD = null;
+  private ProgramRuleVariable programRuleVariableC;
 
   private OrganisationUnit organisationUnit;
 
   private TrackedEntityAttribute trackedEntityAttribute;
 
-  private TrackedEntityAttributeValue trackedEntityAttributeValue;
-
   private DataElement dataElement;
-
-  private EventDataValue eventDataValueA;
-
-  private EventDataValue eventDataValueB;
-
-  private Enrollment enrollment;
-
-  private Enrollment enrollmentB;
-
-  private TrackedEntity trackedEntity;
-
-  private Event eventA;
-
-  private Event eventB;
-
-  private Event eventC;
-
-  private RuleEvent expectedRuleEvent;
-
-  @Mock private ProgramRuleService programRuleService;
 
   @Mock private ProgramRuleVariableService programRuleVariableService;
 
@@ -161,24 +144,108 @@ class ProgramRuleEntityMapperServiceTest extends TestBase {
 
   @Mock private I18n i18n;
 
-  private DefaultProgramRuleEntityMapperService subject;
+  @InjectMocks private DefaultProgramRuleEntityMapperService mapper;
 
   @BeforeEach
   public void initTest() {
-    subject =
-        new DefaultProgramRuleEntityMapperService(
-            programRuleVariableService, constantService, i18nManager);
 
-    setUpProgramRules();
+    program = createProgram('P');
+    programStage = createProgramStage('S', program);
+
+    TrackedEntityAttribute attribute = createTrackedEntityAttribute('Z');
+    attribute.setName("Tracked_entity_attribute_A");
+
+    DataElement dataElement1 = createDataElement('E');
+    dataElement1.setFormName("DateElement_E");
+
+    OptionSet optionSet = new OptionSet();
+    Option option = new Option();
+    option.setName("optionName");
+    option.setCode("optionCode");
+
+    optionSet.setOptions(List.of(option));
+
+    DataElement dataElementWithOptionSet = createDataElement('F');
+    dataElementWithOptionSet.setFormName("dataElementWithOptionSet");
+    dataElementWithOptionSet.setOptionSet(optionSet);
+
+    dataElement = createDataElement('D');
+    dataElement.setValueType(ValueType.TEXT);
+    organisationUnit = createOrganisationUnit('O');
+
+    trackedEntityAttribute = createTrackedEntityAttribute('A', ValueType.TEXT);
+
+    programRuleVariableA =
+        createProgramRuleVariable(
+            'A',
+            ProgramRuleVariableSourceType.CALCULATED_VALUE,
+            program,
+            createDataElement('D'),
+            null);
+
+    programRuleVariableB =
+        createProgramRuleVariable(
+            'B', ProgramRuleVariableSourceType.TEI_ATTRIBUTE, program, null, attribute);
+
+    programRuleVariableC =
+        createProgramRuleVariable(
+            'C',
+            ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT,
+            program,
+            dataElement1,
+            null);
+
+    programRuleVariables.add(programRuleVariableA);
+    programRuleVariables.add(programRuleVariableB);
+    programRuleVariables.add(programRuleVariableC);
+
+    ProgramRuleAction assignAction = createProgramRuleAction('I', ASSIGN, "test_variable", "2+2");
+    ProgramRuleAction displayText =
+        createProgramRuleAction('D', DISPLAYTEXT, "test_variable", "2+2");
+    ProgramRuleAction sendMessageAction = createProgramRuleAction('J', SENDMESSAGE, null, null);
+    ProgramRuleAction showWarning = createProgramRuleAction('L', SHOWWARNING, "warning", "2+2");
+    ProgramRuleAction showError = createProgramRuleAction('M', SHOWERROR, "error", "2+2");
+    ProgramRuleAction warningOnComplete =
+        createProgramRuleAction('N', WARNINGONCOMPLETE, "complete warning", "2+2");
+    ProgramRuleAction errorOnComplete =
+        createProgramRuleAction('O', ERRORONCOMPLETE, "complete error", "2+2");
+    ProgramRuleAction setMandatoryField =
+        createProgramRuleAction('P', SETMANDATORYFIELD, null, "2+2");
+    ProgramRuleAction scheduleMessage =
+        createProgramRuleAction('Q', SCHEDULEMESSAGE, "test_variable", "2+2");
+
+    ProgramRule programRuleA =
+        createProgramRule('A', Sets.newHashSet(assignAction, displayText, errorOnComplete), 1);
+    ProgramRule programRuleB =
+        createProgramRule('B', Sets.newHashSet(sendMessageAction, showWarning, showError), 4);
+    ProgramRule programRuleD =
+        createProgramRule(
+            'D',
+            Sets.newHashSet(
+                sendMessageAction, warningOnComplete, setMandatoryField, scheduleMessage),
+            null);
+
+    programRules.add(programRuleA);
+    programRules.add(programRuleB);
+    programRules.add(programRuleD);
   }
 
   @Test
-  void testMappedRuleVariableValues() {
+  void shouldMapProgramRules() {
+    List<Rule> mappedProgramRules = mapper.toMappedProgramRules(programRules);
+
+    for (int i = 0; i < mappedProgramRules.size(); i++) {
+      assertRule(programRules.get(i), mappedProgramRules.get(i));
+    }
+  }
+
+  @Test
+  void shouldToMapProgramRuleVariables() {
     when(programRuleVariableService.getAllProgramRuleVariable()).thenReturn(programRuleVariables);
     RuleVariableAttribute ruleVariableAttribute;
     RuleVariableCalculatedValue ruleVariableCalculatedValue;
 
-    List<RuleVariable> ruleVariables = subject.toMappedProgramRuleVariables();
+    List<RuleVariable> ruleVariables = mapper.toMappedProgramRuleVariables();
 
     assertEquals(ruleVariables.size(), programRuleVariables.size());
 
@@ -198,41 +265,87 @@ class ProgramRuleEntityMapperServiceTest extends TestBase {
   }
 
   @Test
-  void testExceptionWhenMandatoryFieldIsMissingInRuleEvent() {
-    assertThrows(NullPointerException.class, () -> subject.toMappedRuleEvent(eventC));
+  void shouldFailToMapEventWhenProgramStageIsNull() {
+    Event event = event();
+    event.setProgramStage(null);
+
+    assertThrows(NullPointerException.class, () -> mapper.toMappedRuleEvent(event));
   }
 
   @Test
-  void testMappedRuleEvent() {
-    RuleEvent ruleEvent = subject.toMappedRuleEvent(eventA);
+  void shouldMapEventToRuleEvent() {
+    Event event = event();
 
-    assertEquals(expectedRuleEvent, ruleEvent);
+    RuleEvent ruleEvent = mapper.toMappedRuleEvent(event);
+
+    assertEvent(event, ruleEvent);
   }
 
   @Test
-  void testMappedRuleEvents() {
-    List<RuleEvent> ruleEvents = subject.toMappedRuleEvents(Sets.newHashSet(eventA, eventB));
+  void shouldMapEventToRuleEventWhenOrganisationUnitCodeIsNull() {
+    OrganisationUnit organisationUnitWithNullCode = createOrganisationUnit('A');
+    organisationUnitWithNullCode.setCode(null);
+    Event event = event();
+    event.setOrganisationUnit(organisationUnitWithNullCode);
+
+    RuleEvent ruleEvent = mapper.toMappedRuleEvent(event);
+
+    assertEvent(event, ruleEvent);
+  }
+
+  @Test
+  void shouldMapEventsToRuleEvents() {
+    Event eventA = event();
+    Event eventB = event();
+    List<RuleEvent> ruleEvents = mapper.toMappedRuleEvents(Sets.newHashSet(eventA, eventB));
 
     assertEquals(2, ruleEvents.size());
+    assertEvent(
+        eventA,
+        ruleEvents.stream().filter(e -> e.getEvent().equals(eventA.getUid())).findFirst().get());
+    assertEvent(
+        eventB,
+        ruleEvents.stream().filter(e -> e.getEvent().equals(eventB.getUid())).findFirst().get());
   }
 
   @Test
-  void testExceptionWhenMandatoryValueMissingMappedEnrollment() {
+  void shouldFailToMapEnrollmentWhenProgramIsNull() {
+    Enrollment enrollment = enrollment();
+    enrollment.setProgram(null);
     List<TrackedEntityAttributeValue> trackedEntityAttributeValues = Collections.emptyList();
+
     assertThrows(
         NullPointerException.class,
-        () -> subject.toMappedRuleEnrollment(enrollmentB, trackedEntityAttributeValues));
+        () -> mapper.toMappedRuleEnrollment(enrollment, trackedEntityAttributeValues));
   }
 
   @Test
-  void testMappedEnrollment() {
-    RuleEnrollment ruleEnrollment =
-        subject.toMappedRuleEnrollment(enrollment, List.of(trackedEntityAttributeValue));
+  void shouldMapEnrollmentToRuleEnrollment() {
+    Enrollment enrollment = enrollment();
+    TrackedEntityAttributeValue trackedEntityAttributeValue =
+        createTrackedEntityAttributeValue('E', trackedEntity(), trackedEntityAttribute);
+    trackedEntityAttributeValue.setValue(SAMPLE_VALUE_A);
 
-    assertEquals(ruleEnrollment.getEnrollment(), enrollment.getUid());
-    assertEquals(ruleEnrollment.getOrganisationUnit(), enrollment.getOrganisationUnit().getUid());
-    assertEquals(1, ruleEnrollment.getAttributeValues().size());
-    assertEquals(SAMPLE_VALUE_A, ruleEnrollment.getAttributeValues().get(0).getValue());
+    RuleEnrollment ruleEnrollment =
+        mapper.toMappedRuleEnrollment(enrollment, List.of(trackedEntityAttributeValue));
+
+    assertEnrollment(enrollment, ruleEnrollment);
+  }
+
+  @Test
+  void shouldMapEnrollmentToRuleEnrollmentWhenOrganisationUnitCodeIsNull() {
+    OrganisationUnit organisationUnitWithNullCode = createOrganisationUnit('A');
+    organisationUnitWithNullCode.setCode(null);
+    Enrollment enrollment = enrollment();
+    enrollment.setOrganisationUnit(organisationUnitWithNullCode);
+    TrackedEntityAttributeValue trackedEntityAttributeValue =
+        createTrackedEntityAttributeValue('E', trackedEntity(), trackedEntityAttribute);
+    trackedEntityAttributeValue.setValue(SAMPLE_VALUE_A);
+
+    RuleEnrollment ruleEnrollment =
+        mapper.toMappedRuleEnrollment(enrollment, List.of(trackedEntityAttributeValue));
+
+    assertEnrollment(enrollment, ruleEnrollment);
   }
 
   @Test
@@ -249,7 +362,7 @@ class ProgramRuleEntityMapperServiceTest extends TestBase {
     when(i18n.getString(anyString())).thenReturn(envVariable);
 
     Map<String, DataItem> itemStore =
-        subject.getItemStore(
+        mapper.getItemStore(
             List.of(programRuleVariableA, programRuleVariableB, programRuleVariableC));
 
     assertNotNull(itemStore);
@@ -279,219 +392,199 @@ class ProgramRuleEntityMapperServiceTest extends TestBase {
     assertEquals("Gravity", itemStore.get(constant.getUid()).getDisplayName());
   }
 
-  private void setUpProgramRules() {
-    Date now = new Date();
-    program = createProgram('P');
-    programStage = createProgramStage('S', program);
-
-    TrackedEntityAttribute attribute = createTrackedEntityAttribute('Z');
-    attribute.setName("Tracked_entity_attribute_A");
-
-    DataElement dataElement1 = createDataElement('E');
-    dataElement1.setFormName("DateElement_E");
-
-    OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setName("optionName");
-    option.setCode("optionCode");
-
-    optionSet.setOptions(List.of(option));
-
-    DataElement dataElementWithOptionSet = createDataElement('F');
-    dataElementWithOptionSet.setFormName("dataElementWithOptionSet");
-    dataElementWithOptionSet.setOptionSet(optionSet);
-
-    programRuleVariableA = createProgramRuleVariable('A', program);
-    programRuleVariableB = createProgramRuleVariable('B', program);
-    programRuleVariableC = createProgramRuleVariable('C', program);
-    programRuleVariableD = createProgramRuleVariable('D', program);
-
-    programRuleVariableA =
-        setProgramRuleVariable(
-            programRuleVariableA,
-            ProgramRuleVariableSourceType.CALCULATED_VALUE,
-            program,
-            null,
-            createDataElement('D'),
-            null);
-
-    programRuleVariableB =
-        setProgramRuleVariable(
-            programRuleVariableB,
-            ProgramRuleVariableSourceType.TEI_ATTRIBUTE,
-            program,
-            null,
-            null,
-            attribute);
-
-    programRuleVariableC =
-        setProgramRuleVariable(
-            programRuleVariableC,
-            ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT,
-            program,
-            null,
-            dataElement1,
-            null);
-
-    programRuleVariableD =
-        setProgramRuleVariable(
-            programRuleVariableC,
-            ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT,
-            program,
-            null,
-            dataElementWithOptionSet,
-            null);
-
-    programRuleVariables.add(programRuleVariableA);
-    programRuleVariables.add(programRuleVariableB);
-    programRuleVariables.add(programRuleVariableC);
-    programRuleVariables.add(programRuleVariableD);
-
-    programRuleA = createProgramRule('A', program);
-    programRuleB = createProgramRule('B', program);
-    programRuleD = createProgramRule('D', program);
-
-    assignAction = createProgramRuleAction('I');
-    sendMessageAction = createProgramRuleAction('J');
-    displayText = createProgramRuleAction('D');
-
-    assignAction =
-        setProgramRuleAction(assignAction, ProgramRuleActionType.ASSIGN, "test_variable", "2+2");
-    displayText =
-        setProgramRuleAction(
-            displayText, ProgramRuleActionType.DISPLAYTEXT, "test_variable", "2+2");
-    sendMessageAction =
-        setProgramRuleAction(sendMessageAction, ProgramRuleActionType.SENDMESSAGE, null, "");
-
-    programRuleA = setProgramRule(programRuleA, "", Sets.newHashSet(assignAction, displayText), 1);
-    programRuleB = setProgramRule(programRuleB, "", Sets.newHashSet(sendMessageAction), 4);
-    programRuleD = setProgramRule(programRuleD, "", Sets.newHashSet(sendMessageAction), null);
-
-    programRules.add(programRuleA);
-    programRules.add(programRuleB);
-    programRules.add(programRuleC);
-    programRules.add(programRuleD);
-
-    dataElement = createDataElement('D');
-    dataElement.setValueType(ValueType.TEXT);
-    organisationUnit = createOrganisationUnit('O');
-
-    trackedEntityAttribute = createTrackedEntityAttribute('A', ValueType.TEXT);
-    trackedEntity = createTrackedEntity('I', organisationUnit, trackedEntityAttribute);
-    trackedEntityAttributeValue =
-        createTrackedEntityAttributeValue('E', trackedEntity, trackedEntityAttribute);
-    trackedEntityAttributeValue.setValue(SAMPLE_VALUE_A);
-    trackedEntity.setTrackedEntityAttributeValues(Sets.newHashSet(trackedEntityAttributeValue));
-
-    eventDataValueA = new EventDataValue();
-    eventDataValueA.setDataElement(dataElement.getUid());
-    eventDataValueA.setValue(SAMPLE_VALUE_A);
-    eventDataValueA.setAutoFields();
-
-    RuleDataValue ruleDataValue =
-        new RuleDataValue(
-            Instant.Companion.fromEpochMilliseconds(now.getTime()),
-            programStage.getUid(),
-            dataElement.getUid(),
-            SAMPLE_VALUE_A);
-
-    eventDataValueB = new EventDataValue();
-    eventDataValueB.setDataElement(dataElement.getUid());
-    eventDataValueB.setValue(SAMPLE_VALUE_B);
-    eventDataValueB.setAutoFields();
-
-    enrollmentB = new Enrollment(now, now, trackedEntity, program);
-    enrollment = new Enrollment(now, now, trackedEntity, program);
-    enrollment.setOrganisationUnit(organisationUnit);
-    enrollment.setStatus(EnrollmentStatus.ACTIVE);
-    enrollment.setAutoFields();
-    enrollment.setEnrollmentDate(now);
-    enrollment.setOccurredDate(now);
-    enrollment.setTrackedEntity(trackedEntity);
-
-    eventA = new Event(enrollment, programStage);
-    eventB = new Event(enrollment, programStage);
-    eventC = new Event(enrollment, programStage);
-
-    eventA.setOrganisationUnit(organisationUnit);
-    eventA.setAutoFields();
-    eventA.setScheduledDate(now);
-    eventA.setOccurredDate(now);
-    eventA.setEventDataValues(Sets.newHashSet(eventDataValueA));
-
-    eventB.setOrganisationUnit(organisationUnit);
-    eventB.setAutoFields();
-    eventB.setScheduledDate(now);
-    eventB.setOccurredDate(now);
-    eventB.setEventDataValues(Sets.newHashSet(eventDataValueB));
-
-    expectedRuleEvent =
-        new RuleEvent(
-            eventA.getUid(),
-            programStage.getUid(),
-            programStage.getName(),
-            RuleEventStatus.valueOf(eventA.getStatus().name()),
-            Instant.Companion.fromEpochMilliseconds(now.getTime()),
-            LocalDateTime.Formats.INSTANCE.getISO().parse(DateUtils.toIso8601NoTz(now)).getDate(),
-            null,
-            organisationUnit.getUid(),
-            organisationUnit.getCode(),
-            List.of(ruleDataValue));
-  }
-
-  private ProgramRule setProgramRule(
-      ProgramRule programRule,
-      String condition,
-      Set<ProgramRuleAction> ruleActions,
-      Integer priority) {
+  private ProgramRule createProgramRule(
+      char uniqueCharacter, Set<ProgramRuleAction> ruleActions, Integer priority) {
+    ProgramRule programRule = createProgramRule(uniqueCharacter, program);
     programRule.setPriority(priority);
-    programRule.setCondition(condition);
+    programRule.setCondition("");
     programRule.setProgramRuleActions(ruleActions);
 
     return programRule;
   }
 
-  private ProgramRuleAction setProgramRuleAction(
-      ProgramRuleAction programRuleActionA,
-      ProgramRuleActionType type,
-      String content,
-      String data) {
-    programRuleActionA.setProgramRuleActionType(type);
+  private ProgramRuleAction createProgramRuleAction(
+      char uniqueCharacter, ProgramRuleActionType type, String content, String data) {
+    ProgramRuleAction programRuleAction = createProgramRuleAction(uniqueCharacter);
+    programRuleAction.setProgramRuleActionType(type);
 
-    if (type == ProgramRuleActionType.ASSIGN) {
-      programRuleActionA.setContent(content);
-      programRuleActionA.setData(data);
+    switch (type) {
+      case DISPLAYTEXT -> {
+        programRuleAction.setLocation("feedback");
+        programRuleAction.setContent("content");
+        programRuleAction.setData("true");
+      }
+      case ASSIGN, SHOWERROR, SHOWWARNING, ERRORONCOMPLETE, WARNINGONCOMPLETE -> {
+        programRuleAction.setContent(content);
+        programRuleAction.setData(data);
+        programRuleAction.setDataElement(dataElement);
+      }
+      case SETMANDATORYFIELD -> {
+        programRuleAction.setDataElement(dataElement);
+      }
+      case SENDMESSAGE, SCHEDULEMESSAGE -> {
+        ProgramNotificationTemplate notificationTemplate = new ProgramNotificationTemplate();
+        notificationTemplate.setUid("uid0");
+        programRuleAction.setTemplateUid(notificationTemplate.getUid());
+        programRuleAction.setData(data);
+      }
+      default -> throw new IllegalStateException("Unexpected value: " + type);
     }
 
-    if (type == ProgramRuleActionType.DISPLAYTEXT) {
-      programRuleActionA.setLocation("feedback");
-      programRuleActionA.setContent("content");
-      programRuleActionA.setData("true");
-    }
-
-    if (type == ProgramRuleActionType.SENDMESSAGE) {
-      ProgramNotificationTemplate notificationTemplate = new ProgramNotificationTemplate();
-      notificationTemplate.setUid("uid0");
-      programRuleActionA.setTemplateUid(notificationTemplate.getUid());
-      programRuleActionA.setData(data);
-    }
-
-    return programRuleActionA;
+    return programRuleAction;
   }
 
-  private ProgramRuleVariable setProgramRuleVariable(
-      ProgramRuleVariable variable,
+  private ProgramRuleVariable createProgramRuleVariable(
+      char uniqueCharacter,
       ProgramRuleVariableSourceType sourceType,
       Program program,
-      ProgramStage programStage,
       DataElement dataElement,
       TrackedEntityAttribute attribute) {
+    ProgramRuleVariable variable = createProgramRuleVariable(uniqueCharacter, program);
     variable.setSourceType(sourceType);
     variable.setProgram(program);
-    variable.setProgramStage(programStage);
     variable.setDataElement(dataElement);
     variable.setAttribute(attribute);
 
     return variable;
+  }
+
+  private TrackedEntity trackedEntity() {
+    return createTrackedEntity('I', organisationUnit, trackedEntityAttribute);
+  }
+
+  private Enrollment enrollment() {
+    Enrollment enrollment = new Enrollment(NOW, TOMORROW, trackedEntity(), program);
+    enrollment.setOrganisationUnit(organisationUnit);
+    enrollment.setStatus(EnrollmentStatus.ACTIVE);
+    enrollment.setAutoFields();
+    return enrollment;
+  }
+
+  private Event event() {
+    Event event = new Event(enrollment(), programStage);
+    event.setUid(CodeGenerator.generateUid());
+    event.setOrganisationUnit(organisationUnit);
+    event.setAutoFields();
+    event.setScheduledDate(YESTERDAY);
+    event.setOccurredDate(AFTER_TOMORROW);
+    event.setEventDataValues(Sets.newHashSet(eventDataValue(dataElement.getUid(), SAMPLE_VALUE_A)));
+    return event;
+  }
+
+  private EventDataValue eventDataValue(String dataElementUid, String value) {
+    EventDataValue eventDataValue = new EventDataValue();
+    eventDataValue.setDataElement(dataElementUid);
+    eventDataValue.setValue(value);
+    eventDataValue.setAutoFields();
+    return eventDataValue;
+  }
+
+  private void assertRule(ProgramRule expectedRule, Rule actualRule) {
+    String expectedProgramStage =
+        expectedRule.getProgramStage() == null ? "" : expectedRule.getProgramStage().getUid();
+
+    assertEquals(expectedRule.getUid(), actualRule.getUid());
+    assertEquals(expectedProgramStage, actualRule.getProgramStage());
+    assertEquals(expectedRule.getName(), actualRule.getName());
+    assertEquals(expectedRule.getCondition(), actualRule.getCondition());
+    assertEquals(expectedRule.getPriority(), actualRule.getPriority());
+    assertActions(expectedRule.getProgramRuleActions(), actualRule.getActions());
+  }
+
+  private void assertActions(Set<ProgramRuleAction> programRuleActions, List<RuleAction> actions) {
+    for (RuleAction actualAction : actions) {
+      ProgramRuleAction expectedProgramRuleAction =
+          programRuleActions.stream()
+              .filter(a -> a.getProgramRuleActionType().name().equals(actualAction.getType()))
+              .findFirst()
+              .get();
+      assertAction(expectedProgramRuleAction, actualAction);
+    }
+  }
+
+  private void assertAction(ProgramRuleAction expectedRuleAction, RuleAction actualRuleAction) {
+    switch (expectedRuleAction.getProgramRuleActionType()) {
+      case ASSIGN, SHOWWARNING, WARNINGONCOMPLETE, SHOWERROR, ERRORONCOMPLETE ->
+          assertGenericAction(expectedRuleAction, actualRuleAction);
+      case SETMANDATORYFIELD -> assertMandatoryField(expectedRuleAction, actualRuleAction);
+      case SENDMESSAGE -> assertSendMessage(expectedRuleAction, actualRuleAction);
+      case SCHEDULEMESSAGE -> assertScheduleMessage(expectedRuleAction, actualRuleAction);
+      default ->
+          throw new IllegalStateException(
+              "Unexpected value: " + expectedRuleAction.getProgramRuleActionType());
+    }
+  }
+
+  private void assertScheduleMessage(
+      ProgramRuleAction expectedRuleAction, RuleAction actualRuleAction) {
+    assertEquals(expectedRuleAction.getData(), actualRuleAction.getData());
+    assertEquals(
+        expectedRuleAction.getNotificationTemplate().getUid(),
+        actualRuleAction.getValues().get(NOTIFICATION));
+  }
+
+  private void assertSendMessage(
+      ProgramRuleAction expectedRuleAction, RuleAction actualRuleAction) {
+    assertNull(actualRuleAction.getData());
+    assertEquals(
+        expectedRuleAction.getNotificationTemplate().getUid(),
+        actualRuleAction.getValues().get(NOTIFICATION));
+  }
+
+  private void assertMandatoryField(
+      ProgramRuleAction expectedRuleAction, RuleAction actualRuleAction) {
+    assertNull(actualRuleAction.getData());
+    assertNull(actualRuleAction.getValues().get(CONTENT));
+    assertEquals(
+        expectedRuleAction.getDataElement().getUid(), actualRuleAction.getValues().get(FIELD));
+    assertEquals(
+        AttributeType.DATA_ELEMENT.name(), actualRuleAction.getValues().get(ATTRIBUTE_TYPE));
+  }
+
+  private void assertGenericAction(
+      ProgramRuleAction expectedRuleAction, RuleAction actualRuleAction) {
+    assertEquals(expectedRuleAction.getData(), actualRuleAction.getData());
+    assertEquals(expectedRuleAction.getContent(), actualRuleAction.getValues().get(CONTENT));
+    assertEquals(
+        expectedRuleAction.getDataElement().getUid(), actualRuleAction.getValues().get(FIELD));
+    assertEquals(
+        AttributeType.DATA_ELEMENT.name(), actualRuleAction.getValues().get(ATTRIBUTE_TYPE));
+  }
+
+  private void assertEvent(Event event, RuleEvent ruleEvent) {
+    assertEquals(event.getUid(), ruleEvent.getEvent());
+    assertEquals(event.getProgramStage().getUid(), ruleEvent.getProgramStage());
+    assertEquals(event.getProgramStage().getName(), ruleEvent.getProgramStageName());
+    assertEquals(event.getStatus().name(), ruleEvent.getStatus().name());
+    assertDates(event.getOccurredDate(), ruleEvent.getEventDate());
+    assertNull(ruleEvent.getCompletedDate());
+    assertEquals(event.getOrganisationUnit().getUid(), ruleEvent.getOrganisationUnit());
+    assertEquals(event.getOrganisationUnit().getCode(), ruleEvent.getOrganisationUnitCode());
+    assertDataValue(event.getEventDataValues().iterator().next(), ruleEvent.getDataValues().get(0));
+  }
+
+  private void assertDates(Date expected, Instant actual) {
+    assertEquals(expected.getTime(), actual.getValue$kotlinx_datetime().toEpochMilli());
+  }
+
+  private void assertDataValue(EventDataValue expectedDataValue, RuleDataValue actualDataValue) {
+    assertEquals(expectedDataValue.getValue(), actualDataValue.getValue());
+    assertEquals(expectedDataValue.getDataElement(), actualDataValue.getDataElement());
+  }
+
+  private void assertEnrollment(Enrollment enrollment, RuleEnrollment ruleEnrollment) {
+    assertEquals(enrollment.getUid(), ruleEnrollment.getEnrollment());
+    assertEquals(enrollment.getProgram().getName(), ruleEnrollment.getProgramName());
+    assertDates(enrollment.getOccurredDate(), ruleEnrollment.getIncidentDate());
+    assertDates(enrollment.getEnrollmentDate(), ruleEnrollment.getEnrollmentDate());
+    assertEquals(enrollment.getStatus().name(), ruleEnrollment.getStatus().name());
+    assertEquals(enrollment.getOrganisationUnit().getUid(), ruleEnrollment.getOrganisationUnit());
+    assertEquals(
+        enrollment.getOrganisationUnit().getCode(), ruleEnrollment.getOrganisationUnitCode());
+    assertEquals(SAMPLE_VALUE_A, ruleEnrollment.getAttributeValues().get(0).getValue());
+  }
+
+  private void assertDates(Date expected, LocalDate actual) {
+    assertEquals(DateUtils.toMediumDate(expected), actual.toString());
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -96,7 +96,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.0.0</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.0.1-SNAPSHOT</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.0</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->
@@ -171,7 +171,7 @@
     <fop.version>2.9</fop.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <geotools.version>29.6</geotools.version>
-    <jts.version>1.20.0</jts.version>
+    <jts.version>1.19.0</jts.version>
 
     <!-- Apache Artemis -->
     <artemis.version>2.37.0</artemis.version>
@@ -244,7 +244,7 @@
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
     <restrict-imports-enforcer.version>2.5.0</restrict-imports-enforcer.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
-    <dependency-check-maven.version>10.0.4</dependency-check-maven.version>
+    <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
     <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
     <spotless.version>2.43.0</spotless.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -96,7 +96,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.0.1-SNAPSHOT</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.0.1</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.0</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -171,7 +171,7 @@
     <fop.version>2.9</fop.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <geotools.version>29.6</geotools.version>
-    <jts.version>1.19.0</jts.version>
+    <jts.version>1.20.0</jts.version>
 
     <!-- Apache Artemis -->
     <artemis.version>2.37.0</artemis.version>
@@ -244,7 +244,7 @@
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
     <restrict-imports-enforcer.version>2.5.0</restrict-imports-enforcer.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
-    <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
+    <dependency-check-maven.version>10.0.4</dependency-check-maven.version>
     <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
     <spotless.version>2.43.0</spotless.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>


### PR DESCRIPTION
Bump `rule-engine` version.
New `rule-engine` allows to create an event or an enrollment with a `null` organisation unit code.
In this PR I added the related tests and refactor the whole test class.