### PR TITLE
fix: Analytics API returns invalid totalAggregationType [2.39-DHIS2-18045-backport] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -115,7 +115,9 @@ public class BaseDimensionalItemObject extends BaseNameableObject implements Dim
 
   @Override
   public TotalAggregationType getTotalAggregationType() {
-    return TotalAggregationType.SUM;
+    return getAggregationType() == AggregationType.NONE
+        ? TotalAggregationType.NONE
+        : TotalAggregationType.SUM;
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/common/BaseDimensionalItemObjectTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/common/BaseDimensionalItemObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,33 @@
  */
 package org.hisp.dhis.common;
 
-public enum TotalAggregationType {
-  NONE,
-  SUM,
-  AVERAGE
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.hisp.dhis.analytics.AggregationType;
+import org.junit.jupiter.api.Test;
+
+class BaseDimensionalItemObjectTest {
+  @Test
+  void testWhenBaseDimensionalItemObjectAggregationTypeIsNoneTotalAggregationTypeIsNone() {
+    // given
+    BaseDimensionalItemObject baseDimensionalItemObject = new BaseDimensionalItemObject();
+
+    // when
+    baseDimensionalItemObject.setAggregationType(AggregationType.NONE);
+
+    // then
+    assertSame(TotalAggregationType.NONE, baseDimensionalItemObject.getTotalAggregationType());
+  }
+
+  @Test
+  void testWhenBaseDimensionalItemObjectAggregationTypeIsNotNoneTotalAggregationTypeIsSum() {
+    // given
+    BaseDimensionalItemObject baseDimensionalItemObject = new BaseDimensionalItemObject();
+
+    // when
+    baseDimensionalItemObject.setAggregationType(AggregationType.AVERAGE_SUM_ORG_UNIT);
+
+    // then
+    assertSame(TotalAggregationType.SUM, baseDimensionalItemObject.getTotalAggregationType());
+  }
 }


### PR DESCRIPTION
**BACKPORT**
The Analytics API is returning an incorrect TotalAggregationType. It doesn't align with the AggregationType set to NONE. The fix involves ensuring that both values are set to NONE.