### PR TITLE
fix: make sure API tokens are backward compatible

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_49__Update_api_token_tokentype.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_49__Update_api_token_tokentype.sql
@@ -1,0 +1,2 @@
+-- DHIS2-17496: Make sure API tokens are backward compatible
+update api_token set type = 'PERSONAL_ACCESS_TOKEN_V1' where type = 'PERSONAL_ACCESS_TOKEN';


### PR DESCRIPTION
# Summary
The personal access tokens was updated in 2.41, and the type names was changed, making existing tokens made before this change, incompatible. This PR adds a .sql Flyway migration script that updates the existing PATs to use the new enum type names.

## Manual test:
1. Start a 2.40 server with an empty DB
2. Create some PATs
3. Upgrade and start a 2.41 server on the same DB
4. Observe the tokens has gotten the new type names in the DB (api_tokens)

### Jira:
[DHIS2-17496](https://dhis2.atlassian.net/browse/DHIS2-17496)

[DHIS2-17496]: https://dhis2.atlassian.net/browse/DHIS2-17496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ