### PR TITLE
fix: filter redirect URLs after login

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -226,17 +226,21 @@ public class AuthenticationController {
     SavedRequest savedRequest = requestCache.getRequest(request, null);
     if (savedRequest != null) {
       DefaultSavedRequest defaultSavedRequest = (DefaultSavedRequest) savedRequest;
-
-      if (defaultSavedRequest.getQueryString() != null) {
-        redirectUrl =
-            defaultSavedRequest.getRequestURI() + "?" + defaultSavedRequest.getQueryString();
-      } else {
-        redirectUrl = defaultSavedRequest.getRequestURI();
+      if (!filterSavedRequest(defaultSavedRequest)) {
+        if (defaultSavedRequest.getQueryString() != null) {
+          redirectUrl =
+              defaultSavedRequest.getRequestURI() + "?" + defaultSavedRequest.getQueryString();
+        } else {
+          redirectUrl = defaultSavedRequest.getRequestURI();
+        }
       }
-
       this.requestCache.removeRequest(request, response);
     }
-
     return redirectUrl;
+  }
+
+  private boolean filterSavedRequest(DefaultSavedRequest savedRequest) {
+    String requestURI = savedRequest.getRequestURI();
+    return !requestURI.endsWith(".html") && !requestURI.endsWith("/") && requestURI.contains(".");
   }
 }

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -217,7 +217,26 @@ class AuthTest {
     testRedirectUrl("/api/users");
   }
 
+  @Test
+  void testRedirectToResource() {
+    testRedirectUrl("/api/users/resource.js", "/dhis-web-dashboard/");
+  }
+
+  @Test
+  void testRedirectToResourceWorker() {
+    testRedirectUrl("/dhis-web-dashboard/service-worker.js", "/dhis-web-dashboard/");
+  }
+
+  @Test
+  void testRedirectToCssResourceWorker() {
+    testRedirectUrl("/dhis-web-dashboard/static/css/main.4536e618.css", "/dhis-web-dashboard/");
+  }
+
   private static void testRedirectUrl(String url) {
+    testRedirectUrl(url, url);
+  }
+
+  private static void testRedirectUrl(String url, String redirectUrl) {
     String port = Integer.toString(availablePort);
 
     RestTemplate restTemplate = new RestTemplate();
@@ -243,6 +262,6 @@ class AuthTest {
     assertNotNull(body);
     assertEquals(LoginResponse.STATUS.SUCCESS, body.getLoginStatus());
 
-    assertEquals(url, body.getRedirectUrl());
+    assertEquals(redirectUrl, body.getRedirectUrl());
   }
 }

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -223,6 +223,16 @@ class AuthTest {
   }
 
   @Test
+  void testRedirectToHtmlResource() {
+    testRedirectUrl("/api/users/resource.html", "/api/users/resource.html");
+  }
+
+  @Test
+  void testRedirectToSlashEnding() {
+    testRedirectUrl("/api/users/", "/api/users/resource.html");
+  }
+
+  @Test
   void testRedirectToResourceWorker() {
     testRedirectUrl("/dhis-web-dashboard/service-worker.js", "/dhis-web-dashboard/");
   }

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -229,7 +229,7 @@ class AuthTest {
 
   @Test
   void testRedirectToSlashEnding() {
-    testRedirectUrl("/api/users/", "/api/users/resource.html");
+    testRedirectUrl("/api/users/", "/api/users/");
   }
 
   @Test


### PR DESCRIPTION
## Summary
This PR introduces a simple URL filter method, to make sure redirects (saved requests) after login, never redirects to a resource file, like .css, .js etc.
The filter will only allow redirects to URLs ending in `.html`, `/` or nothing (i.e. contains no `.`).

### Automatic tests:
org.hisp.dhis.auth.AuthTest()#testRedirectToResource
org.hisp.dhis.auth.AuthTest()#testRedirectToResourceWorker
org.hisp.dhis.auth.AuthTest()#testRedirectToCssResourceWorker

### Manual tests:
1. Make sure you are logged out.
2. Manually write in a URL, like this: http://localhost:8080/dhis-web-dashboard/mstile-150x150.png
3. Observe you get redirected to login page.
4. Log in and observe you get redirected to the dashboard.

### Jira:
[DHIS2-17851](https://dhis2.atlassian.net/browse/DHIS2-17851)

[DHIS2-17851]: https://dhis2.atlassian.net/browse/DHIS2-17851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ