### PR TITLE
feat: adds log4j-layout-template-json for json based logs

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -121,6 +121,10 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-json-template-layout</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -122,7 +122,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-json-template-layout</artifactId>
+      <artifactId>log4j-layout-template-json</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1010,6 +1010,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-json-template-layout</artifactId>
+        <version>${log4j.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-web</artifactId>
         <version>${log4j.version}</version>
       </dependency>
@@ -2050,6 +2056,7 @@ jasperreports.version=${jasperreports.version}
               <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports-fonts</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-json-template-layout</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.jclouds.provider:aws-s3</ignoredUnusedDeclaredDependency>
               <!-- Needed by dhis-web modules -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1010,7 +1010,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-json-template-layout</artifactId>
+        <artifactId>log4j-layout-template-json</artifactId>
         <version>${log4j.version}</version>
         <scope>runtime</scope>
       </dependency>
@@ -2056,7 +2056,7 @@ jasperreports.version=${jasperreports.version}
               <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports-fonts</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-json-template-layout</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-layout-template-json</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.jclouds.provider:aws-s3</ignoredUnusedDeclaredDependency>
               <!-- Needed by dhis-web modules -->


### PR DESCRIPTION
Adds dependency on `log4j-layout-template-json` which allows template based json layout to be applied to logs coming out of log4j. This won’t affect any existing system but its very useful when you are using a custom `log4j2.xml` file.

Backport from V42.

[DHIS2-18063](https://dhis2.atlassian.net/browse/DHIS2-18063)

[DHIS2-18063]: https://dhis2.atlassian.net/browse/DHIS2-18063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ