### PR TITLE
fix: login fails when there is attribute values assigned to the user

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -417,8 +417,10 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isFavorite() {
-    UserDetails user = CurrentUserUtil.getCurrentUserDetails();
-    return user != null && favorites != null && favorites.contains(user.getUid());
+    if (favorites == null || !CurrentUserUtil.hasCurrentUser()) {
+      return false;
+    }
+    return favorites.contains(CurrentUserUtil.getCurrentUserDetails().getUid());
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
@@ -99,7 +99,6 @@ public class CurrentUserUtil {
    * @return list of authority names
    */
   public static List<String> getCurrentUserAuthorities() {
-
     if (!CurrentUserUtil.hasCurrentUser()) {
       return List.of();
     }
@@ -136,11 +135,10 @@ public class CurrentUserUtil {
   @Nullable
   @SuppressWarnings("unchecked")
   public static <T> T getUserSetting(UserSettingKey key) {
-    UserDetails currentUser = getCurrentUserDetails();
-    if (currentUser == null) {
+    if (!hasCurrentUser()) {
       return null;
     }
-
+    UserDetails currentUser = getCurrentUserDetails();
     return (T) currentUser.getUserSettings().get(key.getName());
   }
 
@@ -153,15 +151,12 @@ public class CurrentUserUtil {
    */
   @SuppressWarnings("unchecked")
   public static <T> T getUserSetting(UserSettingKey key, @Nonnull T defaultValue) {
-    UserDetails currentUser = getCurrentUserDetails();
-    if (currentUser == null) {
+    if (!hasCurrentUser()) {
       return defaultValue;
     }
-
+    UserDetails currentUser = getCurrentUserDetails();
     Map<String, Serializable> userSettings = currentUser.getUserSettings();
-
     Serializable setting = userSettings.get(key.getName());
-
     return setting != null ? (T) setting : defaultValue;
   }
 


### PR DESCRIPTION
## Summary
As a side effect of adding attributes to the user, we end up with the user deserializer trying to fetch the user settings before the user is logged in. This is caused by tight coupling of the user settings into the domain model.
This PR patches the methods called and allow for null and default values when deserialization before user is logged in occurs.

## Automatic tests:
N/A

## Manual tests:

1. Open the [version 41 play instance](https://play.im.dhis2.org/stable-2-41-1)
2. Navigate to Maintenance > Others > Attribute > Add attribute
3. Set value 'FCM Token' to name, shortName, and code
4. Add a description
5. Select value type as Text
7. Check 'User' field
8. Save
9. Navigate to the users app
10. Select your current user to edit
11. Add a value to the attribute field
12. Save changes
13. Log out
14. Log in with correct credentials
15. Observe you are logged in without any error.
