### PR TITLE
fix: fix broken redirect when missing trailing slash

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrailingSlashInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrailingSlashInterceptor.java
@@ -1,9 +1,36 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.webapi.mvc.interceptor;
 
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
 public class TrailingSlashInterceptor implements HandlerInterceptor {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrailingSlashInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrailingSlashInterceptor.java
@@ -1,0 +1,37 @@
+package org.hisp.dhis.webapi.mvc.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class TrailingSlashInterceptor implements HandlerInterceptor {
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+    String requestURI = request.getRequestURI();
+    String contextPath = request.getContextPath();
+
+    // Ignore API paths
+    if (requestURI.startsWith(contextPath + "/api")) {
+      return true;
+    }
+
+    // Check if the path does not end with '/' or contains .
+    if (!requestURI.endsWith("/") && !requestURI.contains(".")) {
+      String queryString = request.getQueryString();
+      String redirectURI = requestURI + "/";
+      if (queryString != null) {
+        redirectURI += "?" + queryString;
+      }
+      response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+      response.setHeader("Location", redirectURI);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -267,8 +267,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
     registry.addInterceptor(new UserContextInterceptor(userSettingService));
     registry.addInterceptor(new RequestInfoInterceptor(requestInfoService));
     registry.addInterceptor(authorityInterceptor);
-    registry.addInterceptor(new TrailingSlashInterceptor())
-        .excludePathPatterns("/api/**");
+    registry.addInterceptor(new TrailingSlashInterceptor()).excludePathPatterns("/api/**");
   }
 
   @Override

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
 import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.AuthorityInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
+import org.hisp.dhis.webapi.mvc.interceptor.TrailingSlashInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConverter;
@@ -266,6 +267,8 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
     registry.addInterceptor(new UserContextInterceptor(userSettingService));
     registry.addInterceptor(new RequestInfoInterceptor(requestInfoService));
     registry.addInterceptor(authorityInterceptor);
+    registry.addInterceptor(new TrailingSlashInterceptor())
+        .excludePathPatterns("/api/**");
   }
 
   @Override

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -322,13 +322,6 @@ class AuthTest {
     HttpHeaders loginHeaders = loginResponse.getHeaders();
     String loggedInCookie = loginHeaders.get(HttpHeaders.SET_COOKIE).get(0);
 
-    assertNotNull(loginResponse);
-    assertEquals(HttpStatus.OK, loginResponse.getStatusCode());
-    LoginResponse body = loginResponse.getBody();
-    assertNotNull(body);
-    assertEquals(LoginResponse.STATUS.SUCCESS, body.getLoginStatus());
-    assertEquals(redirectUrl, body.getRedirectUrl());
-
     HttpHeaders headers = new HttpHeaders();
     headers.set("Cookie", loggedInCookie);
     HttpEntity<String> entity = new HttpEntity<>(headers);


### PR DESCRIPTION
## Summary
After the removal of Struts and restructuring of how resources are served in 2.42, the server's ability to redirect a resource URL without ending slash to one with, is no longer present.
This PR adds an interceptor to make sure resource URLs/apps are redirected properly with an appending slash.

### Automatic tests:
AuthTest#testRedirectMissingEndingSlash()

### Manual tests:
1. Log in as normal
2. Manually enter a URL like this: http://localhost:8080/dhis-web-dashboard
3. Observe you get redirected to: http://localhost:8080/dhis-web-dashboard/

### Jira:
[DHIS2-17493](https://dhis2.atlassian.net/browse/DHIS2-17493)

[DHIS2-17493]: https://dhis2.atlassian.net/browse/DHIS2-17493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ