### PR TITLE
ci: use existing node installation on CI

### DIFF
--- a/dhis-2/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web-apps/pom.xml
@@ -26,56 +26,107 @@
 
   <build>
     <finalName>dhis-web-apps</finalName>
-
-    <plugins>
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.15.0</version>
-        <configuration>
-          <installDirectory>target</installDirectory>
-          <environmentVariables>
-            <BUILD_DIR>${project.build.directory}</BUILD_DIR>
-            <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
-            <APPS>./apps-to-bundle.json</APPS>
-            <DEFAULT_BRANCH>master</DEFAULT_BRANCH>
-          </environmentVariables>
-        </configuration>
-        <executions>
-
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <nodeVersion>v16.13.2</nodeVersion>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-          </execution>
-
-          <execution>
-            <id>clone apps</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <arguments>run bundle-apps</arguments>
-            </configuration>
-          </execution>
-
-        </executions>
-      </plugin>
-
-    </plugins>
   </build>
+
+  <profiles>
+    <!-- nodejs is downloaded locally to clone bundled apps -->
+    <profile>
+      <id>local</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+          <value>false</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>1.15.0</version>
+            <configuration>
+              <installDirectory>target</installDirectory>
+              <environmentVariables>
+                <BUILD_DIR>${project.build.directory}</BUILD_DIR>
+                <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
+                <APPS>./apps-to-bundle.json</APPS>
+                <DEFAULT_BRANCH>master</DEFAULT_BRANCH>
+              </environmentVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <id>install node and npm</id>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <nodeVersion>v20.17.0</nodeVersion>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>npm install</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <phase>generate-resources</phase>
+              </execution>
+
+              <execution>
+                <id>bundle-apps</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <arguments>run bundle-apps</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- nodejs is present on CI (GitHub, Jenkins) to clone bundled apps -->
+    <profile>
+      <id>ci</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <executable>npm</executable>
+              <arguments>
+                <argument>run</argument>
+                <argument>bundle-apps</argument>
+              </arguments>
+              <environmentVariables>
+                <BUILD_DIR>${project.build.directory}</BUILD_DIR>
+                <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
+                <APPS>./apps-to-bundle.json</APPS>
+                <DEFAULT_BRANCH>master</DEFAULT_BRANCH>
+              </environmentVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <id>bundle-apps</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -9,8 +9,7 @@
 
   <description>DHIS2 is a free and open-source software platform for collecting, managing, analyzing, and sharing data.
     It supports online and offline data capture via web and mobile devices, and includes built-in features for data validation and visualization.
-    The generic DHIS2 data model supports both routine aggregate/statistical data collection and individual/event data, a
-    nd can be applied to use cases in any sector, allowing decentralized access to data throughout an organizational hierarchy.
+    The generic DHIS2 data model supports both routine aggregate/statistical data collection and individual/event data, and can be applied to use cases in any sector, allowing decentralized access to data throughout an organizational hierarchy.
     DHIS2 is fully customizable through the user interface without the need for coding skills,
     and can be extended with custom applications, scripts, and integrations.
     Each DHIS2 instance and the data stored within it are locally owned and managed.
@@ -60,7 +59,7 @@
   <properties>
     <!-- Build Properties -->
     <rootDir/>
-    <!-- Custom source directory property, as <build><sourceDirectory> cannot 
+    <!-- Custom source directory property, as <build><sourceDirectory> cannot
       be set in a profile. See https://github.com/awhitford/lombok.maven/issues/17#issuecomment-136606104 -->
     <sourceDir>${project.basedir}/src/main/java</sourceDir>
 
@@ -74,7 +73,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <surefireArgLine>-Xmx2024m</surefireArgLine>
 
-    <!-- Needed so we can disable running tests when the default profile 
+    <!-- Needed so we can disable running tests when the default profile
       is used (activated by default). It does not honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->
     <skipTests>false</skipTests>
 
@@ -236,6 +235,7 @@
     <!-- Maven plugin versions -->
     <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-exec-plugin.version>3.4.1</maven-exec-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
     <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
@@ -1667,8 +1667,8 @@
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
-      <!-- Depend only on mockito-inline (includes mockito-core already) 
-        if you must use mockStatic (can you rewrite your code, so it's not necessary 
+      <!-- Depend only on mockito-inline (includes mockito-core already)
+        if you must use mockStatic (can you rewrite your code, so it's not necessary
         ;)), otherwise depend on mockito-core only -->
       <dependency>
         <groupId>org.mockito</groupId>
@@ -1727,9 +1727,9 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
-          <!-- 
+          <!--
             Junit 4 cannot be excluded yet, because of this issue
-            https://github.com/testcontainers/testcontainers-java/issues/970 
+            https://github.com/testcontainers/testcontainers-java/issues/970
           -->
           <!--
           <exclusion>
@@ -1917,6 +1917,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${maven-exec-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
GitHub and Jenkins builds fail often because of

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.15.0:install-node-and-npm (install node and npm) on project 
dhis-web-apps: Could not download Node.js: Could not download https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.gz: 
Premature end of Content-Length delimited message body (expected: 32,399,497; received: 2,269,184) -> [Help 1]
```

We are using [Node.js to `git clone`](https://github.com/dhis2/dhis2-core/blob/cb0dad1ff6d886c2a8ab1f6c5e6028cac60af5de/dhis-2/dhis-web-apps/scripts/bundle-apps.js#L35) the [bundled web apps](https://github.com/dhis2/dhis2-core/blob/cb0dad1ff6d886c2a8ab1f6c5e6028cac60af5de/dhis-2/dhis-web-apps/apps-to-bundle.json#L2).

Node.js is already installed on [GitHub](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#nodejs) and [Jenkins](https://github.com/dhis2-sre/jenkins/blob/6dc024d083a81403c732e6364d35b4ebc007e203/agents/ec2/jdk17/cloud-config.yaml#L51). Use a maven profile that is activated when environment var `CI=true` to use the existing Node.js.

You can see on GitHub and Jenkins that the `exec-maven-plugin` is used to run the same command that is run by the `` locally.

```
[INFO] --- exec-maven-plugin:3.4.1:exec (bundle-apps) @ dhis-web-apps ---

> dhis-web-apps@1.0.0 bundle-apps
> node ./scripts/bundle-apps.js
```

Update Node.js version to latest LTS https://nodejs.org/en/about/previous-releases when running the build locally. This will still run by default on devs machines (environment `CI=false`).

```
[dhis-web-apps] [INFO] --- frontend-maven-plugin:1.15.0:install-node-and-npm (install node and npm) @ dhis-web-apps ---
[dhis-web-apps] [INFO] Installing node version v20.17.0
[dhis-web-apps] [INFO] Unpacking /home/ivo/.m2/repository/com/github/eirslett/node/20.17.0/node-20.17.0-linux-x64.tar.gz into /home/ivo/code/dhis2/core/dhis-2/dhis-web-apps/target/node/tmp
...
[dhis-web-apps] [INFO] --- frontend-maven-plugin:1.15.0:npm (bundle-apps) @ dhis-web-apps ---
[dhis-web-apps] [INFO] Running 'npm run bundle-apps' in /home/ivo/code/dhis2/core/dhis-2/dhis-web-apps
[INFO] 
[INFO] > dhis-web-apps@1.0.0 bundle-apps
[INFO] > node ./scripts/bundle-apps.js
```
