### PR TITLE
ci: activate the local profile when CI env and absent

### DIFF
--- a/dhis-2/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web-apps/pom.xml
@@ -34,8 +34,8 @@
       <id>local</id>
       <activation>
         <property>
-          <name>env.CI</name>
-          <value>false</value>
+          <name>!env.CI</name>
+          <!-- Activates when CI is not defined or false -->
         </property>
       </activation>
       <build>


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/18612

Only `CI=false` activated the local profile but not setting the `CI` env explicitly did not. So `./dhis-2/build-dev.sh` did not bundle the apps no my machine. This change fixes that.