### PR TITLE
ci: fix build docker image script for non-latest major versions [skip ci]

### DIFF
--- a/dhis-2/build-docker-image.sh
+++ b/dhis-2/build-docker-image.sh
@@ -60,7 +60,7 @@ function create_rolling_tags() {
   )"
 
   if [[ "$major" -gt "$latest_major_version" ]] || \
-     [[ "$minor" -gt "$latest_minor_version" && "$major" -eq "$latest_major_version" ]] || \
+     [[ "$minor" -gt "$latest_minor_version" ]] || \
      [[ "$patch" -ge "$latest_patch_version" && "$minor" -eq "$latest_minor_version" ]]; then
     echo "New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags."
     rolling_tags+=(


### PR DESCRIPTION
The major version of the version to be built was incorrectly compared to the latest major version we have in the `stable.json` file even if the version to be built was not the latest major version.

This was tested locally by the following command and with modifying the script to exit early without actually building anything, but just listing the rolling and immutable tags that would be created:
```
$ echo "42.0.0 41.2.0 41.1.0 40.5.0 40.4.2 40.4.0 39.5.1" | xargs -n 1 -I {} ./dhis-2/build-docker-image.sh -t "{}"

New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags.
Immutable tag:
42.0.0-20240919T143148Z
Rolling tags:
42.0.0 2.42.0.0 42.0 42 2.42.0 2.42

New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags.
Immutable tag:
41.2.0-20240919T143148Z
Rolling tags:
41.2.0 2.41.2.0 41.2 41 2.41.2 2.41

New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags.
Immutable tag:
41.1.0-20240919T143148Z
Rolling tags:
41.1.0 2.41.1.0 41.1 41 2.41.1 2.41

New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags.
Immutable tag:
40.5.0-20240919T143148Z
Rolling tags:
40.5.0 2.40.5.0 40.5 40 2.40.5 2.40

New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags.
Immutable tag:
40.4.2-20240919T143149Z
Rolling tags:
40.4.2 2.40.4.2 40.4 40 2.40.4 2.40

Immutable tag:
40.4.0-20240919T143149Z
Rolling tags:
40.4.0 2.40.4.0

New patch for a non-latest minor version, creating M.m tags.
Immutable tag:
39.5.1-20240919T143149Z
Rolling tags:
39.5.1 2.39.5.1 39.5 2.39.5
```

Please take a look at the example DHIS2 versions used for the test command above and let me know if there's any other case I might be missing. 🙏 
