### PR TITLE
fix: bundling apps on CI

### DIFF
--- a/dhis-2/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web-apps/pom.xml
@@ -121,7 +121,7 @@
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>package</phase>
+                <phase>generate-resources</phase>
               </execution>
             </executions>
           </plugin>

--- a/dhis-2/dhis-web-apps/scripts/bundle-apps.js
+++ b/dhis-2/dhis-web-apps/scripts/bundle-apps.js
@@ -51,7 +51,7 @@ async function main(opts = {}) {
     }
 
     try {
-        await mkdir(target_path)
+        await mkdir(target_path, { recursive: true })
     } catch (err) {
         if (err.code === 'EEXIST') {
             console.log(`[bundle] ${target_path} exists already`)


### PR DESCRIPTION
In CI, the apps where cloned but after the war was packaged so the apps were not in the war. Run exec in the same maven phase as we do the frontend plugin (when not in CI). The `target` folder is not created by maven at the `generate-resources` stage. I assume the frontend plugin creates it for us. Now, when running in CI we create it via the `bundle-apps.js` script.