### PR TITLE
chore: Remove userid from tracker import params [DHIS2-18001]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -82,7 +82,7 @@ public class DefaultTrackerImportService implements TrackerImportService {
   @IndirectTransactional
   public ImportReport importTracker(
       TrackerImportParams params, TrackerObjects trackerObjects, JobProgress jobProgress) {
-    User user = trackerUserService.getUser(params.getUserId());
+    User user = trackerUserService.getCurrentUser();
 
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportParams.java
@@ -43,9 +43,6 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundleMode;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TrackerImportParams implements JobParameters {
-  /** User uid to use for import job. */
-  @JsonProperty private String userId;
-
   /** Should import be imported or just validated. */
   @JsonProperty @Builder.Default
   private final TrackerBundleMode importMode = TrackerBundleMode.COMMIT;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerUserService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerUserService.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.tracker.imports.preheat.mappers.FullUserMapper;
 import org.hisp.dhis.user.CurrentUserUtil;
@@ -47,22 +46,10 @@ public class TrackerUserService {
 
   private final IdentifiableObjectManager manager;
 
-  /**
-   * Fetch a User by user uid
-   *
-   * @param userUid a User uid
-   * @return a User
-   */
   @Transactional(readOnly = true)
-  public User getUser(String userUid) {
-    User user = null;
+  public User getCurrentUser() {
+    User user = manager.get(User.class, CurrentUserUtil.getCurrentUserDetails().getUid());
 
-    if (!StringUtils.isEmpty(userUid)) {
-      user = manager.get(User.class, userUid);
-    }
-    if (user == null) {
-      user = manager.get(User.class, CurrentUserUtil.getCurrentUserDetails().getUid());
-    }
     // Make a copy of the user object, retaining only the properties
     // required for
     // the import operation

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
@@ -94,13 +94,7 @@ public class DeleteEventSMSListener extends CompressionSMSListener {
     DeleteSmsSubmission subm = (DeleteSmsSubmission) submission;
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .userId(
-                user.getUid()) // SMS processing is done inside a job executed as the user that sent
-            // the SMS. We might want to remove the params user in favor of the currentUser set on
-            // the thread.
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
     TrackerObjects trackerObjects =
         TrackerObjects.builder()
             .events(List.of(Event.builder().event(subm.getEvent().getUid()).build()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListener.java
@@ -110,13 +110,7 @@ public class RelationshipSMSListener extends CompressionSMSListener {
     }
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .importStrategy(TrackerImportStrategy.CREATE)
-            .userId(
-                user.getUid()) // SMS processing is done inside a job executed as the user that sent
-            // the SMS. We might want to remove the params user in favor of the currentUser set on
-            // the thread.
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.CREATE).build();
     TrackerObjects trackerObjects =
         TrackerObjects.builder()
             .relationships(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
@@ -122,10 +122,6 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
     TrackerImportParams params =
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
-            .userId(
-                user.getUid()) // SMS processing is done inside a job executed as the user that sent
-            // the SMS. We might want to remove the params user in favor of the currentUser set on
-            // the thread.
             .build();
     TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event.build())).build();
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -94,7 +93,7 @@ class TrackerImporterServiceTest {
     event.setEvent("EventUid");
     final List<Event> events = List.of(event);
 
-    params = TrackerImportParams.builder().userId("123").build();
+    params = TrackerImportParams.builder().build();
 
     trackerObjects =
         TrackerObjects.builder()
@@ -104,7 +103,7 @@ class TrackerImporterServiceTest {
             .trackedEntities(new ArrayList<>())
             .build();
 
-    when(trackerUserService.getUser(anyString())).thenReturn(getUser());
+    when(trackerUserService.getCurrentUser()).thenReturn(getUser());
 
     when(validationService.validate(any(TrackerBundle.class))).thenReturn(validationResult);
     when(validationService.validateRuleEngine(any(TrackerBundle.class)))
@@ -115,8 +114,7 @@ class TrackerImporterServiceTest {
 
   @Test
   void testSkipSideEffect() {
-    TrackerImportParams parameters =
-        TrackerImportParams.builder().skipSideEffects(true).userId("123").build();
+    TrackerImportParams parameters = TrackerImportParams.builder().skipSideEffects(true).build();
 
     TrackerObjects objects =
         TrackerObjects.builder()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -118,7 +118,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -90,7 +90,7 @@ class AclEventExporterTest extends TrackerTest {
     User userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(userA.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -80,7 +80,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    importParams = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    importParams = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             importParams, fromJson("tracker/event_and_enrollment.json")));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -114,7 +114,7 @@ class EventExporterTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -67,7 +67,7 @@ class EventDataValueTest extends TrackerTest {
     final User userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(userA.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
     TrackerObjects enTrackerObjects = fromJson("tracker/single_enrollment.json");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -81,7 +81,7 @@ class LastUpdateImportTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
 
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -114,10 +114,8 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.UPDATE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
+
     assertNoErrors(trackerImportService.importTracker(params, fromJson("tracker/single_te.json")));
 
     Date lastUpdateAfter = getTrackedEntity().getLastUpdated();
@@ -135,16 +133,13 @@ class LastUpdateImportTest extends TrackerTest {
 
     clearSession();
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/event_with_data_values.json")));
 
-    params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.UPDATE)
-            .build();
+    params = TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
+
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/event_with_updated_data_values.json")));
@@ -174,10 +169,8 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.UPDATE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
+
     enrollment.setStatus(EnrollmentStatus.COMPLETED);
 
     assertNoErrors(
@@ -209,10 +202,8 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     ImportReport importReport =
         trackerImportService.importTracker(
             params, TrackerObjects.builder().trackedEntities(List.of(trackedEntity)).build());
@@ -244,10 +235,8 @@ class LastUpdateImportTest extends TrackerTest {
 
     // delete cascade
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     ImportReport importReport =
         trackerImportService.importTracker(
             params, TrackerObjects.builder().trackedEntities(List.of(trackedEntity)).build());
@@ -294,10 +283,7 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(user.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, TrackerObjects.builder().enrollments(List.of(enrollment)).build());
@@ -370,10 +356,7 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(user.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
 
     assertNoErrors(
         trackerImportService.importTracker(
@@ -443,10 +426,7 @@ class LastUpdateImportTest extends TrackerTest {
     clearSession();
 
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(user.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
 
     assertNoErrors(
         trackerImportService.importTracker(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -83,7 +83,7 @@ class OwnershipTest extends TrackerTest {
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/ownership_te.json")));
     assertNoErrors(
@@ -119,8 +119,7 @@ class OwnershipTest extends TrackerTest {
   void testClientDatesForTrackedEntityEnrollmentEvent() throws IOException {
     User nonSuperUser = userService.getUser(this.nonSuperUser.getUid());
     injectSecurityContextUser(nonSuperUser);
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_event.json");
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     manager.flush();
@@ -166,8 +165,7 @@ class OwnershipTest extends TrackerTest {
   @Test
   void testUpdateEnrollment() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     List<Enrollment> enrollments = manager.getAll(Enrollment.class);
     assertEquals(2, enrollments.size());
     Enrollment enrollment =
@@ -198,8 +196,7 @@ class OwnershipTest extends TrackerTest {
 
   @Test
   void testDeleteEnrollment() throws IOException {
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
     List<Enrollment> enrollments = manager.getAll(Enrollment.class);
     assertEquals(2, enrollments.size());
@@ -215,8 +212,7 @@ class OwnershipTest extends TrackerTest {
   @Test
   void testCreateEnrollmentAfterDeleteEnrollment() throws IOException {
     injectSecurityContextUser(userService.getUser(nonSuperUser.getUid()));
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
     List<Enrollment> enrollments = manager.getAll(Enrollment.class);
     assertEquals(2, enrollments.size());
@@ -238,8 +234,7 @@ class OwnershipTest extends TrackerTest {
   @Test
   void testCreateEnrollmentWithoutOwnership() throws IOException, ForbiddenException {
     injectSecurityContextUser(userService.getUser(nonSuperUser.getUid()));
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
     List<Enrollment> enrollments = manager.getAll(Enrollment.class);
     assertEquals(2, enrollments.size());
@@ -262,10 +257,7 @@ class OwnershipTest extends TrackerTest {
   void shouldFailWhenCreatingTEAndEnrollmentAndUserHasNoAccessToEnrollmentOU() throws IOException {
     injectSecurityContextUser(userService.getUser(nonSuperUser.getUid()));
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(nonSuperUser.getUid())
-            .atomicMode(AtomicMode.OBJECT)
-            .build();
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_te_ok_enrollment_no_access.json");
     ImportReport report = trackerImportService.importTracker(params, trackerObjects);
     assertEquals(1, report.getStats().getCreated());
@@ -279,8 +271,7 @@ class OwnershipTest extends TrackerTest {
     TrackedEntity trackedEntity = manager.get(TrackedEntity.class, "IOR1AXXl24H");
     OrganisationUnit ou = manager.get(OrganisationUnit.class, "B1nCbRV3qtP");
     Program pgm = manager.get(Program.class, "BFcipDERJnf");
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
     trackerOwnershipManager.transferOwnership(trackedEntity, pgm, ou);
     params.setImportStrategy(TrackerImportStrategy.DELETE);
@@ -296,8 +287,7 @@ class OwnershipTest extends TrackerTest {
     OrganisationUnit ou = manager.get(OrganisationUnit.class, "B1nCbRV3qtP");
     Program pgm = manager.get(Program.class, "BFcipDERJnf");
     trackerOwnershipManager.transferOwnership(trackedEntity, pgm, ou);
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(nonSuperUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/ownership_enrollment.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     ImportReport updatedReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +67,7 @@ class RelationshipImportTest extends TrackerTest {
     userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(userA.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(trackerImportService.importTracker(params, fromJson("tracker/single_te.json")));
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/single_enrollment.json")));
@@ -75,10 +76,15 @@ class RelationshipImportTest extends TrackerTest {
     manager.flush();
   }
 
+  @AfterEach
+  void setUpUser() {
+    injectSecurityContextUser(userA);
+  }
+
   @Test
   void successImportingRelationships() throws IOException {
-    userA = userService.getUser("M5zQapPyTZI");
-    TrackerImportParams params = TrackerImportParams.builder().userId(userA.getUid()).build();
+    injectSecurityContextUser(userService.getUser("M5zQapPyTZI"));
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(params, fromJson("tracker/relationships.json"));
     assertThat(importReport.getStatus(), is(Status.OK));
@@ -87,8 +93,8 @@ class RelationshipImportTest extends TrackerTest {
 
   @Test
   void shouldFailWhenUserNotAuthorizedToCreateRelationship() throws IOException {
-    userA = userService.getUser("o1HMTIzBGo7");
-    TrackerImportParams params = TrackerImportParams.builder().userId(userA.getUid()).build();
+    injectSecurityContextUser(userService.getUser("o1HMTIzBGo7"));
+    TrackerImportParams params = TrackerImportParams.builder().build();
 
     ImportReport importReport =
         trackerImportService.importTracker(params, fromJson("tracker/relationships.json"));
@@ -99,8 +105,7 @@ class RelationshipImportTest extends TrackerTest {
 
   @Test
   void successUpdateRelationships() throws IOException {
-    TrackerImportParams trackerImportParams =
-        TrackerImportParams.builder().userId(userA.getUid()).build();
+    TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/relationships.json");
     trackerImportService.importTracker(trackerImportParams, trackerObjects);
     trackerObjects = fromJson("tracker/relationshipToUpdate.json");
@@ -114,8 +119,7 @@ class RelationshipImportTest extends TrackerTest {
 
   @Test
   void shouldFailWhenTryingToUpdateADeletedRelationship() throws IOException {
-    TrackerImportParams trackerImportParams =
-        TrackerImportParams.builder().userId(userA.getUid()).build();
+    TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/relationships.json");
     trackerImportService.importTracker(trackerImportParams, trackerObjects);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -44,8 +44,8 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.user.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -76,7 +76,7 @@ class RelationshipImportTest extends TrackerTest {
     manager.flush();
   }
 
-  @AfterEach
+  @BeforeEach
   void setUpUser() {
     injectSecurityContextUser(userA);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.user.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -98,7 +98,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
     manager.clear();
   }
 
-  @AfterEach
+  @BeforeEach
   void setUpUser() {
     injectSecurityContextUser(importUser);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +75,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
 
     TrackerObjects trackerObjects = fromJson("tracker/tracker_basic_data_before_deletion.json");
     assertEquals(13, trackerObjects.getTrackedEntities().size());
@@ -97,13 +98,17 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
     manager.clear();
   }
 
+  @AfterEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
+  }
+
   @Test
   void shouldFailToDeleteNotExistentRelationship() throws IOException {
     TrackerObjects trackerObjects =
         fromJson("tracker/relationships_existent_and_not_existent_for_deletion.json");
     TrackerImportParams params =
         TrackerImportParams.builder()
-            .userId(importUser.getUid())
             .importStrategy(TrackerImportStrategy.DELETE)
             .atomicMode(AtomicMode.OBJECT)
             .build();
@@ -119,10 +124,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
     TrackerObjects trackerObjects = fromJson("tracker/relationships_basic_data_for_deletion.json");
     assertEquals(2, trackerObjects.getRelationships().size());
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -132,11 +134,11 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
   @Test
   void shouldSuccessfullyDeleteTrackedEntityAndNotAccessibleRelationshipLinkedToIt()
       throws IOException {
+    injectSecurityContextUser(userService.getUser(USER_10));
     TrackerObjects trackerObjects =
         fromJson("tracker/te_with_inaccessible_relationship_for_deletion.json");
     TrackerImportParams params =
         TrackerImportParams.builder()
-            .userId(USER_10)
             .importStrategy(TrackerImportStrategy.DELETE)
             .atomicMode(AtomicMode.OBJECT)
             .build();
@@ -152,10 +154,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
   void testTrackedEntityDeletion() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/tracked_entity_basic_data_for_deletion.json");
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     assertEquals(9, trackerObjects.getTrackedEntities().size());
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -174,10 +174,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
     dbmsManager.clearSession();
     assertEquals(2, manager.getAll(Event.class).size());
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     TrackerObjects trackerObjects = fromJson("tracker/enrollment_basic_data_for_deletion.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -193,10 +191,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
   @Test
   void testEventDeletion() throws IOException {
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     TrackerObjects trackerObjects = fromJson("tracker/event_basic_data_for_deletion.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -211,10 +207,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
   @Test
   void testNonExistentEnrollment() throws IOException {
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     TrackerObjects trackerObjects =
         fromJson("tracker/non_existent_enrollment_basic_data_for_deletion.json");
 
@@ -226,10 +220,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
   @Test
   void testDeleteMultipleEntities() throws IOException {
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.DELETE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+
     TrackerObjects trackerObjects = fromJson("tracker/tracker_data_for_deletion.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
@@ -63,7 +63,7 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedTE() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
 
     ImportReport trackerImportTeReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -78,13 +78,10 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedAndOneUpdatedTE() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_te_and_one_new_te.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportTeReport = trackerImportService.importTracker(params, trackerObjects);
@@ -100,13 +97,10 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedAndOneUpdatedTEAndOneInvalidTE() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_te_and_one_new_te_and_one_invalid_te.json");
-    params.setUserId(userA.getUid());
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
@@ -125,13 +119,10 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedEnrollment() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -148,13 +139,10 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedEnrollmentAndUpdateSameEnrollment() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -167,7 +155,6 @@ class ReportSummaryIntegrationTest extends TrackerTest {
     assertEquals(0, trackerImportEnrollmentReport.getStats().getDeleted());
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     trackerImportEnrollmentReport = trackerImportService.importTracker(params, trackerObjects);
@@ -183,18 +170,13 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneUpdateEnrollmentAndOneCreatedEnrollment() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/one_update_te_and_one_new_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_enrollment_and_one_new_enrollment.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -212,19 +194,14 @@ class ReportSummaryIntegrationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/three_tes.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_and_one_new_and_one_invalid_enrollment.json");
 
-    params.setUserId(userA.getUid());
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
@@ -244,19 +221,13 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneCreatedEvent() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_event.json");
-    params.setUserId(userA.getUid());
-
     ImportReport trackerImportEventReport =
         trackerImportService.importTracker(params, trackerObjects);
 
@@ -271,23 +242,16 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneUpdateEventAndOneNewEvent() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_event.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_event_and_one_new_event.json");
-    params.setUserId(userA.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEventReport =
@@ -304,23 +268,16 @@ class ReportSummaryIntegrationTest extends TrackerTest {
   void testStatsCountForOneUpdateEventAndOneNewEventAndOneInvalidEvent() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/single_te.json");
     TrackerImportParams params =
-        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).userId(userA.getUid()).build();
-    params.setUserId(userA.getUid());
-
+        TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_enrollment.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/single_event.json");
-    params.setUserId(userA.getUid());
-
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects = fromJson("tracker/one_update_and_one_new_and_one_invalid_event.json");
-    params.setUserId(userA.getUid());
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -92,7 +92,7 @@ class TrackedEntityAttributeTest extends TrackerTest {
 
   @Test
   void testTrackedAttributeValueBundleImporter() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/te_with_tea_data.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeValueChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeValueChangeLogTest.java
@@ -77,7 +77,7 @@ class TrackedEntityAttributeValueChangeLogTest extends TrackerTest {
 
   @Test
   void testTrackedEntityAttributeValueAuditCreate() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/te_program_with_tea_data.json")));
@@ -104,7 +104,7 @@ class TrackedEntityAttributeValueChangeLogTest extends TrackerTest {
 
   @Test
   void testTrackedEntityAttributeValueAuditDelete() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/te_program_with_tea_data.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -73,7 +73,7 @@ class TrackedEntityProgramAttributeEncryptionTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeEncryptedValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/te_program_with_tea_encryption_data.json"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -76,7 +76,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeFileResourceValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     FileResource fileResource =
         new FileResource(
             "test.pdf",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
@@ -70,7 +70,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/te_program_with_tea_data.json");
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -85,7 +85,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdate() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/te_program_with_tea_data.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -115,7 +115,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdateAndDelete() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/te_program_with_tea_data.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
@@ -62,7 +62,7 @@ class TrackerEventBundleServiceTest extends TrackerTest {
 
   @Test
   void testCreateSingleEventData() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/event_events_and_enrollment.json");
     assertEquals(8, trackerObjects.getEvents().size());
 
@@ -77,7 +77,6 @@ class TrackerEventBundleServiceTest extends TrackerTest {
   void testUpdateSingleEventData() throws IOException {
     TrackerImportParams params =
         TrackerImportParams.builder()
-            .userId(importUser.getUid())
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
     TrackerObjects trackerObjects = fromJson("tracker/event_events_and_enrollment.json");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerNotificationHandlerServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerNotificationHandlerServiceTest.java
@@ -168,7 +168,6 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
     ImportReport importReport =
         trackerImportService.importTracker(
             TrackerImportParams.builder()
-                .userId(user.getUid())
                 .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
                 .build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build());
@@ -218,7 +217,6 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
     ImportReport importReport =
         trackerImportService.importTracker(
             TrackerImportParams.builder()
-                .userId(user.getUid())
                 .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
                 .build(),
             TrackerObjects.builder()
@@ -255,10 +253,7 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
 
     importReport =
         trackerImportService.importTracker(
-            TrackerImportParams.builder()
-                .userId(user.getUid())
-                .importStrategy(TrackerImportStrategy.UPDATE)
-                .build(),
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build(),
             TrackerObjects.builder().events(List.of(eventUpdated)).build());
 
     assertNoErrors(importReport);
@@ -293,7 +288,6 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
     ImportReport importReport =
         trackerImportService.importTracker(
             TrackerImportParams.builder()
-                .userId(user.getUid())
                 .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
                 .build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build());
@@ -324,10 +318,7 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
 
     importReport =
         trackerImportService.importTracker(
-            TrackerImportParams.builder()
-                .userId(user.getUid())
-                .importStrategy(TrackerImportStrategy.UPDATE)
-                .build(),
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build(),
             TrackerObjects.builder().enrollments(List.of(enrollmentUpdated)).build());
 
     assertNoErrors(importReport);
@@ -362,7 +353,6 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
     ImportReport importReport =
         trackerImportService.importTracker(
             TrackerImportParams.builder()
-                .userId(user.getUid())
                 .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
                 .build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build());
@@ -384,7 +374,6 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
     importReport =
         trackerImportService.importTracker(
             TrackerImportParams.builder()
-                .userId(user.getUid())
                 .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
                 .build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerRuleEngineSideEffectsHandlerServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerRuleEngineSideEffectsHandlerServiceTest.java
@@ -85,8 +85,7 @@ class TrackerRuleEngineSideEffectsHandlerServiceTest extends PostgresIntegration
                 .getInputStream(),
             TrackerObjects.class);
     ImportReport importReport =
-        trackerImportService.importTracker(
-            TrackerImportParams.builder().userId(importUser.getUid()).build(), trackerObjects);
+        trackerImportService.importTracker(TrackerImportParams.builder().build(), trackerObjects);
     assertNoErrors(importReport);
 
     await()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentAttrValidationTest.java
@@ -56,7 +56,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_te-data_2.json")));
@@ -65,7 +65,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void failValidationWhenTrackedEntityAttributeHasWrongOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_with_invalid_option_value.json"));
@@ -75,7 +75,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void successValidationWhenTrackedEntityAttributeHasValidOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_with_valid_option_value.json"));
@@ -85,7 +85,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesMissingUid() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-missing-uuid.json"));
@@ -95,7 +95,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesMissingValues() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-missing-value.json"));
@@ -105,7 +105,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesMissingTeA() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-non-existing.json"));
@@ -115,7 +115,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesMissingMandatory() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-missing-mandatory.json"));
@@ -125,7 +125,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesUniquenessInSameTrackedEntity() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_unique_attr_same_te.json"));
@@ -135,7 +135,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesUniquenessAlreadyInDB() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_te-data_3.json"));
@@ -163,7 +163,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesUniquenessInDifferentTrackedEntities() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
 
     assertNoErrors(
         trackerImportService.importTracker(
@@ -180,7 +180,7 @@ class EnrollmentAttrValidationTest extends TrackerTest {
 
   @Test
   void testAttributesOnlyProgramAttrAllowed() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-only-program-attr.json"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -71,7 +71,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_te-data.json")));
@@ -86,7 +86,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testEnrollmentValidationOkAll() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_enrollments-data.json"));
@@ -96,7 +96,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testPreheatOwnershipForSubsequentEnrollment() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_enrollments-data.json"));
@@ -126,7 +126,6 @@ class EnrollmentImportValidationTest extends TrackerTest {
   void testNoWriteAccessToOrg() throws IOException {
     User user = userService.getUser(USER_2);
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     injectSecurityContextUser(user);
 
     ImportReport importReport =
@@ -138,7 +137,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testOnlyProgramAttributesAllowedOnEnrollments() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_error_non_program_attr.json"));
@@ -148,7 +147,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testAttributesOk() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-data.json"));
@@ -166,7 +165,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testDeleteCascadeEnrollments() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_attr-data.json"));
@@ -175,8 +174,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
     manager.flush();
     importEvents();
     manager.flush();
-    User user2 = userService.getUser(USER_4);
-    params.setUserId(user2.getUid());
+    injectSecurityContextUser(userService.getUser(USER_4));
     params.setImportStrategy(TrackerImportStrategy.DELETE);
 
     ImportReport trackerImportDeleteReport =
@@ -188,10 +186,8 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   protected void importEvents() throws IOException {
     TrackerImportParams params =
-        TrackerImportParams.builder()
-            .userId(importUser.getUid())
-            .importStrategy(TrackerImportStrategy.CREATE)
-            .build();
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.CREATE).build();
+
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-with-registration.json"));
@@ -201,7 +197,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testActiveEnrollmentAlreadyExists() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_double-te-enrollment_part1.json"));
@@ -220,7 +216,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
 
   @Test
   void testEnrollmentDeleteOk() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_enrollments-data.json"));
@@ -242,7 +238,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
   /** Notes with no value are ignored */
   @Test
   void testBadEnrollmentNoteNoValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_bad-note-no-value.json"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
@@ -112,7 +112,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_te-data.json")));
@@ -183,7 +183,6 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     User user = userService.getUser(USER_2);
     injectSecurityContextUser(user);
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     params.setImportStrategy(CREATE);
 
     ImportReport importReport =
@@ -210,7 +209,6 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     injectSecurityContextUser(user);
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_no-access-te.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     params.setImportStrategy(CREATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -238,7 +236,6 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/enrollments_no-access-program.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     params.setImportStrategy(CREATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -262,7 +259,6 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/enrollments_no-access-program.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     params.setImportStrategy(CREATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -285,7 +281,6 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/enrollments_program-tetype-missmatch.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(user.getUid());
     params.setImportStrategy(CREATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -299,8 +294,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     setup();
     TrackedEntity trackedEntityB = createTrackedEntity(trackedEntityType, organisationUnitB);
     User userA = createUser(organisationUnitA);
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(userA.getUid()).importStrategy(CREATE).build();
+    TrackerImportParams params = TrackerImportParams.builder().importStrategy(CREATE).build();
 
     injectSecurityContextUser(userA);
     ImportReport importReport =
@@ -320,8 +314,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     Program programB = createProgram(organisationUnitB);
     TrackedEntity trackedEntityB = createTrackedEntity(trackedEntityType, organisationUnitB);
     User userB = createUser(organisationUnitB);
-    TrackerImportParams params =
-        TrackerImportParams.builder().userId(userB.getUid()).importStrategy(CREATE).build();
+    TrackerImportParams params = TrackerImportParams.builder().importStrategy(CREATE).build();
 
     injectSecurityContextUser(userB);
     ImportReport importReport =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,7 +80,7 @@ class EventImportValidationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
 
     assertNoErrors(
         trackerImportService.importTracker(
@@ -89,9 +90,14 @@ class EventImportValidationTest extends TrackerTest {
             params, fromJson("tracker/validations/enrollments_te_enrollments-data.json")));
   }
 
+  @AfterEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
+  }
+
   @Test
   void testInvalidEnrollmentPreventsValidEventFromBeingCreated() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/invalid_enrollment_with_valid_event.json"));
@@ -101,7 +107,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void failValidationWhenTrackedEntityAttributeHasWrongOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-with_invalid_option_value.json"));
@@ -111,7 +117,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void successWhenTrackedEntityAttributeHasValidOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-with_valid_option_value.json"));
@@ -121,7 +127,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testEventValidationOkAll() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-with-registration.json"));
@@ -131,7 +137,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testEventValidationOkWithoutAttributeOptionCombo() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-without-attribute-option-combo.json"));
@@ -141,7 +147,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testTrackerAndProgramEventUpdateSuccess() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/program_and_tracker_events.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -156,8 +162,7 @@ class EventImportValidationTest extends TrackerTest {
   void testCantWriteAccessCatCombo() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/events-cat-write-access.json");
     TrackerImportParams params = new TrackerImportParams();
-    User user = userService.getUser(USER_6);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_6));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -173,15 +178,14 @@ class EventImportValidationTest extends TrackerTest {
   void testNoWriteAccessToOrg() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/events-with-registration.json");
     TrackerImportParams params = new TrackerImportParams();
-    User user = userService.getUser(USER_2);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_2));
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertHasOnlyErrors(importReport, ValidationCode.E1000);
   }
 
   @Test
   void testNonRepeatableProgramStage() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/events_non-repeatable-programstage_part1.json");
 
@@ -198,7 +202,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void shouldSuccessfullyImportRepeatedEventsInEventProgram() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/program_events_non-repeatable-programstage_part1.json");
 
@@ -216,7 +220,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testEventProgramHasNonDefaultCategoryCombo() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_non-default-combo.json"));
@@ -226,7 +230,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testCategoryOptionComboNotFound() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_cant-find-cat-opt-combo.json"));
@@ -236,7 +240,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testCategoryOptionComboNotFoundGivenSubsetOfCategoryOptions() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_cant-find-aoc-with-subset-of-cos.json"));
@@ -246,7 +250,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testCOFoundButAOCNotFound() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_cant-find-aoc-but-co-exists.json"));
@@ -256,7 +260,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testCategoryOptionsNotFound() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_cant-find-cat-option.json"));
@@ -266,7 +270,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testAttributeCategoryOptionNotInProgramCC() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-aoc-not-in-program-cc.json"));
@@ -276,7 +280,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testAttributeCategoryOptionAndCODoNotMatch() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events-aoc-and-co-dont-match.json"));
@@ -287,7 +291,7 @@ class EventImportValidationTest extends TrackerTest {
   @Test
   void testAttributeCategoryOptionCannotBeFoundForEventProgramCCAndGivenCategoryOption()
       throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params,
@@ -299,7 +303,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testWrongDatesInCatCombo() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/events_combo-date-wrong.json"));
@@ -373,7 +377,6 @@ class EventImportValidationTest extends TrackerTest {
     manager.delete(event);
     TrackerObjects trackerObjects = fromJson("tracker/validations/events-with-notes-data.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(importUser.getUid());
     params.setImportStrategy(importStrategy);
     // When
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -383,7 +386,7 @@ class EventImportValidationTest extends TrackerTest {
 
   @Test
   void testEventDeleteOk() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/events-with-registration.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -406,7 +409,6 @@ class EventImportValidationTest extends TrackerTest {
     // Given
     TrackerObjects trackerObjects = fromJson(jsonPayload);
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(importUser.getUid());
     params.setImportStrategy(CREATE_AND_UPDATE);
     // When
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -60,8 +60,8 @@ import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.User;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -90,7 +90,7 @@ class EventImportValidationTest extends TrackerTest {
             params, fromJson("tracker/validations/enrollments_te_enrollments-data.json")));
   }
 
-  @AfterEach
+  @BeforeEach
   void setUpUser() {
     injectSecurityContextUser(importUser);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -122,7 +123,7 @@ class EventSecurityImportValidationTest extends TrackerTest {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/enrollments_te_te-data.json")));
@@ -218,15 +219,20 @@ class EventSecurityImportValidationTest extends TrackerTest {
     manager.update(importUser);
   }
 
+  @BeforeEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
+  }
+
   @Test
   void testNoWriteAccessToProgramStage() throws IOException {
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/events_error-no-programStage-access.json");
     TrackerImportParams params = new TrackerImportParams();
     User user = userService.getUser(USER_3);
-    params.setUserId(user.getUid());
     user.addOrganisationUnit(organisationUnitA);
     manager.update(user);
+    injectSecurityContextUser(user);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -236,7 +242,7 @@ class EventSecurityImportValidationTest extends TrackerTest {
   @Test
   void testNoUncompleteEventAuth() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/events_error-no-uncomplete.json");
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     params.setImportStrategy(TrackerImportStrategy.CREATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -256,9 +262,9 @@ class EventSecurityImportValidationTest extends TrackerTest {
     User user = userService.getUser(USER_4);
     user.addOrganisationUnit(organisationUnitA);
     manager.update(user);
+    injectSecurityContextUser(user);
     manager.flush();
     manager.clear();
-    params.setUserId(user.getUid());
     params.setImportStrategy(TrackerImportStrategy.UPDATE);
     importReport = trackerImportService.importTracker(params, trackerObjects);
     assertHasOnlyErrors(importReport, ValidationCode.E1083);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -51,18 +52,25 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
 
   @Autowired private TrackerImportService trackerImportService;
 
+  private User importUser;
+
   @BeforeAll
   void setUp() throws IOException {
     setUpMetadata("tracker/tracker_basic_metadata.json");
 
-    User importUser = userService.getUser("tTgjgobT1oS");
+    importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoErrors(
         trackerImportService.importTracker(
             params, fromJson("tracker/validations/te_relationship.json")));
     manager.flush();
+  }
+
+  @BeforeEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
   }
 
   @Test
@@ -70,7 +78,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -82,11 +89,11 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     RelationshipType relationshipType = manager.get(RelationshipType.class, "xLmPUYJX8Ks");
     relationshipType.getSharing().getUsers().remove(USER_11);
     manager.update(relationshipType);
+    injectSecurityContextUser(userService.getUser(USER_11));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -99,11 +106,11 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     Program program = manager.get(Program.class, "E8o1E9tAppy");
     program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_11));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -116,11 +123,11 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     Program program = manager.get(Program.class, "YYY1E9tAbbW");
     program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_11));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -132,7 +139,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -148,7 +154,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -156,6 +161,7 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
     RelationshipType relationshipType = manager.get(RelationshipType.class, "xLmPUYJX8Ks");
     relationshipType.getSharing().getUsers().remove(USER_11);
     manager.update(relationshipType);
+    injectSecurityContextUser(userService.getUser(USER_11));
 
     params.setImportStrategy(TrackerImportStrategy.DELETE);
     importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -169,7 +175,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -177,6 +182,7 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
     Program program = manager.get(Program.class, "E8o1E9tAppy");
     program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     params.setImportStrategy(TrackerImportStrategy.DELETE);
     importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -190,7 +196,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_11);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -198,6 +203,7 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
     Program program = manager.get(Program.class, "YYY1E9tAbbW");
     program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_11));
 
     params.setImportStrategy(TrackerImportStrategy.DELETE);
     importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -210,8 +216,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
   }
@@ -221,11 +225,10 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     RelationshipType relationshipType = manager.get(RelationshipType.class, "TV9oB9LT3sh");
     relationshipType.getSharing().getUsers().remove(USER_12);
     manager.update(relationshipType);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -237,11 +240,10 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     Program program = manager.get(Program.class, "E8o1E9tAppy");
     program.getSharing().getUsers().get(USER_12).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -253,11 +255,10 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     Program program = manager.get(Program.class, "YYY1E9tAbbW");
     program.getSharing().getUsers().remove(USER_12);
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -269,8 +270,6 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
 
@@ -288,14 +287,13 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
 
     RelationshipType relationshipType = manager.get(RelationshipType.class, "TV9oB9LT3sh");
     relationshipType.getSharing().getUsers().remove(USER_12);
     manager.update(relationshipType);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     params.setImportStrategy(TrackerImportStrategy.DELETE);
     importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -308,14 +306,13 @@ class RelationshipSecurityImportValidationTest extends TrackerTest {
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
     TrackerImportParams params = new TrackerImportParams();
-    params.setUserId(USER_12);
-
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
 
     Program program = manager.get(Program.class, "E8o1E9tAppy");
     program.getSharing().getUsers().get(USER_12).setAccess("r-r-----");
     manager.update(program);
+    injectSecurityContextUser(userService.getUser(USER_12));
 
     params.setImportStrategy(TrackerImportStrategy.DELETE);
     importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaEncryptionValidationTest.java
@@ -57,7 +57,7 @@ class TeTaEncryptionValidationTest extends TrackerTest {
 
   @Test
   void testUniqueFailInOrgUnit() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_unique_data_in_country.json");
 
@@ -81,7 +81,7 @@ class TeTaEncryptionValidationTest extends TrackerTest {
 
   @Test
   void testUniqueFail() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_unique_data.json");
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
@@ -76,7 +76,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testTrackedEntityProgramAttributeFileResourceValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     FileResource fileResource =
         new FileResource(
             "test.pdf",
@@ -105,7 +105,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testFileAlreadyAssign() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     FileResource fileResource =
         new FileResource(
             "test.pdf",
@@ -139,7 +139,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testNoFileRef() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_fileresource_data.json");
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -151,7 +151,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testTeaMaxTextValueLength() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_too_long_text_value.json");
 
@@ -162,7 +162,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testTeaInvalidFormat() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_invalid_format_value.json");
 
@@ -173,7 +173,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testTeaInvalidImage() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_invalid_image_value.json");
 
@@ -184,7 +184,7 @@ class TeTaValidationTest extends TrackerTest {
 
   @Test
   void testTeaIsNull() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_invalid_value_isnull.json");
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -76,9 +77,14 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     injectSecurityContextUser(importUser);
   }
 
+  @BeforeEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
+  }
+
   @Test
   void failValidationWhenTrackedEntityAttributeHasWrongOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-with_invalid_option_value.json");
 
@@ -89,7 +95,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void successValidationWhenTrackedEntityAttributeHasValidOptionValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-with_valid_option_value.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -99,7 +105,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void failValidationWhenTrackedEntityAttributesHaveSameUniqueValues() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-with_unique_attributes.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -109,7 +115,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testTeValidationOkAll() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -121,8 +127,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   void testNoCreateTeAccessOutsideCaptureScopeOu() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
     TrackerImportParams params = new TrackerImportParams();
-    User user = userService.getUser(USER_7);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_7));
     params.setAtomicMode(AtomicMode.OBJECT);
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertHasOnlyErrors(importReport, ValidationCode.E1000);
@@ -132,7 +137,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testUpdateAccessInSearchScopeOu() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -141,8 +146,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     assertEquals(3, importReport.getStats().getCreated());
 
     trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
-    User user = userService.getUser(USER_8);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_8));
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     params.setAtomicMode(AtomicMode.OBJECT);
     importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -152,7 +156,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testNoUpdateAccessOutsideSearchScopeOu() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -161,8 +165,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     assertEquals(3, importReport.getStats().getCreated());
 
     trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
-    User user = userService.getUser(USER_5);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_5));
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     params.setAtomicMode(AtomicMode.OBJECT);
 
@@ -177,8 +180,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   void testNoWriteAccessInAcl() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_ok.json");
     TrackerImportParams params = new TrackerImportParams();
-    User user = userService.getUser(USER_1);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_1));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
@@ -189,8 +191,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   void testWriteAccessInAclViaUserGroup() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_ok.json");
     TrackerImportParams params = new TrackerImportParams();
-    User user = userService.getUser(USER_3);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(userService.getUser(USER_3));
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
@@ -198,7 +199,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testGeoOk() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data_error_geo-ok.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -208,7 +209,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testTeAttrNonExistentAttr() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-data_error_attr-non-existing.json");
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -218,7 +219,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testDeleteCascadeEnrollments() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -227,8 +228,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     manager.flush();
     manager.clear();
     trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
-    User user2 = userService.getUser(USER_4);
-    params.setUserId(user2.getUid());
+    injectSecurityContextUser(userService.getUser(USER_4));
     params.setImportStrategy(TrackerImportStrategy.DELETE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -239,7 +239,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   @Test
   void shouldFailToDeleteWhenUserHasAccessToRegistrationUnitAndTEWasTransferred()
       throws IOException, ForbiddenException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -260,7 +260,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   void
       shouldFailToDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsNotInCaptureScope()
           throws IOException, ForbiddenException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -280,7 +280,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   @Test
   void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsInCaptureScope()
       throws IOException, ForbiddenException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -300,14 +300,13 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   @Test
   void shouldFailToUpdateWhenUserHasAccessToRegistrationUnitAndTEWasTransferred()
       throws IOException, ForbiddenException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
 
     trackerObjects = fromJson("tracker/validations/enrollments_te_enrollments-data_2.json");
     TrackerImportParams trackerImportParams = new TrackerImportParams();
-    trackerImportParams.setUserId(USER_8);
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
     assertNoErrors(importReport);
@@ -326,7 +325,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   @Test
   void shouldUpdateWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnit()
       throws IOException, ForbiddenException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
 
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -346,7 +345,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
 
   @Test
   void testTeDeleteOk() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data.json");
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -364,7 +363,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   }
 
   protected void importEnrollments() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/enrollments_te_enrollments-data.json");
 
@@ -376,7 +375,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-transferred-data-delete.json");
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.DELETE);
-    params.setUserId(user.getUid());
+    injectSecurityContextUser(user);
     return trackerImportService.importTracker(params, trackerObjects);
   }
 
@@ -386,7 +385,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     trackerObjects.getTrackedEntities().get(0).setTrackedEntity(trackedEntity);
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.UPDATE);
-    params.setUserId(userId);
+    injectSecurityContextUser(userService.getUser(userId));
     return trackerImportService.importTracker(params, trackerObjects);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerPostgresTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerPostgresTest.java
@@ -99,7 +99,7 @@ class TrackedEntitiesExportControllerPostgresTest extends PostgresControllerInte
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().userId(importUser.getUid()).build();
+    TrackerImportParams params = TrackerImportParams.builder().build();
     assertNoDataErrors(
         trackerImportService.importTracker(params, fromJson("tracker/single_te.json")));
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -62,7 +62,6 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -104,8 +103,6 @@ public class TrackerImportController {
 
   private final ObjectMapper jsonMapper;
 
-  private final UserService userService;
-
   @PostMapping(value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public WebMessage asyncPostJsonTracker(
@@ -116,7 +113,7 @@ public class TrackerImportController {
     String userUid = currentUserDetails.getUid();
 
     TrackerImportParams trackerImportParams =
-        TrackerImportParamsMapper.trackerImportParams(userUid, importRequestParams);
+        TrackerImportParamsMapper.trackerImportParams(importRequestParams);
     TrackerObjects trackerObjects =
         TrackerImportParamsMapper.trackerObjects(body, trackerImportParams.getIdSchemes());
 
@@ -157,11 +154,7 @@ public class TrackerImportController {
   public ResponseEntity<ImportReport> syncPostJsonTracker(
       ImportRequestParams importRequestParams, @RequestBody Body body) {
 
-    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-    String userUid = currentUserDetails.getUid();
-
-    TrackerImportParams params =
-        TrackerImportParamsMapper.trackerImportParams(userUid, importRequestParams);
+    TrackerImportParams params = TrackerImportParamsMapper.trackerImportParams(importRequestParams);
     TrackerObjects trackerObjects =
         TrackerImportParamsMapper.trackerObjects(body, params.getIdSchemes());
     ImportReport importReport =
@@ -197,7 +190,7 @@ public class TrackerImportController {
     Body body = Body.builder().events(events).build();
 
     TrackerImportParams trackerImportParams =
-        TrackerImportParamsMapper.trackerImportParams(userUid, importRequest);
+        TrackerImportParamsMapper.trackerImportParams(importRequest);
 
     TrackerObjects trackerObjects =
         TrackerImportParamsMapper.trackerObjects(body, trackerImportParams.getIdSchemes());
@@ -217,17 +210,13 @@ public class TrackerImportController {
       @RequestParam(required = false, defaultValue = "true") boolean skipFirst,
       @RequestParam(defaultValue = "errors", required = false) TrackerBundleReportMode reportMode)
       throws IOException, ParseException {
-
-    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-    String userUid = currentUserDetails.getUid();
-
     InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat(request.getInputStream());
 
     List<Event> events = csvEventService.read(inputStream, skipFirst);
     Body body = Body.builder().events(events).build();
 
     TrackerImportParams trackerImportParams =
-        TrackerImportParamsMapper.trackerImportParams(userUid, importRequest);
+        TrackerImportParamsMapper.trackerImportParams(importRequest);
     TrackerObjects trackerObjects =
         TrackerImportParamsMapper.trackerObjects(body, trackerImportParams.getIdSchemes());
     ImportReport importReport =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapper.java
@@ -57,8 +57,7 @@ public class TrackerImportParamsMapper {
 
   private TrackerImportParamsMapper() {}
 
-  public static TrackerImportParams trackerImportParams(
-      String userId, ImportRequestParams request) {
+  public static TrackerImportParams trackerImportParams(ImportRequestParams request) {
     TrackerIdSchemeParam defaultIdSchemeParam = request.getIdScheme();
     TrackerIdSchemeParams idSchemeParams =
         TrackerIdSchemeParams.builder()
@@ -85,8 +84,7 @@ public class TrackerImportParamsMapper {
             .flushMode(request.getFlushMode())
             .skipSideEffects(request.isSkipSideEffects())
             .skipRuleEngine(request.isSkipRuleEngine())
-            .reportMode(request.getReportMode())
-            .userId(userId);
+            .reportMode(request.getReportMode());
     return paramsBuilder.build();
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -64,7 +64,6 @@ import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.user.SystemUser;
-import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
@@ -96,7 +95,6 @@ class TrackerImportControllerTest {
   @Mock private JobSchedulerService jobSchedulerService;
 
   @Mock private JobConfigurationService jobConfigurationService;
-  @Mock private UserService userService;
 
   private RenderService renderService;
 
@@ -118,8 +116,7 @@ class TrackerImportControllerTest {
             notifier,
             jobSchedulerService,
             jobConfigurationService,
-            new ObjectMapper(),
-            userService);
+            new ObjectMapper());
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapperTest.java
@@ -62,7 +62,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().validationMode(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(params.getValidationMode(), is(e));
             });
   }
@@ -75,7 +75,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().importMode(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(params.getImportMode(), is(e));
             });
   }
@@ -88,7 +88,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().atomicMode(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(params.getAtomicMode(), is(e));
             });
   }
@@ -101,7 +101,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().flushMode(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(params.getFlushMode(), is(e));
             });
   }
@@ -114,7 +114,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().importStrategy(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(params.getImportStrategy(), is(e));
             });
   }
@@ -123,8 +123,7 @@ class TrackerImportParamsMapperTest {
   void testIdSchemeUsingIdSchemeName() {
     ImportRequestParams importRequestParams =
         ImportRequestParams.builder().idScheme(TrackerIdSchemeParam.NAME).build();
-    TrackerImportParams params =
-        TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+    TrackerImportParams params = TrackerImportParamsMapper.trackerImportParams(importRequestParams);
 
     TrackerIdSchemeParam expected = TrackerIdSchemeParam.NAME;
     assertEquals(expected, params.getIdSchemes().getIdScheme());
@@ -142,8 +141,7 @@ class TrackerImportParamsMapperTest {
         ImportRequestParams.builder()
             .idScheme(TrackerIdSchemeParam.ofAttribute("WSiOAALYocA"))
             .build();
-    TrackerImportParams params =
-        TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+    TrackerImportParams params = TrackerImportParamsMapper.trackerImportParams(importRequestParams);
 
     TrackerIdSchemeParam expected = TrackerIdSchemeParam.ofAttribute("WSiOAALYocA");
     assertEquals(expected, params.getIdSchemes().getIdScheme());
@@ -163,7 +161,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().orgUnitIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getOrgUnitIdScheme().getIdScheme(), is(e.getIdScheme()));
             });
@@ -177,7 +175,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().programIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getProgramIdScheme().getIdScheme(), is(e.getIdScheme()));
             });
@@ -189,8 +187,7 @@ class TrackerImportParamsMapperTest {
         ImportRequestParams.builder()
             .programIdScheme(TrackerIdSchemeParam.ofAttribute("WSiOAALYocA"))
             .build();
-    TrackerImportParams params =
-        TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+    TrackerImportParams params = TrackerImportParamsMapper.trackerImportParams(importRequestParams);
 
     assertEquals(
         TrackerIdSchemeParam.ofAttribute("WSiOAALYocA"),
@@ -205,7 +202,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().programStageIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getProgramStageIdScheme().getIdScheme(),
                   is(e.getIdScheme()));
@@ -220,7 +217,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().dataElementIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getDataElementIdScheme().getIdScheme(),
                   is(e.getIdScheme()));
@@ -235,7 +232,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().categoryOptionComboIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getCategoryOptionComboIdScheme().getIdScheme(),
                   is(e.getIdScheme()));
@@ -250,7 +247,7 @@ class TrackerImportParamsMapperTest {
               ImportRequestParams importRequestParams =
                   ImportRequestParams.builder().categoryOptionIdScheme(e).build();
               TrackerImportParams params =
-                  TrackerImportParamsMapper.trackerImportParams("userId", importRequestParams);
+                  TrackerImportParamsMapper.trackerImportParams(importRequestParams);
               assertThat(
                   params.getIdSchemes().getCategoryOptionIdScheme().getIdScheme(),
                   is(e.getIdScheme()));


### PR DESCRIPTION
`TrackerImportService` is always executed by the current user and can be retrieved using `CurrentUserUtil.getCurrentUserDetails()`. No matter if it runs in a `Job`, the current user is always correctly set.

This PR removes the `userId` field from the `TrackerImportParams` used to set the `User` for the `TrackerImportService` execution.
Instead, the `User` object is always created from `CurrentUserUtil.getCurrentUserDetails()`.

**NEXT**
- Continue harmonization on tracker importer. At the moment, we have `User`, `UserDetails` and `UserInfoSnapshot` used in different places.
- Harmonize exporters