### PR TITLE
ci: run all test on mvn test by default

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,8 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: maven
-      - name: Test core
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml
+      - name: Run unit tests
+        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3
@@ -65,7 +65,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -Pintegration --update-snapshots --file ./dhis-2/pom.xml
+        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure
@@ -116,7 +116,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -PintegrationH2 --update-snapshots --file ./dhis-2/pom.xml
+        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure

--- a/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
@@ -55,12 +55,12 @@
       <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/dhis-2/dhis-web-server/pom.xml
+++ b/dhis-2/dhis-web-server/pom.xml
@@ -75,6 +75,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.system.util.HttpHeadersBuilder;
+import org.hisp.dhis.test.IntegrationTest;
 import org.hisp.dhis.webapi.controller.security.LoginRequest;
 import org.hisp.dhis.webapi.controller.security.LoginResponse;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,6 +66,7 @@ import org.testcontainers.utility.DockerImageName;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Slf4j
+@IntegrationTest
 @ActiveProfiles(profiles = {"test-postgres"})
 class AuthTest {
   private static final String POSTGRES_POSTGIS_VERSION = "13-3.4-alpine";

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -72,10 +72,6 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <surefireArgLine>-Xmx2024m</surefireArgLine>
 
-    <!-- Needed so we can disable running tests when the default profile
-      is used (activated by default). It does not honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->
-    <skipTests>false</skipTests>
-
     <!-- *Build* -->
     <jib.version>3.4.3</jib.version>
     <jib.from.image>tomcat:10.1.30-jre21</jib.from.image>
@@ -1931,6 +1927,11 @@
           <version>${maven-surefire-plugin.version}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-report-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${maven-exec-plugin.version}</version>
@@ -2147,12 +2148,23 @@ jasperreports.version=${jasperreports.version}
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco-maven-plugin.version}</version>
+          <!-- disable the jacoco coverage agent if we skip running tests -->
+          <configuration>
+            <skip>${skipTests}</skip>
+          </configuration>
+          <executions>
+            <execution>
+              <id>prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
@@ -2357,14 +2369,6 @@ jasperreports.version=${jasperreports.version}
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
     <!-- <build><sourceDirectory> cannot be set in a profile, so it needs
@@ -2394,13 +2398,9 @@ jasperreports.version=${jasperreports.version}
   </reporting>
 
   <profiles>
-
-    <!-- Default profile, runs all unit tests, not integration tests -->
+    <!-- runs all unit tests -->
     <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
+      <id>unit-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2425,10 +2425,9 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- Integration test profile, runs all integrations tests, not unit
-      tests -->
+    <!-- runs all integration tests using Postgres DB -->
     <profile>
-      <id>integration</id>
+      <id>integration-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2451,10 +2450,9 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- IntegrationH2 test profile, runs all integrations tests with H2,
-      not unit tests -->
+    <!-- runs all integrations tests using H2 in-memory DB -->
     <profile>
-      <id>integrationH2</id>
+      <id>integration-h2-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2472,42 +2470,6 @@ jasperreports.version=${jasperreports.version}
                 <log4j2.configurationFile>log4j2-test.xml</log4j2.configurationFile>
               </systemPropertyVariables>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>dev</id>
-      <properties>
-        <skipTests>true</skipTests>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-              <trimStackTrace>false</trimStackTrace>
-              <argLine>@{argLine} ${surefireArgLine}</argLine>
-              <excludedGroups>integration,integrationH2</excludedGroups>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>jrebel-maven-plugin</artifactId>
-            <version>${jrebel-x-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>generate-rebel-xml</id>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration/>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>
@@ -2547,7 +2509,5 @@ jasperreports.version=${jasperreports.version}
         </plugins>
       </build>
     </profile>
-
   </profiles>
-
 </project>

--- a/dhis-2/run-api.sh
+++ b/dhis-2/run-api.sh
@@ -59,7 +59,7 @@ function build_dhis2() {
     --file "$(dirname "$0")/pom.xml" \
     --batch-mode --threads 100C \
     -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true \
-    --activate-profiles dev,embedded
+    --activate-profiles embedded
 }
 
 # Read command line options

--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -47,7 +47,7 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --activate-profiles -default --update-snapshots'
+                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -37,7 +37,7 @@ pipeline {
                     gitHelper.setCommitStatus("${env.DHIS2_COMMIT_SHA}", "${env.DHIS2_REPO_URL}")
 
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --activate-profiles -default --update-snapshots'
+                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -26,7 +26,7 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --activate-profiles -default --update-snapshots'
+                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -52,7 +52,7 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --activate-profiles -default --update-snapshots'
+                        sh 'mvn --threads 4 --batch-mode --no-transfer-progress clean install --file dhis-2/pom.xml --activate-profiles --update-snapshots'
                     }
                 }
             }


### PR DESCRIPTION
Before we had to add `--activate-profiles -default` which excludes the `default` profile to run all tests. That is confusing. The default is now that we run all types of tests by default. This way we cannot miss any tests in a pipeline due to forgetting to remove the default profile. So with these changes

* `mvn test` - runs all tests
* `mvn test --activate-profiles unit-test` - only runs unit tests
* `mvn test --activate-profiles integration-test` - only runs postgres integration tests annotated with `@Integration`
* `mvn test --activate-profiles integration-h2-test` - only runs H2 integration tests annotated with `@IntegrationH2`

On Jenkins we simply do `mvn clean install` which runs all tests and creates the war. We can do that since the machines running Jenkins have more resources than the ones on GH. On GitHub we already ran each of these types of tests in a concurrent job. It should now be easier to understand as each category has its own maven profile.

* `AuthTest` was not properly classified as an integration test. Now it will run with all and in the `integration-test` profile.
* Disable the jacoco test coverage agent when not running tests.
* Use the same version for the `maven-surefire-report-plugin` as the `maven-surefire-plugin` running tests and producing xml files the report plugin should be able to parse.
* Remove unused `dev` profile in `pom.xml`.
* Use long form options in scripts so they are easier to read without a man page/help.

## Cross-check

I made sure the number of tests when no profile is active and each profile is run individually adds up.

### Method

Run all tests and each category on its own

* all `mvn clean test --file ./dhis-2/pom.xml`
* unit `mvn clean test --file dhis-2/pom.xml --activate-profiles unit-test`
* integration `mvn clean test --file dhis-2/pom.xml --activate-profiles integration-test`
* integration h2 `mvn clean test --file dhis-2/pom.xml --activate-profiles integration-h2-test`

from the same [commit](https://github.com/dhis2/dhis2-core/tree/ae2685320bb330b1d44e7c3a10375c804f41187f).

For each of the runs capture the build log and the surefire aggregate report

    mvn surefire-report:report-only -Daggregate=true --file ./dhis-2/pom.xml

Get the totals for all and each category via build log and surefire aggregate reports. I am only posting the aggregate report numbers as they are the same as in the build logs.

| Profile              | Tests | Errors | Failures | Skipped | Success Rate | Time    |
|----------------------|-------|--------|----------|---------|--------------|---------|
| unit-test            | 4477  | 0      | 0        | 4       | 99.9%        | 182.6 s |
| integration-test     | 3606  | 0      | 0        | 109     | 97.0%        | 664.3 s |
| integration-h2-test  | 1397  | 0      | 0        | 8       | 99.4%        | 291.2 s |
|----------------------|-------|--------|----------|---------|--------------|---------|
| **No profile (all tests)** | **9480** | **0**    | **0**    | **121**  | **98.7%**  | **1222 s**  |

