### PR TITLE
chore: automatically add tracker-backend as reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,5 @@ jenkinsfiles/** @dhis2/devops
 docker-compose.yml @dhis2/devops
 
 jib.yaml @dhis2/devops
+
+dhis-2/dhis-services/dhis-service-tracker/** @dhis2/tracker-backend


### PR DESCRIPTION
to changes in code that is clearly owned by the tracker team. I do not want to invest much time in making this an exhaustive list. When we reduced the number of modules we should cover most of our code with one or two lines.