### PR TITLE
fix: Harmonize user in tracker exporters [DHIS2-18001]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.common;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-
 import java.util.Collections;
 import java.util.Set;
 import lombok.Value;
@@ -41,7 +39,7 @@ import lombok.Value;
 public class AssignedUserQueryParam {
 
   public static final AssignedUserQueryParam ALL =
-      new AssignedUserQueryParam(AssignedUserSelectionMode.ALL, Collections.emptySet());
+      new AssignedUserQueryParam(AssignedUserSelectionMode.ALL, Collections.emptySet(), null);
 
   private final AssignedUserSelectionMode mode;
 
@@ -53,7 +51,8 @@ public class AssignedUserQueryParam {
    * @param mode assigned user mode
    * @param assignedUsers assigned user uids
    */
-  public AssignedUserQueryParam(AssignedUserSelectionMode mode, Set<String> assignedUsers) {
+  public AssignedUserQueryParam(
+      AssignedUserSelectionMode mode, Set<String> assignedUsers, String userUid) {
     if (mode == AssignedUserSelectionMode.PROVIDED
         && (assignedUsers == null || assignedUsers.isEmpty())) {
       throw new IllegalQueryException(
@@ -70,7 +69,7 @@ public class AssignedUserQueryParam {
 
     if (mode == AssignedUserSelectionMode.CURRENT) {
       this.mode = AssignedUserSelectionMode.PROVIDED;
-      this.assignedUsers = Collections.singleton(getCurrentUserDetails().getUid());
+      this.assignedUsers = Collections.singleton(userUid);
     } else if ((mode == null || mode == AssignedUserSelectionMode.PROVIDED)
         && (assignedUsers != null && !assignedUsers.isEmpty())) {
       this.mode = AssignedUserSelectionMode.PROVIDED;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.tracker.export;
 
 import static org.hisp.dhis.changelog.ChangeLogType.READ;
 import static org.hisp.dhis.security.Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -48,8 +46,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.deprecated.audit.TrackedEntityAuditService;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -78,38 +75,40 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if a validation error occurs for any of the three aforementioned
    *     modes
    */
-  public static void validateOrgUnitMode(OrganisationUnitSelectionMode orgUnitMode, Program program)
+  public static void validateOrgUnitMode(
+      OrganisationUnitSelectionMode orgUnitMode, Program program, UserDetails user)
       throws BadRequestException {
     switch (orgUnitMode) {
-      case ALL -> validateUserCanSearchOrgUnitModeALL();
-      case SELECTED, ACCESSIBLE, DESCENDANTS, CHILDREN -> validateUserScope(program);
-      case CAPTURE -> validateCaptureScope();
+      case ALL -> validateUserCanSearchOrgUnitModeALL(user);
+      case SELECTED, ACCESSIBLE, DESCENDANTS, CHILDREN -> validateUserScope(program, user);
+      case CAPTURE -> validateCaptureScope(user);
     }
   }
 
-  private static void validateUserCanSearchOrgUnitModeALL() throws BadRequestException {
-    if (!CurrentUserUtil.getCurrentUserDetails()
-        .isAuthorized(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS)) {
+  private static void validateUserCanSearchOrgUnitModeALL(UserDetails user)
+      throws BadRequestException {
+    if (!user.isAuthorized(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS)) {
       throw new BadRequestException(
           "Current user is not authorized to query across all organisation units");
     }
   }
 
-  private static void validateUserScope(Program program) throws BadRequestException {
+  private static void validateUserScope(Program program, UserDetails user)
+      throws BadRequestException {
 
     if (program != null && (program.isClosed() || program.isProtected())) {
-      if (getCurrentUserDetails().getUserOrgUnitIds().isEmpty()) {
+      if (user.getUserOrgUnitIds().isEmpty()) {
         throw new BadRequestException("User needs to be assigned data capture org units");
       }
 
-    } else if (getCurrentUserDetails().getUserEffectiveSearchOrgUnitIds().isEmpty()) {
+    } else if (user.getUserEffectiveSearchOrgUnitIds().isEmpty()) {
       throw new BadRequestException(
           "User needs to be assigned either search or data capture org units");
     }
   }
 
-  private static void validateCaptureScope() throws BadRequestException {
-    if (getCurrentUserDetails().getUserOrgUnitIds().isEmpty()) {
+  private static void validateCaptureScope(UserDetails user) throws BadRequestException {
+    if (user.getUserOrgUnitIds().isEmpty()) {
       throw new BadRequestException("User needs to be assigned data capture org units");
     }
   }
@@ -122,9 +121,9 @@ public class OperationsParamsValidator {
    * @throws ForbiddenException if the user has no data read access to the program or its tracked
    *     entity type
    */
-  public Program validateTrackerProgram(String programUid)
+  public Program validateTrackerProgram(String programUid, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program = validateProgramAccess(programUid);
+    Program program = validateProgramAccess(programUid, user);
 
     if (program == null) {
       return null;
@@ -135,7 +134,7 @@ public class OperationsParamsValidator {
     }
 
     if (program.getTrackedEntityType() != null
-        && !aclService.canDataRead(getCurrentUserDetails(), program.getTrackedEntityType())) {
+        && !aclService.canDataRead(user, program.getTrackedEntityType())) {
       throw new ForbiddenException(
           "Current user is not authorized to read data from selected program's tracked entity type: "
               + program.getTrackedEntityType().getUid());
@@ -152,7 +151,7 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the program uid does not exist
    * @throws ForbiddenException if the user has no data read access to the program
    */
-  public Program validateProgramAccess(String programUid)
+  public Program validateProgramAccess(String programUid, UserDetails user)
       throws BadRequestException, ForbiddenException {
     if (programUid == null) {
       return null;
@@ -163,7 +162,7 @@ public class OperationsParamsValidator {
       throw new BadRequestException("Program is specified but does not exist: " + programUid);
     }
 
-    if (!aclService.canDataRead(getCurrentUserDetails(), program)) {
+    if (!aclService.canDataRead(user, program)) {
       throw new ForbiddenException("User has no access to program: " + program.getUid());
     }
 
@@ -177,7 +176,7 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the tracked entity uid does not exist
    * @throws ForbiddenException if the user has no data read access to type of the tracked entity
    */
-  public TrackedEntity validateTrackedEntity(String trackedEntityUid, User user)
+  public TrackedEntity validateTrackedEntity(String trackedEntityUid, UserDetails user)
       throws BadRequestException, ForbiddenException {
     if (trackedEntityUid == null) {
       return null;
@@ -189,7 +188,7 @@ public class OperationsParamsValidator {
       throw new BadRequestException(
           "Tracked entity is specified but does not exist: " + trackedEntityUid);
     }
-    trackedEntityAuditService.addTrackedEntityAudit(trackedEntity, getCurrentUsername(), READ);
+    trackedEntityAuditService.addTrackedEntityAudit(trackedEntity, user.getUsername(), READ);
 
     if (trackedEntity.getTrackedEntityType() != null
         && !aclService.canDataRead(user, trackedEntity.getTrackedEntityType())) {
@@ -208,7 +207,7 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the tracked entity type uid does not exist
    * @throws ForbiddenException if the user has no data read access to the tracked entity type
    */
-  public TrackedEntityType validateTrackedEntityType(String uid)
+  public TrackedEntityType validateTrackedEntityType(String uid, UserDetails user)
       throws BadRequestException, ForbiddenException {
     if (uid == null) {
       return null;
@@ -219,7 +218,7 @@ public class OperationsParamsValidator {
       throw new BadRequestException("Tracked entity type is specified but does not exist: " + uid);
     }
 
-    if (!aclService.canDataRead(getCurrentUserDetails(), trackedEntityType)) {
+    if (!aclService.canDataRead(user, trackedEntityType)) {
       throw new ForbiddenException(
           "Current user is not authorized to read data from selected tracked entity type: "
               + trackedEntityType.getUid());
@@ -235,7 +234,7 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the org unit uid does not exist
    * @throws ForbiddenException if the org unit is not part of the user scope
    */
-  public Set<OrganisationUnit> validateOrgUnits(Set<String> orgUnitIds)
+  public Set<OrganisationUnit> validateOrgUnits(Set<String> orgUnitIds, UserDetails user)
       throws BadRequestException, ForbiddenException {
     Set<OrganisationUnit> orgUnits = new HashSet<>();
     for (String orgUnitUid : orgUnitIds) {
@@ -244,8 +243,7 @@ public class OperationsParamsValidator {
         throw new BadRequestException("Organisation unit does not exist: " + orgUnitUid);
       }
 
-      if (!getCurrentUserDetails().isSuper()
-          && !getCurrentUserDetails().isInUserEffectiveSearchOrgUnitHierarchy(orgUnit.getPath())) {
+      if (!user.isSuper() && !user.isInUserEffectiveSearchOrgUnitHierarchy(orgUnit.getPath())) {
         throw new ForbiddenException(
             "Organisation unit is not part of the search scope: " + orgUnit.getUid());
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
@@ -89,7 +89,7 @@ public class OperationsParamsValidator {
       throws BadRequestException {
     if (!user.isAuthorized(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS)) {
       throw new BadRequestException(
-          "Current user is not authorized to query across all organisation units");
+          "User is not authorized to query across all organisation units");
     }
   }
 
@@ -136,7 +136,7 @@ public class OperationsParamsValidator {
     if (program.getTrackedEntityType() != null
         && !aclService.canDataRead(user, program.getTrackedEntityType())) {
       throw new ForbiddenException(
-          "Current user is not authorized to read data from selected program's tracked entity type: "
+          "User is not authorized to read data from selected program's tracked entity type: "
               + program.getTrackedEntityType().getUid());
     }
 
@@ -193,7 +193,7 @@ public class OperationsParamsValidator {
     if (trackedEntity.getTrackedEntityType() != null
         && !aclService.canDataRead(user, trackedEntity.getTrackedEntityType())) {
       throw new ForbiddenException(
-          "Current user is not authorized to read data from type of selected tracked entity: "
+          "User is not authorized to read data from type of selected tracked entity: "
               + trackedEntity.getTrackedEntityType().getUid());
     }
 
@@ -220,7 +220,7 @@ public class OperationsParamsValidator {
 
     if (!aclService.canDataRead(user, trackedEntityType)) {
       throw new ForbiddenException(
-          "Current user is not authorized to read data from selected tracked entity type: "
+          "User is not authorized to read data from selected tracked entity type: "
               + trackedEntityType.getUid());
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -74,12 +74,14 @@ class DefaultEnrollmentService implements EnrollmentService {
   private final EnrollmentOperationParamsMapper paramsMapper;
 
   @Override
-  public Enrollment getEnrollment(String uid) throws ForbiddenException, NotFoundException {
+  public Enrollment getEnrollment(@Nonnull String uid)
+      throws ForbiddenException, NotFoundException {
     return getEnrollment(uid, EnrollmentParams.FALSE, false);
   }
 
   @Override
-  public Enrollment getEnrollment(String uid, EnrollmentParams params, boolean includeDeleted)
+  public Enrollment getEnrollment(
+      @Nonnull String uid, @Nonnull EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
     UserDetails currentUser = getCurrentUserDetails();
     Enrollment enrollment = enrollmentStore.getByUid(uid);
@@ -99,9 +101,9 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   private Enrollment getEnrollment(
       @Nonnull Enrollment enrollment,
-      EnrollmentParams params,
+      @Nonnull EnrollmentParams params,
       boolean includeDeleted,
-      UserDetails currentUser) {
+      @Nonnull UserDetails user) {
 
     Enrollment result = new Enrollment();
     result.setId(enrollment.getId());
@@ -131,16 +133,15 @@ class DefaultEnrollmentService implements EnrollmentService {
     result.setDeleted(enrollment.isDeleted());
     result.setNotes(enrollment.getNotes());
     if (params.isIncludeEvents()) {
-      result.setEvents(getEvents(currentUser, enrollment, includeDeleted));
+      result.setEvents(getEvents(user, enrollment, includeDeleted));
     }
     if (params.isIncludeRelationships()) {
-      result.setRelationshipItems(getRelationshipItems(currentUser, enrollment, includeDeleted));
+      result.setRelationshipItems(getRelationshipItems(user, enrollment, includeDeleted));
     }
     if (params.isIncludeAttributes()) {
       result
           .getTrackedEntity()
-          .setTrackedEntityAttributeValues(
-              getTrackedEntityAttributeValues(currentUser, enrollment));
+          .setTrackedEntityAttributeValues(getTrackedEntityAttributeValues(user, enrollment));
     }
 
     return result;
@@ -148,7 +149,8 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   public RelationshipItem getEnrollmentInRelationshipItem(
-      String uid, EnrollmentParams params, boolean includeDeleted) throws NotFoundException {
+      @Nonnull String uid, @Nonnull EnrollmentParams params, boolean includeDeleted)
+      throws NotFoundException {
 
     RelationshipItem relationshipItem = new RelationshipItem();
     Enrollment enrollment = enrollmentStore.getByUid(uid);
@@ -248,7 +250,7 @@ class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  public List<Enrollment> getEnrollments(EnrollmentOperationParams params)
+  public List<Enrollment> getEnrollments(@Nonnull EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 
@@ -260,7 +262,8 @@ class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  public Page<Enrollment> getEnrollments(EnrollmentOperationParams params, PageParams pageParams)
+  public Page<Enrollment> getEnrollments(
+      @Nonnull EnrollmentOperationParams params, PageParams pageParams)
       throws ForbiddenException, BadRequestException, NotFoundException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrg
 
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -59,7 +60,8 @@ class EnrollmentOperationParamsMapper {
   private final OperationsParamsValidator paramsValidator;
 
   @Transactional(readOnly = true)
-  public EnrollmentQueryParams map(EnrollmentOperationParams operationParams, UserDetails user)
+  public EnrollmentQueryParams map(
+      @Nonnull EnrollmentOperationParams operationParams, @Nonnull UserDetails user)
       throws BadRequestException, ForbiddenException {
     Program program = paramsValidator.validateTrackerProgram(operationParams.getProgramUid(), user);
     TrackedEntityType trackedEntityType =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -39,13 +39,9 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.UserDetails;
 
 public interface EnrollmentService {
   Enrollment getEnrollment(String uid) throws ForbiddenException, NotFoundException;
-
-  Enrollment getEnrollment(String uid, UserDetails currentUser)
-      throws ForbiddenException, NotFoundException;
 
   Enrollment getEnrollment(String uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -81,7 +81,7 @@ class DefaultEventService implements EventService {
   private final EventOperationParamsMapper paramsMapper;
 
   @Override
-  public FileResourceStream getFileResource(UID event, UID dataElement)
+  public FileResourceStream getFileResource(@Nonnull UID event, @Nonnull UID dataElement)
       throws NotFoundException, ForbiddenException {
     FileResource fileResource = getFileResourceMetadata(event, dataElement);
     return FileResourceStream.of(fileResourceService, fileResource);
@@ -89,7 +89,7 @@ class DefaultEventService implements EventService {
 
   @Override
   public FileResourceStream getFileResourceImage(
-      UID event, UID dataElement, ImageFileDimension dimension)
+      @Nonnull UID event, @Nonnull UID dataElement, ImageFileDimension dimension)
       throws NotFoundException, ForbiddenException {
     FileResource fileResource = getFileResourceMetadata(event, dataElement);
     return FileResourceStream.ofImage(fileResourceService, fileResource, dimension);
@@ -137,13 +137,13 @@ class DefaultEventService implements EventService {
   }
 
   @Override
-  public Event getEvent(@Nonnull UID event, UserDetails user)
+  public Event getEvent(@Nonnull UID event, @Nonnull UserDetails user)
       throws ForbiddenException, NotFoundException {
     return getEvent(event, EventParams.FALSE, user);
   }
 
   @Override
-  public Event getEvent(@Nonnull UID event, EventParams eventParams)
+  public Event getEvent(@Nonnull UID event, @Nonnull EventParams eventParams)
       throws ForbiddenException, NotFoundException {
     return getEvent(event, eventParams, CurrentUserUtil.getCurrentUserDetails());
   }
@@ -163,7 +163,7 @@ class DefaultEventService implements EventService {
     return getEvent(event, eventParams, user);
   }
 
-  private Event getEvent(@Nonnull Event event, EventParams eventParams, UserDetails currentUser) {
+  private Event getEvent(@Nonnull Event event, EventParams eventParams, UserDetails user) {
     Event result = new Event();
     result.setId(event.getId());
     result.setUid(event.getUid());
@@ -221,7 +221,7 @@ class DefaultEventService implements EventService {
 
       for (RelationshipItem relationshipItem : event.getRelationshipItems()) {
         Relationship daoRelationship = relationshipItem.getRelationship();
-        if (trackerAccessManager.canRead(currentUser, daoRelationship).isEmpty()
+        if (trackerAccessManager.canRead(user, daoRelationship).isEmpty()
             && (!daoRelationship.isDeleted())) {
           relationshipItems.add(relationshipItem);
         }
@@ -234,22 +234,23 @@ class DefaultEventService implements EventService {
   }
 
   @Override
-  public List<Event> getEvents(EventOperationParams operationParams)
+  public List<Event> getEvents(@Nonnull EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     return eventStore.getEvents(queryParams);
   }
 
   @Override
-  public Page<Event> getEvents(EventOperationParams operationParams, PageParams pageParams)
+  public Page<Event> getEvents(
+      @Nonnull EventOperationParams operationParams, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     return eventStore.getEvents(queryParams, pageParams);
   }
 
   @Override
-  public RelationshipItem getEventInRelationshipItem(String uid, EventParams eventParams)
-      throws NotFoundException {
+  public RelationshipItem getEventInRelationshipItem(
+      @Nonnull String uid, @Nonnull EventParams eventParams) throws NotFoundException {
     RelationshipItem relationshipItem = new RelationshipItem();
 
     Event event = manager.get(Event.class, uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -236,14 +236,14 @@ class DefaultEventService implements EventService {
   @Override
   public List<Event> getEvents(EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
-    EventQueryParams queryParams = paramsMapper.map(operationParams);
+    EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     return eventStore.getEvents(queryParams);
   }
 
   @Override
   public Page<Event> getEvents(EventOperationParams operationParams, PageParams pageParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
-    EventQueryParams queryParams = paramsMapper.map(operationParams);
+    EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     return eventStore.getEvents(queryParams, pageParams);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrg
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserQueryParam;
@@ -79,7 +80,8 @@ class EventOperationParamsMapper {
   private final OperationsParamsValidator paramsValidator;
 
   @Transactional(readOnly = true)
-  public EventQueryParams map(EventOperationParams operationParams, UserDetails user)
+  public EventQueryParams map(
+      @Nonnull EventOperationParams operationParams, @Nonnull UserDetails user)
       throws BadRequestException, ForbiddenException {
     Program program = paramsValidator.validateProgramAccess(operationParams.getProgramUid(), user);
     ProgramStage programStage = validateProgramStage(operationParams.getProgramStageUid(), user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -114,7 +114,9 @@ class EventOperationParamsMapper {
         .setOrgUnitMode(operationParams.getOrgUnitMode())
         .setAssignedUserQueryParam(
             new AssignedUserQueryParam(
-                operationParams.getAssignedUserMode(), operationParams.getAssignedUsers()))
+                operationParams.getAssignedUserMode(),
+                operationParams.getAssignedUsers(),
+                user.getUid()))
         .setOccurredStartDate(operationParams.getOccurredAfter())
         .setOccurredEndDate(operationParams.getOccurredBefore())
         .setScheduledStartDate(operationParams.getScheduledAfter())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -59,7 +59,7 @@ public class DefaultRelationshipService implements RelationshipService {
   private final RelationshipOperationParamsMapper mapper;
 
   @Override
-  public List<Relationship> getRelationships(RelationshipOperationParams params)
+  public List<Relationship> getRelationships(@Nonnull RelationshipOperationParams params)
       throws ForbiddenException, NotFoundException, BadRequestException {
     RelationshipQueryParams queryParams = mapper.map(params);
 
@@ -68,7 +68,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   @Override
   public Page<Relationship> getRelationships(
-      RelationshipOperationParams params, PageParams pageParams)
+      @Nonnull RelationshipOperationParams params, @Nonnull PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException {
     RelationshipQueryParams queryParams = mapper.map(params);
 
@@ -76,7 +76,8 @@ public class DefaultRelationshipService implements RelationshipService {
   }
 
   @Override
-  public Relationship getRelationship(String uid) throws ForbiddenException, NotFoundException {
+  public Relationship getRelationship(@Nonnull String uid)
+      throws ForbiddenException, NotFoundException {
     Relationship relationship = relationshipStore.getByUid(uid);
 
     if (relationship == null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
@@ -54,7 +55,7 @@ class RelationshipOperationParamsMapper {
   private final TrackerAccessManager accessManager;
 
   @Transactional(readOnly = true)
-  public RelationshipQueryParams map(RelationshipOperationParams params)
+  public RelationshipQueryParams map(@Nonnull RelationshipOperationParams params)
       throws NotFoundException, ForbiddenException, BadRequestException {
 
     IdentifiableObject entity =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -27,21 +27,16 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventService;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,11 +57,9 @@ class RelationshipOperationParamsMapper {
   public RelationshipQueryParams map(RelationshipOperationParams params)
       throws NotFoundException, ForbiddenException, BadRequestException {
 
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-
     IdentifiableObject entity =
         switch (params.getType()) {
-          case TRACKED_ENTITY -> validateTrackedEntity(currentUser, params.getIdentifier());
+          case TRACKED_ENTITY -> trackedEntityService.getTrackedEntity(params.getIdentifier());
           case ENROLLMENT -> enrollmentService.getEnrollment(params.getIdentifier());
           case EVENT -> eventService.getEvent(UID.of(params.getIdentifier()));
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
@@ -77,21 +70,5 @@ class RelationshipOperationParamsMapper {
         .order(params.getOrder())
         .includeDeleted(params.isIncludeDeleted())
         .build();
-  }
-
-  private TrackedEntity validateTrackedEntity(UserDetails user, String uid)
-      throws NotFoundException, ForbiddenException, BadRequestException {
-    TrackedEntity trackedEntity =
-        trackedEntityService.getTrackedEntity(uid, null, TrackedEntityParams.FALSE, false);
-    if (trackedEntity == null) {
-      throw new NotFoundException(TrackedEntity.class, uid);
-    }
-
-    List<String> errors = accessManager.canRead(user, trackedEntity);
-    if (!errors.isEmpty()) {
-      throw new ForbiddenException(TrackedEntity.class, uid);
-    }
-
-    return trackedEntity;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -123,8 +123,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
       PageParams pageParams)
       throws NotFoundException, ForbiddenException, BadRequestException {
     TrackedEntity trackedEntity =
-        trackedEntityService.getTrackedEntity(
-            trackedEntityUid.getValue(), null, TrackedEntityParams.FALSE, false);
+        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue());
     if (trackedEntity == null) {
       throw new NotFoundException(TrackedEntity.class, trackedEntityUid.getValue());
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -209,7 +209,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public TrackedEntity getTrackedEntity(String uid) throws NotFoundException, ForbiddenException {
-    return getTrackedEntity(uid, null);
+    return getTrackedEntity(uid, CurrentUserUtil.getCurrentUserDetails());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -208,6 +208,11 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
+  public TrackedEntity getTrackedEntity(String uid) throws NotFoundException, ForbiddenException {
+    return getTrackedEntity(uid, null);
+  }
+
+  @Override
   public TrackedEntity getTrackedEntity(
       String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
@@ -468,7 +473,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   @Override
   public List<TrackedEntity> getTrackedEntities(TrackedEntityOperationParams operationParams)
       throws ForbiddenException, NotFoundException, BadRequestException {
-    TrackedEntityQueryParams queryParams = mapper.map(operationParams);
+    TrackedEntityQueryParams queryParams = mapper.map(operationParams, getCurrentUserDetails());
     final List<Long> ids = getTrackedEntityIds(queryParams);
 
     List<TrackedEntity> trackedEntities =
@@ -492,7 +497,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   public Page<TrackedEntity> getTrackedEntities(
       TrackedEntityOperationParams operationParams, PageParams pageParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
-    TrackedEntityQueryParams queryParams = mapper.map(operationParams);
+    TrackedEntityQueryParams queryParams = mapper.map(operationParams, getCurrentUserDetails());
     final Page<Long> ids = getTrackedEntityIds(queryParams, pageParams);
 
     List<TrackedEntity> trackedEntities =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
@@ -109,14 +110,18 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public FileResourceStream getFileResource(
-      UID trackedEntity, UID attribute, @CheckForNull UID program) throws NotFoundException {
+      @Nonnull UID trackedEntity, @Nonnull UID attribute, @CheckForNull UID program)
+      throws NotFoundException {
     FileResource fileResource = getFileResourceMetadata(trackedEntity, attribute, program);
     return FileResourceStream.of(fileResourceService, fileResource);
   }
 
   @Override
   public FileResourceStream getFileResourceImage(
-      UID trackedEntity, UID attribute, @CheckForNull UID program, ImageFileDimension dimension)
+      @Nonnull UID trackedEntity,
+      @Nonnull UID attribute,
+      @CheckForNull UID program,
+      ImageFileDimension dimension)
       throws NotFoundException {
     FileResource fileResource = getFileResourceMetadata(trackedEntity, attribute, program);
     return FileResourceStream.ofImage(fileResourceService, fileResource, dimension);
@@ -208,13 +213,25 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  public TrackedEntity getTrackedEntity(String uid) throws NotFoundException, ForbiddenException {
-    return getTrackedEntity(uid, CurrentUserUtil.getCurrentUserDetails());
+  public TrackedEntity getTrackedEntity(@Nonnull String uid)
+      throws NotFoundException, ForbiddenException {
+    UserDetails currentUser = getCurrentUserDetails();
+    TrackedEntity trackedEntity =
+        mapTrackedEntity(
+            getTrackedEntity(uid, currentUser),
+            TrackedEntityParams.FALSE,
+            currentUser,
+            null,
+            false);
+    mapTrackedEntityTypeAttributes(trackedEntity);
+    return trackedEntity;
   }
 
   @Override
   public TrackedEntity getTrackedEntity(
-      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
+      @Nonnull String uid,
+      @CheckForNull String programIdentifier,
+      @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException {
     Program program = null;
 
@@ -227,7 +244,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     TrackedEntity trackedEntity;
     if (program != null) {
-      trackedEntity = getTrackedEntity(uid, program, params, includeDeleted);
+      trackedEntity = getTrackedEntity(uid, program, params);
 
       if (params.isIncludeProgramOwners()) {
         Set<TrackedEntityProgramOwner> filteredProgramOwners =
@@ -240,8 +257,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UserDetails userDetails = getCurrentUserDetails();
 
       trackedEntity =
-          mapTrackedEntity(
-              getTrackedEntity(uid, userDetails), params, userDetails, null, includeDeleted);
+          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, null, false);
 
       mapTrackedEntityTypeAttributes(trackedEntity);
     }
@@ -255,8 +271,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
    * @throws NotFoundException if uid does not exist
    * @throws ForbiddenException if TE owner is not in user's scope or not enough sharing access
    */
-  private TrackedEntity getTrackedEntity(
-      String uid, Program program, TrackedEntityParams params, boolean includeDeleted)
+  private TrackedEntity getTrackedEntity(String uid, Program program, TrackedEntityParams params)
       throws NotFoundException, ForbiddenException {
     TrackedEntity trackedEntity = trackedEntityStore.getByUid(uid);
     trackedEntityAuditService.addTrackedEntityAudit(trackedEntity, getCurrentUsername(), READ);
@@ -278,7 +293,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       throw new ForbiddenException(error);
     }
 
-    return mapTrackedEntity(trackedEntity, params, userDetails, program, includeDeleted);
+    return mapTrackedEntity(trackedEntity, params, userDetails, program, false);
   }
 
   /**
@@ -322,7 +337,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   private TrackedEntity mapTrackedEntity(
       TrackedEntity trackedEntity,
       TrackedEntityParams params,
-      UserDetails currentUser,
+      UserDetails user,
       Program program,
       boolean includeDeleted) {
     TrackedEntity result = new TrackedEntity();
@@ -343,10 +358,10 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     result.setLastUpdatedByUserInfo(trackedEntity.getLastUpdatedByUserInfo());
     result.setGeometry(trackedEntity.getGeometry());
     if (params.isIncludeRelationships()) {
-      result.setRelationshipItems(getRelationshipItems(trackedEntity, currentUser, includeDeleted));
+      result.setRelationshipItems(getRelationshipItems(trackedEntity, user, includeDeleted));
     }
     if (params.isIncludeEnrollments()) {
-      result.setEnrollments(getEnrollments(trackedEntity, currentUser, includeDeleted, program));
+      result.setEnrollments(getEnrollments(trackedEntity, user, includeDeleted, program));
     }
     if (params.isIncludeProgramOwners()) {
       result.setProgramOwners(trackedEntity.getProgramOwners());
@@ -471,7 +486,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  public List<TrackedEntity> getTrackedEntities(TrackedEntityOperationParams operationParams)
+  public List<TrackedEntity> getTrackedEntities(
+      @Nonnull TrackedEntityOperationParams operationParams)
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityQueryParams queryParams = mapper.map(operationParams, getCurrentUserDetails());
     final List<Long> ids = getTrackedEntityIds(queryParams);
@@ -495,7 +511,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public Page<TrackedEntity> getTrackedEntities(
-      TrackedEntityOperationParams operationParams, PageParams pageParams)
+      @Nonnull TrackedEntityOperationParams operationParams, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityQueryParams queryParams = mapper.map(operationParams, getCurrentUserDetails());
     final Page<Long> ids = getTrackedEntityIds(queryParams, pageParams);
@@ -532,7 +548,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
    */
   private void mapRelationshipItems(
       List<TrackedEntity> trackedEntities, TrackedEntityParams params, boolean includeDeleted)
-      throws ForbiddenException, NotFoundException {
+      throws NotFoundException {
     if (params.isIncludeRelationships()) {
       for (TrackedEntity trackedEntity : trackedEntities) {
         mapRelationshipItems(trackedEntity, includeDeleted);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -657,12 +657,11 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    */
   private void handleOrganisationUnits(TrackedEntityQueryParams params) {
     UserDetails user = getCurrentUserDetails();
-    if (user != null && params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {
+    if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {
       params.setOrgUnits(
           new HashSet<>(organisationUnitStore.getByUid(user.getUserEffectiveSearchOrgUnitIds())));
       params.setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
-    } else if (user != null
-        && params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CAPTURE)) {
+    } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CAPTURE)) {
       params.setOrgUnits(new HashSet<>(organisationUnitStore.getByUid(user.getUserOrgUnitIds())));
       params.setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -50,6 +50,9 @@ public interface TrackedEntityService {
       UID trackedEntity, UID attribute, UID program, ImageFileDimension dimension)
       throws NotFoundException;
 
+  TrackedEntity getTrackedEntity(String uid)
+      throws NotFoundException, ForbiddenException, BadRequestException;
+
   TrackedEntity getTrackedEntity(
       String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException, BadRequestException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -50,11 +50,23 @@ public interface TrackedEntityService {
       UID trackedEntity, UID attribute, UID program, ImageFileDimension dimension)
       throws NotFoundException;
 
+  /**
+   * Get the tracked entity matching given {@code UID} under the privileges of the currently
+   * authenticated user. No program attributes are included, only TETAs. Enrollments and
+   * relationships are not included. Use {@link #getTrackedEntity(String, String,
+   * TrackedEntityParams)} instead to also get the relationships, enrollments and program
+   * attributes.
+   */
   TrackedEntity getTrackedEntity(String uid)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
-  TrackedEntity getTrackedEntity(
-      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
+  /**
+   * Get the tracked entity matching given {@code UID} under the privileges of the currently
+   * authenticated user. If @param programIdentifier is defined, program attributes for such program
+   * are included, otherwise only TETAs are included. It will include enrollments, relationships,
+   * attributes and ownerships as defined in @param params
+   */
+  TrackedEntity getTrackedEntity(String uid, String programIdentifier, TrackedEntityParams params)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
   /** Get all tracked entities matching given params. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -97,8 +97,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
           trackedEntityService.getTrackedEntity(
               subm.getTrackedEntityInstance().getUid(),
               subm.getTrackerProgram().getUid(),
-              TrackedEntityParams.FALSE.withIncludeAttributes(true),
-              false);
+              TrackedEntityParams.FALSE.withIncludeAttributes(true));
     } catch (NotFoundException e) {
       // new TE will be created
     } catch (ForbiddenException | BadRequestException e) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.UserService;
@@ -157,8 +156,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
 
     try {
       smsEnrollmentService.enrollTrackedEntity(
-          trackedEntityService.getTrackedEntity(
-              trackedEntity.getUid(), null, TrackedEntityParams.FALSE, false),
+          trackedEntityService.getTrackedEntity(trackedEntity.getUid()),
           program,
           orgUnit,
           occurredDate);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.program.ProgramType.WITHOUT_REGISTRATION;
 import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrgUnitMode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
@@ -50,7 +49,6 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.deprecated.audit.TrackedEntityAuditService;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserRole;
@@ -62,7 +60,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -104,6 +101,8 @@ class OperationsParamsValidatorTest {
 
   @InjectMocks private OperationsParamsValidator paramsValidator;
 
+  private final UserDetails user = UserDetails.fromUser(new User());
+
   @BeforeEach
   public void setUp() {
     OrganisationUnit organisationUnit = createOrgUnit("orgUnit", PARENT_ORG_UNIT_UID);
@@ -112,16 +111,11 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldFailWhenOuModeCaptureAndUserHasNoOrgUnitsAssigned() {
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      Exception exception =
-          Assertions.assertThrows(
-              BadRequestException.class, () -> validateOrgUnitMode(CAPTURE, program));
+    Exception exception =
+        Assertions.assertThrows(
+            BadRequestException.class, () -> validateOrgUnitMode(CAPTURE, program, user));
 
-      assertEquals("User needs to be assigned data capture org units", exception.getMessage());
-    }
+    assertEquals("User needs to be assigned data capture org units", exception.getMessage());
   }
 
   @ParameterizedTest
@@ -131,34 +125,24 @@ class OperationsParamsValidatorTest {
   void shouldFailWhenOuModeRequiresUserScopeOrgUnitAndUserHasNoOrgUnitsAssigned(
       OrganisationUnitSelectionMode orgUnitMode) {
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      Exception exception =
-          Assertions.assertThrows(
-              BadRequestException.class, () -> validateOrgUnitMode(orgUnitMode, program));
+    Exception exception =
+        Assertions.assertThrows(
+            BadRequestException.class, () -> validateOrgUnitMode(orgUnitMode, program, user));
 
-      assertEquals(
-          "User needs to be assigned either search or data capture org units",
-          exception.getMessage());
-    }
+    assertEquals(
+        "User needs to be assigned either search or data capture org units",
+        exception.getMessage());
   }
 
   @Test
   void shouldFailWhenOuModeAllAndNotSuperuser() {
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      Exception exception =
-          Assertions.assertThrows(
-              BadRequestException.class, () -> validateOrgUnitMode(ALL, program));
+    Exception exception =
+        Assertions.assertThrows(
+            BadRequestException.class, () -> validateOrgUnitMode(ALL, program, user));
 
-      assertEquals(
-          "Current user is not authorized to query across all organisation units",
-          exception.getMessage());
-    }
+    assertEquals(
+        "Current user is not authorized to query across all organisation units",
+        exception.getMessage());
   }
 
   @Test
@@ -167,7 +151,8 @@ class OperationsParamsValidatorTest {
 
     Exception exception =
         Assertions.assertThrows(
-            BadRequestException.class, () -> paramsValidator.validateTrackerProgram(PROGRAM_UID));
+            BadRequestException.class,
+            () -> paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
 
     assertEquals(
         String.format("Program is specified but does not exist: %s", PROGRAM_UID),
@@ -177,102 +162,73 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnProgramWhenUserHasAccessToProgram()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program)).thenReturn(true);
-
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      assertEquals(program, paramsValidator.validateTrackerProgram(PROGRAM_UID));
-    }
+    when(aclService.canDataRead(user, program)).thenReturn(true);
+    assertEquals(program, paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
   }
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToProgram() {
-    User user = new User();
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program)).thenReturn(false);
+    when(aclService.canDataRead(user, program)).thenReturn(false);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          Assertions.assertThrows(
-              ForbiddenException.class, () -> paramsValidator.validateTrackerProgram(PROGRAM_UID));
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
 
-      assertEquals(
-          String.format("User has no access to program: %s", program.getUid()),
-          exception.getMessage());
-    }
+    assertEquals(
+        String.format("User has no access to program: %s", program.getUid()),
+        exception.getMessage());
   }
 
   @Test
   void shouldReturnProgramWhenUserHasAccessToProgramTrackedEntityType()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     program.setTrackedEntityType(trackedEntityType);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program)).thenReturn(true);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program.getTrackedEntityType()))
-        .thenReturn(true);
+    when(aclService.canDataRead(user, program)).thenReturn(true);
+    when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      assertEquals(program, paramsValidator.validateTrackerProgram(PROGRAM_UID));
-    }
+    assertEquals(program, paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
   }
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToProgramTrackedEntityType() {
-    User user = new User();
+
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     program.setTrackedEntityType(trackedEntityType);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program)).thenReturn(true);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program.getTrackedEntityType()))
-        .thenReturn(false);
+    when(aclService.canDataRead(user, program)).thenReturn(true);
+    when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(false);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          Assertions.assertThrows(
-              ForbiddenException.class, () -> paramsValidator.validateTrackerProgram(PROGRAM_UID));
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
 
-      assertEquals(
-          String.format(
-              "Current user is not authorized to read data from selected program's tracked entity type: %s",
-              trackedEntityType.getUid()),
-          exception.getMessage());
-    }
+    assertEquals(
+        String.format(
+            "Current user is not authorized to read data from selected program's tracked entity type: %s",
+            trackedEntityType.getUid()),
+        exception.getMessage());
   }
 
   @Test
   void shouldThrowBadRequestExceptionWhenRequestingTrackedEntitiesAndProgramIsNotATrackerProgram() {
-    User user = new User();
     program.setProgramType(WITHOUT_REGISTRATION);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(UserDetails.fromUser(user), program)).thenReturn(true);
+    when(aclService.canDataRead(user, program)).thenReturn(true);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          Assertions.assertThrows(
-              BadRequestException.class, () -> paramsValidator.validateTrackerProgram(PROGRAM_UID));
+    Exception exception =
+        Assertions.assertThrows(
+            BadRequestException.class,
+            () -> paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
 
-      assertEquals(
-          String.format("Program specified is not a tracker program: %s", PROGRAM_UID),
-          exception.getMessage());
-    }
+    assertEquals(
+        String.format("Program specified is not a tracker program: %s", PROGRAM_UID),
+        exception.getMessage());
   }
 
   @Test
@@ -280,8 +236,7 @@ class OperationsParamsValidatorTest {
       throws ForbiddenException, BadRequestException {
     when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
 
-    assertEquals(
-        trackedEntity, paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, new User()));
+    assertEquals(trackedEntity, paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user));
   }
 
   @Test
@@ -291,7 +246,7 @@ class OperationsParamsValidatorTest {
     Exception exception =
         Assertions.assertThrows(
             BadRequestException.class,
-            () -> paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, new User()));
+            () -> paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user));
 
     assertEquals(
         String.format("Tracked entity is specified but does not exist: %s", TRACKED_ENTITY_UID),
@@ -301,7 +256,7 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnTrackedEntityWhenUserHasAccessToTrackedEntity()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
+
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     trackedEntity.setTrackedEntityType(trackedEntityType);
     when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
@@ -312,7 +267,7 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToTrackedEntity() {
-    User user = new User();
+
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     trackedEntity.setTrackedEntityType(trackedEntityType);
     when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
@@ -337,7 +292,7 @@ class OperationsParamsValidatorTest {
     Exception exception =
         Assertions.assertThrows(
             BadRequestException.class,
-            () -> paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID));
+            () -> paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, user));
 
     assertEquals(
         String.format(
@@ -348,42 +303,32 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnTrackedEntityTypeWhenUserHasAccessToTrackedEntityType()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
+
     when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
         .thenReturn(trackedEntityType);
-    when(aclService.canDataRead(UserDetails.fromUser(user), trackedEntityType)).thenReturn(true);
+    when(aclService.canDataRead(user, trackedEntityType)).thenReturn(true);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      assertEquals(
-          trackedEntityType, paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID));
-    }
+    assertEquals(
+        trackedEntityType,
+        paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, user));
   }
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToTrackedEntityType() {
-    User user = new User();
     when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
         .thenReturn(trackedEntityType);
-    when(aclService.canDataRead(UserDetails.fromUser(user), trackedEntityType)).thenReturn(false);
+    when(aclService.canDataRead(user, trackedEntityType)).thenReturn(false);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          Assertions.assertThrows(
-              ForbiddenException.class,
-              () -> paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID));
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, user));
 
-      assertEquals(
-          String.format(
-              "Current user is not authorized to read data from selected tracked entity type: %s",
-              trackedEntityType.getUid()),
-          exception.getMessage());
-    }
+    assertEquals(
+        String.format(
+            "Current user is not authorized to read data from selected tracked entity type: %s",
+            trackedEntityType.getUid()),
+        exception.getMessage());
   }
 
   @Test
@@ -393,7 +338,7 @@ class OperationsParamsValidatorTest {
     Exception exception =
         Assertions.assertThrows(
             BadRequestException.class,
-            () -> paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID)));
+            () -> paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID), user));
 
     assertEquals(
         String.format("Organisation unit does not exist: %s", ORG_UNIT_UID),
@@ -403,55 +348,44 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnOrgUnitWhenUserHasAccessToOrgUnit()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
-    user.setOrganisationUnits(Set.of(orgUnit));
+    User userWithOrgUnits = new User();
+    userWithOrgUnits.setOrganisationUnits(Set.of(orgUnit));
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      assertEquals(Set.of(orgUnit), paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID)));
-    }
+    assertEquals(
+        Set.of(orgUnit),
+        paramsValidator.validateOrgUnits(
+            Set.of(ORG_UNIT_UID), UserDetails.fromUser(userWithOrgUnits)));
   }
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToOrgUnit() {
-    User user = new User();
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          Assertions.assertThrows(
-              ForbiddenException.class,
-              () -> paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID)));
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID), user));
 
-      assertEquals(
-          String.format("Organisation unit is not part of the search scope: %s", orgUnit.getUid()),
-          exception.getMessage());
-    }
+    assertEquals(
+        String.format("Organisation unit is not part of the search scope: %s", orgUnit.getUid()),
+        exception.getMessage());
   }
 
   @Test
   void shouldReturnOrgUnitsWhenUserIsSuperButHasNoAccessToOrgUnit()
       throws ForbiddenException, BadRequestException {
-    User user = new User();
+
+    User userWithRoles = new User();
     UserRole userRole = new UserRole();
     userRole.setAuthorities(Sets.newHashSet("ALL"));
-    user.setUserRoles(Set.of(userRole));
+    userWithRoles.setUserRoles(Set.of(userRole));
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Set<OrganisationUnit> orgUnits = paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID));
+    Set<OrganisationUnit> orgUnits =
+        paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID), UserDetails.fromUser(userWithRoles));
 
-      assertEquals(Set.of(orgUnit), orgUnits);
-    }
+    assertEquals(Set.of(orgUnit), orgUnits);
   }
 
   private OrganisationUnit createOrgUnit(String name, String uid) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -141,8 +141,7 @@ class OperationsParamsValidatorTest {
             BadRequestException.class, () -> validateOrgUnitMode(ALL, program, user));
 
     assertEquals(
-        "Current user is not authorized to query across all organisation units",
-        exception.getMessage());
+        "User is not authorized to query across all organisation units", exception.getMessage());
   }
 
   @Test
@@ -210,7 +209,7 @@ class OperationsParamsValidatorTest {
 
     assertEquals(
         String.format(
-            "Current user is not authorized to read data from selected program's tracked entity type: %s",
+            "User is not authorized to read data from selected program's tracked entity type: %s",
             trackedEntityType.getUid()),
         exception.getMessage());
   }
@@ -280,7 +279,7 @@ class OperationsParamsValidatorTest {
 
     assertEquals(
         String.format(
-            "Current user is not authorized to read data from type of selected tracked entity: %s",
+            "User is not authorized to read data from type of selected tracked entity: %s",
             trackedEntity.getUid()),
         exception.getMessage());
   }
@@ -326,7 +325,7 @@ class OperationsParamsValidatorTest {
 
     assertEquals(
         String.format(
-            "Current user is not authorized to read data from selected tracked entity type: %s",
+            "User is not authorized to read data from selected tracked entity type: %s",
             trackedEntityType.getUid()),
         exception.getMessage());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -97,12 +97,12 @@ class EnrollmentOperationParamsMapperTest {
 
   private OrganisationUnit orgUnit2;
 
-  private UserDetails currentUser;
+  private UserDetails user;
 
   @BeforeEach
   void setUp() throws ForbiddenException, BadRequestException {
-    User user = new User();
-    user.setUsername("admin");
+    User testUser = new User();
+    testUser.setUsername("admin");
 
     orgUnit1 = new OrganisationUnit("orgUnit1");
     orgUnit1.setUid(ORG_UNIT_1_UID);
@@ -121,9 +121,9 @@ class EnrollmentOperationParamsMapperTest {
         .thenReturn(List.of(orgUnit1));
     when(organisationUnitService.getOrganisationUnit(orgUnit2.getUid())).thenReturn(orgUnit2);
 
-    user.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
-    user.setOrganisationUnits(Set.of(orgUnit2));
-    currentUser = UserDetails.fromUser(user);
+    testUser.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
+    testUser.setOrganisationUnits(Set.of(orgUnit2));
+    user = UserDetails.fromUser(testUser);
 
     TrackedEntityType trackedEntityType = new TrackedEntityType();
     trackedEntityType.setUid(TRACKED_ENTITY_TYPE_UID);
@@ -139,12 +139,11 @@ class EnrollmentOperationParamsMapperTest {
     trackedEntity.setUid(TRACKED_ENTITY_UID);
     trackedEntity.setTrackedEntityType(trackedEntityType);
 
-    when(paramsValidator.validateTrackerProgram(PROGRAM_UID, currentUser)).thenReturn(program);
-    when(paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, currentUser))
+    when(paramsValidator.validateTrackerProgram(PROGRAM_UID, user)).thenReturn(program);
+    when(paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, user))
         .thenReturn(trackedEntityType);
-    when(paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, currentUser))
-        .thenReturn(trackedEntity);
-    when(paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID), currentUser))
+    when(paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user)).thenReturn(trackedEntity);
+    when(paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID), user))
         .thenReturn(Set.of(orgUnit1, orgUnit2));
   }
 
@@ -154,7 +153,7 @@ class EnrollmentOperationParamsMapperTest {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
-    mapper.map(operationParams, currentUser);
+    mapper.map(operationParams, user);
 
     verifyNoInteractions(programService);
     verifyNoInteractions(trackedEntityTypeService);
@@ -170,7 +169,7 @@ class EnrollmentOperationParamsMapperTest {
             .orgUnitMode(ACCESSIBLE)
             .build();
 
-    EnrollmentQueryParams params = mapper.map(operationParams, currentUser);
+    EnrollmentQueryParams params = mapper.map(operationParams, user);
 
     assertEquals(
         List.of(
@@ -185,7 +184,7 @@ class EnrollmentOperationParamsMapperTest {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
-    EnrollmentQueryParams params = mapper.map(operationParams, currentUser);
+    EnrollmentQueryParams params = mapper.map(operationParams, user);
 
     assertIsEmpty(params.getOrder());
   }
@@ -196,11 +195,11 @@ class EnrollmentOperationParamsMapperTest {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
-    EnrollmentQueryParams params = mapper.map(operationParams, currentUser);
+    EnrollmentQueryParams params = mapper.map(operationParams, user);
 
     assertEquals(DESCENDANTS, params.getOrganisationUnitMode());
     assertEquals(
-        currentUser.getUserEffectiveSearchOrgUnitIds(),
+        user.getUserEffectiveSearchOrgUnitIds(),
         params.getOrganisationUnits().stream()
             .map(BaseIdentifiableObject::getUid)
             .collect(Collectors.toSet()));
@@ -212,11 +211,11 @@ class EnrollmentOperationParamsMapperTest {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(CAPTURE).build();
 
-    EnrollmentQueryParams params = mapper.map(operationParams, currentUser);
+    EnrollmentQueryParams params = mapper.map(operationParams, user);
 
     assertEquals(DESCENDANTS, params.getOrganisationUnitMode());
     assertEquals(
-        currentUser.getUserOrgUnitIds(),
+        user.getUserOrgUnitIds(),
         params.getOrganisationUnits().stream()
             .map(BaseIdentifiableObject::getUid)
             .collect(Collectors.toSet()));
@@ -232,7 +231,7 @@ class EnrollmentOperationParamsMapperTest {
             .orgUnitMode(CHILDREN)
             .build();
 
-    EnrollmentQueryParams params = mapper.map(operationParams, currentUser);
+    EnrollmentQueryParams params = mapper.map(operationParams, user);
 
     assertEquals(CHILDREN, params.getOrganisationUnitMode());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -122,7 +122,7 @@ class EventOperationParamsMapperTest {
 
   @InjectMocks private EventOperationParamsMapper mapper;
 
-  private UserDetails currentUser;
+  private UserDetails user;
 
   private final Map<String, User> userMap = new HashMap<>();
 
@@ -138,10 +138,10 @@ class EventOperationParamsMapperTest {
             createOrgUnit("captureScopeChild", "captureScopeChildUid"),
             createOrgUnit("searchScopeChild", "searchScopeChildUid")));
 
-    User user = new User();
-    user.setUsername("test");
-    user.setOrganisationUnits(Set.of(orgUnit));
-    currentUser = UserDetails.fromUser(user);
+    User testUser = new User();
+    testUser.setUsername("test");
+    testUser.setOrganisationUnits(Set.of(orgUnit));
+    user = UserDetails.fromUser(testUser);
 
     // By default, set to ACCESSIBLE for tests that don't set an orgUnit. The orgUnitMode needs to
     // be
@@ -159,11 +159,11 @@ class EventOperationParamsMapperTest {
     EventOperationParams eventOperationParams =
         eventBuilder.programStageUid(programStage.getUid()).build();
 
-    when(aclService.canDataRead(currentUser, programStage)).thenReturn(false);
+    when(aclService.canDataRead(user, programStage)).thenReturn(false);
     when(programStageService.getProgramStage("PlZSBEN7iZd")).thenReturn(programStage);
 
     Exception exception =
-        assertThrows(ForbiddenException.class, () -> mapper.map(eventOperationParams, currentUser));
+        assertThrows(ForbiddenException.class, () -> mapper.map(eventOperationParams, user));
     assertEquals(
         "User has no access to program stage: " + programStage.getUid(), exception.getMessage());
   }
@@ -174,8 +174,7 @@ class EventOperationParamsMapperTest {
         EventOperationParams.builder().programStageUid("NeU85luyD4w").build();
 
     Exception exception =
-        assertThrows(
-            BadRequestException.class, () -> mapper.map(eventOperationParams, currentUser));
+        assertThrows(BadRequestException.class, () -> mapper.map(eventOperationParams, user));
     assertEquals(
         "Program stage is specified but does not exist: NeU85luyD4w", exception.getMessage());
   }
@@ -197,7 +196,7 @@ class EventOperationParamsMapperTest {
         .thenReturn(false);
 
     Exception exception =
-        assertThrows(ForbiddenException.class, () -> mapper.map(eventOperationParams, currentUser));
+        assertThrows(ForbiddenException.class, () -> mapper.map(eventOperationParams, user));
 
     assertEquals(
         "User has no access to attribute category option combo: " + combo.getUid(),
@@ -220,7 +219,7 @@ class EventOperationParamsMapperTest {
     when(aclService.canDataRead(any(UserDetails.class), any(CategoryOptionCombo.class)))
         .thenReturn(true);
 
-    EventQueryParams queryParams = mapper.map(operationParams, currentUser);
+    EventQueryParams queryParams = mapper.map(operationParams, user);
 
     assertEquals(combo, queryParams.getCategoryOptionCombo());
   }
@@ -233,7 +232,7 @@ class EventOperationParamsMapperTest {
             .assignedUserMode(AssignedUserSelectionMode.PROVIDED)
             .build();
 
-    EventQueryParams queryParams = mapper.map(operationParams, currentUser);
+    EventQueryParams queryParams = mapper.map(operationParams, user);
 
     assertContainsOnly(
         Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
@@ -261,7 +260,7 @@ class EventOperationParamsMapperTest {
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
-    EventQueryParams queryParams = mapper.map(operationParams, currentUser);
+    EventQueryParams queryParams = mapper.map(operationParams, user);
 
     Map<TrackedEntityAttribute, List<QueryFilter>> attributes = queryParams.getAttributes();
     assertNotNull(attributes);
@@ -283,7 +282,7 @@ class EventOperationParamsMapperTest {
     when(trackedEntityAttributeService.getTrackedEntityAttribute(filterName)).thenReturn(null);
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
 
     assertContains(
         "Tracked entity attribute '" + filterName + "' does not exist", exception.getMessage());
@@ -309,7 +308,7 @@ class EventOperationParamsMapperTest {
             .orderBy("scheduledDate", SortDirection.ASC)
             .build();
 
-    EventQueryParams params = mapper.map(operationParams, currentUser);
+    EventQueryParams params = mapper.map(operationParams, user);
 
     assertEquals(
         List.of(
@@ -335,7 +334,7 @@ class EventOperationParamsMapperTest {
         eventBuilder.orderBy(UID.of(TEA_1_UID), SortDirection.ASC).build();
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
     assertStartsWith("Cannot order by '" + TEA_1_UID, exception.getMessage());
   }
 
@@ -350,7 +349,7 @@ class EventOperationParamsMapperTest {
         eventBuilder.orderBy(UID.of("lastUpdated"), SortDirection.ASC).build();
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
     assertStartsWith("Cannot order by 'lastUpdated'", exception.getMessage());
   }
 
@@ -373,7 +372,7 @@ class EventOperationParamsMapperTest {
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
-    EventQueryParams queryParams = mapper.map(operationParams, currentUser);
+    EventQueryParams queryParams = mapper.map(operationParams, user);
 
     Map<DataElement, List<QueryFilter>> dataElements = queryParams.getDataElements();
     assertNotNull(dataElements);
@@ -395,7 +394,7 @@ class EventOperationParamsMapperTest {
     when(dataElementService.getDataElement(filterName)).thenReturn(null);
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
 
     assertContains("Data element '" + filterName + "' does not exist", exception.getMessage());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -53,10 +52,7 @@ import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventService;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,8 +85,6 @@ class RelationshipOperationParamsMapperTest extends TestBase {
 
   private Event event;
 
-  private UserDetails user;
-
   @BeforeEach
   public void setUp() {
     OrganisationUnit organisationUnit = createOrganisationUnit('A');
@@ -103,20 +97,12 @@ class RelationshipOperationParamsMapperTest extends TestBase {
     enrollment.setUid(EN_UID);
     event = createEvent(programStage, enrollment, organisationUnit);
     event.setUid(EV_UID);
-
-    User u = new User();
-    u.setUsername("admin");
-
-    user = UserDetails.fromUser(u);
-    injectSecurityContext(user);
   }
 
   @Test
   void shouldMapTrackedEntityWhenATrackedEntityIsPassed()
       throws NotFoundException, ForbiddenException, BadRequestException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, null, TrackedEntityParams.FALSE, false))
-        .thenReturn(trackedEntity);
-    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of());
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
@@ -124,29 +110,6 @@ class RelationshipOperationParamsMapperTest extends TestBase {
 
     assertInstanceOf(TrackedEntity.class, queryParams.getEntity());
     assertEquals(TE_UID, queryParams.getEntity().getUid());
-  }
-
-  @Test
-  void shouldThrowWhenTrackedEntityIsNotFound()
-      throws ForbiddenException, NotFoundException, BadRequestException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, null, TrackedEntityParams.FALSE, false))
-        .thenReturn(null);
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
-
-    assertThrows(NotFoundException.class, () -> mapper.map(params));
-  }
-
-  @Test
-  void shouldThrowWhenUserHasNoAccessToTrackedEntity()
-      throws ForbiddenException, NotFoundException, BadRequestException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, null, TrackedEntityParams.FALSE, false))
-        .thenReturn(trackedEntity);
-    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of("error"));
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
-
-    assertThrows(ForbiddenException.class, () -> mapper.map(params));
   }
 
   @Test
@@ -178,9 +141,7 @@ class RelationshipOperationParamsMapperTest extends TestBase {
   @Test
   void shouldMapOrderInGivenOrder()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, null, TrackedEntityParams.FALSE, false))
-        .thenReturn(trackedEntity);
-    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of());
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
 
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
@@ -197,9 +158,7 @@ class RelationshipOperationParamsMapperTest extends TestBase {
   @Test
   void shouldMapNullOrderingParamsWhenNoOrderingParamsAreSpecified()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, null, TrackedEntityParams.FALSE, false))
-        .thenReturn(trackedEntity);
-    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of());
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
 
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
@@ -75,7 +74,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.export.OperationsParamsValidator;
 import org.hisp.dhis.tracker.export.Order;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,7 +82,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -122,7 +119,7 @@ class TrackedEntityOperationParamsMapperTest {
 
   @InjectMocks private TrackedEntityOperationParamsMapper mapper;
 
-  private User user;
+  private UserDetails currentUser;
 
   private Program program;
 
@@ -141,10 +138,9 @@ class TrackedEntityOperationParamsMapperTest {
     orgUnit1.setUid(ORG_UNIT_1_UID);
     orgUnit2 = new OrganisationUnit("orgUnit2");
     orgUnit2.setUid(ORG_UNIT_2_UID);
-    user = new User();
+    User user = new User();
     user.setOrganisationUnits(Set.of(orgUnit1, orgUnit2));
-
-    //    when(getCurrentUser()).thenReturn(user);
+    currentUser = UserDetails.fromUser(user);
 
     when(organisationUnitService.getOrganisationUnit(orgUnit1.getUid())).thenReturn(orgUnit1);
     when(organisationUnitService.isInUserHierarchy(
@@ -169,7 +165,7 @@ class TrackedEntityOperationParamsMapperTest {
     program.setProgramStages(Set.of(programStage));
 
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
+    when(aclService.canDataRead(currentUser, program.getTrackedEntityType())).thenReturn(true);
 
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
@@ -185,59 +181,54 @@ class TrackedEntityOperationParamsMapperTest {
   void testMapping() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(any(UserDetails.class), any(TrackedEntityType.class)))
         .thenReturn(true);
-    when(paramsValidator.validateTrackedEntityType(trackedEntityType.getUid()))
+    when(paramsValidator.validateTrackedEntityType(trackedEntityType.getUid(), currentUser))
         .thenReturn(trackedEntityType);
     when(trackedEntityTypeService.getAllTrackedEntityType()).thenReturn(List.of(trackedEntityType));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityOperationParams operationParams =
-          TrackedEntityOperationParams.builder()
-              .orgUnitMode(ACCESSIBLE)
-              .assignedUserQueryParam(
-                  new AssignedUserQueryParam(AssignedUserSelectionMode.CURRENT, null))
-              .orgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
-              .enrollmentStatus(EnrollmentStatus.ACTIVE)
-              .followUp(true)
-              .lastUpdatedStartDate(getDate(2019, 1, 1))
-              .lastUpdatedEndDate(getDate(2020, 1, 1))
-              .lastUpdatedDuration("20")
-              .programEnrollmentStartDate(getDate(2019, 5, 5))
-              .programEnrollmentEndDate(getDate(2020, 5, 5))
-              .trackedEntityTypeUid(TRACKED_ENTITY_TYPE_UID)
-              .eventStatus(EventStatus.COMPLETED)
-              .eventStartDate(getDate(2019, 7, 7))
-              .eventEndDate(getDate(2020, 7, 7))
-              .includeDeleted(true)
-              .build();
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityOperationParams.builder()
+            .orgUnitMode(ACCESSIBLE)
+            .assignedUserQueryParam(
+                new AssignedUserQueryParam(AssignedUserSelectionMode.CURRENT, null))
+            .orgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
+            .enrollmentStatus(EnrollmentStatus.ACTIVE)
+            .followUp(true)
+            .lastUpdatedStartDate(getDate(2019, 1, 1))
+            .lastUpdatedEndDate(getDate(2020, 1, 1))
+            .lastUpdatedDuration("20")
+            .programEnrollmentStartDate(getDate(2019, 5, 5))
+            .programEnrollmentEndDate(getDate(2020, 5, 5))
+            .trackedEntityTypeUid(TRACKED_ENTITY_TYPE_UID)
+            .eventStatus(EventStatus.COMPLETED)
+            .eventStartDate(getDate(2019, 7, 7))
+            .eventEndDate(getDate(2020, 7, 7))
+            .includeDeleted(true)
+            .build();
 
-      final TrackedEntityQueryParams params = mapper.map(operationParams);
+    final TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertThat(params.getTrackedEntityType(), is(trackedEntityType));
-      assertThat(params.getEnrollmentStatus(), is(EnrollmentStatus.ACTIVE));
-      assertThat(params.getFollowUp(), is(true));
-      assertThat(params.getLastUpdatedStartDate(), is(operationParams.getLastUpdatedStartDate()));
-      assertThat(params.getLastUpdatedEndDate(), is(operationParams.getLastUpdatedEndDate()));
-      assertThat(
-          params.getProgramEnrollmentStartDate(),
-          is(operationParams.getProgramEnrollmentStartDate()));
-      assertThat(
-          params.getProgramEnrollmentEndDate(), is(operationParams.getProgramEnrollmentEndDate()));
-      assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
-      assertThat(params.getEventStartDate(), is(operationParams.getEventStartDate()));
-      assertThat(params.getEventEndDate(), is(operationParams.getEventEndDate()));
-      assertThat(
-          params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
-      assertThat(params.isIncludeDeleted(), is(true));
-    }
+    assertThat(params.getTrackedEntityType(), is(trackedEntityType));
+    assertThat(params.getEnrollmentStatus(), is(EnrollmentStatus.ACTIVE));
+    assertThat(params.getFollowUp(), is(true));
+    assertThat(params.getLastUpdatedStartDate(), is(operationParams.getLastUpdatedStartDate()));
+    assertThat(params.getLastUpdatedEndDate(), is(operationParams.getLastUpdatedEndDate()));
+    assertThat(
+        params.getProgramEnrollmentStartDate(),
+        is(operationParams.getProgramEnrollmentStartDate()));
+    assertThat(
+        params.getProgramEnrollmentEndDate(), is(operationParams.getProgramEnrollmentEndDate()));
+    assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
+    assertThat(params.getEventStartDate(), is(operationParams.getEventStartDate()));
+    assertThat(params.getEventEndDate(), is(operationParams.getEventEndDate()));
+    assertThat(
+        params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
+    assertThat(params.isIncludeDeleted(), is(true));
   }
 
   @Test
   void testMappingProgramEnrollmentStartDate() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     Date date = parseDate("2022-12-13");
     TrackedEntityOperationParams operationParams =
@@ -247,19 +238,14 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(program.getUid())
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
-      assertEquals(date, params.getProgramEnrollmentStartDate());
-    }
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
+    assertEquals(date, params.getProgramEnrollmentStartDate());
   }
 
   @Test
   void testMappingProgramEnrollmentEndDate() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     Date date = parseDate("2022-12-13");
     TrackedEntityOperationParams operationParams =
@@ -269,20 +255,15 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(program.getUid())
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertEquals(date, params.getProgramEnrollmentEndDate());
-    }
+    assertEquals(date, params.getProgramEnrollmentEndDate());
   }
 
   @Test
   void testFilter() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -296,54 +277,48 @@ class TrackedEntityOperationParamsMapperTest {
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      Map<TrackedEntityAttribute, List<QueryFilter>> items = params.getFilters();
-      assertNotNull(items);
-      // mapping to UIDs as the error message by just relying on QueryItem
-      // equals() is not helpful
-      assertContainsOnly(
-          List.of(TEA_1_UID, TEA_2_UID),
-          items.keySet().stream().map(BaseIdentifiableObject::getUid).collect(Collectors.toList()));
+    Map<TrackedEntityAttribute, List<QueryFilter>> items = params.getFilters();
+    assertNotNull(items);
+    // mapping to UIDs as the error message by just relying on QueryItem
+    // equals() is not helpful
+    assertContainsOnly(
+        List.of(TEA_1_UID, TEA_2_UID),
+        items.keySet().stream().map(BaseIdentifiableObject::getUid).collect(Collectors.toList()));
 
-      // QueryItem equals() does not take the QueryFilter into account so
-      // assertContainsOnly alone does not ensure operators and filter value
-      // are correct
-      // the following block is needed because of that
-      // assertion is order independent as the order of QueryItems is not
-      // guaranteed
-      Map<String, QueryFilter> expectedFilters =
-          Map.of(
-              TEA_1_UID,
-              new QueryFilter(QueryOperator.EQ, "2"),
-              TEA_2_UID,
-              new QueryFilter(QueryOperator.LIKE, "foo"));
-      assertAll(
-          items.entrySet().stream()
-              .map(
-                  i ->
-                      (Executable)
-                          () -> {
-                            String uid = i.getKey().getUid();
-                            QueryFilter expected = expectedFilters.get(uid);
-                            assertEquals(
-                                expected,
-                                i.getValue().get(0),
-                                () ->
-                                    String.format("QueryFilter mismatch for TEA with UID %s", uid));
-                          })
-              .collect(Collectors.toList()));
-    }
+    // QueryItem equals() does not take the QueryFilter into account so
+    // assertContainsOnly alone does not ensure operators and filter value
+    // are correct
+    // the following block is needed because of that
+    // assertion is order independent as the order of QueryItems is not
+    // guaranteed
+    Map<String, QueryFilter> expectedFilters =
+        Map.of(
+            TEA_1_UID,
+            new QueryFilter(QueryOperator.EQ, "2"),
+            TEA_2_UID,
+            new QueryFilter(QueryOperator.LIKE, "foo"));
+    assertAll(
+        items.entrySet().stream()
+            .map(
+                i ->
+                    (Executable)
+                        () -> {
+                          String uid = i.getKey().getUid();
+                          QueryFilter expected = expectedFilters.get(uid);
+                          assertEquals(
+                              expected,
+                              i.getValue().get(0),
+                              () -> String.format("QueryFilter mismatch for TEA with UID %s", uid));
+                        })
+            .collect(Collectors.toList()));
   }
 
   @Test
   void testFilterWhenTEAHasMultipleFilters() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -357,33 +332,28 @@ class TrackedEntityOperationParamsMapperTest {
                         new QueryFilter(QueryOperator.LT, "20"))))
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      Map<TrackedEntityAttribute, List<QueryFilter>> items = params.getFilters();
-      assertNotNull(items);
-      // mapping to UIDs as the error message by just relying on QueryItem
-      // equals() is not helpful
-      assertContainsOnly(
-          List.of(TEA_1_UID),
-          items.keySet().stream().map(BaseIdentifiableObject::getUid).collect(Collectors.toList()));
+    Map<TrackedEntityAttribute, List<QueryFilter>> items = params.getFilters();
+    assertNotNull(items);
+    // mapping to UIDs as the error message by just relying on QueryItem
+    // equals() is not helpful
+    assertContainsOnly(
+        List.of(TEA_1_UID),
+        items.keySet().stream().map(BaseIdentifiableObject::getUid).collect(Collectors.toList()));
 
-      // QueryItem equals() does not take the QueryFilter into account so
-      // assertContainsOnly alone does not ensure operators and filter value
-      // are correct
-      assertContainsOnly(
-          Set.of(new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")),
-          items.values().stream().findAny().get());
-    }
+    // QueryItem equals() does not take the QueryFilter into account so
+    // assertContainsOnly alone does not ensure operators and filter value
+    // are correct
+    assertContainsOnly(
+        Set.of(new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")),
+        items.values().stream().findAny().get());
   }
 
   @Test
   void testMappingProgram() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -391,20 +361,15 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(PROGRAM_UID)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertEquals(program, params.getProgram());
-    }
+    assertEquals(program, params.getProgram());
   }
 
   @Test
   void testMappingProgramStage() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -413,14 +378,9 @@ class TrackedEntityOperationParamsMapperTest {
             .programStageUid(PROGRAM_STAGE_UID)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertEquals(programStage, params.getProgramStage());
-    }
+    assertEquals(programStage, params.getProgramStage());
   }
 
   @Test
@@ -429,7 +389,7 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder().programStageUid(PROGRAM_STAGE_UID).build();
 
     BadRequestException e =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
     assertEquals(
         "Program does not contain the specified programStage: " + PROGRAM_STAGE_UID,
         e.getMessage());
@@ -441,15 +401,15 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder().programStageUid("NeU85luyD4w").build();
 
     BadRequestException e =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
     assertEquals(
         "Program does not contain the specified programStage: NeU85luyD4w", e.getMessage());
   }
 
   @Test
   void testMappingAssignedUsers() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -460,24 +420,18 @@ class TrackedEntityOperationParamsMapperTest {
                     AssignedUserSelectionMode.PROVIDED, Set.of("IsdLBTOBzMi", "l5ab8q5skbB")))
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertContainsOnly(
-          Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
-          params.getAssignedUserQueryParam().getAssignedUsers());
-      assertEquals(
-          AssignedUserSelectionMode.PROVIDED, params.getAssignedUserQueryParam().getMode());
-    }
+    assertContainsOnly(
+        Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+        params.getAssignedUserQueryParam().getAssignedUsers());
+    assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserQueryParam().getMode());
   }
 
   @Test
   void shouldMapOrderInGivenOrder() throws BadRequestException, ForbiddenException {
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
@@ -492,19 +446,14 @@ class TrackedEntityOperationParamsMapperTest {
             .orderBy("createdAtClient", SortDirection.DESC)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      TrackedEntityQueryParams params = mapper.map(operationParams);
+    TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);
 
-      assertEquals(
-          List.of(
-              new Order("created", SortDirection.ASC),
-              new Order(tea1, SortDirection.ASC),
-              new Order("createdAtClient", SortDirection.DESC)),
-          params.getOrder());
-    }
+    assertEquals(
+        List.of(
+            new Order("created", SortDirection.ASC),
+            new Order(tea1, SortDirection.ASC),
+            new Order("createdAtClient", SortDirection.DESC)),
+        params.getOrder());
   }
 
   @Test
@@ -512,8 +461,8 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(null);
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -522,14 +471,9 @@ class TrackedEntityOperationParamsMapperTest {
             .orderBy(UID.of(TEA_1_UID), SortDirection.ASC)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
-      assertStartsWith("Cannot order by '" + TEA_1_UID, exception.getMessage());
-    }
+    Exception exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+    assertStartsWith("Cannot order by '" + TEA_1_UID, exception.getMessage());
   }
 
   @Test
@@ -539,8 +483,8 @@ class TrackedEntityOperationParamsMapperTest {
     // rule out all
     // invalid field names and UIDs. Such invalid order values will be caught in this mapper.
     assertTrue(CodeGenerator.isValidUid("lastUpdated"));
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUser, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUser)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -549,24 +493,22 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(program.getUid())
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception exception =
-          assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
-      assertStartsWith("Cannot order by 'lastUpdated'", exception.getMessage());
-    }
+    Exception exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams, currentUser));
+    assertStartsWith("Cannot order by 'lastUpdated'", exception.getMessage());
   }
 
   @Test
   void shouldFailWhenGlobalSearchAndNoAttributeSpecified()
       throws ForbiddenException, BadRequestException {
-    user.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
-    user.setOrganisationUnits(emptySet());
+    User userWithOrgUnits = new User();
+    userWithOrgUnits.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
+    userWithOrgUnits.setOrganisationUnits(emptySet());
+    UserDetails currentUserWithOrgUnits = UserDetails.fromUser(userWithOrgUnits);
 
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(aclService.canDataRead(currentUserWithOrgUnits, program)).thenReturn(true);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUserWithOrgUnits))
+        .thenReturn(program);
     when(organisationUnitService.getOrganisationUnitsByUid(
             Set.of(orgUnit1.getUid(), orgUnit2.getUid())))
         .thenReturn(List.of(orgUnit1, orgUnit2));
@@ -577,30 +519,30 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(PROGRAM_UID)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception IllegalQueryException =
-          assertThrows(IllegalQueryException.class, () -> mapper.map(operationParams));
+    Exception IllegalQueryException =
+        assertThrows(
+            IllegalQueryException.class,
+            () -> mapper.map(operationParams, currentUserWithOrgUnits));
 
-      assertEquals(
-          "At least 1 attributes should be mentioned in the search criteria.",
-          IllegalQueryException.getMessage());
-    }
+    assertEquals(
+        "At least 1 attributes should be mentioned in the search criteria.",
+        IllegalQueryException.getMessage());
   }
 
   @Test
   void shouldFailWhenGlobalSearchAndMaxTeLimitReached()
       throws ForbiddenException, BadRequestException {
-    user.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
-    user.setOrganisationUnits(emptySet());
+    User userWithOrgUnits = new User();
+    userWithOrgUnits.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
+    userWithOrgUnits.setOrganisationUnits(emptySet());
+    UserDetails currentUserWithOrgUnits = UserDetails.fromUser(userWithOrgUnits);
 
     when(aclService.canDataRead(any(UserDetails.class), any(Program.class))).thenReturn(true);
     program.setMinAttributesRequiredToSearch(0);
     program.setMaxTeiCountToReturn(1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(paramsValidator.validateTrackerProgram(program.getUid())).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUserWithOrgUnits))
+        .thenReturn(program);
 
     when(trackedEntityStore.getTrackedEntityCountWithMaxTrackedEntityLimit(any())).thenReturn(100);
     when(organisationUnitService.getOrganisationUnitsByUid(
@@ -613,21 +555,20 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(PROGRAM_UID)
             .build();
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(user));
-      Exception IllegalQueryException =
-          assertThrows(IllegalQueryException.class, () -> mapper.map(operationParams));
-      assertEquals("maxteicountreached", IllegalQueryException.getMessage());
-    }
+    Exception IllegalQueryException =
+        assertThrows(
+            IllegalQueryException.class,
+            () -> mapper.map(operationParams, currentUserWithOrgUnits));
+    assertEquals("maxteicountreached", IllegalQueryException.getMessage());
   }
 
   @Test
   void shouldFailWhenUserHasNoAccessToAnyTrackedEntityType() {
-    user.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
-    user.setOrganisationUnits(emptySet());
-    when(aclService.canDataRead(user, program)).thenReturn(true);
+    User userWithOrgUnits = new User();
+    userWithOrgUnits.setTeiSearchOrganisationUnits(Set.of(orgUnit1, orgUnit2));
+    userWithOrgUnits.setOrganisationUnits(emptySet());
+    UserDetails currentUserWithOrgUnits = UserDetails.fromUser(userWithOrgUnits);
+    when(aclService.canDataRead(currentUserWithOrgUnits, program)).thenReturn(true);
     program.setMinAttributesRequiredToSearch(0);
     program.setMaxTeiCountToReturn(1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
@@ -638,7 +579,8 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
     Exception BadRequestException =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
+        assertThrows(
+            BadRequestException.class, () -> mapper.map(operationParams, currentUserWithOrgUnits));
 
     assertEquals("User has no access to any Tracked Entity Type", BadRequestException.getMessage());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -189,7 +189,8 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
             .assignedUserQueryParam(
-                new AssignedUserQueryParam(AssignedUserSelectionMode.CURRENT, null))
+                new AssignedUserQueryParam(
+                    AssignedUserSelectionMode.CURRENT, null, currentUser.getUid()))
             .orgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
             .followUp(true)
@@ -417,7 +418,9 @@ class TrackedEntityOperationParamsMapperTest {
             .programUid(program.getUid())
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
-                    AssignedUserSelectionMode.PROVIDED, Set.of("IsdLBTOBzMi", "l5ab8q5skbB")))
+                    AssignedUserSelectionMode.PROVIDED,
+                    Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+                    currentUser.getUid()))
             .build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, currentUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -81,7 +81,6 @@ import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventChangeLogService;
 import org.hisp.dhis.tracker.export.event.TrackedEntityDataValueChangeLog;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -314,15 +313,11 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .build();
     manager.save(trackedEntityB);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(
-        trackedEntityService.getTrackedEntity(
-            trackedEntityB.getUid(), null, TrackedEntityParams.FALSE, false));
+    assertNotNull(trackedEntityService.getTrackedEntity(trackedEntityB.getUid()));
     manager.delete(trackedEntityB);
     assertThrows(
         NotFoundException.class,
-        () ->
-            trackedEntityService.getTrackedEntity(
-                trackedEntityB.getUid(), null, TrackedEntityParams.FALSE, false));
+        () -> trackedEntityService.getTrackedEntity(trackedEntityB.getUid()));
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
 
     maintenanceService.deleteSoftDeletedTrackedEntities();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -63,7 +63,6 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.acl.TrackerOwnershipManager;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
@@ -219,9 +218,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te =
-        trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.FALSE, false);
+    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
     // Can Read
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // Can write
@@ -238,9 +235,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te =
-        trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.FALSE, false);
+    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
     // Cannot Read
     assertHasError(trackerAccessManager.canRead(userDetails, te), OWNERSHIP_ACCESS_DENIED);
     // Cannot write

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -201,9 +201,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te =
-        trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.FALSE, false);
+    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
     // Can read te
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // can write te

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
@@ -197,7 +197,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
     assertEquals("OWNERSHIP_ACCESS_DENIED", exception.getMessage());
   }
 
@@ -212,7 +212,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
   }
 
   @Test
@@ -228,7 +228,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
   }
 
   @Test
@@ -238,8 +238,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), null, defaultParams, false));
+        trackedEntityService.getTrackedEntity(trackedEntityA1.getUid(), null, defaultParams));
   }
 
   @Test
@@ -253,7 +252,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), null, defaultParams, false));
+                    trackedEntityA1.getUid(), null, defaultParams));
 
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA1.getUid()),
@@ -300,7 +299,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
     assertEquals(TrackerOwnershipManager.NO_READ_ACCESS_TO_ORG_UNIT, exception.getMessage());
   }
 
@@ -323,7 +322,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
     assertEquals(TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED, exception.getMessage());
   }
 
@@ -356,7 +355,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programB.getUid(), defaultParams, false));
+                    trackedEntityA1.getUid(), programB.getUid(), defaultParams));
     assertEquals(TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED, exception.getMessage());
   }
 
@@ -369,7 +368,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
   }
 
   @Test
@@ -387,7 +386,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams, false));
+                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
     assertEquals(TrackerOwnershipManager.NO_READ_ACCESS_TO_ORG_UNIT, exception.getMessage());
   }
 
@@ -401,8 +400,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(userB);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), null, defaultParams, false));
+        trackedEntityService.getTrackedEntity(trackedEntityA1.getUid(), null, defaultParams));
   }
 
   @Test
@@ -414,7 +412,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), null, defaultParams, false));
+                    trackedEntityA1.getUid(), null, defaultParams));
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA1.getUid()),
         exception.getMessage());
@@ -427,8 +425,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityB1,
-        trackedEntityService.getTrackedEntity(
-            trackedEntityB1.getUid(), null, defaultParams, false));
+        trackedEntityService.getTrackedEntity(trackedEntityB1.getUid(), null, defaultParams));
   }
 
   @Test
@@ -440,7 +437,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityB1.getUid(), null, defaultParams, false));
+                    trackedEntityB1.getUid(), null, defaultParams));
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityB1.getUid()),
         exception.getMessage());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -676,8 +676,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             BadRequestException.class, () -> enrollmentService.getEnrollments(operationParams));
     assertEquals(
-        "Current user is not authorized to query across all organisation units",
-        exception.getMessage());
+        "User is not authorized to query across all organisation units", exception.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -1091,7 +1091,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
-            .assignedUserQueryParam(new AssignedUserQueryParam(null, null))
+            .assignedUserQueryParam(new AssignedUserQueryParam(null, null, user.getUid()))
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .programUid(programA.getUid())
             .eventStartDate(Date.from(Instant.now().minus(10, ChronoUnit.DAYS)))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -611,7 +611,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntity te =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
     assertEquals(1, te.getEnrollments().size());
     assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
 
@@ -690,7 +690,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
 
     assertContainsOnly(Set.of(enrollmentA), trackedEntity.getEnrollments());
   }
@@ -705,7 +705,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false);
+            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(enrollmentA, enrollmentB, enrollmentProgramB), trackedEntity.getEnrollments());
@@ -1779,7 +1779,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             NotFoundException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), programUid, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), programUid, TrackedEntityParams.TRUE));
     assertEquals(
         String.format("Program with id %s could not be found.", programUid),
         exception.getMessage());
@@ -1793,7 +1793,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             NotFoundException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityUid, programA.getUid(), TrackedEntityParams.TRUE, false));
+                    trackedEntityUid, programA.getUid(), TrackedEntityParams.TRUE));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityUid),
         exception.getMessage());
@@ -1815,8 +1815,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
                 trackedEntityService.getTrackedEntity(
                     trackedEntityA.getUid(),
                     inaccessibleProgram.getUid(),
-                    TrackedEntityParams.TRUE,
-                    false));
+                    TrackedEntityParams.TRUE));
     assertContains(
         String.format("User has no data read access to program: %s", inaccessibleProgram.getUid()),
         exception.getMessage());
@@ -1836,7 +1835,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntity.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false));
+                    trackedEntity.getUid(), programA.getUid(), TrackedEntityParams.TRUE));
     assertContains(
         String.format(
             "User has no data read access to tracked entity type: %s",
@@ -1857,7 +1856,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
         exception.getMessage());
@@ -1878,7 +1877,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1903,7 +1902,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1923,7 +1922,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1942,7 +1941,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false));
+                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
 
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1954,7 +1953,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(
@@ -1969,7 +1968,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false);
+            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(trackedEntityAttributeValueA, trackedEntityAttributeValueB),
@@ -1993,7 +1992,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false));
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE));
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -249,14 +249,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
             trackedEntityService.getTrackedEntity(
                 submission.getTrackedEntityInstance().getUid(),
                 submission.getTrackerProgram().getUid(),
-                TrackedEntityParams.FALSE,
-                false));
+                TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
         trackedEntityService.getTrackedEntity(
             submission.getTrackedEntityInstance().getUid(),
             submission.getTrackerProgram().getUid(),
-            TrackedEntityParams.FALSE.withIncludeAttributes(true),
-            false);
+            TrackedEntityParams.FALSE.withIncludeAttributes(true));
     assertAll(
         "created tracked entity with tracked entity attribute values",
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actualTe),
@@ -355,14 +353,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
             trackedEntityService.getTrackedEntity(
                 submission.getTrackedEntityInstance().getUid(),
                 submission.getTrackerProgram().getUid(),
-                TrackedEntityParams.FALSE,
-                false));
+                TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
         trackedEntityService.getTrackedEntity(
             submission.getTrackedEntityInstance().getUid(),
             submission.getTrackerProgram().getUid(),
-            TrackedEntityParams.FALSE.withIncludeAttributes(true),
-            false);
+            TrackedEntityParams.FALSE.withIncludeAttributes(true));
     assertAll(
         "update tracked entity with tracked entity attribute values",
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actualTe),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler;
@@ -160,7 +161,8 @@ class TrackedEntitiesExportController {
   ResponseEntity<Page<ObjectNode>> getTrackedEntities(TrackedEntityRequestParams requestParams)
       throws BadRequestException, ForbiddenException, NotFoundException {
     validatePaginationParameters(requestParams);
-    TrackedEntityOperationParams operationParams = paramsMapper.map(requestParams);
+    TrackedEntityOperationParams operationParams =
+        paramsMapper.map(requestParams, CurrentUserUtil.getCurrentUserDetails());
 
     if (requestParams.isPaged()) {
       PageParams pageParams =
@@ -198,7 +200,8 @@ class TrackedEntitiesExportController {
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS);
+        paramsMapper.map(
+            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -218,7 +221,8 @@ class TrackedEntitiesExportController {
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS);
+        paramsMapper.map(
+            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE + ZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -239,7 +243,8 @@ class TrackedEntitiesExportController {
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS);
+        paramsMapper.map(
+            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE + GZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -64,7 +64,8 @@ import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
-import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler;
@@ -158,11 +159,11 @@ class TrackedEntitiesExportController {
       // use the text/html Accept header to default to a Json response when a generic request comes
       // from a browser
       )
-  ResponseEntity<Page<ObjectNode>> getTrackedEntities(TrackedEntityRequestParams requestParams)
+  ResponseEntity<Page<ObjectNode>> getTrackedEntities(
+      TrackedEntityRequestParams requestParams, @CurrentUser UserDetails currentUser)
       throws BadRequestException, ForbiddenException, NotFoundException {
     validatePaginationParameters(requestParams);
-    TrackedEntityOperationParams operationParams =
-        paramsMapper.map(requestParams, CurrentUserUtil.getCurrentUserDetails());
+    TrackedEntityOperationParams operationParams = paramsMapper.map(requestParams, currentUser);
 
     if (requestParams.isPaged()) {
       PageParams pageParams =
@@ -197,11 +198,11 @@ class TrackedEntitiesExportController {
   void getTrackedEntitiesAsCsv(
       TrackedEntityRequestParams trackedEntityRequestParams,
       HttpServletResponse response,
-      @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
+      @RequestParam(required = false, defaultValue = "false") boolean skipHeader,
+      @CurrentUser UserDetails currentUser)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(
-            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
+        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS, currentUser);
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -218,11 +219,11 @@ class TrackedEntitiesExportController {
   void getTrackedEntitiesAsCsvZip(
       TrackedEntityRequestParams trackedEntityRequestParams,
       HttpServletResponse response,
-      @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
+      @RequestParam(required = false, defaultValue = "false") boolean skipHeader,
+      @CurrentUser UserDetails currentUser)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(
-            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
+        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS, currentUser);
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE + ZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -240,11 +241,11 @@ class TrackedEntitiesExportController {
   void getTrackedEntitiesAsCsvGZip(
       TrackedEntityRequestParams trackedEntityRequestParams,
       HttpServletResponse response,
-      @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
+      @RequestParam(required = false, defaultValue = "false") boolean skipHeader,
+      @CurrentUser UserDetails currentUser)
       throws IOException, BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(
-            trackedEntityRequestParams, CSV_FIELDS, CurrentUserUtil.getCurrentUserDetails());
+        paramsMapper.map(trackedEntityRequestParams, CSV_FIELDS, currentUser);
 
     ResponseHeader.addContentDispositionAttachment(response, TE_CSV_FILE + GZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -270,10 +271,7 @@ class TrackedEntitiesExportController {
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.from(
             trackedEntityService.getTrackedEntity(
-                uid.getValue(),
-                program == null ? null : program.getValue(),
-                trackedEntityParams,
-                false));
+                uid.getValue(), program == null ? null : program.getValue(), trackedEntityParams));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(trackedEntity, fields));
   }
@@ -291,7 +289,7 @@ class TrackedEntitiesExportController {
 
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.from(
-            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams, false));
+            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams));
 
     OutputStream outputStream = response.getOutputStream();
     response.setContentType(CONTENT_TYPE_CSV);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams.TrackedEntityOperationParamsBuilder;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
@@ -68,13 +69,16 @@ class TrackedEntityRequestParamsMapper {
 
   private final TrackedEntityFieldsParamMapper fieldsParamMapper;
 
-  public TrackedEntityOperationParams map(TrackedEntityRequestParams trackedEntityRequestParams)
+  public TrackedEntityOperationParams map(
+      TrackedEntityRequestParams trackedEntityRequestParams, UserDetails user)
       throws BadRequestException {
-    return map(trackedEntityRequestParams, trackedEntityRequestParams.getFields());
+    return map(trackedEntityRequestParams, trackedEntityRequestParams.getFields(), user);
   }
 
   public TrackedEntityOperationParams map(
-      TrackedEntityRequestParams trackedEntityRequestParams, List<FieldPath> fields)
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      List<FieldPath> fields,
+      UserDetails user)
       throws BadRequestException {
     validateRemovedParameters(trackedEntityRequestParams);
 
@@ -159,7 +163,8 @@ class TrackedEntityRequestParamsMapper {
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
                     trackedEntityRequestParams.getAssignedUserMode(),
-                    UID.toValueSet(assignedUsers)))
+                    UID.toValueSet(assignedUsers),
+                    user.getUid()))
             .trackedEntityUids(UID.toValueSet(trackedEntities))
             .filters(filters)
             .includeDeleted(trackedEntityRequestParams.isIncludeDeleted())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -60,7 +60,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
@@ -106,11 +106,11 @@ public class TrackerImportController {
   @PostMapping(value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public WebMessage asyncPostJsonTracker(
-      HttpServletRequest request, ImportRequestParams importRequestParams, @RequestBody Body body)
+      HttpServletRequest request,
+      ImportRequestParams importRequestParams,
+      @RequestBody Body body,
+      @CurrentUser UserDetails currentUser)
       throws ConflictException, NotFoundException, IOException {
-
-    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-    String userUid = currentUserDetails.getUid();
 
     TrackerImportParams trackerImportParams =
         TrackerImportParamsMapper.trackerImportParams(importRequestParams);
@@ -121,7 +121,7 @@ public class TrackerImportController {
         trackerImportParams,
         MimeType.valueOf("application/json"),
         trackerObjects,
-        userUid,
+        currentUser.getUid(),
         request);
   }
 
@@ -177,11 +177,9 @@ public class TrackerImportController {
   public WebMessage asyncPostCsvTracker(
       HttpServletRequest request,
       ImportRequestParams importRequest,
-      @RequestParam(required = false, defaultValue = "true") boolean skipFirst)
+      @RequestParam(required = false, defaultValue = "true") boolean skipFirst,
+      @CurrentUser UserDetails currentUser)
       throws IOException, ParseException, ConflictException, NotFoundException {
-
-    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-    String userUid = currentUserDetails.getUid();
 
     InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat(request.getInputStream());
 
@@ -196,7 +194,11 @@ public class TrackerImportController {
         TrackerImportParamsMapper.trackerObjects(body, trackerImportParams.getIdSchemes());
 
     return startAsyncTracker(
-        trackerImportParams, MimeType.valueOf("application/csv"), trackerObjects, userUid, request);
+        trackerImportParams,
+        MimeType.valueOf("application/csv"),
+        trackerObjects,
+        currentUser.getUid(),
+        request);
   }
 
   @PostMapping(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.tracker.acl.TrackerOwnershipManager;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
@@ -96,8 +95,7 @@ public class TrackerOwnershipController {
             "trackedEntityInstance", trackedEntityInstance, "trackedEntity", trackedEntity);
 
     trackerOwnershipAccessManager.transferOwnership(
-        trackedEntityService.getTrackedEntity(
-            trackedEntityUid.getValue(), null, TrackedEntityParams.FALSE, false),
+        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue()),
         programService.getProgram(program),
         organisationUnitService.getOrganisationUnit(ou));
     return ok("Ownership transferred");
@@ -117,8 +115,7 @@ public class TrackerOwnershipController {
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
-        trackedEntityService.getTrackedEntity(
-            trackedEntityUid.getValue(), null, TrackedEntityParams.FALSE, false),
+        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue()),
         programService.getProgram(program),
         currentUser,
         reason);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -150,7 +150,7 @@ class EventRequestParamsMapperTest {
     when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
 
     TrackedEntity trackedEntity = new TrackedEntity();
-    when(trackedEntityService.getTrackedEntity("qnR1RK4cTIZ", null, FALSE, false))
+    when(trackedEntityService.getTrackedEntity("qnR1RK4cTIZ", null, FALSE))
         .thenReturn(trackedEntity);
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -39,7 +39,6 @@ import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mockStatic;
 
 import java.util.List;
 import java.util.Map;
@@ -54,8 +53,7 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
@@ -65,7 +63,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,6 +82,8 @@ class TrackedEntityRequestParamsMapperTest {
   @InjectMocks private TrackedEntityRequestParamsMapper mapper;
 
   private TrackedEntityRequestParams trackedEntityRequestParams;
+
+  UserDetails user = new SystemUser();
 
   @BeforeEach
   public void setUp() {
@@ -108,38 +107,31 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertThat(params.getProgramUid(), is(PROGRAM_UID));
-      assertThat(params.getProgramStageUid(), is(PROGRAM_STAGE_UID));
-      assertThat(params.getFollowUp(), is(true));
-      assertThat(
-          params.getLastUpdatedStartDate(),
-          is(trackedEntityRequestParams.getUpdatedAfter().toDate()));
-      assertThat(
-          params.getLastUpdatedEndDate(),
-          is(trackedEntityRequestParams.getUpdatedBefore().toDate()));
-      assertThat(
-          params.getProgramIncidentStartDate(),
-          is(trackedEntityRequestParams.getEnrollmentOccurredAfter().toDate()));
-      assertThat(
-          params.getProgramIncidentEndDate(),
-          is(trackedEntityRequestParams.getEnrollmentOccurredBefore().toDate()));
-      assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
-      assertThat(
-          params.getEventStartDate(),
-          is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
-      assertThat(
-          params.getEventEndDate(),
-          is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
-      assertThat(
-          params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
-      assertThat(params.isIncludeDeleted(), is(true));
-    }
+    assertThat(params.getProgramUid(), is(PROGRAM_UID));
+    assertThat(params.getProgramStageUid(), is(PROGRAM_STAGE_UID));
+    assertThat(params.getFollowUp(), is(true));
+    assertThat(
+        params.getLastUpdatedStartDate(),
+        is(trackedEntityRequestParams.getUpdatedAfter().toDate()));
+    assertThat(
+        params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore().toDate()));
+    assertThat(
+        params.getProgramIncidentStartDate(),
+        is(trackedEntityRequestParams.getEnrollmentOccurredAfter().toDate()));
+    assertThat(
+        params.getProgramIncidentEndDate(),
+        is(trackedEntityRequestParams.getEnrollmentOccurredBefore().toDate()));
+    assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
+    assertThat(
+        params.getEventStartDate(),
+        is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
+    assertThat(
+        params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
+    assertThat(
+        params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
+    assertThat(params.isIncludeDeleted(), is(true));
   }
 
   @Test
@@ -153,33 +145,26 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertThat(params.getTrackedEntityTypeUid(), is(TRACKED_ENTITY_TYPE_UID));
-      assertThat(
-          params.getLastUpdatedStartDate(), is(trackedEntityRequestParams.getUpdatedAfter()));
-      assertThat(params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore()));
-      assertThat(
-          params.getProgramIncidentStartDate(),
-          is(trackedEntityRequestParams.getEnrollmentOccurredAfter()));
-      assertThat(
-          params.getProgramIncidentEndDate(),
-          is(trackedEntityRequestParams.getEnrollmentOccurredBefore()));
-      assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
-      assertThat(
-          params.getEventStartDate(),
-          is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
-      assertThat(
-          params.getEventEndDate(),
-          is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
-      assertThat(
-          params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
-      assertThat(params.isIncludeDeleted(), is(true));
-    }
+    assertThat(params.getTrackedEntityTypeUid(), is(TRACKED_ENTITY_TYPE_UID));
+    assertThat(params.getLastUpdatedStartDate(), is(trackedEntityRequestParams.getUpdatedAfter()));
+    assertThat(params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore()));
+    assertThat(
+        params.getProgramIncidentStartDate(),
+        is(trackedEntityRequestParams.getEnrollmentOccurredAfter()));
+    assertThat(
+        params.getProgramIncidentEndDate(),
+        is(trackedEntityRequestParams.getEnrollmentOccurredBefore()));
+    assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
+    assertThat(
+        params.getEventStartDate(),
+        is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
+    assertThat(
+        params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
+    assertThat(
+        params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
+    assertThat(params.isIncludeDeleted(), is(true));
   }
 
   @Test
@@ -188,7 +173,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setOrgUnitMode(CAPTURE);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
     assertEquals(CAPTURE, params.getOrgUnitMode());
   }
@@ -199,7 +184,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setOuMode(CAPTURE);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
     assertEquals(CAPTURE, params.getOrgUnitMode());
   }
@@ -209,7 +194,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
     assertEquals(ACCESSIBLE, params.getOrgUnitMode());
   }
@@ -220,7 +205,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setOrgUnitMode(SELECTED);
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+        assertThrows(
+            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
 
     assertStartsWith("Only one parameter of 'ouMode' and 'orgUnitMode'", exception.getMessage());
   }
@@ -231,7 +217,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+        assertThrows(
+            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
 
     assertStartsWith(
         "Only one parameter of 'programStatus' and 'enrollmentStatus'", exception.getMessage());
@@ -243,28 +230,18 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEnrollmentEnrolledAfter(startDate);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertEquals(startDate.toDate(), params.getProgramEnrollmentStartDate());
-    }
+    assertEquals(startDate.toDate(), params.getProgramEnrollmentStartDate());
   }
 
   @Test
   void testMappingProgram() throws BadRequestException {
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertEquals(PROGRAM_UID, params.getProgramUid());
-    }
+    assertEquals(PROGRAM_UID, params.getProgramUid());
   }
 
   @Test
@@ -272,28 +249,17 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
     trackedEntityRequestParams.setProgramStage(UID.of(PROGRAM_STAGE_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertEquals(PROGRAM_STAGE_UID, params.getProgramStageUid());
-    }
+    assertEquals(PROGRAM_STAGE_UID, params.getProgramStageUid());
   }
 
   @Test
   void testMappingTrackedEntityType() throws BadRequestException {
     trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
-
-      assertEquals(TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityTypeUid());
-    }
+    assertEquals(TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityTypeUid());
   }
 
   @Test
@@ -302,7 +268,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
     assertContainsOnly(
         Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
@@ -317,7 +283,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
     assertContainsOnly(
         Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
@@ -331,7 +297,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+        assertThrows(
+            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
 
     assertStartsWith("`program` must be defined when `programStatus`", exception.getMessage());
   }
@@ -342,7 +309,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+        assertThrows(
+            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
 
     assertStartsWith("`program` must be defined when `enrollmentStatus`", exception.getMessage());
   }
@@ -351,7 +319,7 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldFailIfGivenStatusAndNotOccurredEventDates() {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -359,7 +327,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
     trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -367,7 +335,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-11-11"));
     trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -375,7 +343,7 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setOrgUnit("IsdLBTOBzMi");
     trackedEntityRequestParams.setOrgUnits(Set.of(UID.of("IsdLBTOBzMi")));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -383,28 +351,28 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setTrackedEntity("IsdLBTOBzMi");
     trackedEntityRequestParams.setTrackedEntities(Set.of(UID.of("IsdLBTOBzMi")));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
   void shouldFailIfGivenRemovedQueryParameter() {
     trackedEntityRequestParams.setQuery("query");
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
   void shouldFailIfGivenRemovedAttributeParameter() {
     trackedEntityRequestParams.setAttribute("IsdLBTOBzMi");
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
   void shouldFailIfGivenRemovedIncludeAllAttributesParameter() {
     trackedEntityRequestParams.setIncludeAllAttributes("true");
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -413,33 +381,23 @@ class TrackedEntityRequestParamsMapperTest {
         OrderCriteria.fromOrderString("createdAt:asc,zGlzbfreTOH,enrolledAt:desc"));
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertEquals(
-          List.of(
-              new Order("created", SortDirection.ASC),
-              new Order(UID.of("zGlzbfreTOH"), SortDirection.ASC),
-              new Order("enrollment.enrollmentDate", SortDirection.DESC)),
-          params.getOrder());
-    }
+    assertEquals(
+        List.of(
+            new Order("created", SortDirection.ASC),
+            new Order(UID.of("zGlzbfreTOH"), SortDirection.ASC),
+            new Order("enrollment.enrollmentDate", SortDirection.DESC)),
+        params.getOrder());
   }
 
   @Test
   void testMappingOrderParamsNoOrder() throws BadRequestException {
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams);
+    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-      assertIsEmpty(params.getOrder());
-    }
+    assertIsEmpty(params.getOrder());
   }
 
   @Test
@@ -448,7 +406,7 @@ class TrackedEntityRequestParamsMapperTest {
         OrderCriteria.fromOrderString("unsupportedProperty1:asc,enrolledAt:asc"));
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams));
+        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () -> assertContains("unsupportedProperty1", exception.getMessage()));
@@ -460,19 +418,15 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setFilter(TEA_1_UID + ":like:value1," + TEA_2_UID + ":like:value2");
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
-    try (MockedStatic<CurrentUserUtil> userUtilMockedStatic = mockStatic(CurrentUserUtil.class)) {
-      userUtilMockedStatic
-          .when(CurrentUserUtil::getCurrentUserDetails)
-          .thenReturn(UserDetails.fromUser(new User()));
-      Map<String, List<QueryFilter>> filters = mapper.map(trackedEntityRequestParams).getFilters();
+    Map<String, List<QueryFilter>> filters =
+        mapper.map(trackedEntityRequestParams, user).getFilters();
 
-      assertEquals(
-          Map.of(
-              TEA_1_UID,
-              List.of(new QueryFilter(QueryOperator.LIKE, "value1")),
-              TEA_2_UID,
-              List.of(new QueryFilter(QueryOperator.LIKE, "value2"))),
-          filters);
-    }
+    assertEquals(
+        Map.of(
+            TEA_1_UID,
+            List.of(new QueryFilter(QueryOperator.LIKE, "value1")),
+            TEA_2_UID,
+            List.of(new QueryFilter(QueryOperator.LIKE, "value2"))),
+        filters);
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -64,9 +64,11 @@ import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.user.SystemUser;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,6 +98,8 @@ class TrackerImportControllerTest {
 
   @Mock private JobConfigurationService jobConfigurationService;
 
+  @Mock private UserService userService;
+
   private RenderService renderService;
 
   @BeforeEach
@@ -121,6 +125,7 @@ class TrackerImportControllerTest {
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(new CrudControllerAdvice())
+            .setCustomArgumentResolvers(new CurrentUserHandlerMethodArgumentResolver(userService))
             .build();
   }
 


### PR DESCRIPTION
This PR harmonize user management in the `org.hisp.dhis.tracker.export` package.

- Make export services call `CurrentUserUtil.getCurrentUserDetails()` and pass user to the operation params mappers.
- Remove all static mocks of `CurrentUserUtil`
- Remove all `injectSecurityContext` calls from unit tests

**NEXT**
- Push back user into TrackerBundle