### PR TITLE
test: fix test failure on Jenkins

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessor.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.tracker.imports.preprocess;
 
+import static java.util.Objects.nonNull;
+
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -45,7 +47,7 @@ public class EventWithoutRegistrationPreProcessor implements BundlePreProcessor 
   @Override
   public void process(TrackerBundle bundle) {
     for (Event event : bundle.getEvents()) {
-      if (event.getProgramStage().isNotBlank()) {
+      if (nonNull(event.getProgramStage()) && event.getProgramStage().isNotBlank()) {
         ProgramStage programStage = bundle.getPreheat().getProgramStage(event.getProgramStage());
 
         if (programStage != null) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerCreateRelationshipSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerCreateRelationshipSMSTest.java
@@ -112,6 +112,8 @@ class TrackerCreateRelationshipSMSTest extends PostgresControllerIntegrationTest
 
   @BeforeEach
   void setUp() {
+    messageSender.clearMessages();
+
     coc = categoryService.getDefaultCategoryOptionCombo();
 
     orgUnit = createOrganisationUnit('A');

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -123,6 +123,8 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
 
   @BeforeEach
   void setUp() {
+    messageSender.clearMessages();
+
     orgUnit = createOrganisationUnit('A');
 
     user = createUserWithAuth("tester", Authorities.toStringArray(Authorities.F_MOBILE_SETTINGS));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -95,7 +95,6 @@ import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -142,10 +141,11 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
   private DataElement de;
 
   private Program eventProgram;
-  private ProgramStage eventProgramStage;
 
   @BeforeEach
   void setUp() {
+    messageSender.clearMessages();
+
     coc = categoryService.getDefaultCategoryOptionCombo();
 
     orgUnit = createOrganisationUnit('A');
@@ -192,7 +192,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     eventProgram.setProgramType(ProgramType.WITHOUT_REGISTRATION);
     manager.save(eventProgram, false);
 
-    eventProgramStage = createProgramStage('B', eventProgram);
+    ProgramStage eventProgramStage = createProgramStage('B', eventProgram);
     eventProgramStage.setFeatureType(FeatureType.POINT);
     eventProgramStage.getSharing().setOwner(user);
     eventProgramStage.getSharing().addUserAccess(fullAccess(user));
@@ -232,11 +232,11 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "/sms/inbound",
                 format(
                     """
-        {
-        "text": "%s",
-        "originator": "%s"
-        }
-        """,
+                    {
+                    "text": "%s",
+                    "originator": "%s"
+                    }
+                    """,
                     text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
@@ -327,11 +327,11 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "/sms/inbound",
                 format(
                     """
-    {
-    "text": "%s",
-    "originator": "%s"
-    }
-    """,
+                    {
+                    "text": "%s",
+                    "originator": "%s"
+                    }
+                    """,
                     text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
@@ -379,11 +379,11 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "/sms/inbound",
                 format(
                     """
-    {
-    "text": "%s",
-    "originator": "%s"
-    }
-    """,
+                    {
+                    "text": "%s",
+                    "originator": "%s"
+                    }
+                    """,
                     text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
@@ -490,7 +490,6 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertNull(actual.getGeometry()));
   }
 
-  @Disabled("TODO(DHIS2-17729) fix NPE in EventWithoutRegistrationPreProcessor.java:48")
   @Test
   void shouldCreateEventInEventProgram()
       throws SmsCompressionException, ForbiddenException, NotFoundException {


### PR DESCRIPTION
We see

```
Error:  Failures: 
Error:    TrackerEventSMSTest.shouldCreateEventInEventProgram:532 Multiple Failures (3 failures)
	org.opentest4j.AssertionFailedError: expected: <PROCESSED> but was: <FAILED>
```

only on Jenkins. It is due to an NPE at [EventWithoutRegistrationPreProcessor](https://github.com/dhis2/dhis2-core/blob/cc7c00e285e44f52c772a6b38bf2b54d68760f6c/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessor.java#L48
) because the `event.programStage` is null.

The reason we see the NPE on Jenkins and not on GH is the different order of preprocessors. I can make the test fail consistently on GH and Jenkins using Springs `@Order` making `EventWithoutRegistrationPreProcessor` run before `EventProgramPreProcessor`.

- `EventProgramPreProcessor` sets the `event.program` or `event.programStage` if one of them is not in the payload. One of `event.program` or `event.programStage` must be in the payload.
- `EventWithoutRegistrationPreProcessor` is responsible for setting the `event.enrollment` for events in event programs. It does that either via the `event.programStage.program` or the `event.program`.

Since the `EventWithoutRegistrationPreProcessor` was not null-safe it relied on the `EventProgramPreProcessor` having run before.

What's interesting is, why has this never happened before?

The order of the preprocessors when importing an event into an event program into DHIS2 running in Docker (built locally)

1. `EventProgramPreProcessor` called
2. `EventWithoutRegistrationPreProcessor` called

Running on GH

1. `EventProgramPreProcessor` called
2. `EventWithoutRegistrationPreProcessor` called

Running on Jenkins

1. `EventWithoutRegistrationPreProcessor` called
2. `EventProgramPreProcessor` called

So on Jenkins `EventProgramPreProcessor` runs after `EventWithoutRegistrationPreProcessor` which is why the `event.programStage` is not set and we see the NPE.

## Fix

Make `EventWithoutRegistrationPreProcessor` null-safe.

## Why

* Did we not yet have 1 integration test importing an event into an event program?
