### PR TITLE
fix: Put user field back in tracker bundle [DHIS2-18001]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -52,6 +52,8 @@ import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationResult;
 import org.hisp.dhis.tracker.imports.validation.ValidationService;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 
 /**
@@ -79,10 +81,12 @@ public class DefaultTrackerImportService implements TrackerImportService {
   @IndirectTransactional
   public ImportReport importTracker(
       TrackerImportParams params, TrackerObjects trackerObjects, JobProgress jobProgress) {
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
         jobProgress.nonNullStagePostCondition(
-            jobProgress.runStage(() -> trackerBundleService.create(params, trackerObjects)));
+            jobProgress.runStage(
+                () -> trackerBundleService.create(params, trackerObjects, currentUser)));
 
     jobProgress.startingStage("Calculating Payload Size");
     Map<TrackerType, Integer> bundleSize =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -77,10 +77,13 @@ public class DefaultTrackerImportService implements TrackerImportService {
     }
   }
 
+  @Nonnull
   @Override
   @IndirectTransactional
   public ImportReport importTracker(
-      TrackerImportParams params, TrackerObjects trackerObjects, JobProgress jobProgress) {
+      @Nonnull TrackerImportParams params,
+      @Nonnull TrackerObjects trackerObjects,
+      @Nonnull JobProgress jobProgress) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
@@ -194,9 +197,10 @@ public class DefaultTrackerImportService implements TrackerImportService {
    *
    * @return a copy of the current TrackerImportReport
    */
+  @Nonnull
   @Override
   public ImportReport buildImportReport(
-      ImportReport originalImportReport, TrackerBundleReportMode reportMode) {
+      @Nonnull ImportReport originalImportReport, @Nonnull TrackerBundleReportMode reportMode) {
     ImportReport.ImportReportBuilder importReportBuilder =
         ImportReport.builder()
             .status(originalImportReport.getStatus())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/ParamsConverter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/ParamsConverter.java
@@ -29,12 +29,14 @@ package org.hisp.dhis.tracker.imports;
 
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Luciano Fiandesio
  */
 public class ParamsConverter {
-  public static TrackerBundle convert(TrackerImportParams params, TrackerObjects trackerObjects) {
+  public static TrackerBundle convert(
+      TrackerImportParams params, TrackerObjects trackerObjects, UserDetails user) {
     return TrackerBundle.builder()
         .importMode(params.getImportMode())
         .importStrategy(params.getImportStrategy())
@@ -47,6 +49,7 @@ public class ParamsConverter {
         .enrollments(trackerObjects.getEnrollments())
         .events(trackerObjects.getEvents())
         .relationships(trackerObjects.getRelationships())
+        .user(user)
         .build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports;
 
+import javax.annotation.Nonnull;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.RecordingJobProgress;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
@@ -50,7 +51,9 @@ public interface TrackerImportService {
    * @param trackerObjects the objects to import
    * @return report giving status of import (and any errors)
    */
-  default ImportReport importTracker(TrackerImportParams params, TrackerObjects trackerObjects) {
+  @Nonnull
+  default ImportReport importTracker(
+      @Nonnull TrackerImportParams params, @Nonnull TrackerObjects trackerObjects) {
     return importTracker(params, trackerObjects, RecordingJobProgress.transitory());
   }
 
@@ -63,8 +66,11 @@ public interface TrackerImportService {
    * @param jobProgress to track import progress
    * @return Report giving status of import (and any errors)
    */
+  @Nonnull
   ImportReport importTracker(
-      TrackerImportParams params, TrackerObjects trackerObjects, JobProgress jobProgress);
+      @Nonnull TrackerImportParams params,
+      @Nonnull TrackerObjects trackerObjects,
+      @Nonnull JobProgress jobProgress);
 
   /**
    * Build the report based on the mode selected by the client.
@@ -72,5 +78,7 @@ public interface TrackerImportService {
    * @param importReport report with all the data collected during import
    * @return TrackerImportReport report with filtered data based on reportMode
    */
-  ImportReport buildImportReport(ImportReport importReport, TrackerBundleReportMode reportMode);
+  @Nonnull
+  ImportReport buildImportReport(
+      @Nonnull ImportReport importReport, @Nonnull TrackerBundleReportMode reportMode);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Session;
@@ -86,9 +87,12 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
     this.notificationHandlers = notificationHandlers;
   }
 
+  @Nonnull
   @Override
   public TrackerBundle create(
-      TrackerImportParams params, TrackerObjects trackerObjects, UserDetails user) {
+      @Nonnull TrackerImportParams params,
+      @Nonnull TrackerObjects trackerObjects,
+      @Nonnull UserDetails user) {
     TrackerPreheat preheat = trackerPreheatService.preheat(trackerObjects, params.getIdSchemes());
     TrackerBundle trackerBundle = ParamsConverter.convert(params, trackerObjects, user);
     trackerBundle.setPreheat(preheat);
@@ -96,16 +100,18 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
     return trackerBundle;
   }
 
+  @Nonnull
   @Override
-  public TrackerBundle runRuleEngine(TrackerBundle trackerBundle) {
+  public TrackerBundle runRuleEngine(@Nonnull TrackerBundle trackerBundle) {
     programRuleService.calculateRuleEffects(trackerBundle, trackerBundle.getPreheat());
 
     return trackerBundle;
   }
 
+  @Nonnull
   @Override
   @Transactional
-  public PersistenceReport commit(TrackerBundle bundle) {
+  public PersistenceReport commit(@Nonnull TrackerBundle bundle) {
     if (TrackerBundleMode.VALIDATE == bundle.getImportMode()) {
       return PersistenceReport.emptyReport();
     }
@@ -126,7 +132,7 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
 
   @Override
   @Transactional
-  public void postCommit(TrackerBundle bundle) {
+  public void postCommit(@Nonnull TrackerBundle bundle) {
     updateTrackedEntitiesLastUpdated(bundle);
   }
 
@@ -166,13 +172,14 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
   }
 
   @Override
-  public void sendNotifications(List<TrackerNotificationDataBundle> bundles) {
+  public void sendNotifications(@Nonnull List<TrackerNotificationDataBundle> bundles) {
     notificationHandlers.forEach(handler -> handler.handleNotifications(bundles));
   }
 
+  @Nonnull
   @Override
   @Transactional
-  public PersistenceReport delete(TrackerBundle bundle)
+  public PersistenceReport delete(@Nonnull TrackerBundle bundle)
       throws ForbiddenException, NotFoundException {
     if (TrackerBundleMode.VALIDATE == bundle.getImportMode()) {
       return PersistenceReport.emptyReport();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.user.UserDetails;
 @Builder
 @AllArgsConstructor
 public class TrackerBundle {
+  /** User making the import */
   private UserDetails user;
 
   /** Should import be imported or just validated. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.tracker.imports.domain.TrackerDto;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.imports.programrule.executor.RuleActionExecutor;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -63,6 +64,8 @@ import org.hisp.dhis.tracker.imports.programrule.executor.RuleActionExecutor;
 @Builder
 @AllArgsConstructor
 public class TrackerBundle {
+  private UserDetails user;
+
   /** Should import be imported or just validated. */
   @Builder.Default private TrackerBundleMode importMode = TrackerBundleMode.COMMIT;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.imports.bundle;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
@@ -46,40 +47,48 @@ public interface TrackerBundleService {
    * @param params Params object for this bundle.
    * @return Configured TrackerBundle instance(s) (if bundle splitting is enabled)
    */
-  TrackerBundle create(TrackerImportParams params, TrackerObjects trackerObjects, UserDetails user);
+  @Nonnull
+  TrackerBundle create(
+      @Nonnull TrackerImportParams params,
+      @Nonnull TrackerObjects trackerObjects,
+      @Nonnull UserDetails user);
 
   /**
    * Call rule engine for tracker bundle.
    *
    * @return Tracker bundle populated with rule effects
    */
-  TrackerBundle runRuleEngine(TrackerBundle bundle);
+  @Nonnull
+  TrackerBundle runRuleEngine(@Nonnull TrackerBundle bundle);
 
   /**
    * Commits objects from bundle into persistence store if bundle mode COMMIT is enabled.
    *
    * @param bundle TrackerBundle to commit.
    */
-  PersistenceReport commit(TrackerBundle bundle);
+  @Nonnull
+  PersistenceReport commit(@Nonnull TrackerBundle bundle);
 
   /**
    * Carry out notifications for TrackerImporter.
    *
    * @param bundles {@link TrackerNotificationDataBundle} to hold data for notifications.
    */
-  void sendNotifications(List<TrackerNotificationDataBundle> bundles);
+  void sendNotifications(@Nonnull List<TrackerNotificationDataBundle> bundles);
 
   /**
    * Deletes objects in the bundle from persistence store if bundle mode DELETE is enabled.
    *
    * @param bundle TrackerBundle to delete.
    */
-  PersistenceReport delete(TrackerBundle bundle) throws ForbiddenException, NotFoundException;
+  @Nonnull
+  PersistenceReport delete(@Nonnull TrackerBundle bundle)
+      throws ForbiddenException, NotFoundException;
 
   /**
    * Finalize bundle objects
    *
    * @param bundle to process in post commit operations if any
    */
-  void postCommit(TrackerBundle bundle);
+  void postCommit(@Nonnull TrackerBundle bundle);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -45,7 +46,7 @@ public interface TrackerBundleService {
    * @param params Params object for this bundle.
    * @return Configured TrackerBundle instance(s) (if bundle splitting is enabled)
    */
-  TrackerBundle create(TrackerImportParams params, TrackerObjects trackerObjects);
+  TrackerBundle create(TrackerImportParams params, TrackerObjects trackerObjects, UserDetails user);
 
   /**
    * Call rule engine for tracker bundle.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -67,6 +66,7 @@ import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Luciano Fiandesio
@@ -121,7 +121,8 @@ public abstract class AbstractTrackerPersister<
         //
         persistOwnership(bundle.getPreheat(), convertedDto);
 
-        updateDataValues(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+        updateDataValues(
+            entityManager, bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser());
 
         //
         // Save or update the entity
@@ -130,10 +131,12 @@ public abstract class AbstractTrackerPersister<
           entityManager.persist(convertedDto);
           typeReport.getStats().incCreated();
           typeReport.addEntity(objectReport);
-          updateAttributes(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+          updateAttributes(
+              entityManager, bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser());
         } else {
           if (isUpdatable()) {
-            updateAttributes(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+            updateAttributes(
+                entityManager, bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser());
             entityManager.merge(convertedDto);
             typeReport.getStats().incUpdated();
             typeReport.addEntity(objectReport);
@@ -204,11 +207,19 @@ public abstract class AbstractTrackerPersister<
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(
-      EntityManager entityManager, TrackerPreheat preheat, T trackerDto, V hibernateEntity);
+      EntityManager entityManager,
+      TrackerPreheat preheat,
+      T trackerDto,
+      V hibernateEntity,
+      UserDetails user);
 
   /** Execute the persistence of Attribute values linked to the entity being processed */
   protected abstract void updateAttributes(
-      EntityManager entityManager, TrackerPreheat preheat, T trackerDto, V hibernateEntity);
+      EntityManager entityManager,
+      TrackerPreheat preheat,
+      T trackerDto,
+      V hibernateEntity,
+      UserDetails user);
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -299,7 +310,8 @@ public abstract class AbstractTrackerPersister<
       EntityManager entityManager,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
-      TrackedEntity trackedEntity) {
+      TrackedEntity trackedEntity,
+      UserDetails user) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
@@ -331,7 +343,7 @@ public abstract class AbstractTrackerPersister<
           }
 
           if (isDelete) {
-            delete(entityManager, preheat, trackedEntityAttributeValue, trackedEntity);
+            delete(entityManager, preheat, trackedEntityAttributeValue, trackedEntity, user);
           } else {
             if (!isNew) {
               isUpdated = !trackedEntityAttributeValue.getPlainValue().equals(attribute.getValue());
@@ -355,7 +367,8 @@ public abstract class AbstractTrackerPersister<
                 isNew,
                 trackedEntity,
                 trackedEntityAttributeValue,
-                isUpdated);
+                isUpdated,
+                user);
           }
 
           handleReservedValue(trackedEntityAttributeValue);
@@ -366,7 +379,8 @@ public abstract class AbstractTrackerPersister<
       EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
-      TrackedEntity trackedEntity) {
+      TrackedEntity trackedEntity,
+      UserDetails user) {
     if (isFileResource(trackedEntityAttributeValue)) {
       unassignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
@@ -378,7 +392,7 @@ public abstract class AbstractTrackerPersister<
             : entityManager.merge(trackedEntityAttributeValue));
 
     logTrackedEntityAttributeValueHistory(
-        getCurrentUsername(), trackedEntityAttributeValue, trackedEntity, ChangeLogType.DELETE);
+        user.getUsername(), trackedEntityAttributeValue, trackedEntity, ChangeLogType.DELETE);
   }
 
   private void saveOrUpdate(
@@ -387,7 +401,8 @@ public abstract class AbstractTrackerPersister<
       boolean isNew,
       TrackedEntity trackedEntity,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
-      boolean isUpdated) {
+      boolean isUpdated,
+      UserDetails user) {
     if (isFileResource(trackedEntityAttributeValue)) {
       assignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
@@ -410,7 +425,7 @@ public abstract class AbstractTrackerPersister<
     }
 
     logTrackedEntityAttributeValueHistory(
-        getCurrentUsername(), trackedEntityAttributeValue, trackedEntity, changeLogType);
+        user.getUsername(), trackedEntityAttributeValue, trackedEntity, changeLogType);
   }
 
   private static boolean isFileResource(TrackedEntityAttributeValue trackedEntityAttributeValue) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +43,7 @@ import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -75,12 +74,14 @@ public class EnrollmentPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-      Enrollment enrollmentToPersist) {
+      Enrollment enrollmentToPersist,
+      UserDetails user) {
     handleTrackedEntityAttributeValues(
         entityManager,
         preheat,
         enrollment.getAttributes(),
-        preheat.getTrackedEntity(enrollmentToPersist.getTrackedEntity().getUid()));
+        preheat.getTrackedEntity(enrollmentToPersist.getTrackedEntity().getUid()),
+        user);
   }
 
   @Override
@@ -88,7 +89,8 @@ public class EnrollmentPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-      Enrollment enrollmentToPersist) {
+      Enrollment enrollmentToPersist,
+      UserDetails user) {
     // DO NOTHING - TE HAVE NO DATA VALUES
   }
 
@@ -116,7 +118,7 @@ public class EnrollmentPersister
             bundle.getEnrollmentNotifications().get(UID.of(enrollment.getUid())))
         .object(enrollment.getUid())
         .importStrategy(bundle.getImportStrategy())
-        .accessedBy(getCurrentUsername())
+        .accessedBy(bundle.getUser().getUsername())
         .enrollment(enrollment)
         .program(enrollment.getProgram())
         .triggers(triggers)
@@ -151,7 +153,7 @@ public class EnrollmentPersister
   @Override
   protected Enrollment convert(
       TrackerBundle bundle, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment) {
-    return enrollmentConverter.from(bundle.getPreheat(), enrollment);
+    return enrollmentConverter.from(bundle.getPreheat(), enrollment, bundle.getUser());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -62,6 +61,7 @@ import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
 
@@ -105,7 +105,7 @@ public class EventPersister
         .eventNotifications(bundle.getEventNotifications().get(UID.of(event.getUid())))
         .object(event.getUid())
         .importStrategy(bundle.getImportStrategy())
-        .accessedBy(getCurrentUsername())
+        .accessedBy(bundle.getUser().getUsername())
         .event(event)
         .program(event.getProgramStage().getProgram())
         .triggers(triggers)
@@ -136,7 +136,7 @@ public class EventPersister
 
   @Override
   protected Event convert(TrackerBundle bundle, org.hisp.dhis.tracker.imports.domain.Event event) {
-    return eventConverter.from(bundle.getPreheat(), event);
+    return eventConverter.from(bundle.getPreheat(), event, bundle.getUser());
   }
 
   @Override
@@ -149,7 +149,8 @@ public class EventPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Event event,
-      Event hibernateEntity) {
+      Event hibernateEntity,
+      UserDetails user) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 
@@ -158,15 +159,17 @@ public class EventPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Event event,
-      Event hibernateEntity) {
-    handleDataValues(entityManager, preheat, event.getDataValues(), hibernateEntity);
+      Event hibernateEntity,
+      UserDetails user) {
+    handleDataValues(entityManager, preheat, event.getDataValues(), hibernateEntity, user);
   }
 
   private void handleDataValues(
       EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
-      Event event) {
+      Event event,
+      UserDetails user) {
     Map<String, EventDataValue> dataValueDBMap =
         Optional.ofNullable(preheat.getEvent(event.getUid()))
             .map(
@@ -212,7 +215,7 @@ public class EventPersister
           }
 
           logTrackedEntityDataValueHistory(
-              getCurrentUsername(), dataElement, event, new Date(), valuesHolder);
+              user.getUsername(), dataElement, event, new Date(), valuesHolder);
         });
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -62,7 +63,7 @@ public class RelationshipPersister
   @Override
   protected org.hisp.dhis.relationship.Relationship convert(
       TrackerBundle bundle, Relationship trackerDto) {
-    return relationshipConverter.from(bundle.getPreheat(), trackerDto);
+    return relationshipConverter.from(bundle.getPreheat(), trackerDto, bundle.getUser());
   }
 
   @Override
@@ -70,7 +71,8 @@ public class RelationshipPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
-      org.hisp.dhis.relationship.Relationship hibernateEntity) {
+      org.hisp.dhis.relationship.Relationship hibernateEntity,
+      UserDetails user) {
     // NOTHING TO DO
   }
 
@@ -79,7 +81,8 @@ public class RelationshipPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
-      org.hisp.dhis.relationship.Relationship hibernateEntity) {
+      org.hisp.dhis.relationship.Relationship hibernateEntity,
+      UserDetails user) {
     // NOTHING TO DO
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,8 +69,10 @@ public class TrackedEntityPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity te) {
-    handleTrackedEntityAttributeValues(entityManager, preheat, trackerDto.getAttributes(), te);
+      TrackedEntity te,
+      UserDetails user) {
+    handleTrackedEntityAttributeValues(
+        entityManager, preheat, trackerDto.getAttributes(), te, user);
   }
 
   @Override
@@ -77,7 +80,8 @@ public class TrackedEntityPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity te) {
+      TrackedEntity te,
+      UserDetails user) {
     // DO NOTHING - TE HAVE NO DATA VALUES
   }
 
@@ -89,7 +93,7 @@ public class TrackedEntityPersister
   @Override
   protected TrackedEntity convert(
       TrackerBundle bundle, org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto) {
-    return teConverter.from(bundle.getPreheat(), trackerDto);
+    return teConverter.from(bundle.getPreheat(), trackerDto, bundle.getUser());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/AttributeValueConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/AttributeValueConverterService.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 
 /**
@@ -64,11 +65,11 @@ public class AttributeValueConverterService
 
   @Override
   public List<Attribute> to(List<TrackedEntityAttributeValue> attributeValues) {
-    return attributeValues.stream().map(this::to).collect(Collectors.toList());
+    return attributeValues.stream().map(this::to).toList();
   }
 
   @Override
-  public TrackedEntityAttributeValue from(TrackerPreheat preheat, Attribute at) {
+  public TrackedEntityAttributeValue from(TrackerPreheat preheat, Attribute at, UserDetails user) {
     TrackedEntityAttribute attribute = preheat.getTrackedEntityAttribute(at.getAttribute());
 
     if (attribute == null) {
@@ -88,10 +89,10 @@ public class AttributeValueConverterService
 
   @Override
   public List<TrackedEntityAttributeValue> from(
-      TrackerPreheat preheat, List<Attribute> attributes) {
+      TrackerPreheat preheat, List<Attribute> attributes, UserDetails user) {
     return attributes.stream()
         .filter(Objects::nonNull)
-        .map(n -> from(preheat, n))
+        .map(n -> from(preheat, n, user))
         .collect(Collectors.toList());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.tracker.imports.converter;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,6 +43,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
@@ -86,29 +85,36 @@ public class EnrollmentTrackerConverterService
 
   @Override
   public Enrollment from(
-      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment) {
+      TrackerPreheat preheat,
+      org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
+      UserDetails user) {
     Enrollment preheatEnrollment = preheat.getEnrollment(enrollment.getEnrollment());
-    return from(preheat, enrollment, preheatEnrollment);
+    return from(preheat, enrollment, preheatEnrollment, user);
   }
 
   @Override
   public List<Enrollment> from(
-      TrackerPreheat preheat, List<org.hisp.dhis.tracker.imports.domain.Enrollment> enrollments) {
+      TrackerPreheat preheat,
+      List<org.hisp.dhis.tracker.imports.domain.Enrollment> enrollments,
+      UserDetails user) {
     return enrollments.stream()
-        .map(enrollment -> from(preheat, enrollment))
+        .map(enrollment -> from(preheat, enrollment, user))
         .collect(Collectors.toList());
   }
 
   @Override
   public Enrollment fromForRuleEngine(
-      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment) {
-    return from(preheat, enrollment, null);
+      TrackerPreheat preheat,
+      org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
+      UserDetails user) {
+    return from(preheat, enrollment, null, user);
   }
 
   private Enrollment from(
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-      Enrollment dbEnrollment) {
+      Enrollment dbEnrollment,
+      UserDetails user) {
     OrganisationUnit organisationUnit = preheat.getOrganisationUnit(enrollment.getOrgUnit());
 
     Program program = preheat.getProgram(enrollment.getProgram());
@@ -125,11 +131,11 @@ public class EnrollmentTrackerConverterService
               : enrollment.getUid());
       dbEnrollment.setCreated(now);
       dbEnrollment.setStoredBy(enrollment.getStoredBy());
-      dbEnrollment.setCreatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+      dbEnrollment.setCreatedByUserInfo(UserInfoSnapshot.from(user));
     }
 
     dbEnrollment.setLastUpdated(now);
-    dbEnrollment.setLastUpdatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+    dbEnrollment.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
     dbEnrollment.setDeleted(false);
     dbEnrollment.setCreatedAtClient(DateUtils.fromInstant(enrollment.getCreatedAtClient()));
     dbEnrollment.setLastUpdatedAtClient(DateUtils.fromInstant(enrollment.getUpdatedAtClient()));
@@ -152,14 +158,16 @@ public class EnrollmentTrackerConverterService
     if (previousStatus != dbEnrollment.getStatus()) {
       if (dbEnrollment.isCompleted()) {
         dbEnrollment.setCompletedDate(now);
-        dbEnrollment.setCompletedBy(getCurrentUsername());
+        dbEnrollment.setCompletedBy(user.getUsername());
       } else if (EnrollmentStatus.CANCELLED == dbEnrollment.getStatus()) {
         dbEnrollment.setCompletedDate(now);
       }
     }
 
     if (isNotEmpty(enrollment.getNotes())) {
-      dbEnrollment.getNotes().addAll(notesConverterService.from(preheat, enrollment.getNotes()));
+      dbEnrollment
+          .getNotes()
+          .addAll(notesConverterService.from(preheat, enrollment.getNotes(), user));
     }
     return dbEnrollment;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.tracker.imports.converter;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,6 +55,7 @@ import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
@@ -147,20 +146,23 @@ public class EventTrackerConverterService
   }
 
   @Override
-  public Event from(TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Event event) {
-    return from(preheat, event, preheat.getEvent(event.getEvent()));
+  public Event from(
+      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Event event, UserDetails user) {
+    return from(preheat, event, preheat.getEvent(event.getEvent()), user);
   }
 
   @Override
   public List<Event> from(
-      TrackerPreheat preheat, List<org.hisp.dhis.tracker.imports.domain.Event> events) {
-    return events.stream().map(e -> from(preheat, e)).collect(Collectors.toList());
+      TrackerPreheat preheat,
+      List<org.hisp.dhis.tracker.imports.domain.Event> events,
+      UserDetails user) {
+    return events.stream().map(e -> from(preheat, e, user)).toList();
   }
 
   @Override
   public Event fromForRuleEngine(
-      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Event event) {
-    Event result = from(preheat, event, null);
+      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Event event, UserDetails user) {
+    Event result = from(preheat, event, null, user);
     // merge data values from DB
     result.getEventDataValues().addAll(getDataValues(preheat, event));
     return result;
@@ -191,7 +193,10 @@ public class EventTrackerConverterService
   }
 
   private Event from(
-      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Event event, Event result) {
+      TrackerPreheat preheat,
+      org.hisp.dhis.tracker.imports.domain.Event event,
+      Event result,
+      UserDetails user) {
     ProgramStage programStage = preheat.getProgramStage(event.getProgramStage());
     Program program = preheat.getProgram(event.getProgram());
     OrganisationUnit organisationUnit = preheat.getOrganisationUnit(event.getOrgUnit());
@@ -203,10 +208,10 @@ public class EventTrackerConverterService
       result.setUid(!StringUtils.isEmpty(event.getEvent()) ? event.getEvent() : event.getUid());
       result.setCreated(now);
       result.setStoredBy(event.getStoredBy());
-      result.setCreatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+      result.setCreatedByUserInfo(UserInfoSnapshot.from(user));
       result.setCreatedAtClient(DateUtils.fromInstant(event.getCreatedAtClient()));
     }
-    result.setLastUpdatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+    result.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
     result.setLastUpdated(now);
     result.setDeleted(false);
     result.setLastUpdatedAtClient(DateUtils.fromInstant(event.getUpdatedAtClient()));
@@ -230,7 +235,7 @@ public class EventTrackerConverterService
 
     if (currentStatus != previousStatus && currentStatus == EventStatus.COMPLETED) {
       result.setCompletedDate(now);
-      result.setCompletedBy(getCurrentUsername());
+      result.setCompletedBy(user.getUsername());
     }
 
     if (currentStatus != EventStatus.COMPLETED) {
@@ -264,14 +269,14 @@ public class EventTrackerConverterService
       // dataElementIdSchemes are supported
       DataElement dataElement = preheat.getDataElement(dataValue.getDataElement());
       eventDataValue.setDataElement(dataElement.getUid());
-      eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
-      eventDataValue.setCreatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+      eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
+      eventDataValue.setCreatedByUserInfo(UserInfoSnapshot.from(user));
 
       result.getEventDataValues().add(eventDataValue);
     }
 
     if (isNotEmpty(event.getNotes())) {
-      result.getNotes().addAll(notesConverterService.from(preheat, event.getNotes()));
+      result.getNotes().addAll(notesConverterService.from(preheat, event.getNotes(), user));
     }
 
     return result;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/NotesConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/NotesConverterService.java
@@ -27,13 +27,12 @@
  */
 package org.hisp.dhis.tracker.imports.converter;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
@@ -68,21 +67,23 @@ public class NotesConverterService
   }
 
   @Override
-  public Note from(TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Note note) {
+  public Note from(
+      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Note note, UserDetails user) {
     org.hisp.dhis.note.Note trackerNote = new org.hisp.dhis.note.Note();
     trackerNote.setUid(note.getNote());
     trackerNote.setAutoFields();
     trackerNote.setNoteText(note.getValue());
 
-    trackerNote.setLastUpdatedBy(
-        preheat.getUserByUid(getCurrentUserDetails().getUid()).orElse(null));
+    trackerNote.setLastUpdatedBy(preheat.getUserByUid(user.getUid()).orElse(null));
     trackerNote.setCreator(note.getStoredBy());
     return trackerNote;
   }
 
   @Override
   public List<Note> from(
-      TrackerPreheat preheat, List<org.hisp.dhis.tracker.imports.domain.Note> notes) {
-    return notes.stream().map(n -> from(preheat, n)).toList();
+      TrackerPreheat preheat,
+      List<org.hisp.dhis.tracker.imports.domain.Note> notes,
+      UserDetails user) {
+    return notes.stream().map(n -> from(preheat, n, user)).toList();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterService.java
@@ -34,13 +34,13 @@ import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTA
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.hisp.dhis.relationship.RelationshipKey;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.util.RelationshipKeySupport;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
@@ -81,7 +81,7 @@ public class RelationshipTrackerConverterService
 
               return toRelationship;
             })
-        .collect(Collectors.toList());
+        .toList();
   }
 
   private RelationshipItem convertRelationshipType(
@@ -97,7 +97,7 @@ public class RelationshipTrackerConverterService
 
   @Override
   public org.hisp.dhis.relationship.Relationship from(
-      TrackerPreheat preheat, Relationship fromRelationship) {
+      TrackerPreheat preheat, Relationship fromRelationship, UserDetails user) {
     org.hisp.dhis.relationship.Relationship toRelationship =
         preheat.getRelationship(fromRelationship.getRelationship());
     return from(preheat, fromRelationship, toRelationship);
@@ -105,8 +105,8 @@ public class RelationshipTrackerConverterService
 
   @Override
   public List<org.hisp.dhis.relationship.Relationship> from(
-      TrackerPreheat preheat, List<Relationship> fromRelationships) {
-    return fromRelationships.stream().map(r -> from(preheat, r)).collect(Collectors.toList());
+      TrackerPreheat preheat, List<Relationship> fromRelationships, UserDetails user) {
+    return fromRelationships.stream().map(r -> from(preheat, r, user)).toList();
   }
 
   private org.hisp.dhis.relationship.Relationship from(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RuleEngineConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RuleEngineConverterService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.imports.converter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * Converts rule-engine domain objects to tracker domain objects and vice versa.
@@ -37,11 +38,11 @@ import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
  * @author Enrico Colasante
  */
 public interface RuleEngineConverterService<From, To> extends TrackerConverterService<From, To> {
-  To fromForRuleEngine(TrackerPreheat preheat, From object);
+  To fromForRuleEngine(TrackerPreheat preheat, From object, UserDetails user);
 
-  default List<To> fromForRuleEngine(TrackerPreheat preheat, List<From> objects) {
+  default List<To> fromForRuleEngine(TrackerPreheat preheat, List<From> objects, UserDetails user) {
     return objects.stream()
-        .map(object -> fromForRuleEngine(preheat, object))
+        .map(object -> fromForRuleEngine(preheat, object, user))
         .collect(Collectors.toList());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/TrackedEntityTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/TrackedEntityTrackerConverterService.java
@@ -27,17 +27,15 @@
  */
 package org.hisp.dhis.tracker.imports.converter;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
@@ -72,27 +70,31 @@ public class TrackedEntityTrackerConverterService
 
               return trackedEntity;
             })
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Override
   public TrackedEntity from(
-      TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity) {
+      TrackerPreheat preheat,
+      org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity,
+      UserDetails user) {
     TrackedEntity te = preheat.getTrackedEntity(trackedEntity.getTrackedEntity());
-    return from(preheat, trackedEntity, te);
+    return from(preheat, trackedEntity, te, user);
   }
 
   @Override
   public List<TrackedEntity> from(
       TrackerPreheat preheat,
-      List<org.hisp.dhis.tracker.imports.domain.TrackedEntity> trackedEntities) {
-    return trackedEntities.stream().map(te -> from(preheat, te)).collect(Collectors.toList());
+      List<org.hisp.dhis.tracker.imports.domain.TrackedEntity> trackedEntities,
+      UserDetails user) {
+    return trackedEntities.stream().map(te -> from(preheat, te, user)).toList();
   }
 
   private TrackedEntity from(
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity teFrom,
-      TrackedEntity teTo) {
+      TrackedEntity teTo,
+      UserDetails user) {
     OrganisationUnit organisationUnit = preheat.getOrganisationUnit(teFrom.getOrgUnit());
     TrackedEntityType trackedEntityType =
         preheat.getTrackedEntityType(teFrom.getTrackedEntityType());
@@ -103,10 +105,10 @@ public class TrackedEntityTrackerConverterService
       teTo = new TrackedEntity();
       teTo.setUid(teFrom.getTrackedEntity());
       teTo.setCreated(now);
-      teTo.setCreatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+      teTo.setCreatedByUserInfo(UserInfoSnapshot.from(user));
     }
 
-    teTo.setLastUpdatedByUserInfo(UserInfoSnapshot.from(getCurrentUserDetails()));
+    teTo.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
     teTo.setStoredBy(teFrom.getStoredBy());
     teTo.setLastUpdated(now);
     teTo.setDeleted(false);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/TrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/TrackerConverterService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.imports.converter;
 
 import java.util.List;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -38,9 +39,9 @@ public interface TrackerConverterService<From, To> {
 
   List<From> to(List<To> objects);
 
-  To from(TrackerPreheat preheat, From object);
+  To from(TrackerPreheat preheat, From object, UserDetails user);
 
-  List<To> from(TrackerPreheat preheat, List<From> objects);
+  List<To> from(TrackerPreheat preheat, List<From> objects, UserDetails user);
 
   default boolean isNewEntity(To entity) {
     return entity == null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/DefaultTrackerPreheatService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.imports.preheat;
 
 import java.beans.Introspector;
 import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.preheat.PreheatException;
@@ -63,10 +64,11 @@ public class DefaultTrackerPreheatService
   // TODO this flag should be configurable
   private static final boolean FAIL_FAST_ON_PREHEAT_ERROR = false;
 
+  @Nonnull
   @Override
   @Transactional(readOnly = true)
   public TrackerPreheat preheat(
-      TrackerObjects trackerObjects, TrackerIdSchemeParams idSchemeParams) {
+      @Nonnull TrackerObjects trackerObjects, @Nonnull TrackerIdSchemeParams idSchemeParams) {
     TrackerPreheat preheat = new TrackerPreheat();
     preheat.setIdSchemes(idSchemeParams);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.preheat;
 
+import javax.annotation.Nonnull;
 import org.hisp.dhis.tracker.imports.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 
@@ -43,5 +44,7 @@ public interface TrackerPreheatService {
    * @param idSchemeParams id schema identifier
    * @return
    */
-  TrackerPreheat preheat(TrackerObjects trackerObjects, TrackerIdSchemeParams idSchemeParams);
+  @Nonnull
+  TrackerPreheat preheat(
+      @Nonnull TrackerObjects trackerObjects, @Nonnull TrackerIdSchemeParams idSchemeParams);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DefaultTrackerPreprocessService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DefaultTrackerPreprocessService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.imports.preprocess;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -45,8 +46,9 @@ public class DefaultTrackerPreprocessService implements TrackerPreprocessService
     this.preProcessors = preProcessors;
   }
 
+  @Nonnull
   @Override
-  public TrackerBundle preprocess(TrackerBundle bundle) {
+  public TrackerBundle preprocess(@Nonnull TrackerBundle bundle) {
     for (BundlePreProcessor preProcessor : preProcessors) {
       if (preProcessor.needsToRun(bundle.getImportStrategy())) {
         preProcessor.process(bundle);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/TrackerPreprocessService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/TrackerPreprocessService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.preprocess;
 
+import javax.annotation.Nonnull;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 
 /**
@@ -38,5 +39,6 @@ public interface TrackerPreprocessService {
    *
    * @param bundle Bundle to preprocess
    */
-  TrackerBundle preprocess(TrackerBundle bundle);
+  @Nonnull
+  TrackerBundle preprocess(@Nonnull TrackerBundle bundle);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
@@ -36,14 +36,16 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.user.UserDetails;
 
 public interface ProgramRuleEngine {
   RuleEngineEffects evaluateEnrollmentAndEvents(
       Enrollment enrollment,
       Set<Event> events,
-      List<TrackedEntityAttributeValue> trackedEntityAttributeValues);
+      List<TrackedEntityAttributeValue> trackedEntityAttributeValues,
+      UserDetails user);
 
-  RuleEngineEffects evaluateProgramEvents(Set<Event> events, Program program);
+  RuleEngineEffects evaluateProgramEvents(Set<Event> events, Program program, UserDetails user);
 
   /**
    * To getDescription rule condition in order to fetch its description

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/SupplementaryDataProvider.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/SupplementaryDataProvider.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.programrule.engine;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -57,7 +56,8 @@ public class SupplementaryDataProvider {
 
   @Nonnull private final OrganisationUnitGroupService organisationUnitGroupService;
 
-  public Map<String, List<String>> getSupplementaryData(List<ProgramRule> programRules) {
+  public Map<String, List<String>> getSupplementaryData(
+      List<ProgramRule> programRules, UserDetails user) {
     List<String> orgUnitGroups = new ArrayList<>();
 
     for (ProgramRule programRule : programRules) {
@@ -85,7 +85,7 @@ public class SupplementaryDataProvider {
                               .toList()));
     }
 
-    supplementaryData.put(USER, new ArrayList<>(getCurrentUserDetails().getUserRoleIds()));
+    supplementaryData.put(USER, new ArrayList<>(user.getUserRoleIds()));
 
     return supplementaryData;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports.validation;
 
 import static org.hisp.dhis.tracker.imports.validation.PersistablesFilter.filter;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -66,7 +65,7 @@ public class DefaultValidationService implements ValidationService {
   }
 
   private ValidationResult validate(TrackerBundle bundle, Validator<TrackerBundle> validator) {
-    UserDetails user = getCurrentUserDetails();
+    UserDetails user = bundle.getUser();
     if (user.isSuper() && ValidationMode.SKIP == bundle.getValidationMode()) {
       log.warn(
           "Skipping validation for metadata import by user '"

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.tracker.imports.validation.PersistablesFilter.filter
 
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -54,13 +55,15 @@ public class DefaultValidationService implements ValidationService {
   @Qualifier("org.hisp.dhis.tracker.imports.validation.validator.RuleEngineValidator")
   private final Validator<TrackerBundle> ruleEngineValidator;
 
+  @Nonnull
   @Override
-  public ValidationResult validate(TrackerBundle bundle) {
+  public ValidationResult validate(@Nonnull TrackerBundle bundle) {
     return validate(bundle, validator);
   }
 
+  @Nonnull
   @Override
-  public ValidationResult validateRuleEngine(TrackerBundle bundle) {
+  public ValidationResult validateRuleEngine(@Nonnull TrackerBundle bundle) {
     return validate(bundle, ruleEngineValidator);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.validation;
 
+import javax.annotation.Nonnull;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 
 /**
@@ -38,12 +39,14 @@ public interface ValidationService {
    *
    * @param bundle Bundle to validate
    */
-  ValidationResult validate(TrackerBundle bundle);
+  @Nonnull
+  ValidationResult validate(@Nonnull TrackerBundle bundle);
 
   /**
    * Validate tracker bundle with validations created by rule engine
    *
    * @param bundle Bundle to validate
    */
-  ValidationResult validateRuleEngine(TrackerBundle bundle);
+  @Nonnull
+  ValidationResult validateRuleEngine(@Nonnull TrackerBundle bundle);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1043;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1046;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1047;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1050;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.time.Instant;
 import java.util.Date;
@@ -50,6 +49,7 @@ import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.Validator;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -70,12 +70,13 @@ class DateValidator implements Validator<Event> {
       return;
     }
 
-    validateExpiryDays(reporter, event, program);
+    validateExpiryDays(reporter, event, program, bundle.getUser());
     validatePeriodType(reporter, event, program);
   }
 
-  private void validateExpiryDays(Reporter reporter, Event event, Program program) {
-    if (getCurrentUserDetails().isAuthorized(Authorities.F_EDIT_EXPIRED.name())) {
+  private void validateExpiryDays(
+      Reporter reporter, Event event, Program program, UserDetails user) {
+    if (user.isAuthorized(Authorities.F_EDIT_EXPIRED.name())) {
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.imports.validation.validator.event;
 
 import static org.hisp.dhis.security.Authorities.F_UNCOMPLETE_EVENT;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1083;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -99,7 +98,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       if (organisationUnit == null) {
         log.warn(ORG_UNIT_NO_USER_ASSIGNED, event.getUid());
       } else {
-        checkOrgUnitInCaptureScope(reporter, event, organisationUnit);
+        checkOrgUnitInCaptureScope(reporter, event, organisationUnit, bundle.getUser());
       }
     }
 
@@ -117,7 +116,8 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
           event,
           preheatEvent,
           trackedEntity == null ? null : trackedEntity.getUid(),
-          ownerOrgUnit);
+          ownerOrgUnit,
+          bundle.getUser());
     } else {
       validateCreateEvent(
           reporter,
@@ -169,8 +169,8 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       org.hisp.dhis.tracker.imports.domain.Event event,
       Event preheatEvent,
       String teUid,
-      OrganisationUnit ownerOrgUnit) {
-    UserDetails user = getCurrentUserDetails();
+      OrganisationUnit ownerOrgUnit,
+      UserDetails user) {
     TrackerImportStrategy strategy = bundle.getStrategy(event);
 
     checkEventWriteAccess(
@@ -227,8 +227,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
   }
 
   private void checkOrgUnitInCaptureScope(
-      Reporter reporter, TrackerDto dto, OrganisationUnit orgUnit) {
-    UserDetails user = getCurrentUserDetails();
+      Reporter reporter, TrackerDto dto, OrganisationUnit orgUnit, UserDetails user) {
     if (!user.isInUserHierarchy(orgUnit.getPath())) {
       reporter.addError(dto, ValidationCode.E1000, user, orgUnit);
     }
@@ -239,8 +238,8 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       TrackerDto dto,
       String trackedEntity,
       OrganisationUnit ownerOrganisationUnit,
-      Program program) {
-    UserDetails user = getCurrentUserDetails();
+      Program program,
+      UserDetails user) {
     if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
       reporter.addError(dto, ValidationCode.E1104, user, program, program.getTrackedEntityType());
     }
@@ -263,23 +262,29 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       boolean isCreatableInSearchScope) {
 
     if (bundle.getStrategy(event) != TrackerImportStrategy.UPDATE) {
-      checkEventOrgUnitWriteAccess(reporter, event, eventOrgUnit, isCreatableInSearchScope);
+      checkEventOrgUnitWriteAccess(
+          reporter, event, eventOrgUnit, isCreatableInSearchScope, bundle.getUser());
     }
 
     if (programStage.getProgram().isWithoutRegistration()) {
-      checkProgramWriteAccess(reporter, event, programStage.getProgram());
+      checkProgramWriteAccess(reporter, event, programStage.getProgram(), bundle.getUser());
     } else {
-      checkProgramStageWriteAccess(reporter, event, programStage);
+      checkProgramStageWriteAccess(reporter, event, programStage, bundle.getUser());
       final Program program = programStage.getProgram();
 
-      checkProgramReadAccess(reporter, event, program);
+      checkProgramReadAccess(reporter, event, program, bundle.getUser());
 
       checkTeTypeAndTeProgramAccess(
-          reporter, event, trackedEntity, ownerOrgUnit, programStage.getProgram());
+          reporter,
+          event,
+          trackedEntity,
+          ownerOrgUnit,
+          programStage.getProgram(),
+          bundle.getUser());
     }
 
     if (categoryOptionCombo != null) {
-      checkWriteCategoryOptionComboAccess(reporter, event, categoryOptionCombo);
+      checkWriteCategoryOptionComboAccess(reporter, event, categoryOptionCombo, bundle.getUser());
     }
   }
 
@@ -287,8 +292,8 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       Reporter reporter,
       org.hisp.dhis.tracker.imports.domain.Event event,
       OrganisationUnit eventOrgUnit,
-      boolean isCreatableInSearchScope) {
-    UserDetails user = getCurrentUserDetails();
+      boolean isCreatableInSearchScope,
+      UserDetails user) {
     if (eventOrgUnit == null) {
       log.warn(ORG_UNIT_NO_USER_ASSIGNED, event.getUid());
     } else if (isCreatableInSearchScope
@@ -298,31 +303,32 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
     }
   }
 
-  private void checkProgramReadAccess(Reporter reporter, TrackerDto dto, Program program) {
-    UserDetails user = getCurrentUserDetails();
+  private void checkProgramReadAccess(
+      Reporter reporter, TrackerDto dto, Program program, UserDetails user) {
     if (!aclService.canDataRead(user, program)) {
       reporter.addError(dto, ValidationCode.E1096, user, program);
     }
   }
 
   private void checkProgramStageWriteAccess(
-      Reporter reporter, TrackerDto dto, ProgramStage programStage) {
-    UserDetails user = getCurrentUserDetails();
+      Reporter reporter, TrackerDto dto, ProgramStage programStage, UserDetails user) {
     if (!aclService.canDataWrite(user, programStage)) {
       reporter.addError(dto, ValidationCode.E1095, user, programStage);
     }
   }
 
-  private void checkProgramWriteAccess(Reporter reporter, TrackerDto dto, Program program) {
-    UserDetails user = getCurrentUserDetails();
+  private void checkProgramWriteAccess(
+      Reporter reporter, TrackerDto dto, Program program, UserDetails user) {
     if (!aclService.canDataWrite(user, program)) {
       reporter.addError(dto, ValidationCode.E1091, user, program);
     }
   }
 
   public void checkWriteCategoryOptionComboAccess(
-      Reporter reporter, TrackerDto dto, CategoryOptionCombo categoryOptionCombo) {
-    UserDetails user = getCurrentUserDetails();
+      Reporter reporter,
+      TrackerDto dto,
+      CategoryOptionCombo categoryOptionCombo,
+      UserDetails user) {
     for (CategoryOption categoryOption : categoryOptionCombo.getCategoryOptions()) {
       if (!aclService.canDataWrite(user, categoryOption)) {
         reporter.addError(dto, ValidationCode.E1099, user, categoryOption);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidator.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.validation.validator.relationship;
 
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
@@ -51,7 +49,7 @@ class SecurityOwnershipValidator implements Validator<Relationship> {
   @Override
   public void validate(Reporter reporter, TrackerBundle bundle, Relationship relationship) {
     TrackerImportStrategy strategy = bundle.getStrategy(relationship);
-    UserDetails user = getCurrentUserDetails();
+    UserDetails user = bundle.getUser();
 
     if (strategy.isDelete()
         && (!trackerAccessManager
@@ -63,7 +61,9 @@ class SecurityOwnershipValidator implements Validator<Relationship> {
     if (strategy.isCreate()
         && (!trackerAccessManager
             .canWrite(
-                user, relationshipTrackerConverterService.from(bundle.getPreheat(), relationship))
+                user,
+                relationshipTrackerConverterService.from(
+                    bundle.getPreheat(), relationship, bundle.getUser()))
             .isEmpty())) {
       reporter.addError(relationship, ValidationCode.E4020, user, relationship.getRelationship());
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.test.TestBase.injectSecurityContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +50,7 @@ import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationResult;
 import org.hisp.dhis.tracker.imports.validation.ValidationService;
 import org.hisp.dhis.user.SystemUser;
+import org.hisp.dhis.user.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,10 +77,10 @@ class TrackerImporterServiceTest {
 
   private TrackerObjects trackerObjects;
 
+  private final UserDetails user = new SystemUser();
+
   @BeforeEach
   public void setUp() {
-    injectSecurityContext(new SystemUser());
-
     subject =
         new DefaultTrackerImportService(
             trackerBundleService, validationService, trackerPreprocessService);
@@ -103,7 +103,7 @@ class TrackerImporterServiceTest {
     when(validationService.validateRuleEngine(any(TrackerBundle.class)))
         .thenReturn(validationResult);
     when(trackerPreprocessService.preprocess(any(TrackerBundle.class)))
-        .thenReturn(ParamsConverter.convert(params, trackerObjects));
+        .thenReturn(ParamsConverter.convert(params, trackerObjects, user));
   }
 
   @Test
@@ -118,8 +118,8 @@ class TrackerImporterServiceTest {
             .trackedEntities(new ArrayList<>())
             .build();
 
-    when(trackerBundleService.create(any(TrackerImportParams.class), any()))
-        .thenReturn(ParamsConverter.convert(parameters, objects));
+    when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
+        .thenReturn(ParamsConverter.convert(parameters, objects, user));
     when(trackerBundleService.commit(any(TrackerBundle.class)))
         .thenReturn(PersistenceReport.emptyReport());
 
@@ -131,8 +131,8 @@ class TrackerImporterServiceTest {
   @Test
   void testWithSideEffects() {
     doAnswer(invocationOnMock -> null).when(trackerBundleService).sendNotifications(anyList());
-    when(trackerBundleService.create(any(TrackerImportParams.class), any()))
-        .thenReturn(ParamsConverter.convert(params, trackerObjects));
+    when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
+        .thenReturn(ParamsConverter.convert(params, trackerObjects, user));
     when(trackerBundleService.commit(any(TrackerBundle.class)))
         .thenReturn(PersistenceReport.emptyReport());
 
@@ -143,8 +143,8 @@ class TrackerImporterServiceTest {
 
   @Test
   void shouldRaiseExceptionWhenExceptionWasThrownInsideAStage() {
-    when(trackerBundleService.create(any(TrackerImportParams.class), any()))
-        .thenReturn(ParamsConverter.convert(params, trackerObjects));
+    when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
+        .thenReturn(ParamsConverter.convert(params, trackerObjects, user));
     when(trackerBundleService.commit(any(TrackerBundle.class)))
         .thenThrow(new IllegalArgumentException("ERROR"));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
@@ -97,11 +97,14 @@ class EventTrackerConverterServiceTest extends TestBase {
 
   private org.hisp.dhis.user.User user;
 
+  private UserDetails currentUser;
+
   @BeforeEach
   void setUpTest() {
     converter = new EventTrackerConverterService(notesConverterService);
     user = makeUser("U");
-    injectSecurityContext(UserDetails.fromUser(user));
+    currentUser = UserDetails.fromUser(user);
+
     programStage = createProgramStage('A', 1);
     programStage.setUid(PROGRAM_STAGE_UID);
     programStage.setProgram(program);
@@ -140,7 +143,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     org.hisp.dhis.tracker.imports.domain.Event event =
         event(dataValue(MetadataIdentifier.ofUid(dataElement.getUid()), "value"));
 
-    Event result = converter.from(preheat, event);
+    Event result = converter.from(preheat, event, currentUser);
 
     assertNotNull(result);
     assertNotNull(result.getProgramStage());
@@ -172,7 +175,7 @@ class EventTrackerConverterServiceTest extends TestBase {
         event(dataValue(MetadataIdentifier.ofUid(dataElement.getUid()), "value"));
     event.setStatus(EventStatus.COMPLETED);
 
-    Event result = converter.from(preheat, event);
+    Event result = converter.from(preheat, event, currentUser);
 
     assertNotNull(result);
     assertNotNull(result.getProgramStage());
@@ -206,7 +209,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     org.hisp.dhis.tracker.imports.domain.Event event =
         event(eventUid, dataValue(MetadataIdentifier.ofUid(dataElement.getUid()), "value"));
 
-    Event result = converter.from(preheat, event);
+    Event result = converter.from(preheat, event, currentUser);
 
     assertNotNull(result);
     assertNotNull(result.getProgramStage());
@@ -241,7 +244,7 @@ class EventTrackerConverterServiceTest extends TestBase {
         event(eventUid, dataValue(MetadataIdentifier.ofUid(dataElement.getUid()), "value"));
     event.setStatus(EventStatus.COMPLETED);
 
-    Event result = converter.from(preheat, event);
+    Event result = converter.from(preheat, event, currentUser);
 
     assertNotNull(result);
     assertNotNull(result.getProgramStage());
@@ -272,7 +275,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     DataValue dataValue = dataValue(metadataIdentifier, "900");
     org.hisp.dhis.tracker.imports.domain.Event event = event(dataValue);
 
-    Event result = converter.fromForRuleEngine(preheat, event);
+    Event result = converter.fromForRuleEngine(preheat, event, currentUser);
 
     assertNotNull(result);
     assertNotNull(result.getProgramStage());
@@ -311,7 +314,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     org.hisp.dhis.tracker.imports.domain.Event event = event(existingEvent.getUid(), newDataValue);
     when(preheat.getEvent(existingEvent.getUid())).thenReturn(existingEvent);
 
-    Event result = converter.fromForRuleEngine(preheat, event);
+    Event result = converter.fromForRuleEngine(preheat, event, currentUser);
 
     assertEquals(2, result.getEventDataValues().size());
     EventDataValue expect1 = new EventDataValue();
@@ -341,7 +344,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     org.hisp.dhis.tracker.imports.domain.Event event = event(existingEvent.getUid(), updatedValue);
     when(preheat.getEvent(event.getEvent())).thenReturn(existingEvent);
 
-    Event result = converter.fromForRuleEngine(preheat, event);
+    Event result = converter.fromForRuleEngine(preheat, event, currentUser);
 
     assertEquals(1, result.getEventDataValues().size());
     EventDataValue expect1 = new EventDataValue();
@@ -374,7 +377,7 @@ class EventTrackerConverterServiceTest extends TestBase {
     org.hisp.dhis.tracker.imports.domain.Event event = event(existingEvent.getUid(), updatedValue);
     when(preheat.getEvent(event.getEvent())).thenReturn(existingEvent);
 
-    Event actual = converter.fromForRuleEngine(preheat, event);
+    Event actual = converter.fromForRuleEngine(preheat, event, currentUser);
 
     assertEquals(1, actual.getEventDataValues().size());
     EventDataValue expect1 = new EventDataValue();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/NotesConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/NotesConverterServiceTest.java
@@ -57,14 +57,16 @@ class NotesConverterServiceTest extends TestBase {
 
   private TrackerPreheat preheat;
 
+  private UserDetails currentUser;
+
   private User user;
 
   @BeforeEach
   void setUp() {
     this.notesConverterService = new NotesConverterService();
     user = makeUser("A");
-    UserDetails userDetails = UserDetails.fromUser(user);
-    injectSecurityContext(userDetails);
+    currentUser = UserDetails.fromUser(user);
+
     this.preheat = new TrackerPreheat();
     this.preheat.addUsers(Set.of(user));
   }
@@ -72,7 +74,7 @@ class NotesConverterServiceTest extends TestBase {
   @Test
   void verifyConvertTrackerNoteToNote() {
     org.hisp.dhis.tracker.imports.domain.Note trackerNote = trackerNote();
-    final Note note = notesConverterService.from(preheat, trackerNote);
+    final Note note = notesConverterService.from(preheat, trackerNote, currentUser);
     assertNoteValues(note, trackerNote);
   }
 
@@ -80,7 +82,7 @@ class NotesConverterServiceTest extends TestBase {
   void verifyConvertTrackerNoteToNoteWithNoStoredByDefined() {
     org.hisp.dhis.tracker.imports.domain.Note trackerNote = trackerNote();
     trackerNote.setStoredBy(null);
-    final Note note = notesConverterService.from(preheat, trackerNote);
+    final Note note = notesConverterService.from(preheat, trackerNote, currentUser);
     assertNoteValues(note, trackerNote);
   }
 
@@ -88,7 +90,7 @@ class NotesConverterServiceTest extends TestBase {
   void verifyConvertTrackerNotesToNotes() {
     List<org.hisp.dhis.tracker.imports.domain.Note> trackerNotes =
         List.of(trackerNote(), trackerNote());
-    final List<Note> notes = notesConverterService.from(preheat, trackerNotes);
+    final List<Note> notes = notesConverterService.from(preheat, trackerNotes, currentUser);
     assertThat(notes, hasSize(2));
     for (org.hisp.dhis.tracker.imports.domain.Note note : trackerNotes) {
       assertNoteValues(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterServiceTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.user.SystemUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -123,7 +124,8 @@ class RelationshipTrackerConverterServiceTest extends TestBase {
     when(preheat.getEvent(EVENT)).thenReturn(event);
 
     List<org.hisp.dhis.relationship.Relationship> from =
-        relationshipConverterService.from(preheat, List.of(relationshipA(), relationshipB()));
+        relationshipConverterService.from(
+            preheat, List.of(relationshipA(), relationshipB()), new SystemUser());
     assertNotNull(from);
     assertEquals(2, from.size());
     from.forEach(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/SupplementaryDataProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/SupplementaryDataProviderTest.java
@@ -70,13 +70,15 @@ class SupplementaryDataProviderTest extends TestBase {
 
   private OrganisationUnit orgUnitB;
 
+  private UserDetails currentUser;
+
   @BeforeEach
   void setUp() {
     User user = makeUser("A");
     user.setUsername("A");
     user.setUserRoles(getUserRoles());
 
-    injectSecurityContext(UserDetails.fromUser(user));
+    currentUser = UserDetails.fromUser(user);
 
     orgUnitA = createOrganisationUnit('A');
     orgUnitB = createOrganisationUnit('B');
@@ -93,7 +95,7 @@ class SupplementaryDataProviderTest extends TestBase {
   @Test
   void getSupplementaryData() {
     Map<String, List<String>> supplementaryData =
-        providerToTest.getSupplementaryData(getProgramRules());
+        providerToTest.getSupplementaryData(getProgramRules(), currentUser);
     assertFalse(supplementaryData.isEmpty());
     assertEquals(getUserRoleUids(), Set.copyOf(supplementaryData.get("USER")));
     assertFalse(supplementaryData.get(ORG_UNIT_GROUP_UID).isEmpty());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationServiceTest.java
@@ -81,18 +81,17 @@ class DefaultValidationServiceTest extends TestBase {
 
     User userA = makeUser("A");
     UserDetails user = UserDetails.fromUser(userA);
-    injectSecurityContext(user);
 
-    bundleBuilder = newBundle();
+    bundleBuilder = TrackerBundle.builder().user(user).preheat(preheat).skipRuleEngine(true);
   }
 
   @Test
   void shouldNotValidateWhenModeIsSkipAndUserIsASuperUser() {
-    superUser();
     bundle =
         bundleBuilder
             .validationMode(ValidationMode.SKIP)
             .trackedEntities(trackedEntities(trackedEntity()))
+            .user(new SystemUser())
             .build();
     service = new DefaultValidationService(validator, ruleEngineValidator);
 
@@ -152,19 +151,11 @@ class DefaultValidationServiceTest extends TestBase {
     assertTrue(bundle.getTrackedEntities().contains(validTrackedEntity));
   }
 
-  private void superUser() {
-    injectSecurityContext(new SystemUser());
-  }
-
   private TrackedEntity trackedEntity() {
     return TrackedEntity.builder().trackedEntity(CodeGenerator.generateUid()).build();
   }
 
   private List<TrackedEntity> trackedEntities(TrackedEntity... trackedEntities) {
     return List.of(trackedEntities);
-  }
-
-  private TrackerBundle.TrackerBundleBuilder newBundle() {
-    return TrackerBundle.builder().preheat(preheat).skipRuleEngine(true);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
@@ -110,14 +110,14 @@ class SecurityOwnershipValidatorTest extends TestBase {
 
   @BeforeEach
   public void setUp() {
-    when(bundle.getPreheat()).thenReturn(preheat);
+    organisationUnit = createOrganisationUnit('A');
+    organisationUnit.setUid(ORG_UNIT_ID);
 
     User u = makeUser("A");
     user = UserDetails.fromUser(u);
-    injectSecurityContext(user);
 
-    organisationUnit = createOrganisationUnit('A');
-    organisationUnit.setUid(ORG_UNIT_ID);
+    when(bundle.getPreheat()).thenReturn(preheat);
+    when(bundle.getUser()).thenReturn(user);
 
     trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.setUid(TE_TYPE_ID);
@@ -146,7 +146,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
     User userB = makeUser("B", auths);
     userB.setOrganisationUnits(Set.of(organisationUnit));
     UserDetails userDetails = UserDetails.fromUser(userB);
-    injectSecurityContext(userDetails);
+    when(bundle.getUser()).thenReturn(userDetails);
     return userDetails;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
@@ -81,11 +81,11 @@ class DateValidatorTest extends TestBase {
   public void setUp() {
     validator = new DateValidator();
 
-    bundle = TrackerBundle.builder().preheat(preheat).build();
+    bundle =
+        TrackerBundle.builder().user(UserDetails.fromUser(makeUser("A"))).preheat(preheat).build();
 
     TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
     reporter = new Reporter(idSchemes);
-    injectSecurityContext(UserDetails.fromUser(makeUser("A")));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
@@ -110,7 +110,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   @BeforeEach
   public void setUp() {
     when(bundle.getPreheat()).thenReturn(preheat);
-
+    when(bundle.getUser()).thenReturn(user);
     organisationUnit = createOrganisationUnit('A');
     organisationUnit.setUid(ORG_UNIT_ID);
 
@@ -128,22 +128,20 @@ class SecurityOwnershipValidatorTest extends TestBase {
     reporter = new Reporter(idSchemes);
 
     validator = new SecurityOwnershipValidator(aclService, ownershipAccessManager);
-
-    injectSecurityContext(user);
   }
 
   private UserDetails setUpUserWithOrgUnit() {
     User userWithOrgUnit = makeUser("B");
     userWithOrgUnit.setOrganisationUnits(Set.of(organisationUnit));
     UserDetails currentUserDetails = UserDetails.fromUser(userWithOrgUnit);
-    injectSecurityContext(currentUserDetails);
+    when(bundle.getUser()).thenReturn(currentUserDetails);
     return currentUserDetails;
   }
 
   private UserDetails changeCompletedEventAuthorisedUser() {
     User authorizedUser = makeUser("A", Lists.newArrayList("F_UNCOMPLETE_EVENT"));
     UserDetails userDetails = UserDetails.fromUser(authorizedUser);
-    injectSecurityContext(userDetails);
+    when(bundle.getUser()).thenReturn(userDetails);
     return userDetails;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidatorTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.tracker.imports.converter.RelationshipTrackerConverterServi
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
+import org.hisp.dhis.user.SystemUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -88,8 +89,10 @@ class SecurityOwnershipValidatorTest {
 
   @Test
   void shouldCreateWhenUserHasWriteAccessToRelationship() {
+    SystemUser user = new SystemUser();
     when(bundle.getStrategy(relationship)).thenReturn(CREATE);
-    when(converterService.from(preheat, relationship)).thenReturn(convertedRelationship);
+    when(bundle.getUser()).thenReturn(user);
+    when(converterService.from(preheat, relationship, user)).thenReturn(convertedRelationship);
     when(trackerAccessManager.canWrite(any(), eq(convertedRelationship))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, relationship);
@@ -99,8 +102,10 @@ class SecurityOwnershipValidatorTest {
 
   @Test
   void shouldFailToCreateWhenUserHasNoWriteAccessToRelationship() {
+    SystemUser user = new SystemUser();
     when(bundle.getStrategy(relationship)).thenReturn(CREATE);
-    when(converterService.from(preheat, relationship)).thenReturn(convertedRelationship);
+    when(bundle.getUser()).thenReturn(user);
+    when(converterService.from(preheat, relationship, user)).thenReturn(convertedRelationship);
     when(trackerAccessManager.canWrite(any(), eq(convertedRelationship)))
         .thenReturn(List.of("error"));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -103,15 +103,15 @@ class SecurityOwnershipValidatorTest extends TestBase {
 
   @BeforeEach
   public void setUp() {
-    when(bundle.getPreheat()).thenReturn(preheat);
-
     organisationUnit = createOrganisationUnit('A');
     organisationUnit.setUid(ORG_UNIT_ID);
 
     User userA = makeUser("A");
     userA.addOrganisationUnit(organisationUnit);
     user = UserDetails.fromUser(userA);
-    injectSecurityContext(user);
+
+    when(bundle.getPreheat()).thenReturn(preheat);
+    when(bundle.getUser()).thenReturn(user);
 
     trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.setUid(TE_TYPE_ID);
@@ -332,14 +332,14 @@ class SecurityOwnershipValidatorTest extends TestBase {
         makeUser("A", Lists.newArrayList(Authorities.F_TEI_CASCADE_DELETE.name()));
     authorizedUser.setOrganisationUnits(Set.of(organisationUnit));
     UserDetails userDetails = UserDetails.fromUser(authorizedUser);
-    injectSecurityContext(userDetails);
+    when(bundle.getUser()).thenReturn(userDetails);
     return userDetails;
   }
 
   private UserDetails incorrectCaptureScopeUser() {
     User authorizedUser = makeUser("B");
     UserDetails userDetails = UserDetails.fromUser(authorizedUser);
-    injectSecurityContext(userDetails);
+    when(bundle.getUser()).thenReturn(userDetails);
     return userDetails;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleServiceTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.user.SystemUser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,7 +73,7 @@ class TrackerBundleServiceTest extends TrackerTest {
     TrackerObjects trackerObjects = fromJson("tracker/trackedentity_basic_data.json");
     assertEquals(13, trackerObjects.getTrackedEntities().size());
     TrackerBundle trackerBundle =
-        trackerBundleService.create(new TrackerImportParams(), trackerObjects);
+        trackerBundleService.create(new TrackerImportParams(), trackerObjects, new SystemUser());
     trackerBundleService.commit(trackerBundle);
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(13, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerProgramRuleBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerProgramRuleBundleServiceTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.user.SystemUser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +93,7 @@ class TrackerProgramRuleBundleServiceTest extends TrackerTest {
     TrackerObjects trackerObjects = fromJson("tracker/event_events_and_enrollment.json");
     assertEquals(8, trackerObjects.getEvents().size());
     TrackerBundle trackerBundle =
-        trackerBundleService.create(new TrackerImportParams(), trackerObjects);
+        trackerBundleService.create(new TrackerImportParams(), trackerObjects, new SystemUser());
     trackerBundle = trackerBundleService.runRuleEngine(trackerBundle);
     assertEquals(trackerBundle.getEvents().size(), trackerBundle.getEventNotifications().size());
   }


### PR DESCRIPTION
Last PR for user harmonization.
Putting back the `user` field into `TrackerBundle` to be used as a context user to validate data and to update user related fields (`createdBy` and `updatedBy`) in tracker importer.
This change makes much more unit testable all the steps inside the importer and make it possible to remove `injectSecurityContext` calls from the unit tests.