### PR TITLE
fix: use tracker importer in SingleEventListener DHIS2-17729

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -87,24 +87,28 @@ public abstract class CommandSMSListener extends BaseSMSListener {
 
   @Override
   public void receive(@Nonnull IncomingSms sms, @Nonnull String username) {
+    // we cannot annotate getSMSCommand itself with Nonnull as it can return null but
+    // receive is only called when accept returned true, which is if there is a non-null command
     SMSCommand smsCommand = getSMSCommand(sms);
 
-    Map<String, String> parsedMessage = this.parseMessageInput(sms, smsCommand);
+    Map<String, String> codeValues = parseCodeValuePairs(sms, smsCommand);
 
-    if (!hasCorrectFormat(sms, smsCommand)
-        || !validateInputValues(parsedMessage, smsCommand, sms)) {
+    if (!hasCorrectFormat(sms, smsCommand) || !validateInputValues(sms, smsCommand, codeValues)) {
       return;
     }
 
-    postProcess(sms, smsCommand, parsedMessage);
+    postProcess(sms, username, smsCommand, codeValues);
   }
 
   protected abstract void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage);
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues);
 
-  protected abstract SMSCommand getSMSCommand(IncomingSms sms);
+  protected abstract SMSCommand getSMSCommand(@Nonnull IncomingSms sms);
 
-  protected boolean hasCorrectFormat(IncomingSms sms, SMSCommand smsCommand) {
+  protected boolean hasCorrectFormat(@Nonnull IncomingSms sms, @Nonnull SMSCommand smsCommand) {
     String regexp = DEFAULT_PATTERN;
 
     if (smsCommand.getSeparator() != null && !smsCommand.getSeparator().trim().isEmpty()) {
@@ -143,9 +147,11 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     return userService.getUser(sms.getCreatedBy().getUid());
   }
 
-  protected boolean validateInputValues(
-      Map<String, String> commandValuePairs, SMSCommand smsCommand, IncomingSms sms) {
-    if (!hasMandatoryParameters(commandValuePairs.keySet(), smsCommand.getCodes())) {
+  private boolean validateInputValues(
+      @Nonnull IncomingSms sms,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> commandValuePairs) {
+    if (!hasMandatoryCodes(smsCommand.getCodes(), commandValuePairs.keySet())) {
       sendFeedback(
           StringUtils.defaultIfEmpty(smsCommand.getDefaultMessage(), SMSCommand.PARAMETER_MISSING),
           sms.getOriginator(),
@@ -176,8 +182,14 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     return true;
   }
 
-  protected Map<String, String> parseMessageInput(IncomingSms sms, SMSCommand smsCommand) {
-    HashMap<String, String> output = new HashMap<>();
+  /**
+   * Parses the code value pairs of an SMS command. For example SMS {@code visit bcgd=1,opvd=2} with
+   * command name {@code visit} will lead to a map of SMS code names to values {@code
+   * {bcgd=1,opvd=2}}.
+   */
+  private @Nonnull Map<String, String> parseCodeValuePairs(
+      @Nonnull IncomingSms sms, @Nonnull SMSCommand smsCommand) {
+    HashMap<String, String> result = new HashMap<>();
 
     Pattern pattern = Pattern.compile(DEFAULT_PATTERN);
 
@@ -193,16 +205,16 @@ public abstract class CommandSMSListener extends BaseSMSListener {
       String value = matcher.group(2).trim();
 
       if (!StringUtils.isEmpty(key) && !StringUtils.isEmpty(value)) {
-        output.put(key, value);
+        result.put(key, value);
       }
     }
 
-    return output;
+    return result;
   }
 
-  private boolean hasMandatoryParameters(Set<String> keySet, Set<SMSCode> smsCodes) {
-    for (SMSCode smsCode : smsCodes) {
-      if (smsCode.isCompulsory() && !keySet.contains(smsCode.getCode())) {
+  private boolean hasMandatoryCodes(Set<SMSCode> configuredCodes, Set<String> actualCodes) {
+    for (SMSCode configuredCode : configuredCodes) {
+      if (configuredCode.isCompulsory() && !actualCodes.contains(configuredCode.getCode())) {
         return false;
       }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -113,7 +114,10 @@ public class DataValueSMSListener extends CommandSMSListener {
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {
     String message = sms.getText();
 
     Date date = SmsUtils.lookForDate(message);
@@ -154,12 +158,12 @@ public class DataValueSMSListener extends CommandSMSListener {
     boolean valueStored = false;
 
     for (SMSCode code : smsCommand.getCodes()) {
-      if (parsedMessage.containsKey(code.getCode())) {
-        valueStored = storeDataValue(sms, orgUnit, parsedMessage, code, smsCommand, date);
+      if (codeValues.containsKey(code.getCode())) {
+        valueStored = storeDataValue(sms, orgUnit, codeValues, code, smsCommand, date);
       }
     }
 
-    if (parsedMessage.isEmpty()) {
+    if (codeValues.isEmpty()) {
       sendFeedback(
           org.apache.commons.lang3.StringUtils.defaultIfEmpty(
               smsCommand.getDefaultMessage(),
@@ -181,7 +185,7 @@ public class DataValueSMSListener extends CommandSMSListener {
     }
 
     if (markCompleteDataSet(sms, orgUnit, smsCommand, date)) {
-      sendSuccessFeedback(senderPhoneNumber, smsCommand, parsedMessage, date, orgUnit);
+      sendSuccessFeedback(senderPhoneNumber, smsCommand, codeValues, date, orgUnit);
 
       update(sms, SmsMessageStatus.PROCESSED, true);
     } else {
@@ -192,7 +196,7 @@ public class DataValueSMSListener extends CommandSMSListener {
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(
         SmsUtils.getCommandString(sms), ParserType.KEY_VALUE_PARSER);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageConversationParams;
@@ -75,13 +76,16 @@ public class DhisMessageAlertListener extends CommandSMSListener {
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(SmsUtils.getCommandString(sms), ParserType.ALERT_PARSER);
   }
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {
     String message = sms.getText();
 
     UserGroup userGroup = smsCommand.getUserGroup();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -147,13 +147,16 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return null;
   }
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {}
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {}
 
   private Map<String, String> parse(String sms, SMSCommand smsCommand) {
     String[] keyValuePairs;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.sms.listener;
 
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
@@ -71,19 +72,22 @@ public class UnregisteredSMSListener extends CommandSMSListener {
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(
         SmsUtils.getCommandString(sms), ParserType.UNREGISTERED_PARSER);
   }
 
   @Override
-  protected boolean hasCorrectFormat(IncomingSms sms, SMSCommand smsCommand) {
+  protected boolean hasCorrectFormat(@Nonnull IncomingSms sms, @Nonnull SMSCommand smsCommand) {
     return true;
   }
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {
     UserGroup userGroup = smsCommand.getUserGroup();
 
     String userName = sms.getOriginator();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -115,7 +116,10 @@ public class ProgramStageDataEntrySMSListener extends RegisterSMSListener {
 
   @Override
   public void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {
     Set<OrganisationUnit> ous = getOrganisationUnits(sms);
 
     List<TrackedEntity> trackedEntities = getTrackedEntityByPhoneNumber(sms, smsCommand, ous);
@@ -124,11 +128,11 @@ public class ProgramStageDataEntrySMSListener extends RegisterSMSListener {
       return;
     }
 
-    registerProgramStage(trackedEntities.iterator().next(), sms, smsCommand, parsedMessage, ous);
+    registerProgramStage(trackedEntities.iterator().next(), sms, smsCommand, codeValues, ous);
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(
         SmsUtils.getCommandString(sms), ParserType.PROGRAM_STAGE_DATAENTRY_PARSER);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
@@ -27,96 +27,90 @@
  */
 package org.hisp.dhis.tracker.imports.sms;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.hisp.dhis.tracker.imports.sms.SmsImportMapper.mapCommand;
+
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.sms.listener.SMSProcessingException;
+import org.hisp.dhis.sms.incoming.SmsMessageStatus;
+import org.hisp.dhis.sms.listener.CommandSMSListener;
 import org.hisp.dhis.sms.parse.ParserType;
-import org.hisp.dhis.smscompression.SmsResponse;
 import org.hisp.dhis.system.util.SmsUtils;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.tracker.export.event.EventChangeLogService;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
+@Slf4j
 @Component("org.hisp.dhis.tracker.sms.SingleEventListener")
 @Transactional
-public class SingleEventListener extends RegisterSMSListener {
+public class SingleEventListener extends CommandSMSListener {
   private final SMSCommandService smsCommandService;
+
+  private final TrackerImportService trackerImportService;
 
   public SingleEventListener(
       CategoryService dataElementCategoryService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      EnrollmentService enrollmentService,
-      EventChangeLogService eventChangeLogService,
-      FileResourceService fileResourceService,
-      DhisConfigurationProvider config,
-      IdentifiableObjectManager identifiableObjectManager,
-      SMSCommandService smsCommandService) {
-    super(
-        dataElementCategoryService,
-        userService,
-        incomingSmsService,
-        smsSender,
-        enrollmentService,
-        eventChangeLogService,
-        fileResourceService,
-        config,
-        identifiableObjectManager);
+      SMSCommandService smsCommandService,
+      TrackerImportService trackerImportService) {
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
     this.smsCommandService = smsCommandService;
+    this.trackerImportService = trackerImportService;
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(
         SmsUtils.getCommandString(sms), ParserType.EVENT_REGISTRATION_PARSER);
   }
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> dataValues) {
+    TrackerImportParams params =
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.CREATE).build();
     Set<OrganisationUnit> ous = getOrganisationUnits(sms);
+    OrganisationUnit orgUnit = ous.iterator().next();
+    TrackerObjects trackerObjects =
+        mapCommand(sms, smsCommand, dataValues, orgUnit, username, dataElementCategoryService);
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
-    registerEvent(parsedMessage, smsCommand, sms, ous);
-  }
-
-  private void registerEvent(
-      Map<String, String> commandValuePairs,
-      SMSCommand smsCommand,
-      IncomingSms sms,
-      Set<OrganisationUnit> ous) {
-    List<Enrollment> enrollments;
-    try {
-      enrollments =
-          new ArrayList<>(
-              enrollmentService.getEnrollments(
-                  null, smsCommand.getProgram(), EnrollmentStatus.ACTIVE));
-    } catch (ForbiddenException | BadRequestException | NotFoundException e) {
-      // TODO(tracker) Find a better error message for these exceptions
-      throw new SMSProcessingException(SmsResponse.UNKNOWN_ERROR);
+    if (Status.OK == importReport.getStatus()) {
+      update(sms, SmsMessageStatus.PROCESSED, true);
+      sendFeedback(
+          StringUtils.defaultIfEmpty(smsCommand.getSuccessMessage(), SMSCommand.SUCCESS_MESSAGE),
+          sms.getOriginator(),
+          INFO);
+      return;
     }
 
-    register(enrollments, commandValuePairs, smsCommand, sms, ous);
+    // TODO(DHIS2-18003) we need to map tracker import report errors/warnings to an sms
+    log.error(
+        "Failed to process SMS command {} of parser type EVENT_REGISTRATION_PARSER {}",
+        smsCommand.getName(),
+        importReport);
+    throw new IllegalStateException(importReport.toString());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -108,7 +109,10 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
 
   @Override
   protected void postProcess(
-      IncomingSms sms, SMSCommand smsCommand, Map<String, String> parsedMessage) {
+      @Nonnull IncomingSms sms,
+      @Nonnull String username,
+      @Nonnull SMSCommand smsCommand,
+      @Nonnull Map<String, String> codeValues) {
     String message = sms.getText();
 
     Date occurredDate = SmsUtils.lookForDate(message);
@@ -117,7 +121,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
 
     Program program = smsCommand.getProgram();
 
-    OrganisationUnit orgUnit = SmsUtils.selectOrganisationUnit(orgUnits, parsedMessage, smsCommand);
+    OrganisationUnit orgUnit = SmsUtils.selectOrganisationUnit(orgUnits, codeValues, smsCommand);
 
     if (!programService.hasOrgUnit(program, orgUnit)) {
       sendFeedback(SMSCommand.NO_OU_FOR_PROGRAM, senderPhoneNumber, WARNING);
@@ -133,11 +137,11 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
     Set<TrackedEntityAttributeValue> patientAttributeValues = new HashSet<>();
 
     smsCommand.getCodes().stream()
-        .filter(code -> parsedMessage.containsKey(code.getCode()))
+        .filter(code -> codeValues.containsKey(code.getCode()))
         .forEach(
             code -> {
               TrackedEntityAttributeValue trackedEntityAttributeValue =
-                  this.createTrackedEntityAttributeValue(parsedMessage, code, trackedEntity);
+                  this.createTrackedEntityAttributeValue(codeValues, code, trackedEntity);
               patientAttributeValues.add(trackedEntityAttributeValue);
             });
 
@@ -175,7 +179,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
   }
 
   @Override
-  protected SMSCommand getSMSCommand(IncomingSms sms) {
+  protected SMSCommand getSMSCommand(@Nonnull IncomingSms sms) {
     return smsCommandService.getSMSCommand(
         SmsUtils.getCommandString(sms), ParserType.TRACKED_ENTITY_REGISTRATION_PARSER);
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -131,7 +131,25 @@ public final class Assertions {
    */
   public static void assertNotEmpty(Collection<?> actual) {
     assertNotNull(actual);
-    assertFalse(actual.isEmpty(), actual.toString());
+    assertFalse(actual.isEmpty(), "expected collection not to be empty");
+  }
+
+  /**
+   * Asserts that the given collection contains the expected number of elements.
+   *
+   * @param actual the collection.
+   */
+  public static void assertHasSize(int expected, Collection<?> actual) {
+    assert expected > 0 : "use assertIsEmpty";
+
+    assertNotEmpty(actual);
+    assertEquals(
+        expected,
+        actual.size(),
+        () ->
+            String.format(
+                "expected collection to contain %d elements, it has %d instead: '%s'",
+                expected, actual.size(), actual));
   }
 
   /**

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/SmsTestUtils.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/SmsTestUtils.java
@@ -27,11 +27,22 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.outboundmessage.OutboundMessage;
+import org.hisp.dhis.sms.incoming.IncomingSms;
+import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsCompressionException;
 import org.hisp.dhis.smscompression.SmsSubmissionWriter;
 import org.hisp.dhis.smscompression.models.SmsMetadata;
 import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.test.message.FakeMessageSender;
+import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 
 class SmsTestUtils {
   private static final int SMS_COMPRESSION_VERSION = 2;
@@ -44,5 +55,22 @@ class SmsTestUtils {
     SmsSubmissionWriter smsSubmissionWriter = new SmsSubmissionWriter(new SmsMetadata());
     byte[] compressedText = smsSubmissionWriter.compress(submission, SMS_COMPRESSION_VERSION);
     return Base64.getEncoder().encodeToString(compressedText);
+  }
+
+  /** Get the the incoming SMS stored in the DB with the id from the HTTP response body. */
+  static IncomingSms getSms(IncomingSmsService incomingSmsService, JsonWebMessage response) {
+    assertStartsWith("Received SMS: ", response.getMessage());
+
+    String smsUid = response.getMessage().replaceFirst("^Received SMS: ", "");
+    IncomingSms sms = incomingSmsService.get(smsUid);
+    assertNotNull(sms, "failed to find SMS in DB with UID " + smsUid);
+    return sms;
+  }
+
+  static void assertSmsResponse(
+      String expectedText, String expectedRecipient, FakeMessageSender messageSender) {
+    OutboundMessage expectedMessage =
+        new OutboundMessage(null, expectedText, Set.of(expectedRecipient));
+    assertContainsOnly(List.of(expectedMessage), messageSender.getAllMessages());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -28,13 +28,12 @@
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
-import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.tracker.imports.SmsTestUtils.assertSmsResponse;
 import static org.hisp.dhis.webapi.controller.tracker.imports.SmsTestUtils.encodeSms;
+import static org.hisp.dhis.webapi.controller.tracker.imports.SmsTestUtils.getSms;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 import java.util.List;
@@ -52,7 +51,6 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.outboundmessage.OutboundMessage;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
@@ -231,15 +229,11 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
-    IncomingSms sms = getSms(response);
+    IncomingSms sms = getSms(incomingSmsService, response);
     assertAll(
         () -> assertEquals(SmsMessageStatus.PROCESSED, sms.getStatus()),
-        () -> {
-          String expectedText = submissionId + ":" + SmsResponse.SUCCESS;
-          OutboundMessage expectedMessage =
-              new OutboundMessage(null, expectedText, Set.of(originator));
-          assertContainsOnly(List.of(expectedMessage), messageSender.getAllMessages());
-        });
+        () ->
+            assertSmsResponse(submissionId + ":" + SmsResponse.SUCCESS, originator, messageSender));
     assertDoesNotThrow(() -> enrollmentService.getEnrollment(enrollmentUid));
     Enrollment actual = enrollmentService.getEnrollment(enrollmentUid);
     assertAll(
@@ -335,15 +329,11 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
             .as(JsonWebMessage.class);
 
     manager.clear();
-    IncomingSms sms = getSms(response);
+    IncomingSms sms = getSms(incomingSmsService, response);
     assertAll(
         () -> assertEquals(SmsMessageStatus.PROCESSED, sms.getStatus()),
-        () -> {
-          String expectedText = submissionId + ":" + SmsResponse.SUCCESS;
-          OutboundMessage expectedMessage =
-              new OutboundMessage(null, expectedText, Set.of(originator));
-          assertContainsOnly(List.of(expectedMessage), messageSender.getAllMessages());
-        });
+        () ->
+            assertSmsResponse(submissionId + ":" + SmsResponse.SUCCESS, originator, messageSender));
     Enrollment actual =
         enrollmentService.getEnrollment(
             enrollment.getUid(), EnrollmentParams.FALSE.withIncludeAttributes(true), false);
@@ -375,15 +365,6 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
               Map.of(teaA.getUid(), "AttributeAUpdated", teaC.getUid(), "AttributeCAdded"),
               actualTeav);
         });
-  }
-
-  private IncomingSms getSms(JsonWebMessage response) {
-    assertStartsWith("Received SMS: ", response.getMessage());
-
-    String smsUid = response.getMessage().replaceFirst("^Received SMS: ", "");
-    IncomingSms sms = incomingSmsService.get(smsUid);
-    assertNotNull(sms, "failed to find SMS in DB with UID " + smsUid);
-    return sms;
   }
 
   private TrackedEntityType trackedEntityTypeAccessible() {


### PR DESCRIPTION
As a reference [this is](https://github.com/dhis2/dhis2-core/blob/998f7cc3c5a1271fd7742adf1253521f8e66e234/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java#L112) the `SingleEventListener` processing logic before we made our changes to sms processing. You can see that users were able to create an event in an event program. The logic of creating the dummy enrollment into the event program is done by the metadata importer.

This is how an sms for an sms command can look like

```
{
  "text": "visit s=yes|c=no|h=14|",
  "originator": "+233223232"
}
```

The exact details of the format depend on how you configure the command you create
* https://docs.dhis2.org/en/use/user-guides/dhis-core-version-241/maintaining-the-system/mobile.html?h=sms+2.41#sms-command-for-event-registration
* https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/sms.html#webapi_sms_commands

Change summary

* Use the tracker importer in `SingleEventListener`
* Extract common SMS test functions
* Use `CheckForNull` instead of `Nullable` (I was mistaken, see [wow-preferred_patterns](https://github.com/dhis2/wow-backend/blob/2cbe393af1e1b337ea2c991defc3f57e7a46bfc2/guides/preferred_patterns.md?plain=1#L20)) 
* Improve naming in `CommandSMSListener` regarding what the code value pairs are

## Next

These are the tracker related compression based SMS we changed so they use the importer:

`SubmissionType` => `Listener` class processing these types of SMS
- `DELETE`            => `DeleteEventListener` ✅ (https://github.com/dhis2/dhis2-core/pull/18473)
- `ENROLLMENT`        => `EnrollmentSMSListener` ✅ (https://github.com/dhis2/dhis2-core/pull/18595)
- `RELATIONSHIP`      => `RelationshipSMSListener` ✅ (https://github.com/dhis2/dhis2-core/pull/18509)
- `SIMPLE_EVENT`      => `SimpleEventSMSListener` ✅ (https://github.com/dhis2/dhis2-core/pull/18683)
- `TRACKER_EVENT`     => `TrackerEventSMSListener` ✅ (https://github.com/dhis2/dhis2-core/pull/18522)

The above can be used used by Android when users are offline.

Then there are command based SMS listeners we need to adapt so they use the importer:

- `TRACKED_ENTITY_REGISTRATION_PARSER` => `TrackedEntityRegistrationSMSListener`
- `PROGRAM_STAGE_DATAENTRY_PARSER` => `ProgramStageDataEntrySMSListener`
- `EVENT_REGISTRATION_PARSER` => `SingleEventListener` (this PR)