### PR TITLE
fix: remove username validation to allow old usernames on login

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -58,6 +58,21 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
   @Autowired private SessionRegistry sessionRegistry;
 
   @Test
+  void testSuccessfulLoginWithOldUsername() {
+    User adminUser = userService.getUserByUsername("admin");
+    adminUser.setUsername("Üsername");
+    userService.updateUser(adminUser);
+
+    JsonLoginResponse response =
+        POST("/auth/login", "{'username':'Üsername','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("SUCCESS", response.getLoginStatus());
+    assertEquals("/dhis-web-dashboard/", response.getRedirectUrl());
+  }
+
+  @Test
   void testSuccessfulLogin() {
     JsonLoginResponse response =
         POST("/auth/login", "{'username':'admin','password':'district'}")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.security.LoginResponse.STATUS;
@@ -173,9 +172,6 @@ public class AuthenticationController {
   }
 
   private void validateRequest(LoginRequest loginRequest) {
-    if (!ValidationUtils.usernameIsValid(loginRequest.getUsername())) {
-      throw new BadCredentialsException("Bad credentials");
-    }
     User user = userService.getUserByUsername(loginRequest.getUsername());
     if (user == null) {
       throw new BadCredentialsException("Bad credentials");


### PR DESCRIPTION
## Summary
Remove username validation on login to allow for pre 2.38 style username. Stricter username constraint was introduced in 2.38 and was only enforced on user creation and update. In 2.41 we introduced a new login page that utilize a new back-end controller and logic to validate the username before it is looked up in the database. This fix just removes this check as it is not really necessary.

### Automatic test
AuthenticationControllerTest#testSuccessfulLoginWithOldUsername()

### Manual test
1. Start a new 2.37 instance.
2. Create a user with a username that is not allowed in 2.38+, for example "Üsername".
3. Upgrade the instance to 2.41.
4. Try to log in with the "Üsername" username.
5. Observe you get logged in.