### PR TITLE
fix: add back attribute values at /me endpoint

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
+import org.hisp.dhis.attribute.AttributeValues;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
@@ -46,6 +47,7 @@ import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.web.HttpStatus.Series;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonUser;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -262,5 +264,17 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
     JsonValue id = patTokens.getObject(0).get("id");
 
     assertTrue(id.exists());
+  }
+
+  @Test
+  void testGetCurrentUserAttributeValues() {
+    String currentUsername = CurrentUserUtil.getCurrentUsername();
+    User userByUsername = userService.getUserByUsername(currentUsername);
+    userByUsername.setAttributeValues(
+        AttributeValues.of("{\"myattribute\": {\"value\": \"myvalue\"}}"));
+    userService.updateUser(userByUsername);
+
+    assertEquals(
+        "myvalue", GET("/me").content().as(JsonUser.class).getAttributeValues().get(0).getValue());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -36,6 +38,9 @@ import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
+import org.hisp.dhis.attribute.AttributeValues;
+import org.hisp.dhis.attribute.AttributeValuesDeserializer;
+import org.hisp.dhis.attribute.AttributeValuesSerializer;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fileresource.FileResource;
@@ -100,6 +105,8 @@ public class MeDto {
     this.programs = programs;
     this.dataSets = dataSets;
     this.patTokens = patTokens;
+
+    this.attributeValues = user.getAttributeValues();
   }
 
   @JsonProperty() private String id;
@@ -197,4 +204,9 @@ public class MeDto {
   @JsonProperty() private String impersonation;
 
   @JsonProperty() private List<ApiToken> patTokens;
+
+  @JsonProperty()
+  @JsonDeserialize(using = AttributeValuesDeserializer.class)
+  @JsonSerialize(using = AttributeValuesSerializer.class)
+  private AttributeValues attributeValues;
 }


### PR DESCRIPTION
## Summary
Reintroduces attributeValues at the /me endpoint. This value was removed from the response some time in 2.38.
Value is now deserialized in the payload as in any other BaseIndentifiableObejcts.


### Automatic test
MyControllerTest#testGetCurrentUserAttributeValues()

### Manual test
1. Create an attribute on the User object.
2. Set an attribute value on your (logged in user).
3. Check endpoint /me return a JSON with the attributeValues field, and that it contains the value you set in step 2.
