### PR TITLE
fix: use static method for PersistenceExceptionTranslationPostProcessor

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -75,7 +75,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class HibernateConfig {
 
   @Bean
-  public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
+  public static PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
     return new PersistenceExceptionTranslationPostProcessor();
   }
 


### PR DESCRIPTION
### Issue
- In `HibernateConfig` we need to declare all `BeanPostProcessor` with static method. Otherwise Spring will complain as below


```
* WARN  2024-10-04T13:15:16,678 Bean 'hibernateConfig' of type [org.hisp.dhis.config.HibernateConfig$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). The currently created BeanPostProcessor [exceptionTranslation] is declared through a non-static factory method on that class; consider declaring it as static instead. (PostProcessorRegistrationDelegate.java [main])
```
