### PR TITLE
chore: finish up sms move to importer DHIS2-17729

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/SMSCommand.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/SMSCommand.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.base.MoreObjects;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
@@ -247,7 +248,7 @@ public class SMSCommand extends BaseIdentifiableObject implements MetadataObject
 
   @JsonProperty
   @JacksonXmlProperty
-  public String getSuccessMessage() {
+  public @Nonnull String getSuccessMessage() {
     return successMessage != null ? successMessage : SUCCESS_MESSAGE;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/SMSCommand.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/SMSCommand.java
@@ -238,6 +238,7 @@ public class SMSCommand extends BaseIdentifiableObject implements MetadataObject
 
   @JsonProperty
   @JacksonXmlProperty
+  @Nonnull
   public String getNoUserMessage() {
     return noUserMessage != null ? noUserMessage : NO_USER_MESSAGE;
   }
@@ -258,6 +259,7 @@ public class SMSCommand extends BaseIdentifiableObject implements MetadataObject
 
   @JsonProperty
   @JacksonXmlProperty
+  @Nonnull
   public String getMoreThanOneOrgUnitMessage() {
     return moreThanOneOrgUnitMessage != null
         ? moreThanOneOrgUnitMessage

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/incoming/IncomingSmsListener.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/incoming/IncomingSmsListener.java
@@ -28,10 +28,11 @@
 package org.hisp.dhis.sms.incoming;
 
 import javax.annotation.Nonnull;
+import org.hisp.dhis.user.UserDetails;
 
 public interface IncomingSmsListener {
   boolean accept(@Nonnull IncomingSms sms);
 
-  /** Receive processes an sms sent by the given username. */
-  void receive(@Nonnull IncomingSms sms, @Nonnull String username);
+  /** Receive processes an sms sent by the given user. */
+  void receive(@Nonnull IncomingSms sms, @Nonnull UserDetails smsCreatedBy);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -248,6 +248,7 @@ public interface UserService {
    */
   int getUserCount();
 
+  @Nonnull
   List<User> getUsersByPhoneNumber(String phoneNumber);
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.sms.listener;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,7 +44,6 @@ import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.code.SMSCode;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.transaction.annotation.Transactional;
@@ -127,9 +125,7 @@ public abstract class CommandSMSListener extends BaseSMSListener {
       return new HashSet<>();
     }
 
-    return SmsUtils.getOrganisationUnitsByPhoneNumber(
-            sms.getOriginator(), Collections.singleton(user))
-        .get(user.getUid());
+    return user.getOrganisationUnits();
   }
 
   protected User getUser(IncomingSms sms) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -27,15 +27,12 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.message.MessageSender;
@@ -44,7 +41,9 @@ import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.code.SMSCode;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
+import org.hisp.dhis.sms.parse.SMSParserException;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,23 +72,24 @@ public abstract class CommandSMSListener extends BaseSMSListener {
   }
 
   @Override
-  public void receive(@Nonnull IncomingSms sms, @Nonnull String username) {
+  public void receive(@Nonnull IncomingSms sms, @Nonnull UserDetails smsCreatedBy) {
     // we cannot annotate getSMSCommand itself with Nonnull as it can return null but
     // receive is only called when accept returned true, which is if there is a non-null command
     SMSCommand smsCommand = getSMSCommand(sms);
 
     Map<String, String> codeValues = parseCodeValuePairs(sms, smsCommand);
 
-    if (!hasCorrectFormat(sms, smsCommand) || !validateInputValues(sms, smsCommand, codeValues)) {
+    if (!hasCorrectFormat(sms, smsCommand)
+        || !validateInputValues(sms, smsCreatedBy, smsCommand, codeValues)) {
       return;
     }
 
-    postProcess(sms, username, smsCommand, codeValues);
+    postProcess(sms, smsCreatedBy, smsCommand, codeValues);
   }
 
   protected abstract void postProcess(
       @Nonnull IncomingSms sms,
-      @Nonnull String username,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> codeValues);
 
@@ -119,7 +119,7 @@ public abstract class CommandSMSListener extends BaseSMSListener {
   }
 
   protected Set<OrganisationUnit> getOrganisationUnits(IncomingSms sms) {
-    User user = getUser(sms);
+    User user = userService.getUser(sms.getCreatedBy().getUid());
 
     if (user == null) {
       return new HashSet<>();
@@ -128,12 +128,9 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     return user.getOrganisationUnits();
   }
 
-  protected User getUser(IncomingSms sms) {
-    return userService.getUser(sms.getCreatedBy().getUid());
-  }
-
   private boolean validateInputValues(
       @Nonnull IncomingSms sms,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> commandValuePairs) {
     if (!hasMandatoryCodes(smsCommand.getCodes(), commandValuePairs.keySet())) {
@@ -145,21 +142,14 @@ public abstract class CommandSMSListener extends BaseSMSListener {
       return false;
     }
 
-    if (!hasOrganisationUnit(sms)) {
-      sendFeedback(
-          StringUtils.defaultIfEmpty(smsCommand.getNoUserMessage(), SMSCommand.NO_USER_MESSAGE),
-          sms.getOriginator(),
-          ERROR);
+    if (!hasOrganisationUnit(smsCreatedBy)) {
+      sendFeedback(smsCommand.getNoUserMessage(), sms.getOriginator(), ERROR);
 
       return false;
     }
 
-    if (hasMultipleOrganisationUnits(sms)) {
-      sendFeedback(
-          StringUtils.defaultIfEmpty(
-              smsCommand.getMoreThanOneOrgUnitMessage(), SMSCommand.MORE_THAN_ONE_ORGUNIT_MESSAGE),
-          sms.getOriginator(),
-          ERROR);
+    if (hasMultipleOrganisationUnits(smsCreatedBy)) {
+      sendFeedback(smsCommand.getMoreThanOneOrgUnitMessage(), sms.getOriginator(), ERROR);
 
       return false;
     }
@@ -207,20 +197,18 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     return true;
   }
 
-  private boolean hasOrganisationUnit(IncomingSms sms) {
-    Collection<OrganisationUnit> orgUnits = getOrganisationUnits(sms);
-
-    return !(orgUnits == null || orgUnits.isEmpty());
+  static void validateUserOrgUnits(UserDetails userDetails) {
+    if (userDetails.getUserOrgUnitIds().isEmpty()) {
+      throw new SMSParserException(
+          "User is not associated with any orgunit. Please contact your supervisor.");
+    }
   }
 
-  private boolean hasMultipleOrganisationUnits(IncomingSms sms) {
-    List<User> users = userService.getUsersByPhoneNumber(sms.getOriginator());
+  private static boolean hasOrganisationUnit(UserDetails smsCreatedBy) {
+    return !smsCreatedBy.getUserOrgUnitIds().isEmpty();
+  }
 
-    Set<OrganisationUnit> organisationUnits =
-        users.stream()
-            .flatMap(user -> user.getOrganisationUnits().stream())
-            .collect(Collectors.toSet());
-
-    return organisationUnits.size() > 1;
+  private static boolean hasMultipleOrganisationUnits(UserDetails smsCreatedBy) {
+    return smsCreatedBy.getUserOrgUnitIds().size() > 1;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -55,14 +55,15 @@ import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Transactional
 public abstract class CompressionSMSListener extends BaseSMSListener {
   protected abstract SmsResponse postProcess(
-      IncomingSms sms, SmsSubmission submission, String username) throws SMSProcessingException;
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
+      throws SMSProcessingException;
 
   protected abstract boolean handlesType(SubmissionType type);
 
@@ -71,7 +72,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
   public CompressionSMSListener(
       IncomingSmsService incomingSmsService,
       MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager manager) {
     super(incomingSmsService, smsSender);
     this.manager = manager;
@@ -93,7 +93,7 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
   }
 
   @Override
-  public void receive(@Nonnull IncomingSms sms, @Nonnull String username) {
+  public void receive(@Nonnull IncomingSms sms, @Nonnull UserDetails smsCreatedBy) {
     SmsSubmissionReader reader = new SmsSubmissionReader();
     SmsSubmissionHeader header = getHeader(sms);
     if (header == null) {
@@ -114,7 +114,7 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
 
     SmsResponse resp;
     try {
-      resp = postProcess(sms, subm, username);
+      resp = postProcess(sms, subm, smsCreatedBy);
     } catch (SMSProcessingException e) {
       log.error(e.getMessage());
       sendSMSResponse(e.getResp(), sms, header.getSubmissionId());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -66,8 +66,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
 
   protected abstract boolean handlesType(SubmissionType type);
 
-  protected final UserService userService;
-
   protected final IdentifiableObjectManager manager;
 
   public CompressionSMSListener(
@@ -76,7 +74,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
       UserService userService,
       IdentifiableObjectManager manager) {
     super(incomingSmsService, smsSender);
-    this.userService = userService;
     this.manager = manager;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -458,8 +458,7 @@ public class DataValueSMSListener extends CommandSMSListener {
     notInReport = notInReport.substring(0, notInReport.length() - 1);
 
     if (smsMessageSender.isConfigured()) {
-      if (command.getSuccessMessage() != null
-          && !StringUtils.isEmpty(command.getSuccessMessage())) {
+      if (command.getSuccessMessage() != null) {
         smsMessageSender.sendMessage(null, command.getSuccessMessage(), sender);
       } else {
         smsMessageSender.sendMessage(null, reportBack, sender);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.sms.parse.SMSParserException;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
@@ -80,7 +81,7 @@ public class DhisMessageAlertListener extends CommandSMSListener {
   @Override
   protected void postProcess(
       @Nonnull IncomingSms sms,
-      @Nonnull String username,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> codeValues) {
     String message = sms.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -296,10 +296,7 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
       reportBack += notInReport;
     }
 
-    if (command.getSuccessMessage() != null && !StringUtils.isEmpty(command.getSuccessMessage())) {
-      reportBack = command.getSuccessMessage();
-    }
-
+    reportBack = command.getSuccessMessage();
     smsMessageSender.sendMessage(null, reportBack, sender);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.sms.listener;
 
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,6 +61,7 @@ import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.sms.parse.SMSParserException;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.system.util.ValidationUtils;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -104,7 +104,7 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
 
   @Transactional
   @Override
-  public void receive(@Nonnull IncomingSms sms, @Nonnull String username) {
+  public void receive(@Nonnull IncomingSms sms, @Nonnull UserDetails smsCreatedBy) {
     String message = sms.getText();
 
     SMSCommand smsCommand =
@@ -117,11 +117,7 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
     Collection<OrganisationUnit> orgUnits = getOrganisationUnits(sms);
 
     if (orgUnits == null || orgUnits.isEmpty()) {
-      if (StringUtils.isEmpty(smsCommand.getNoUserMessage())) {
-        throw new SMSParserException(SMSCommand.NO_USER_MESSAGE);
-      } else {
-        throw new SMSParserException(smsCommand.getNoUserMessage());
-      }
+      throw new SMSParserException(smsCommand.getNoUserMessage());
     }
 
     OrganisationUnit orgUnit = SmsUtils.selectOrganisationUnit(orgUnits, parsedMessage, smsCommand);
@@ -130,7 +126,7 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
 
     for (SMSCode code : smsCommand.getCodes()) {
       if (parsedMessage.containsKey(code.getCode())) {
-        storeDataValue(sms, orgUnit, parsedMessage, code, smsCommand, period);
+        storeDataValue(sms, smsCreatedBy, orgUnit, parsedMessage, code, period);
         valueStored = true;
       }
     }
@@ -157,7 +153,7 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
   @Override
   protected void postProcess(
       @Nonnull IncomingSms sms,
-      @Nonnull String username,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> codeValues) {}
 
@@ -182,16 +178,15 @@ public class J2MEDataValueSMSListener extends CommandSMSListener {
 
   private void storeDataValue(
       IncomingSms sms,
+      UserDetails smsCreatedBy,
       OrganisationUnit orgUnit,
       Map<String, String> parsedMessage,
       SMSCode code,
-      SMSCommand command,
       Period period) {
+    validateUserOrgUnits(smsCreatedBy);
     String upperCaseCode = code.getCode().toUpperCase();
     String sender = sms.getOriginator();
-
-    String storedBy =
-        SmsUtils.getUser(sender, command, Collections.singletonList(getUser(sms))).getUsername();
+    String storedBy = smsCreatedBy.getUsername();
 
     if (StringUtils.isBlank(storedBy)) {
       storedBy = "[unknown] from [" + sender + "]";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.sms.incoming.SmsMessageStatus;
 import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
@@ -82,7 +83,7 @@ public class UnregisteredSMSListener extends CommandSMSListener {
   @Override
   protected void postProcess(
       @Nonnull IncomingSms sms,
-      @Nonnull String username,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> codeValues) {
     UserGroup userGroup = smsCommand.getUserGroup();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.smscompression.models.SmsDataValue;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -135,7 +136,6 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
         new AggregateDataSetSMSListener(
             incomingSmsService,
             smsSender,
-            userService,
             organisationUnitService,
             categoryService,
             dataElementService,
@@ -174,7 +174,7 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
 
   @Test
   void testAggregateDatasetListener() {
-    subject.receive(incomingSmsAggregate, "frank");
+    subject.receive(incomingSmsAggregate, userDetails("frank"));
 
     assertNotNull(updatedIncomingSms);
     assertTrue(updatedIncomingSms.isParsed());
@@ -185,8 +185,8 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
 
   @Test
   void testAggregateDatasetListenerRepeat() {
-    subject.receive(incomingSmsAggregate, "frank");
-    subject.receive(incomingSmsAggregate, "frank");
+    subject.receive(incomingSmsAggregate, userDetails("frank"));
+    subject.receive(incomingSmsAggregate, userDetails("frank"));
 
     assertNotNull(updatedIncomingSms);
     assertTrue(updatedIncomingSms.isParsed());
@@ -197,7 +197,7 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
 
   @Test
   void testAggregateDatasetListenerNoValues() {
-    subject.receive(incomingSmsAggregateNoValues, "frank");
+    subject.receive(incomingSmsAggregateNoValues, userDetails("frank"));
 
     assertNotNull(updatedIncomingSms);
     assertTrue(updatedIncomingSms.isParsed());
@@ -239,5 +239,11 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
     subm.setSubmissionId(1);
 
     return subm;
+  }
+
+  private static UserDetails userDetails(String username) {
+    User user = new User();
+    user.setUsername(username);
+    return UserDetails.fromUser(user);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -137,12 +137,6 @@ class DefaultEventService implements EventService {
   }
 
   @Override
-  public Event getEvent(@Nonnull UID event, @Nonnull UserDetails user)
-      throws ForbiddenException, NotFoundException {
-    return getEvent(event, EventParams.FALSE, user);
-  }
-
-  @Override
   public Event getEvent(@Nonnull UID event, @Nonnull EventParams eventParams)
       throws ForbiddenException, NotFoundException {
     return getEvent(event, eventParams, CurrentUserUtil.getCurrentUserDetails());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -64,12 +63,6 @@ public interface EventService {
    * Use {@link #getEvent(UID, EventParams)} instead to also get the events relationships.
    */
   Event getEvent(UID uid) throws NotFoundException, ForbiddenException;
-
-  /**
-   * Get event matching given {@code UID} under the privileges of given user. This method does not
-   * get the events relationships.
-   */
-  Event getEvent(UID uid, UserDetails user) throws NotFoundException, ForbiddenException;
 
   /**
    * Get event matching given {@code UID} and params under the privileges of the currently

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -47,14 +47,6 @@ public interface RelationshipService {
   Page<Relationship> getRelationships(RelationshipOperationParams params, PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException;
 
-  /**
-   * Fields the {@link #getRelationships(RelationshipOperationParams)} can order relationships by.
-   * Ordering by fields other than these is considered a programmer error. Validation of user
-   * provided field names should occur before calling {@link
-   * #getRelationships(RelationshipOperationParams)}.
-   */
-  Set<String> getOrderableFields();
-
   Relationship getRelationship(String uid) throws ForbiddenException, NotFoundException;
 
   /**
@@ -63,4 +55,12 @@ public interface RelationshipService {
    */
   List<Relationship> getRelationships(@Nonnull List<String> uids)
       throws ForbiddenException, NotFoundException;
+
+  /**
+   * Fields the {@link #getRelationships(RelationshipOperationParams)} can order relationships by.
+   * Ordering by fields other than these is considered a programmer error. Validation of user
+   * provided field names should occur before calling {@link
+   * #getRelationships(RelationshipOperationParams)}.
+   */
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
@@ -47,7 +47,7 @@ import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,15 +61,15 @@ public class DeleteEventSMSListener extends CompressionSMSListener {
   public DeleteEventSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager identifiableObjectManager,
       TrackerImportService trackerImportService) {
-    super(incomingSmsService, smsSender, userService, identifiableObjectManager);
+    super(incomingSmsService, smsSender, identifiableObjectManager);
     this.trackerImportService = trackerImportService;
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, String username)
+  protected SmsResponse postProcess(
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
       throws SMSProcessingException {
     DeleteSmsSubmission subm = (DeleteSmsSubmission) submission;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -54,7 +54,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,19 +72,19 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
   public EnrollmentSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager identifiableObjectManager,
       TrackerImportService trackerImportService,
       TrackedEntityService trackedEntityService,
       ProgramService programService) {
-    super(incomingSmsService, smsSender, userService, identifiableObjectManager);
+    super(incomingSmsService, smsSender, identifiableObjectManager);
     this.trackerImportService = trackerImportService;
     this.trackedEntityService = trackedEntityService;
     this.programService = programService;
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, String username)
+  protected SmsResponse postProcess(
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
       throws SMSProcessingException {
     EnrollmentSmsSubmission subm = (EnrollmentSmsSubmission) submission;
 
@@ -111,7 +111,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, program, trackedEntity, username);
+    TrackerObjects trackerObjects = map(subm, program, trackedEntity, smsCreatedBy.getUsername());
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
@@ -189,10 +188,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
 
     if (Status.OK == importReport.getStatus()) {
       update(sms, SmsMessageStatus.PROCESSED, true);
-      sendFeedback(
-          StringUtils.defaultIfEmpty(smsCommand.getSuccessMessage(), SMSCommand.SUCCESS_MESSAGE),
-          sms.getOriginator(),
-          INFO);
+      sendFeedback(smsCommand.getSuccessMessage(), sms.getOriginator(), INFO);
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListener.java
@@ -52,7 +52,7 @@ import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,17 +68,17 @@ public class RelationshipSMSListener extends CompressionSMSListener {
   public RelationshipSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager identifiableObjectManager,
       RelationshipTypeService relationshipTypeService,
       TrackerImportService trackerImportService) {
-    super(incomingSmsService, smsSender, userService, identifiableObjectManager);
+    super(incomingSmsService, smsSender, identifiableObjectManager);
     this.relationshipTypeService = relationshipTypeService;
     this.trackerImportService = trackerImportService;
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, String username)
+  protected SmsResponse postProcess(
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
       throws SMSProcessingException {
     RelationshipSmsSubmission subm = (RelationshipSmsSubmission) submission;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,15 +60,15 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
   public SimpleEventSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager identifiableObjectManager,
       TrackerImportService trackerImportService) {
-    super(incomingSmsService, smsSender, userService, identifiableObjectManager);
+    super(incomingSmsService, smsSender, identifiableObjectManager);
     this.trackerImportService = trackerImportService;
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, String username)
+  protected SmsResponse postProcess(
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
       throws SMSProcessingException {
     SimpleEventSmsSubmission subm = (SimpleEventSmsSubmission) submission;
 
@@ -76,7 +76,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, username);
+    TrackerObjects trackerObjects = map(subm, smsCreatedBy.getUsername());
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -101,10 +100,7 @@ public class SingleEventListener extends CommandSMSListener {
 
     if (Status.OK == importReport.getStatus()) {
       update(sms, SmsMessageStatus.PROCESSED, true);
-      sendFeedback(
-          StringUtils.defaultIfEmpty(smsCommand.getSuccessMessage(), SMSCommand.SUCCESS_MESSAGE),
-          sms.getOriginator(),
-          INFO);
+      sendFeedback(smsCommand.getSuccessMessage(), sms.getOriginator(), INFO);
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
@@ -403,7 +403,7 @@ class SmsImportMapper {
       @Nonnull IncomingSms sms,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
-      @Nonnull OrganisationUnit orgUnit,
+      @Nonnull String orgUnit,
       @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService,
       @Nonnull String trackedEntity,
@@ -417,7 +417,7 @@ class SmsImportMapper {
               .enrollment(enrollmentUid)
               .trackedEntity(trackedEntity)
               .program(metadataUid(smsCommand.getProgram()))
-              .orgUnit(metadataUid(orgUnit))
+              .orgUnit(MetadataIdentifier.ofUid(orgUnit))
               .occurredAt(now)
               .enrolledAt(now)
               .status(EnrollmentStatus.ACTIVE)
@@ -437,7 +437,7 @@ class SmsImportMapper {
       @Nonnull IncomingSms sms,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
-      @Nonnull OrganisationUnit orgUnit,
+      @Nonnull String orgUnit,
       @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService) {
     return TrackerObjects.builder()
@@ -502,12 +502,12 @@ class SmsImportMapper {
       @Nonnull IncomingSms sms,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
-      @Nonnull OrganisationUnit orgUnit,
+      @Nonnull String orgUnit,
       @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService) {
     return Event.builder()
         .event(CodeGenerator.generateUid())
-        .orgUnit(metadataUid(orgUnit))
+        .orgUnit(MetadataIdentifier.ofUid(orgUnit))
         .program(metadataUid(smsCommand.getProgram()))
         .programStage(metadataUid(smsCommand.getProgramStage()))
         .occurredAt(sms.getSentDate().toInstant())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,7 +87,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
   @Override
   protected void postProcess(
       @Nonnull IncomingSms sms,
-      @Nonnull String username,
+      @Nonnull UserDetails smsCreatedBy,
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> codeValues) {
     Collection<OrganisationUnit> orgUnits = getOrganisationUnits(sms);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,15 +60,15 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
   public TrackerEventSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
-      UserService userService,
       IdentifiableObjectManager identifiableObjectManager,
       TrackerImportService trackerImportService) {
-    super(incomingSmsService, smsSender, userService, identifiableObjectManager);
+    super(incomingSmsService, smsSender, identifiableObjectManager);
     this.trackerImportService = trackerImportService;
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, String username)
+  protected SmsResponse postProcess(
+      IncomingSms sms, SmsSubmission submission, UserDetails smsCreatedBy)
       throws SMSProcessingException {
     TrackerEventSmsSubmission subm = (TrackerEventSmsSubmission) submission;
 
@@ -76,7 +76,7 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, username);
+    TrackerObjects trackerObjects = map(subm, smsCreatedBy.getUsername());
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Tracker supports importing data via SMS.
+ *
+ * <p>There are two types of supported SMS
+ *
+ * <ol>
+ *   <li>Compression based SMS which use https://github.com/dhis2/sms-compression to compress and
+ *       encode the SMS text. Types found in {@link org.hisp.dhis.smscompression.models} are used to
+ *       build the SMS. Compression based SMS can be used by Android to sync data in case the device
+ *       is offline.
+ *   <li>Command based SMS which are not compressed and do not have dedicated types. These consist
+ *       of plain text which look like {@code "register a=hello|c=there"}. The text is prefixed with
+ *       a command name followed by key value pairs. The key value pairs are often data or attribute
+ *       value pairs. Commands can be created by users. Each command is associated with a {@code
+ *       ParserType} which is connected to one class processing the SMS.
+ * </ol>
+ */
+package org.hisp.dhis.tracker.imports.sms;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/package-info.java
@@ -7,7 +7,7 @@
  *   <li>Compression based SMS which use https://github.com/dhis2/sms-compression to compress and
  *       encode the SMS text. Types found in {@link org.hisp.dhis.smscompression.models} are used to
  *       build the SMS. Compression based SMS can be used by Android to sync data in case the device
- *       is offline.
+ *       is offline. Each type is associated with one class processing the SMS.
  *   <li>Command based SMS which are not compressed and do not have dedicated types. These consist
  *       of plain text which look like {@code "register a=hello|c=there"}. The text is prefixed with
  *       a command name followed by key value pairs. The key value pairs are often data or attribute

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
@@ -151,36 +151,6 @@ public class SmsUtils {
     return date;
   }
 
-  public static User getUser(String sender, SMSCommand smsCommand, List<User> userList) {
-    OrganisationUnit orgunit = null;
-    User user = null;
-
-    for (User u : userList) {
-      OrganisationUnit ou = u.getOrganisationUnit();
-
-      if (ou != null) {
-        if (orgunit == null) {
-          orgunit = ou;
-        } else if (orgunit.getId() == ou.getId()) {
-        } else {
-          throw new SMSParserException(
-              StringUtils.defaultIfBlank(
-                  smsCommand.getMoreThanOneOrgUnitMessage(),
-                  SMSCommand.MORE_THAN_ONE_ORGUNIT_MESSAGE));
-        }
-      }
-
-      user = u;
-    }
-
-    if (user == null) {
-      throw new SMSParserException(
-          "User is not associated with any orgunit. Please contact your supervisor.");
-    }
-
-    return user;
-  }
-
   public static List<String> splitLongUnicodeString(String message, List<String> result) {
     String firstTempString = null;
     String secondTempString = null;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SmsUtils.java
@@ -35,7 +35,6 @@ import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -101,19 +100,6 @@ public class SmsUtils {
     } catch (IllegalArgumentException e) {
       return null;
     }
-  }
-
-  public static Map<String, Set<OrganisationUnit>> getOrganisationUnitsByPhoneNumber(
-      String sender, Collection<User> users) {
-    Map<String, Set<OrganisationUnit>> userOrgUnitMap = new HashMap<>();
-
-    for (User u : users) {
-      if (u.getOrganisationUnits() != null) {
-        userOrgUnitMap.put(u.getUid(), u.getOrganisationUnits());
-      }
-    }
-
-    return userOrgUnitMap;
   }
 
   public static String encode(String value) {

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SmsUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SmsUtilsTest.java
@@ -41,13 +41,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -152,13 +149,6 @@ class SmsUtilsTest {
   }
 
   @Test
-  void testGetOrganisationUnitsByPhoneNumber() {
-    Collection<User> params = Collections.singleton(userA);
-    Map<String, Set<OrganisationUnit>> expected = Map.of(userA.getUid(), Set.of(organisationUnitA));
-    assertEquals(expected, SmsUtils.getOrganisationUnitsByPhoneNumber("sender", params));
-  }
-
-  @Test
   void testLookForDate() throws ParseException {
     GregorianCalendar gc = new GregorianCalendar(2019, 12, 31);
     SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy");
@@ -190,7 +180,8 @@ class SmsUtilsTest {
             "000000000000000000000000000000000000000000000000000000000000000000red-green-blue",
             "red.green.blue000000000000000000000000000000000000000000000000000000000000000000"),
         SmsUtils.splitLongUnicodeString(
-            "000000000000000000000000000000000000000000000000000000000000000000red-green-blue red.green.blue"
+            "000000000000000000000000000000000000000000000000000000000000000000red-green-blue"
+                + " red.green.blue"
                 + "000000000000000000000000000000000000000000000000000000000000000000",
             result));
     result = new ArrayList<>();
@@ -200,9 +191,9 @@ class SmsUtilsTest {
             "red.green.blue000000000000000000000000000000000000000000000000000000000000000000",
             "000000000000000000000000000000000000000000000000000000000000000000red.green.blue"),
         SmsUtils.splitLongUnicodeString(
-            "000000000000000000000000000000000000000000000000000000000000000000red-green-blue red.green.blue"
-                + "000000000000000000000000000000000000000000000000000000000000000000 "
-                + "000000000000000000000000000000000000000000000000000000000000000000red.green.blue",
+            "000000000000000000000000000000000000000000000000000000000000000000red-green-blue"
+                + " red.green.blue000000000000000000000000000000000000000000000000000000000000000000"
+                + " 000000000000000000000000000000000000000000000000000000000000000000red.green.blue",
             result));
   }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SmsUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SmsUtilsTest.java
@@ -164,15 +164,6 @@ class SmsUtilsTest {
   }
 
   @Test
-  void testGetUser() {
-    User returnedUser = SmsUtils.getUser("", new SMSCommand(), Lists.newArrayList(userA));
-    assertEquals(userA, returnedUser);
-    assertThrows(
-        SMSParserException.class,
-        () -> SmsUtils.getUser("", new SMSCommand(), Lists.newArrayList(userA, userB)));
-  }
-
-  @Test
   void testSplitLongUnicodeString() {
     List<String> result = new ArrayList<>();
     assertEquals(


### PR DESCRIPTION
Minor changes:

* remove unused code
* `SmsInboundController`: move vars close to usage for clarity, remove null check if return values are guaranteed to be `@Nonnull`
* remove unnecessary code in command listeners as `getSuccessMessage`/`getMoreThanOneOrgUnitMessage` never returns `null`

Use of `UserDetails`:

Most SMS processing code uses the `username` to set a `storedBy` field. Some code interested in whether a user has one or multiple `orgUnits`. Pass in the `UserDetails` of the `InboundSmsProcessingJob`.

* ensure that `IncomingSms.createdBy` = `CurrentUser` running the `InboundSmsProcessingJob` as that is what the listeners now assume. Validate that at the beginning of the job. Right now only the `SmsInboundController` is the only place where such sms jobs are created.
* `SmsUtils.getOrganisationUnitsByPhoneNumber` was always called with one user effectively doing `user.getOrganisationUnits()`.
* `SmsUtils.getUser(String sender, SMSCommand smsCommand, List<User> userList)` was always called with one user. This meant most of the code in here was dead. Extracted a validation function checking if a user has no orgUnit `"User is not associated with any orgunit.`. It previously also returned a user which we now get via the `UserDetails`.