### PR TITLE
fix: set sms.createdBy consumer thread DHIS2-18187 [2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/SmsConsumerThread.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/SmsConsumerThread.java
@@ -35,8 +35,6 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsListener;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.incoming.SmsMessageStatus;
-import org.hisp.dhis.user.AuthenticationService;
-import org.hisp.dhis.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -54,8 +52,6 @@ public class SmsConsumerThread {
 
   private final IncomingSmsService incomingSmsService;
 
-  private final AuthenticationService authenticationService;
-
   public void spawnSmsConsumer() {
     IncomingSms message = messageQueue.get();
 
@@ -63,9 +59,6 @@ public class SmsConsumerThread {
       log.info("Received SMS: " + message.getText());
 
       try {
-        User createdBy = message.getCreatedBy();
-        authenticationService.obtainAuthentication(createdBy.getUid());
-
         for (IncomingSmsListener listener : listeners) {
           if (listener.accept(message)) {
             listener.receive(message);
@@ -85,8 +78,6 @@ public class SmsConsumerThread {
         message.setStatus(SmsMessageStatus.FAILED);
         message.setParsed(false);
       } finally {
-        authenticationService.clearAuthentication();
-
         messageQueue.remove(message);
 
         incomingSmsService.update(message);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.incoming.SmsMessageStatus;
 import org.hisp.dhis.system.util.SmsUtils;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.transaction.annotation.Transactional;
@@ -238,7 +237,7 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     Enrollment enrollment = enrollments.get(0);
 
     UserInfoSnapshot currentUserInfo =
-        UserInfoSnapshot.from(CurrentUserUtil.getCurrentUserDetails());
+        UserInfoSnapshot.from(userService.getUser(sms.getCreatedBy().getId()));
 
     Event event = new Event();
     event.setOrganisationUnit(ous.iterator().next());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -152,7 +152,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
 
     List<TrackedEntity> trackedEntities = new ArrayList<>();
 
-    attributes.parallelStream()
+    attributes.stream()
         .map(attr -> getParams(attr, sms, command.getProgram(), ous))
         .forEach(
             param ->


### PR DESCRIPTION
## Issue

The UserDetails [refactoring](https://github.com/dhis2/dhis2-core/pull/15727) in 41 broke incoming SMS processing.

The sms processing code 
* https://github.com/dhis2/dhis2-core/blob/db185d69bef00986903510c156860f07e051fcdd/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java#L241
* and any code then using hibernate to update the `IncomingSms` state https://github.com/dhis2/dhis2-core/blob/db185d69bef00986903510c156860f07e051fcdd/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java#L173-L175

## Fix

* Set the system user in the sms consumer thread.
* Use `stream` instead of `parallelStream` as we would need to set the user on those threads as well. We used the same strategy on master in tracker. We are not sure how many people actually use the inbound sms feature in tracker.
* Use the `sms.createdBy` user when setting fields like `storedBy` as it contains the user that sent the sms found/set by the `SmsInboundController.getUserByPhoneNumber`. The user that sent the sms is the one responsible for creating/updating/deleting events and other entities.

https://github.com/dhis2/dhis2-core/blob/db185d69bef00986903510c156860f07e051fcdd/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java#L102-L120

## Tests

I cannot backport the automated tests created on master during https://dhis2.atlassian.net/browse/DHIS2-17729. This would take weeks or more. I briefly tried backporting one but we cannot use controller tests as they cannot be non-transactional in 41. The sms are consumed in another thread so we have the issue of the test transaction isolating us from that thread.

Manual tests
* sent sms shown in https://dhis2.atlassian.net/browse/DHIS2-18187