### PR TITLE
fix: Fix flaky unit tests missing authenticated user

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_ORGUNIT;
 import static org.hisp.dhis.test.TestBase.createDataElement;
 import static org.hisp.dhis.test.TestBase.createProgram;
+import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -56,6 +57,7 @@ import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.user.SystemUser;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -69,6 +71,7 @@ class AnalyticsServiceProgramDataElementTest extends AnalyticsServiceBaseTest {
    */
   @Test
   void verifyProgramDataElementInQueryCallsEventsAnalytics() {
+    injectSecurityContextNoSettings(new SystemUser());
     ArgumentCaptor<EventQueryParams> capturedParams =
         ArgumentCaptor.forClass(EventQueryParams.class);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.RecordingJobProgress;
+import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
@@ -61,7 +62,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Zubair Asghar
  */
 @ExtendWith(MockitoExtension.class)
-class TrackerImporterServiceTest {
+class TrackerImporterServiceTest extends TestBase {
 
   @Mock private TrackerBundleService trackerBundleService;
 
@@ -84,6 +85,8 @@ class TrackerImporterServiceTest {
     subject =
         new DefaultTrackerImportService(
             trackerBundleService, validationService, trackerPreprocessService);
+
+    injectSecurityContext(user);
 
     Event event = new Event();
     event.setEvent("EventUid");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
+import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.RecordingJobProgress;
-import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
@@ -62,7 +62,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Zubair Asghar
  */
 @ExtendWith(MockitoExtension.class)
-class TrackerImporterServiceTest extends TestBase {
+class TrackerImporterServiceTest {
 
   @Mock private TrackerBundleService trackerBundleService;
 
@@ -86,7 +86,7 @@ class TrackerImporterServiceTest extends TestBase {
         new DefaultTrackerImportService(
             trackerBundleService, validationService, trackerPreprocessService);
 
-    injectSecurityContext(user);
+    injectSecurityContextNoSettings(user);
 
     Event event = new Event();
     event.setEvent("EventUid");


### PR DESCRIPTION
Failing tests were missing the authenticated user and `CurrentUserUtil.getCurrentUserDetails` was throwing an exception.
They are flaky tests because depending on the order of tests, some setup was setting the user and not cleaning up the context.