### PR TITLE
fix: remove username validation to allow old usernames on login (#18718)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -58,6 +58,21 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
   @Autowired private SessionRegistry sessionRegistry;
 
   @Test
+  void testSuccessfulLoginWithOldUsername() {
+    User adminUser = userService.getUserByUsername("admin");
+    adminUser.setUsername("Üsername");
+    userService.updateUser(adminUser);
+
+    JsonLoginResponse response =
+        POST("/auth/login", "{'username':'Üsername','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("SUCCESS", response.getLoginStatus());
+    assertEquals("/dhis-web-dashboard/", response.getRedirectUrl());
+  }
+
+  @Test
   void testSuccessfulLogin() {
     JsonLoginResponse response =
         POST("/auth/login", "{'username':'admin','password':'district'}")

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -69,7 +69,7 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
             .as(JsonLoginResponse.class);
 
     assertEquals("SUCCESS", response.getLoginStatus());
-    assertEquals("/dhis-web-dashboard/", response.getRedirectUrl());
+    assertEquals("/dhis-web-dashboard", response.getRedirectUrl());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.security.LoginResponse.STATUS;
@@ -163,9 +162,6 @@ public class AuthenticationController {
   }
 
   private void validateRequest(LoginRequest loginRequest) {
-    if (!ValidationUtils.usernameIsValid(loginRequest.getUsername())) {
-      throw new BadCredentialsException("Bad credentials");
-    }
     User user = userService.getUserByUsername(loginRequest.getUsername());
     if (user == null) {
       throw new BadCredentialsException("Bad credentials");


### PR DESCRIPTION
(cherry picked from commit 3f202cc74b9ceb72b17beb257fc7fb3d34bd55fa)