### PR TITLE
fix: No data returned for data element details/operands as filter [2.39-DHIS2-18182-backport]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -2137,7 +2137,8 @@ public class DataQueryParams {
 
   /** Returns all data element operands part of a dimension or filter. */
   public List<DimensionalItemObject> getAllDataElementOperands() {
-    return ImmutableList.copyOf(ListUtils.union(getDataElementOperands(), getFilterDataElementOperands()));
+    return ImmutableList.copyOf(
+        ListUtils.union(getDataElementOperands(), getFilterDataElementOperands()));
   }
 
   /** Returns all reporting rates part of a dimension or filter. */
@@ -2369,8 +2370,8 @@ public class DataQueryParams {
   /** Returns all data element operands part of the data filter. */
   public List<DimensionalItemObject> getFilterDataElementOperands() {
     return ImmutableList.copyOf(
-            AnalyticsUtils.getByDataDimensionItemType(
-                    DataDimensionItemType.DATA_ELEMENT_OPERAND, getFilterOptions(DATA_X_DIM_ID)));
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.DATA_ELEMENT_OPERAND, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data filter. */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -2135,6 +2135,11 @@ public class DataQueryParams {
     return ImmutableList.copyOf(ListUtils.union(getDataElements(), getFilterDataElements()));
   }
 
+  /** Returns all data element operands part of a dimension or filter. */
+  public List<DimensionalItemObject> getAllDataElementOperands() {
+    return ImmutableList.copyOf(ListUtils.union(getDataElementOperands(), getFilterDataElementOperands()));
+  }
+
   /** Returns all reporting rates part of a dimension or filter. */
   public List<DimensionalItemObject> getAllReportingRates() {
     return ImmutableList.copyOf(ListUtils.union(getReportingRates(), getFilterReportingRates()));
@@ -2359,6 +2364,13 @@ public class DataQueryParams {
     return ImmutableList.copyOf(
         AnalyticsUtils.getByDataDimensionItemType(
             DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
+  }
+
+  /** Returns all data elements part of the data filter. */
+  public List<DimensionalItemObject> getFilterDataElementOperands() {
+    return ImmutableList.copyOf(
+            AnalyticsUtils.getByDataDimensionItemType(
+                    DataDimensionItemType.DATA_ELEMENT_OPERAND, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data filter. */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -2366,7 +2366,7 @@ public class DataQueryParams {
             DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
   }
 
-  /** Returns all data elements part of the data filter. */
+  /** Returns all data element operands part of the data filter. */
   public List<DimensionalItemObject> getFilterDataElementOperands() {
     return ImmutableList.copyOf(
             AnalyticsUtils.getByDataDimensionItemType(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -745,63 +745,114 @@ public class DataHandler {
     List<DimensionalItemObject> attributeOptionCombos =
         newArrayList(getAttributeOptionCombos(operands));
 
-    List<DimensionalItemObject> dimensionDataElements = dataElements.stream()
-            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getDataElement().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> dimensionDataElements =
+        dataElements.stream()
+            .filter(
+                de ->
+                    params.getDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getDataElement()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
-    List<DimensionalItemObject> filterDataElements = dataElements.stream()
-            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getDataElement().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> filterDataElements =
+        dataElements.stream()
+            .filter(
+                de ->
+                    params.getFilterDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getDataElement()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
 
-    List<DimensionalItemObject> dimensionCategoryOptionCombos = categoryOptionCombos.stream()
-            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getCategoryOptionCombo().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> dimensionCategoryOptionCombos =
+        categoryOptionCombos.stream()
+            .filter(
+                de ->
+                    params.getDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getCategoryOptionCombo()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
-    List<DimensionalItemObject> filterCategoryOptionCombos = categoryOptionCombos.stream()
-            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getCategoryOptionCombo().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> filterCategoryOptionCombos =
+        categoryOptionCombos.stream()
+            .filter(
+                de ->
+                    params.getFilterDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getCategoryOptionCombo()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
 
-    List<DimensionalItemObject> dimensionAttributeOptionCombos = attributeOptionCombos.stream()
-            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getAttributeOptionCombo().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> dimensionAttributeOptionCombos =
+        attributeOptionCombos.stream()
+            .filter(
+                de ->
+                    params.getDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getAttributeOptionCombo()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
-    List<DimensionalItemObject> filterAttributeOptionCombos = attributeOptionCombos.stream()
-            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getAttributeOptionCombo().getUid().equals(de.getUid())))
+    List<DimensionalItemObject> filterAttributeOptionCombos =
+        attributeOptionCombos.stream()
+            .filter(
+                de ->
+                    params.getFilterDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getAttributeOptionCombo()
+                                    .getUid()
+                                    .equals(de.getUid())))
             .toList();
 
+    DataQueryParams.Builder builder = newBuilder(params).removeDimension(DATA_X_DIM_ID);
 
-    DataQueryParams.Builder builder =
-        newBuilder(params)
-            .removeDimension(DATA_X_DIM_ID);
-
-    if(!dimensionDataElements.isEmpty()){
+    if (!dimensionDataElements.isEmpty()) {
       builder.addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dimensionDataElements));
     }
 
-    if(!filterDataElements.isEmpty()){
+    if (!filterDataElements.isEmpty()) {
       builder.addFilter(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, filterDataElements));
     }
 
     if (totalType.isCategoryOptionCombo()) {
-      if(!dimensionCategoryOptionCombos.isEmpty()){
+      if (!dimensionCategoryOptionCombos.isEmpty()) {
         builder.addDimension(
-                new BaseDimensionalObject(
-                        CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
+            new BaseDimensionalObject(
+                CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
       }
-      if(!filterCategoryOptionCombos.isEmpty()){
+      if (!filterCategoryOptionCombos.isEmpty()) {
         builder.addFilter(
-                new BaseDimensionalObject(
-                        CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
+            new BaseDimensionalObject(
+                CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
       }
     }
 
     if (totalType.isAttributeOptionCombo()) {
-      if(!dimensionAttributeOptionCombos.isEmpty()){
+      if (!dimensionAttributeOptionCombos.isEmpty()) {
         builder.addDimension(
-                new BaseDimensionalObject(
-                        ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
+            new BaseDimensionalObject(
+                ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
       }
-      if(!filterAttributeOptionCombos.isEmpty()){
+      if (!filterAttributeOptionCombos.isEmpty()) {
         builder.addFilter(
-                new BaseDimensionalObject(
-                        ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
+            new BaseDimensionalObject(
+                ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -804,6 +804,7 @@ public class DataHandler {
             .filter(
                 coc ->
                     params.getDataElementOperands().stream()
+                        .filter(deo -> ((DataElementOperand) deo).getCategoryOptionCombo() != null)
                         .anyMatch(
                             deo ->
                                 ((DataElementOperand) deo)
@@ -816,6 +817,7 @@ public class DataHandler {
             .filter(
                 coc ->
                     params.getFilterDataElementOperands().stream()
+                        .filter(deo -> ((DataElementOperand) deo).getCategoryOptionCombo() != null)
                         .anyMatch(
                             deo ->
                                 ((DataElementOperand) deo)
@@ -829,6 +831,7 @@ public class DataHandler {
             .filter(
                 aoc ->
                     params.getDataElementOperands().stream()
+                        .filter(deo -> ((DataElementOperand) deo).getAttributeOptionCombo() != null)
                         .anyMatch(
                             deo ->
                                 ((DataElementOperand) deo)
@@ -836,11 +839,13 @@ public class DataHandler {
                                     .getUid()
                                     .equals(aoc.getUid())))
             .toList();
+
     List<DimensionalItemObject> filterAttributeOptionCombos =
         attributeOptionCombos.stream()
             .filter(
                 aoc ->
                     params.getFilterDataElementOperands().stream()
+                        .filter(deo -> ((DataElementOperand) deo).getAttributeOptionCombo() != null)
                         .anyMatch(
                             deo ->
                                 ((DataElementOperand) deo)
@@ -851,43 +856,116 @@ public class DataHandler {
 
     DataQueryParams.Builder builder = newBuilder(params).removeDimension(DATA_X_DIM_ID);
 
+    addDataElementDimensionToDataQueryParamBuilder(builder, dimensionDataElements);
+    addDataElementFilterToDataQueryParamBuilder(builder, filterDataElements);
+    addCategoryOptionComboDimensionToDataQueryParamBuilder(
+        builder, dimensionCategoryOptionCombos, totalType);
+    addCategoryOptionComboFilterToDataQueryParamBuilder(
+        builder, filterCategoryOptionCombos, totalType);
+    addAttributeOptionComboDimensionToDataQueryParamBuilder(
+        builder, dimensionAttributeOptionCombos, totalType);
+    addAttributeOptionComboFilterToDataQueryParamBuilder(
+        builder, filterAttributeOptionCombos, totalType);
+
+    return builder.build();
+  }
+
+  /**
+   * Add CategoryOptionCombo dimension to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param dimensionCategoryOptionCombos the collection of the {@link DimensionalItemObject}.
+   * @param totalType the {@link TotalType}.
+   */
+  private void addCategoryOptionComboDimensionToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      List<DimensionalItemObject> dimensionCategoryOptionCombos,
+      TotalType totalType) {
+    if (totalType.isCategoryOptionCombo() && !dimensionCategoryOptionCombos.isEmpty()) {
+      builder.addDimension(
+          new BaseDimensionalObject(
+              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, dimensionCategoryOptionCombos));
+    }
+  }
+
+  /**
+   * Add CategoryOptionCombo filter to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param filterCategoryOptionCombos the collection of the {@link DimensionalItemObject}.
+   * @param totalType the {@link TotalType}.
+   */
+  private void addCategoryOptionComboFilterToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      List<DimensionalItemObject> filterCategoryOptionCombos,
+      TotalType totalType) {
+    if (totalType.isCategoryOptionCombo() && !filterCategoryOptionCombos.isEmpty()) {
+      builder.addFilter(
+          new BaseDimensionalObject(
+              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, filterCategoryOptionCombos));
+    }
+  }
+
+  /**
+   * Add AttributeOptionCombo dimension to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param dimensionAttributeOptionCombos the collection of the {@link DimensionalItemObject}.
+   * @param totalType the {@link TotalType}.
+   */
+  private void addAttributeOptionComboDimensionToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      List<DimensionalItemObject> dimensionAttributeOptionCombos,
+      TotalType totalType) {
+    if (totalType.isAttributeOptionCombo() && !dimensionAttributeOptionCombos.isEmpty()) {
+      builder.addDimension(
+          new BaseDimensionalObject(
+              ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, dimensionAttributeOptionCombos));
+    }
+  }
+
+  /**
+   * Add AttributeOptionCombo filter to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param filterAttributeOptionCombos the collection of the {@link DimensionalItemObject}.
+   * @param totalType the {@link TotalType}.
+   */
+  private void addAttributeOptionComboFilterToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      List<DimensionalItemObject> filterAttributeOptionCombos,
+      TotalType totalType) {
+    if (totalType.isAttributeOptionCombo() && !filterAttributeOptionCombos.isEmpty()) {
+      builder.addFilter(
+          new BaseDimensionalObject(
+              ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, filterAttributeOptionCombos));
+    }
+  }
+
+  /**
+   * Add DataElement dimension to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param dimensionDataElements the collection of the {@link DimensionalItemObject}.
+   */
+  private void addDataElementDimensionToDataQueryParamBuilder(
+      DataQueryParams.Builder builder, List<DimensionalItemObject> dimensionDataElements) {
     if (!dimensionDataElements.isEmpty()) {
       builder.addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dimensionDataElements));
     }
+  }
 
+  /**
+   * Add DataElement filter to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param filterDataElements the collection of the {@link DimensionalItemObject}.
+   */
+  private void addDataElementFilterToDataQueryParamBuilder(
+      DataQueryParams.Builder builder, List<DimensionalItemObject> filterDataElements) {
     if (!filterDataElements.isEmpty()) {
       builder.addFilter(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, filterDataElements));
     }
-
-    if (totalType.isCategoryOptionCombo()) {
-      if (!dimensionCategoryOptionCombos.isEmpty()) {
-        builder.addDimension(
-            new BaseDimensionalObject(
-                CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, dimensionCategoryOptionCombos));
-      }
-      if (!filterCategoryOptionCombos.isEmpty()) {
-        builder.addFilter(
-            new BaseDimensionalObject(
-                CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, filterCategoryOptionCombos));
-      }
-    }
-
-    if (totalType.isAttributeOptionCombo()) {
-      if (!dimensionAttributeOptionCombos.isEmpty()) {
-        builder.addDimension(
-            new BaseDimensionalObject(
-                ATTRIBUTEOPTIONCOMBO_DIM_ID,
-                ATTRIBUTE_OPTION_COMBO,
-                dimensionAttributeOptionCombos));
-      }
-      if (!filterAttributeOptionCombos.isEmpty()) {
-        builder.addFilter(
-            new BaseDimensionalObject(
-                ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, filterAttributeOptionCombos));
-      }
-    }
-
-    return builder.build();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -816,7 +816,7 @@ public class DataHandler {
                                     .getCategoryOptionCombo()
                                     .getUid()
                                     .equals(coc.getUid())))
-            .toList();
+            .collect(toList());
 
     if (!dimensionCategoryOptionCombos.isEmpty()) {
       builder.addDimension(
@@ -848,7 +848,7 @@ public class DataHandler {
                                     .getCategoryOptionCombo()
                                     .getUid()
                                     .equals(coc.getUid())))
-            .toList();
+            .collect(toList());
 
     if (!filterCategoryOptionCombos.isEmpty()) {
       builder.addFilter(
@@ -880,7 +880,7 @@ public class DataHandler {
                                     .getAttributeOptionCombo()
                                     .getUid()
                                     .equals(aoc.getUid())))
-            .toList();
+            .collect(toList());
 
     if (!dimensionAttributeOptionCombos.isEmpty()) {
       builder.addDimension(
@@ -912,7 +912,7 @@ public class DataHandler {
                                     .getAttributeOptionCombo()
                                     .getUid()
                                     .equals(aoc.getUid())))
-            .toList();
+            .collect(toList());
 
     if (!filterAttributeOptionCombos.isEmpty()) {
       builder.addFilter(
@@ -944,7 +944,7 @@ public class DataHandler {
                                     .getDataElement()
                                     .getUid()
                                     .equals(de.getUid())))
-            .toList();
+            .collect(toList());
     if (!dimensionDataElements.isEmpty()) {
       builder.addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dimensionDataElements));
     }
@@ -972,7 +972,7 @@ public class DataHandler {
                                     .getDataElement()
                                     .getUid()
                                     .equals(de.getUid())))
-            .toList();
+            .collect(toList());
     if (!filterDataElements.isEmpty()) {
       builder.addFilter(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, filterDataElements));
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -1219,7 +1219,7 @@ public class DataHandler {
    * @param map the map of metadata identifiers to data values.
    * @param queries the list of {@link DataQueryParams} to execute.
    */
-  private void  executeQueries(
+  private void executeQueries(
       AnalyticsTableType tableType,
       int maxLimit,
       Map<String, Object> map,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -418,7 +418,7 @@ public class DataHandler {
    */
   @Transactional(readOnly = true)
   public void addDataElementOperandValues(DataQueryParams params, Grid grid) {
-    if (!params.getDataElementOperands().isEmpty() && !params.isSkipData()) {
+    if (!params.getAllDataElementOperands().isEmpty() && !params.isSkipData()) {
       DataQueryParams dataSourceParams =
           newBuilder(params).retainDataDimension(DATA_ELEMENT_OPERAND).build();
 
@@ -729,7 +729,7 @@ public class DataHandler {
    * @param totalType the operand {@link TotalType}.
    */
   private void addDataElementOperandValues(DataQueryParams params, Grid grid, TotalType totalType) {
-    List<DataElementOperand> operands = asTypedList(params.getDataElementOperands());
+    List<DataElementOperand> operands = asTypedList(params.getAllDataElementOperands());
     operands =
         operands.stream()
             .filter(o -> totalType.equals(o.getTotalType()))
@@ -745,23 +745,64 @@ public class DataHandler {
     List<DimensionalItemObject> attributeOptionCombos =
         newArrayList(getAttributeOptionCombos(operands));
 
-    // TODO Check if data was dim or filter
+    List<DimensionalItemObject> dimensionDataElements = dataElements.stream()
+            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getDataElement().getUid().equals(de.getUid())))
+            .toList();
+    List<DimensionalItemObject> filterDataElements = dataElements.stream()
+            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getDataElement().getUid().equals(de.getUid())))
+            .toList();
+
+    List<DimensionalItemObject> dimensionCategoryOptionCombos = categoryOptionCombos.stream()
+            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getCategoryOptionCombo().getUid().equals(de.getUid())))
+            .toList();
+    List<DimensionalItemObject> filterCategoryOptionCombos = categoryOptionCombos.stream()
+            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getCategoryOptionCombo().getUid().equals(de.getUid())))
+            .toList();
+
+    List<DimensionalItemObject> dimensionAttributeOptionCombos = attributeOptionCombos.stream()
+            .filter( de -> params.getDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getAttributeOptionCombo().getUid().equals(de.getUid())))
+            .toList();
+    List<DimensionalItemObject> filterAttributeOptionCombos = attributeOptionCombos.stream()
+            .filter( de -> params.getFilterDataElementOperands().stream().anyMatch(deo -> ((DataElementOperand)deo).getAttributeOptionCombo().getUid().equals(de.getUid())))
+            .toList();
+
 
     DataQueryParams.Builder builder =
         newBuilder(params)
-            .removeDimension(DATA_X_DIM_ID)
-            .addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dataElements));
+            .removeDimension(DATA_X_DIM_ID);
+
+    if(!dimensionDataElements.isEmpty()){
+      builder.addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dimensionDataElements));
+    }
+
+    if(!filterDataElements.isEmpty()){
+      builder.addFilter(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, filterDataElements));
+    }
 
     if (totalType.isCategoryOptionCombo()) {
-      builder.addDimension(
-          new BaseDimensionalObject(
-              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
+      if(!dimensionCategoryOptionCombos.isEmpty()){
+        builder.addDimension(
+                new BaseDimensionalObject(
+                        CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
+      }
+      if(!filterCategoryOptionCombos.isEmpty()){
+        builder.addFilter(
+                new BaseDimensionalObject(
+                        CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, categoryOptionCombos));
+      }
     }
 
     if (totalType.isAttributeOptionCombo()) {
-      builder.addDimension(
-          new BaseDimensionalObject(
-              ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
+      if(!dimensionAttributeOptionCombos.isEmpty()){
+        builder.addDimension(
+                new BaseDimensionalObject(
+                        ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
+      }
+      if(!filterAttributeOptionCombos.isEmpty()){
+        builder.addFilter(
+                new BaseDimensionalObject(
+                        ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, attributeOptionCombos));
+      }
     }
 
     DataQueryParams operandParams = builder.build();
@@ -1178,7 +1219,7 @@ public class DataHandler {
    * @param map the map of metadata identifiers to data values.
    * @param queries the list of {@link DataQueryParams} to execute.
    */
-  private void executeQueries(
+  private void  executeQueries(
       AnalyticsTableType tableType,
       int maxLimit,
       Map<String, Object> map,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -774,31 +774,36 @@ public class DataHandler {
     List<DimensionalItemObject> attributeOptionCombos =
         newArrayList(getAttributeOptionCombos(operands));
 
-    List<DimensionalItemObject> dimensionDataElements =
-        dataElements.stream()
-            .filter(
-                de ->
-                    params.getDataElementOperands().stream()
-                        .anyMatch(
-                            deo ->
-                                ((DataElementOperand) deo)
-                                    .getDataElement()
-                                    .getUid()
-                                    .equals(de.getUid())))
-            .toList();
-    List<DimensionalItemObject> filterDataElements =
-        dataElements.stream()
-            .filter(
-                de ->
-                    params.getFilterDataElementOperands().stream()
-                        .anyMatch(
-                            deo ->
-                                ((DataElementOperand) deo)
-                                    .getDataElement()
-                                    .getUid()
-                                    .equals(de.getUid())))
-            .toList();
+    DataQueryParams.Builder builder = newBuilder(params).removeDimension(DATA_X_DIM_ID);
 
+    addDataElementDimensionToDataQueryParamBuilder(builder, params, dataElements);
+    addDataElementFilterToDataQueryParamBuilder(builder, params, dataElements);
+
+    if (totalType.isCategoryOptionCombo()) {
+      addCategoryOptionComboDimensionToDataQueryParamBuilder(builder, params, categoryOptionCombos);
+      addCategoryOptionComboFilterToDataQueryParamBuilder(builder, params, categoryOptionCombos);
+    }
+
+    if (totalType.isAttributeOptionCombo()) {
+      addAttributeOptionComboDimensionToDataQueryParamBuilder(
+          builder, params, attributeOptionCombos);
+      addAttributeOptionComboFilterToDataQueryParamBuilder(builder, params, attributeOptionCombos);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Add CategoryOptionCombo dimension to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param params the {@link DataQueryParams}.
+   * @param categoryOptionCombos the collection of the {@link DimensionalItemObject}.
+   */
+  private void addCategoryOptionComboDimensionToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> categoryOptionCombos) {
     List<DimensionalItemObject> dimensionCategoryOptionCombos =
         categoryOptionCombos.stream()
             .filter(
@@ -812,6 +817,25 @@ public class DataHandler {
                                     .getUid()
                                     .equals(coc.getUid())))
             .toList();
+
+    if (!dimensionCategoryOptionCombos.isEmpty()) {
+      builder.addDimension(
+          new BaseDimensionalObject(
+              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, dimensionCategoryOptionCombos));
+    }
+  }
+
+  /**
+   * Add CategoryOptionCombo filter to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param params the {@link DataQueryParams}.
+   * @param categoryOptionCombos the collection of the {@link DimensionalItemObject}.
+   */
+  private void addCategoryOptionComboFilterToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> categoryOptionCombos) {
     List<DimensionalItemObject> filterCategoryOptionCombos =
         categoryOptionCombos.stream()
             .filter(
@@ -826,6 +850,24 @@ public class DataHandler {
                                     .equals(coc.getUid())))
             .toList();
 
+    if (!filterCategoryOptionCombos.isEmpty()) {
+      builder.addFilter(
+          new BaseDimensionalObject(
+              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, filterCategoryOptionCombos));
+    }
+  }
+
+  /**
+   * Add AttributeOptionCombo dimension to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param params the {@link DataQueryParams}.
+   * @param attributeOptionCombos the collection of the {@link DimensionalItemObject}.
+   */
+  private void addAttributeOptionComboDimensionToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> attributeOptionCombos) {
     List<DimensionalItemObject> dimensionAttributeOptionCombos =
         attributeOptionCombos.stream()
             .filter(
@@ -840,6 +882,24 @@ public class DataHandler {
                                     .equals(aoc.getUid())))
             .toList();
 
+    if (!dimensionAttributeOptionCombos.isEmpty()) {
+      builder.addDimension(
+          new BaseDimensionalObject(
+              ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, dimensionAttributeOptionCombos));
+    }
+  }
+
+  /**
+   * Add AttributeOptionCombo filter to DataQueryParam builder.
+   *
+   * @param builder the {@link DataQueryParams.Builder}.
+   * @param params the {@link DataQueryParams}.
+   * @param attributeOptionCombos the collection of the {@link DimensionalItemObject}.
+   */
+  private void addAttributeOptionComboFilterToDataQueryParamBuilder(
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> attributeOptionCombos) {
     List<DimensionalItemObject> filterAttributeOptionCombos =
         attributeOptionCombos.stream()
             .filter(
@@ -854,88 +914,7 @@ public class DataHandler {
                                     .equals(aoc.getUid())))
             .toList();
 
-    DataQueryParams.Builder builder = newBuilder(params).removeDimension(DATA_X_DIM_ID);
-
-    addDataElementDimensionToDataQueryParamBuilder(builder, dimensionDataElements);
-    addDataElementFilterToDataQueryParamBuilder(builder, filterDataElements);
-    addCategoryOptionComboDimensionToDataQueryParamBuilder(
-        builder, dimensionCategoryOptionCombos, totalType);
-    addCategoryOptionComboFilterToDataQueryParamBuilder(
-        builder, filterCategoryOptionCombos, totalType);
-    addAttributeOptionComboDimensionToDataQueryParamBuilder(
-        builder, dimensionAttributeOptionCombos, totalType);
-    addAttributeOptionComboFilterToDataQueryParamBuilder(
-        builder, filterAttributeOptionCombos, totalType);
-
-    return builder.build();
-  }
-
-  /**
-   * Add CategoryOptionCombo dimension to DataQueryParam builder.
-   *
-   * @param builder the {@link DataQueryParams.Builder}.
-   * @param dimensionCategoryOptionCombos the collection of the {@link DimensionalItemObject}.
-   * @param totalType the {@link TotalType}.
-   */
-  private void addCategoryOptionComboDimensionToDataQueryParamBuilder(
-      DataQueryParams.Builder builder,
-      List<DimensionalItemObject> dimensionCategoryOptionCombos,
-      TotalType totalType) {
-    if (totalType.isCategoryOptionCombo() && !dimensionCategoryOptionCombos.isEmpty()) {
-      builder.addDimension(
-          new BaseDimensionalObject(
-              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, dimensionCategoryOptionCombos));
-    }
-  }
-
-  /**
-   * Add CategoryOptionCombo filter to DataQueryParam builder.
-   *
-   * @param builder the {@link DataQueryParams.Builder}.
-   * @param filterCategoryOptionCombos the collection of the {@link DimensionalItemObject}.
-   * @param totalType the {@link TotalType}.
-   */
-  private void addCategoryOptionComboFilterToDataQueryParamBuilder(
-      DataQueryParams.Builder builder,
-      List<DimensionalItemObject> filterCategoryOptionCombos,
-      TotalType totalType) {
-    if (totalType.isCategoryOptionCombo() && !filterCategoryOptionCombos.isEmpty()) {
-      builder.addFilter(
-          new BaseDimensionalObject(
-              CATEGORYOPTIONCOMBO_DIM_ID, CATEGORY_OPTION_COMBO, filterCategoryOptionCombos));
-    }
-  }
-
-  /**
-   * Add AttributeOptionCombo dimension to DataQueryParam builder.
-   *
-   * @param builder the {@link DataQueryParams.Builder}.
-   * @param dimensionAttributeOptionCombos the collection of the {@link DimensionalItemObject}.
-   * @param totalType the {@link TotalType}.
-   */
-  private void addAttributeOptionComboDimensionToDataQueryParamBuilder(
-      DataQueryParams.Builder builder,
-      List<DimensionalItemObject> dimensionAttributeOptionCombos,
-      TotalType totalType) {
-    if (totalType.isAttributeOptionCombo() && !dimensionAttributeOptionCombos.isEmpty()) {
-      builder.addDimension(
-          new BaseDimensionalObject(
-              ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, dimensionAttributeOptionCombos));
-    }
-  }
-
-  /**
-   * Add AttributeOptionCombo filter to DataQueryParam builder.
-   *
-   * @param builder the {@link DataQueryParams.Builder}.
-   * @param filterAttributeOptionCombos the collection of the {@link DimensionalItemObject}.
-   * @param totalType the {@link TotalType}.
-   */
-  private void addAttributeOptionComboFilterToDataQueryParamBuilder(
-      DataQueryParams.Builder builder,
-      List<DimensionalItemObject> filterAttributeOptionCombos,
-      TotalType totalType) {
-    if (totalType.isAttributeOptionCombo() && !filterAttributeOptionCombos.isEmpty()) {
+    if (!filterAttributeOptionCombos.isEmpty()) {
       builder.addFilter(
           new BaseDimensionalObject(
               ATTRIBUTEOPTIONCOMBO_DIM_ID, ATTRIBUTE_OPTION_COMBO, filterAttributeOptionCombos));
@@ -946,10 +925,26 @@ public class DataHandler {
    * Add DataElement dimension to DataQueryParam builder.
    *
    * @param builder the {@link DataQueryParams.Builder}.
-   * @param dimensionDataElements the collection of the {@link DimensionalItemObject}.
+   * @param params the {@link DataQueryParams}.
+   * @param dataElements the collection of the {@link DimensionalItemObject}.
    */
   private void addDataElementDimensionToDataQueryParamBuilder(
-      DataQueryParams.Builder builder, List<DimensionalItemObject> dimensionDataElements) {
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> dataElements) {
+
+    List<DimensionalItemObject> dimensionDataElements =
+        dataElements.stream()
+            .filter(
+                de ->
+                    params.getDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getDataElement()
+                                    .getUid()
+                                    .equals(de.getUid())))
+            .toList();
     if (!dimensionDataElements.isEmpty()) {
       builder.addDimension(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, dimensionDataElements));
     }
@@ -959,10 +954,25 @@ public class DataHandler {
    * Add DataElement filter to DataQueryParam builder.
    *
    * @param builder the {@link DataQueryParams.Builder}.
-   * @param filterDataElements the collection of the {@link DimensionalItemObject}.
+   * @param params the {@link DataQueryParams}.
+   * @param dataElements the collection of the {@link DimensionalItemObject}.
    */
   private void addDataElementFilterToDataQueryParamBuilder(
-      DataQueryParams.Builder builder, List<DimensionalItemObject> filterDataElements) {
+      DataQueryParams.Builder builder,
+      DataQueryParams params,
+      List<DimensionalItemObject> dataElements) {
+    List<DimensionalItemObject> filterDataElements =
+        dataElements.stream()
+            .filter(
+                de ->
+                    params.getFilterDataElementOperands().stream()
+                        .anyMatch(
+                            deo ->
+                                ((DataElementOperand) deo)
+                                    .getDataElement()
+                                    .getUid()
+                                    .equals(de.getUid())))
+            .toList();
     if (!filterDataElements.isEmpty()) {
       builder.addFilter(new BaseDimensionalObject(DATA_X_DIM_ID, DATA_X, filterDataElements));
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -338,18 +338,21 @@ public class AnalyticsUtils {
       Map<String, T> valueMap, TotalType totalType) {
     Map<String, T> map = Maps.newHashMap();
 
+    int toIndex = totalType.getPropertyCount() + 1;
+
     for (Entry<String, T> entry : valueMap.entrySet()) {
       List<String> items =
           Lists.newArrayList(entry.getKey().split(DimensionalObject.DIMENSION_SEP));
-      if(items.size() < totalType.getPropertyCount() +1) {
+
+      if(items.size() < toIndex) {
         map.put(entry.getKey(), entry.getValue());
         continue;
       }
 
       List<String> operands =
-          Lists.newArrayList(items.subList(0, totalType.getPropertyCount() + 1));
+          Lists.newArrayList(items.subList(0, toIndex));
       List<String> dimensions =
-          Lists.newArrayList(items.subList(totalType.getPropertyCount() + 1, items.size()));
+          Lists.newArrayList(items.subList(toIndex, items.size()));
 
       // Add wild card in place of category option combination
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -344,15 +344,13 @@ public class AnalyticsUtils {
       List<String> items =
           Lists.newArrayList(entry.getKey().split(DimensionalObject.DIMENSION_SEP));
 
-      if(items.size() < toIndex) {
+      if (items.size() < toIndex) {
         map.put(entry.getKey(), entry.getValue());
         continue;
       }
 
-      List<String> operands =
-          Lists.newArrayList(items.subList(0, toIndex));
-      List<String> dimensions =
-          Lists.newArrayList(items.subList(toIndex, items.size()));
+      List<String> operands = Lists.newArrayList(items.subList(0, toIndex));
+      List<String> dimensions = Lists.newArrayList(items.subList(toIndex, items.size()));
 
       // Add wild card in place of category option combination
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -338,19 +338,23 @@ public class AnalyticsUtils {
       Map<String, T> valueMap, TotalType totalType) {
     Map<String, T> map = Maps.newHashMap();
 
-    int toIndex = totalType.getPropertyCount() + 1;
+    final int upperBoundaryMarginOfDimensionalObjectItems = 1;
+    final int upperBoundaryOfDimensionalObjectItems =
+        totalType.getPropertyCount() + upperBoundaryMarginOfDimensionalObjectItems;
 
     for (Entry<String, T> entry : valueMap.entrySet()) {
       List<String> items =
           Lists.newArrayList(entry.getKey().split(DimensionalObject.DIMENSION_SEP));
 
-      if (items.size() < toIndex) {
+      if (items.size() < upperBoundaryOfDimensionalObjectItems) {
         map.put(entry.getKey(), entry.getValue());
         continue;
       }
 
-      List<String> operands = Lists.newArrayList(items.subList(0, toIndex));
-      List<String> dimensions = Lists.newArrayList(items.subList(toIndex, items.size()));
+      List<String> operands =
+          Lists.newArrayList(items.subList(0, upperBoundaryOfDimensionalObjectItems));
+      List<String> dimensions =
+          Lists.newArrayList(items.subList(upperBoundaryOfDimensionalObjectItems, items.size()));
 
       // Add wild card in place of category option combination
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -341,6 +341,11 @@ public class AnalyticsUtils {
     for (Entry<String, T> entry : valueMap.entrySet()) {
       List<String> items =
           Lists.newArrayList(entry.getKey().split(DimensionalObject.DIMENSION_SEP));
+      if(items.size() < totalType.getPropertyCount() +1) {
+        map.put(entry.getKey(), entry.getValue());
+        continue;
+      }
+
       List<String> operands =
           Lists.newArrayList(items.subList(0, totalType.getPropertyCount() + 1));
       List<String> dimensions =


### PR DESCRIPTION
**BACKPORT**
The Analytics API is not returning data for DataElementOperand dimensions passed in the filter parameter. The missing functionality needs to be added to the codebase.