### PR TITLE
test: disable dhis-web-server AuthTest

### DIFF
--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.test.IntegrationTest;
 import org.hisp.dhis.webapi.controller.security.LoginRequest;
 import org.hisp.dhis.webapi.controller.security.LoginResponse;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -65,6 +66,8 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
+@Disabled(
+    "fails to build in CI with Connections could not be acquired from the underlying database!")
 @Slf4j
 @IntegrationTest
 @ActiveProfiles(profiles = {"test-postgres"})


### PR DESCRIPTION
In https://github.com/dhis2/dhis2-core/pull/18669 I correctly tagged [AuthTest](https://github.com/dhis2/dhis2-core/blob/3347ce79cff50bbd9d3ff06f70077e7ffe21a4e0/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java#L69-L71) as an integration test and included its project in our workflows so it actually runs. For some reason we see the following after merging the PR

```
2024-10-10T04:27:59.6850220Z INFO: Initializing ProtocolHandler ["http-nio-63829"]
2024-10-10T04:27:59.7106439Z Oct 10, 2024 4:27:59 AM org.apache.catalina.core.StandardService startInternal
2024-10-10T04:27:59.7107966Z INFO: Starting service [Tomcat]
2024-10-10T04:27:59.7109425Z Oct 10, 2024 4:27:59 AM org.apache.catalina.core.StandardEngine startInternal
2024-10-10T04:27:59.7239881Z INFO: Starting Servlet engine: [Apache Tomcat/10.1.28]
2024-10-10T04:28:00.6992975Z Oct 10, 2024 4:28:00 AM org.apache.catalina.core.ApplicationContext log
2024-10-10T04:28:00.6994857Z INFO: Initializing Spring root WebApplicationContext
2024-10-10T04:28:12.1258779Z 04:28:12.078 [Thread-5] ERROR org.hisp.dhis.datasource.DatabasePoolUtils - Connections could not be acquired from the underlying database!
2024-10-10T04:28:13.3345028Z 04:28:13.317 [Thread-5] ERROR org.springframework.web.context.ContextLoader - Context initialization failed
2024-10-10T04:28:13.3364737Z org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'webMvcConfig': Unsatisfied dependency expressed through field 'currentUserHandlerMethodArgumentResolver': Error creating bean with name 'currentUserHandlerMethodArgumentResolver' defined in URL [jar:file:/home/runner/work/dhis2-core/dhis2-core/dhis-2/dhis-web-api/target/dhis-web-api-2.42-SNAPSHOT.jar!/org/hisp/dhis/webapi/mvc/CurrentUserHandlerMethodArgumentResolver.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'org.hisp.dhis.user.UserService' defined in URL [jar:file:/home/runner/work/dhis2-core/dhis2-core/dhis-2/dhis-services/dhis-service-core/target/dhis-service-core-2.42-SNAPSHOT.jar!/org/hisp/dhis/user/DefaultUserService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'defaultUserSettingsService' defined in URL [jar:file:/home/runner/work/dhis2-core/dhis2-core/dhis-2/dhis-services/dhis-service-core/target/dhis-service-core-2.42-SNAPSHOT.jar!/org/hisp/dhis/user/DefaultUserSettingsService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'org.hisp.dhis.user.UserStore' defined in URL [jar:file:/home/runner/work/dhis2-core/dhis2-core/dhis-2/dhis-services/dhis-service-core/target/dhis-service-core-2.42-SNAPSHOT.jar!/org/hisp/dhis/user/hibernate/HibernateUserStore.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'sharedEntityManager' defined in class path resource [org/hisp/dhis/config/HibernateConfig.class]: Unsatisfied dependency expressed through method 'sharedEntityManager' parameter 0: Error creating bean with name 'flyway' defined in class path resource [org/hisp/dhis/db/migration/config/FlywayConfig.class]: Unable to obtain connection from database: Connections could not be acquired from the underlying database!
2024-10-10T04:28:13.3398420Z ----------------------------------------------------------------------------------------------------------
2024-10-10T04:28:13.3399350Z SQL State  : 08001
2024-10-10T04:28:13.3399932Z Error Code : 0
2024-10-10T04:28:13.3400876Z Message    : Connections could not be acquired from the underlying database!
```

I am disabling the test again to figure out why that is. The test passed in the PR. It also runs fine locally using the commands of our workflow 🤷🏻 