### PR TITLE
chore: Add property projectKey to sonar

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -70,6 +70,8 @@
 
     <sonar.organization>dhis2</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.projectKey>dhis2_dhis2-core</sonar.projectKey>
+
     <surefireArgLine>-Xmx2024m</surefireArgLine>
 
     <!-- *Build* -->


### PR DESCRIPTION
When using sonar and maven, this "projectKey" is usually extracted automatically. However, since it seems the check is failing, I am adding this explicitly to attempt to fix the issue.