### PR TITLE
ci: don't download webapps when only running tests

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -41,13 +41,13 @@ jobs:
             # build and publish multi-arch images using Jib. Image is used for api tests in
             # this workflow and can be pulled from Dockerhub by devs to run locally, ...
             mvn clean verify --threads 2C --batch-mode --no-transfer-progress \
-              -DskipTests -Dmaven.test.skip=true --update-snapshots --file dhis-2/pom.xml \
+              -DskipTests --update-snapshots --file dhis-2/pom.xml \
               --projects dhis-web-server --also-make --activate-profiles jibBuild \
               -Djib.to.image=$CORE_IMAGE_NAME -Djib.container.labels=DHIS2_BUILD_REVISION=${{github.event.pull_request.head.sha}},DHIS2_BUILD_BRANCH=${{github.head_ref}}
           else
             # only build image for running api tests in this workflow i.e. master, 2.39, ...
             mvn clean verify --threads 2C --batch-mode --no-transfer-progress \
-              -DskipTests -Dmaven.test.skip=true --update-snapshots --file dhis-2/pom.xml \
+              -DskipTests --update-snapshots --file dhis-2/pom.xml \
               --projects dhis-web-server --also-make --activate-profiles jibDockerBuild \
               -Djib.to.image=$CORE_IMAGE_NAME
           fi

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -40,13 +40,13 @@ jobs:
           if [ "$DOCKERHUB_PUSH" = "true" ]; then
             # build and publish multi-arch images using Jib. Image is used for api tests in
             # this workflow and can be pulled from Dockerhub by devs to run locally, ...
-            mvn clean package --threads 2C --batch-mode --no-transfer-progress \
+            mvn clean verify --threads 2C --batch-mode --no-transfer-progress \
               -DskipTests -Dmaven.test.skip=true --update-snapshots --file dhis-2/pom.xml \
               --projects dhis-web-server --also-make --activate-profiles jibBuild \
               -Djib.to.image=$CORE_IMAGE_NAME -Djib.container.labels=DHIS2_BUILD_REVISION=${{github.event.pull_request.head.sha}},DHIS2_BUILD_BRANCH=${{github.head_ref}}
           else
             # only build image for running api tests in this workflow i.e. master, 2.39, ...
-            mvn clean package --threads 2C --batch-mode --no-transfer-progress \
+            mvn clean verify --threads 2C --batch-mode --no-transfer-progress \
               -DskipTests -Dmaven.test.skip=true --update-snapshots --file dhis-2/pom.xml \
               --projects dhis-web-server --also-make --activate-profiles jibDockerBuild \
               -Djib.to.image=$CORE_IMAGE_NAME

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run unit tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3
@@ -65,7 +65,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure
@@ -116,7 +116,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure

--- a/dhis-2/dhis-test-coverage/pom.xml
+++ b/dhis-2/dhis-test-coverage/pom.xml
@@ -196,7 +196,7 @@
             <goals>
               <goal>report-aggregate</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>test</phase>
           </execution>
         </executions>
       </plugin>

--- a/dhis-2/dhis-web-server/pom.xml
+++ b/dhis-2/dhis-web-server/pom.xml
@@ -207,7 +207,7 @@
             <goals>
               <goal>exec</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
       </plugin>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2155,6 +2155,14 @@ jasperreports.version=${jasperreports.version}
                 <goal>prepare-agent</goal>
               </goals>
             </execution>
+            <!-- bind it to test instead of default verify so we get coverage reports when only running mvn test -->
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <phase>test</phase>
+            </execution>
           </executions>
         </plugin>
       </plugins>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2362,10 +2362,8 @@ jasperreports.version=${jasperreports.version}
             <goals>
               <goal>analyze-only</goal>
             </goals>
-            <phase>process-test-classes</phase>
             <configuration>
               <failOnWarning>true</failOnWarning>
-              <skip>${skipTests}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
These are the [maven lifecycles](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle) which we can execute. We can also bind 
maven plugins (or some of their commands aka goals) to a phase, some are bound to a phase by default.

| Phase                   | Description                                                                                       |
|-------------------------|---------------------------------------------------------------------------------------------------|
| validate                 | Validate the project is correct and all necessary information is available.                       |
| initialize               | Initialize build state, e.g., set properties or create directories.                               |
| generate-sources         | Generate any source code for inclusion in compilation.                                            |
| process-sources          | Process the source code, for example to filter any values.                                        |
| generate-resources       | Generate resources for inclusion in the package.                                                  |
| process-resources        | Copy and process the resources into the destination directory, ready for packaging.               |
| compile                  | Compile the source code of the project.                                                           |
| process-classes          | Post-process the generated files from compilation, e.g., bytecode enhancement on Java classes.    |
| generate-test-sources    | Generate any test source code for inclusion in compilation.                                       |
| process-test-sources     | Process the test source code, for example to filter any values.                                   |
| generate-test-resources  | Create resources for testing.                                                                     |
| process-test-resources   | Copy and process the resources into the test destination directory.                               |
| test-compile             | Compile the test source code into the test destination directory.                                 |
| process-test-classes     | Post-process the generated files from test compilation, e.g., bytecode enhancement on Java classes.|
| test                     | Run tests using a suitable unit testing framework. These tests should not require packaging.      |
| prepare-package          | Perform operations necessary to prepare a package before the actual packaging.                    |
| package                  | Take the compiled code and package it in its distributable format, such as a JAR.                 |
| pre-integration-test     | Perform actions required before integration tests are executed, such as environment setup.        |
| integration-test         | Process and deploy the package if necessary into an environment where integration tests can run.  |
| post-integration-test    | Perform actions required after integration tests, including cleaning up the environment.          |
| verify                   | Run any checks to verify the package is valid and meets quality criteria.                         |
| install                  | Install the package into the local repository for use as a dependency in other projects locally.  |
| deploy                   | Copies the final package to the remote repository for sharing with other developers and projects. |

We for example bundled the webapps in `generate-resources` (which was used before by the frontend plugin we recently removed) as there was a race condition with packaging the `dhis.war` when I bound it to the `package` phase. This meant that we `git clone`d webapps when running tests. I found that the `prepare-package` phase works and means we do not waste time cloning if we just want to run our tests.

I changed our GitHub CI test jobs to only run up to `test` as we do not want to package the war in every unit and integration test job. The `dhis.war` is packaged in the [run-api-tests.yml](.github/workflows/run-api-tests.yml). You can see that I had to bind the coverage plugin to `test` as it runs in `verify` by default.

## Maven Plugins

### Jacoco plugin

We use the [Jacoco Plugin](https://www.eclemma.org/jacoco/trunk/doc/maven.html) to generate coverage reports for codecov.io.

[jacoco:report-aggregate](https://www.eclemma.org/jacoco/trunk/doc/report-aggregate-mojo.html) is bound to `verify` by default.

Move it earlier to `test` as shown by codecov

https://github.com/codecov/example-java-maven/blob/5b913c6d90c7a83520cf082c4053f5422cd1e9db/pom.xml#L39-L45

### Maven Enforcer Plugin

We use the [Maven enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/enforce-mojo.html) to ensure we import the correct library if there are multiple choices with the same name, ...

We don't bind it to a different phase

https://github.com/dhis2/dhis2-core/blob/fd4619f551122266c874de4dc6b6d18c2e337c60/dhis-2/pom.xml#L2254-L2259

so its default applies which is `validate`.

### Maven Dependency Plugin

We use the [Maven dependency plugin](https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html#dependency-analyze-only) to ensure our builds are more reproducible. It forces us to declare used dependencies instead of relying on a dependency coming in transitively.

We did bind the plugin to the lifecycle phase `process-test-classes` so such problems show up early.

https://github.com/dhis2/dhis2-core/blob/fd4619f551122266c874de4dc6b6d18c2e337c60/dhis-2/pom.xml#L2358-L2363

This annoyed devs as multiple test jobs would then fail for the same reason. So we now rely on its default binding to the lifecycle phase `verify`. Note that we therefore execute `verify` in the `.github/workflows/run-api-tests.yml` so this plugin gets executed when the war is built for the e2e tests.