### PR TITLE
backport: ci: fix build docker image script for non-latest major versions [skip ci] [2.40]

### DIFF
--- a/dhis-2/build-docker-image.sh
+++ b/dhis-2/build-docker-image.sh
@@ -60,7 +60,7 @@ function create_rolling_tags() {
   )"
 
   if [[ "$major" -gt "$latest_major_version" ]] || \
-     [[ "$minor" -gt "$latest_minor_version" && "$major" -eq "$latest_major_version" ]] || \
+     [[ "$minor" -gt "$latest_minor_version" ]] || \
      [[ "$patch" -ge "$latest_patch_version" && "$minor" -eq "$latest_minor_version" ]]; then
     echo "New major, new minor or new/existing patch for the latest minor version, creating M.m and M tags."
     rolling_tags+=(


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/18622