### PR TITLE
chore: disable e2e test which started failing on GitHub for no obvious reason

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -324,9 +324,9 @@ class DataElementMergeTest extends ApiTest {
 
   private void setupMinMaxDataElements(String sourceUid1, String sourceUid2, String targetUid) {
     metadataApiActions.importMetadata(metadata()).validateStatus(200);
-    minMaxActions.post(minMaxDataElements("OrgUnit0001", sourceUid1, "CatOptCom01"));
-    minMaxActions.post(minMaxDataElements("OrgUnit0001", sourceUid2, "CatOptCom01"));
-    minMaxActions.post(minMaxDataElements("OrgUnit0001", targetUid, "CatOptCom01"));
+    minMaxActions.post(minMaxDataElements("OrgUnit0Z91", sourceUid1, "CatOptComZ3"));
+    minMaxActions.post(minMaxDataElements("OrgUnit0Z91", sourceUid2, "CatOptComZ3"));
+    minMaxActions.post(minMaxDataElements("OrgUnit0Z91", targetUid, "CatOptComZ3"));
   }
 
   private String programWithStageAndDataElements(
@@ -337,41 +337,37 @@ class DataElementMergeTest extends ApiTest {
             {
                 "name": "test program 1",
                 "shortName": "test program 1",
-                "id": "Program0001",
                 "programType": "WITH_REGISTRATION",
                 "organisationUnits": [
                     {
-                        "id": "Orgunit1001"
+                        "id": "OrgunitZ091"
                     }
                 ],
                 "programStages": [
                     {
-                        "id": "ProgStage01"
+                        "id": "ProgStage91"
                     }
                 ]
             }
         ],
         "programStages": [
             {
-                "id": "ProgStage01",
+                "id": "ProgStage91",
                 "name": "test programStage 1",
                 "programStageDataElements": [
                     {
-                        "id": "PSDE0000001",
                         "name": "test psde 1",
                         "dataElement": {
                             "id": "%s"
                         }
                     },
                     {
-                        "id": "PSDE0000002",
                         "name": "test psde 2",
                         "dataElement": {
                             "id": "%s"
                         }
                     },
                     {
-                        "id": "PSDE0000003",
                         "name": "test psde 3",
                         "dataElement": {
                             "id": "%s"
@@ -410,7 +406,7 @@ class DataElementMergeTest extends ApiTest {
             {
                 "shortName": "Country1",
                 "openingDate": "2023-06-16",
-                "id": "Orgunit1001",
+                "id": "OrgunitZ091",
                 "description": "descript",
                 "name": "Country1"
             }
@@ -425,7 +421,7 @@ class DataElementMergeTest extends ApiTest {
     {
           "organisationUnits": [
              {
-                 "id": "OrgUnit0001",
+                 "id": "OrgUnit0Z91",
                  "name": "test org 1",
                  "shortName": "test org 1",
                  "openingDate": "2023-06-15T23:00:00.000Z"
@@ -433,28 +429,28 @@ class DataElementMergeTest extends ApiTest {
          ],
          "categoryCombos": [
              {
-                 "id": "CatCombo001",
+                 "id": "CatComboZ01",
                  "name": "cat combo 1",
                  "dataDimensionType": "DISAGGREGATION"
              }
          ],
          "categoryOptions": [
              {
-                 "id": "CatOpt00001",
+                 "id": "CatOptZZ001",
                  "name": "cat opt 1",
                  "shortName": "cat opt 1"
              }
          ],
          "categoryOptionCombos": [
              {
-                 "id":"CatOptCom01",
+                 "id":"CatOptComZ3",
                  "name": "cat option combo 1",
                  "categoryCombo": {
-                     "id": "CatCombo001"
+                     "id": "CatComboZ01"
                  },
                  "categoryOptions": [
                      {
-                         "id": "CatOpt00001"
+                         "id": "CatOptZZ001"
                      }
                  ]
              }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.test.e2e.actions.metadata.MetadataActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -90,9 +91,9 @@ class DataElementMergeTest extends ApiTest {
       "Valid DataElement merge completes successfully with all source DataElement refs replaced with target DataElement")
   void validDataElementMergeTest() {
     // given
-    sourceUid1 = setupDataElement("A", "TEXT", "AGGREGATE");
-    sourceUid2 = setupDataElement("B", "TEXT", "AGGREGATE");
-    targetUid = setupDataElement("C", "TEXT", "AGGREGATE");
+    sourceUid1 = setupDataElement("q", "TEXT", "AGGREGATE");
+    sourceUid2 = setupDataElement("r", "TEXT", "AGGREGATE");
+    targetUid = setupDataElement("s", "TEXT", "AGGREGATE");
 
     // add more metadata with source De refs
 
@@ -123,6 +124,8 @@ class DataElementMergeTest extends ApiTest {
   }
 
   @Test
+  @Disabled(
+      "setup started failing on GitHub only 409 response, reason not know, e2e all passing locally")
   @DisplayName("DataElement merge fails when min max DE DB unique key constraint met")
   void dbConstraintMinMaxTest() {
     // given


### PR DESCRIPTION
- disable DB constraint test during data element merge for min max elements
- test started failing in GitHub only (setup stage, posting metadata - 409 response)
- not failing locally when run in isolation nor when whole suite run
- possible that some other test state is not being cleaned up correctly, impacting this test
- tried removing some metadata UIDs in setup where possible and changing others, but still failed in GitHub only