### PR TITLE
fix: TEAs marked as Confidential are now skipped [DHIS2-18230]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -390,16 +390,16 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
   private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributes(
       TrackedEntityType trackedEntityType, Map<String, List<Program>> programsByTetUid) {
 
-    // given TET has program(s) defined
+    // Given TET has program(s) defined.
     if (programsByTetUid.containsKey(trackedEntityType.getUid())) {
 
-      // programs defined for TET -> get attr from program and TET
+      // Programs defined for TET -> get attr from program and TET.
       return getAllTrackedEntityAttributesByPrograms(
           trackedEntityType, programsByTetUid.get(trackedEntityType.getUid()));
     }
 
-    // no programs defined for TET -> get only attributes from TET
-    return getAllTrackedEntityAttributesByTeT(trackedEntityType);
+    // No programs defined for TET -> get only attributes from TET.
+    return getAllTrackedEntityAttributesByEntityType(trackedEntityType);
   }
 
   /**
@@ -448,11 +448,11 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
             /* all attributes of programs */
             trackedEntityAttributeService.getProgramTrackedEntityAttributes(programs).stream(),
             /* all attributes of the trackedEntityType */
-            getAllTrackedEntityAttributesByTeT(trackedEntityType))
+            getAllTrackedEntityAttributesByEntityType(trackedEntityType))
         .distinct();
   }
 
-  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributesByTeT(
+  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributesByEntityType(
       TrackedEntityType trackedEntityType) {
     return emptyIfNull(trackedEntityType.getTrackedEntityAttributes()).stream();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -89,7 +89,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableManager {
   private static final String PROGRAMS_BY_TET_KEY = "programsByTetUid";
 
-  private static final String ALL_NON_CONFIDENTIAL_TET_ATTRIBUTES = "allTetAttributes";
+  private static final String ALL_NON_CONFIDENTIAL_TET_ATTRIBUTES =
+      "allNonConfidentialTetAttributes";
 
   private final TrackedEntityTypeService trackedEntityTypeService;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.table;
 
 import static java.lang.String.join;
 import static java.util.stream.Collectors.groupingBy;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.EXPORTABLE_EVENT_STATUSES;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getColumnType;
@@ -53,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
@@ -89,7 +89,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableManager {
   private static final String PROGRAMS_BY_TET_KEY = "programsByTetUid";
 
-  private static final String ALL_TET_ATTRIBUTES = "allTetAttributes";
+  private static final String ALL_NON_CONFIDENTIAL_TET_ATTRIBUTES = "allTetAttributes";
 
   private final TrackedEntityTypeService trackedEntityTypeService;
 
@@ -329,7 +329,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
 
   @SuppressWarnings("unchecked")
   private List<AnalyticsTableColumn> getColumns(
-      AnalyticsTableUpdateParams params, TrackedEntityType tet) {
+      AnalyticsTableUpdateParams params, TrackedEntityType trackedEntityType) {
     Map<String, List<Program>> programsByTetUid =
         (Map<String, List<Program>>) params.getExtraParam("", PROGRAMS_BY_TET_KEY);
 
@@ -341,7 +341,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
         where en_0.trackedentityid = te.trackedentityid \
         and en_0.programid = ${programId})""";
 
-    CollectionUtils.emptyIfNull(programsByTetUid.get(tet.getUid()))
+    emptyIfNull(programsByTetUid.get(trackedEntityType.getUid()))
         .forEach(
             program ->
                 columns.add(
@@ -355,15 +355,12 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
                         .build()));
 
     List<TrackedEntityAttribute> trackedEntityAttributes =
-        programsByTetUid.containsKey(tet.getUid())
-            ?
-            // programs defined for TET -> get attr from program and TET
-            getAllTrackedEntityAttributes(tet, programsByTetUid.get(tet.getUid()))
-            :
-            // no programs defined for TET -> get only attributes from TET
-            getAllTrackedEntityAttributes(tet).toList();
+        getAllTrackedEntityAttributes(trackedEntityType, programsByTetUid)
+            .filter(tea -> !tea.isConfidentialBool())
+            .toList();
 
-    params.addExtraParam(tet.getUid(), ALL_TET_ATTRIBUTES, trackedEntityAttributes);
+    params.addExtraParam(
+        trackedEntityType.getUid(), ALL_NON_CONFIDENTIAL_TET_ATTRIBUTES, trackedEntityAttributes);
 
     columns.addAll(
         trackedEntityAttributes.stream()
@@ -380,6 +377,28 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
     columns.addAll(getOrganisationUnitGroupSetColumns());
 
     return columns;
+  }
+
+  /**
+   * Returns all {@link TrackedEntityAttribute} for the given {@link TrackedEntityType}.
+   *
+   * @param trackedEntityType the {@link TrackedEntityType} to get attributes for.
+   * @param programsByTetUid the programs by TrackedEntityType UID.
+   * @return a Stream of {@link TrackedEntityAttribute}.
+   */
+  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributes(
+      TrackedEntityType trackedEntityType, Map<String, List<Program>> programsByTetUid) {
+
+    // given TET has program(s) defined
+    if (programsByTetUid.containsKey(trackedEntityType.getUid())) {
+
+      // programs defined for TET -> get attr from program and TET
+      return getAllTrackedEntityAttributesByPrograms(
+          trackedEntityType, programsByTetUid.get(trackedEntityType.getUid()));
+    }
+
+    // no programs defined for TET -> get only attributes from TET
+    return getAllTrackedEntityAttributesByTeT(trackedEntityType);
   }
 
   /**
@@ -414,20 +433,27 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
     return columnName;
   }
 
-  private List<TrackedEntityAttribute> getAllTrackedEntityAttributes(
+  /**
+   * Returns all {@link TrackedEntityAttribute} for the given {@link TrackedEntityType} and
+   * programs.
+   *
+   * @param trackedEntityType the {@link TrackedEntityType} to get attributes for.
+   * @param programs the programs to get attributes for.
+   * @return a Stream of {@link TrackedEntityAttribute}.
+   */
+  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributesByPrograms(
       TrackedEntityType trackedEntityType, List<Program> programs) {
     return Stream.concat(
             /* all attributes of programs */
             trackedEntityAttributeService.getProgramTrackedEntityAttributes(programs).stream(),
             /* all attributes of the trackedEntityType */
-            getAllTrackedEntityAttributes(trackedEntityType))
-        .distinct()
-        .toList();
+            getAllTrackedEntityAttributesByTeT(trackedEntityType))
+        .distinct();
   }
 
-  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributes(
+  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributesByTeT(
       TrackedEntityType trackedEntityType) {
-    return CollectionUtils.emptyIfNull(trackedEntityType.getTrackedEntityAttributes()).stream();
+    return emptyIfNull(trackedEntityType.getTrackedEntityAttributes()).stream();
   }
 
   /**
@@ -490,7 +516,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
                 Map.of("trackedEntityCreatedMonth", sqlBuilder.dateTrunc("month", "te.created"))));
 
     ((List<TrackedEntityAttribute>)
-            params.getExtraParam(trackedEntityType.getUid(), ALL_TET_ATTRIBUTES))
+            params.getExtraParam(trackedEntityType.getUid(), ALL_NON_CONFIDENTIAL_TET_ATTRIBUTES))
         .forEach(
             tea ->
                 sql.append(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsTable;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
+import org.hisp.dhis.db.model.Column;
+import org.hisp.dhis.db.model.Logged;
+import org.hisp.dhis.db.sql.SqlBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.system.database.DatabaseInfo;
+import org.hisp.dhis.system.database.DatabaseInfoProvider;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class JdbcTrackedEntityAnalyticsTableManagerTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+  @Mock private AnalyticsTableSettings analyticsTableSettings;
+  @Mock private PeriodDataProvider periodDataProvider;
+  @Mock private SqlBuilder sqlBuilder;
+  @Mock private PartitionManager partitionManager;
+  @Mock private SystemSettingsProvider systemSettingsProvider;
+  @Mock private IdentifiableObjectManager identifiableObjectManager;
+  @Mock private TrackedEntityTypeService trackedEntityTypeService;
+  @Mock private TrackedEntityAttributeService trackedEntityAttributeService;
+  @Mock private CategoryService categoryService;
+  @Mock private DataApprovalLevelService dataApprovalLevelService;
+  @Mock private OrganisationUnitService organisationUnitService;
+  @Mock private ResourceTableService resourceTableService;
+  @Mock private AnalyticsTableHookService analyticsTableHookService;
+  @Mock private DatabaseInfoProvider databaseInfoProvider;
+
+  @InjectMocks private JdbcTrackedEntityAnalyticsTableManager tableManager;
+
+  @Test
+  void verifyNonConfidentialTeasAreSkipped() {
+    AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().build();
+
+    TrackedEntityType tet = mock(TrackedEntityType.class);
+    when(tet.getUid()).thenReturn("tetUid");
+
+    TrackedEntityAttribute nonConfidentialTea = new TrackedEntityAttribute();
+    nonConfidentialTea.setUid("nonConfidentialTeaUid");
+    nonConfidentialTea.setConfidential(false);
+    nonConfidentialTea.setValueType(ValueType.TEXT);
+
+    TrackedEntityAttribute confidentialTea = new TrackedEntityAttribute();
+    confidentialTea.setUid("confidentialTeaUid");
+    confidentialTea.setConfidential(true);
+    confidentialTea.setValueType(ValueType.TEXT);
+
+    when(tet.getTrackedEntityAttributes()).thenReturn(List.of(nonConfidentialTea, confidentialTea));
+
+    Program program = mock(Program.class);
+    when(program.getTrackedEntityType()).thenReturn(tet);
+
+    when(trackedEntityTypeService.getAllTrackedEntityType()).thenReturn(List.of(tet));
+
+    when(trackedEntityAttributeService.getProgramTrackedEntityAttributes(List.of(program)))
+        .thenReturn(List.of());
+
+    when(analyticsTableSettings.getTableLogged()).thenReturn(Logged.LOGGED);
+
+    when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
+
+    when(analyticsTableSettings.getTableLogged()).thenReturn(Logged.LOGGED);
+
+    when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
+
+    DatabaseInfo databaseInfo = mock(DatabaseInfo.class);
+    when(databaseInfo.isSpatialSupport()).thenReturn(false);
+    when(databaseInfoProvider.getDatabaseInfo()).thenReturn(databaseInfo);
+
+    List<AnalyticsTable> analyticsTables = tableManager.getAnalyticsTables(params);
+
+    assertEquals(1, analyticsTables.size());
+
+    AnalyticsTable analyticsTable = analyticsTables.get(0);
+
+    assertContainsNonConfidentialTeaColumns(analyticsTable);
+    assertDoesntContainConfidentialTeaColumns(analyticsTable);
+  }
+
+  private void assertDoesntContainConfidentialTeaColumns(AnalyticsTable analyticsTable) {
+    List<Column> columns = analyticsTable.getColumns();
+
+    assertFalse(columns.stream().map(Column::getName).anyMatch("confidentialTeaUid"::equals));
+  }
+
+  private void assertContainsNonConfidentialTeaColumns(AnalyticsTable analyticsTable) {
+    List<Column> columns = analyticsTable.getColumns();
+
+    assertTrue(columns.stream().map(Column::getName).anyMatch("nonConfidentialTeaUid"::equals));
+  }
+}


### PR DESCRIPTION
This pull request improves the readability of `JdbcTrackedEntityAnalyticsTableManager` class and ensures confidential attributes are not exported.