### PR TITLE
ci: set base image in rebuild pipeline, not script [skip ci]

### DIFF
--- a/dhis-2/build-docker-image.sh
+++ b/dhis-2/build-docker-image.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+BASE_IMAGE=${BASE_IMAGE}
 IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-'dhis2/core'}
 IMAGE_APP_ROOT=${IMAGE_APP_ROOT:-'/usr/local/tomcat/webapps/ROOT'}
 IMAGE_USER=${IMAGE_USER:-'65534'}
@@ -210,12 +211,6 @@ if [[ ${rebuild_image:-} -eq 1 ]]; then
 else
   use_new_war
 fi
-
-jdk_version="$(
-  echo "$stable_versions_json" |
-  jq -r --argjson major "$major" '.versions[] | select(.version == $major) .jdk'
-)"
-BASE_IMAGE="${BASE_IMAGE:-"tomcat:10.0-jre$jdk_version"}"
 
 build_main_image
 

--- a/jenkinsfiles/rebuild-image
+++ b/jenkinsfiles/rebuild-image
@@ -20,7 +20,7 @@ pipeline {
         stage('Rebuild Docker images') {
             environment {
                 OLD_VERSION_SCHEMA_PREFIX = '2'
-                SUPPORTED_VERSIONS_JSON = sh(returnStdout: true, script: 'curl -fsSL "https://raw.githubusercontent.com/dhis2/dhis2-releases/master/downloads/v1/versions/stable.json" | jq -r \'.versions[] | select(.supported == true)\'').trim()
+                SUPPORTED_VERSIONS_JSON = sh(returnStdout: true, script: 'curl -fsSL "https://releases.dhis2.org/v1/versions/stable.json" | jq -r \'.versions[] | select(.supported == true)\'').trim()
             }
 
             steps {
@@ -38,16 +38,37 @@ pipeline {
                         // We don't have 2.M.m.p tags with 0 patch version in the dhis2-core git repo,
                         // hence we have to use the version "name" from the stable.json as the matching git tag.
                         env.VERSIONS_TO_REBUILD.tokenize(" ").each { version ->
+                            def majorVersion = version.split('\\.')[0].toInteger()
+                            if (majorVersion >= 42) {
+                                env.BASE_IMAGE = "tomcat:10.0-jre17"
+                            } else if (majorVersion == 41) {
+                                env.BASE_IMAGE = "tomcat:9.0-jre17"
+                            } else {
+                                env.BASE_IMAGE = "tomcat:9.0-jre11"
+                            }
+
                             sh """#!/bin/bash
                                 export VERSION_NAME=\$(jq -r '.patchVersions[] | select(.displayName == \"$version\") .name' <<< \$SUPPORTED_VERSIONS_JSON)
                                 export DHIS2_VERSION=\$VERSION_NAME
+                                export DHIS2_DB_DUMP_URL="https://databases.dhis2.org/sierra-leone/\$DHIS2_VERSION/dhis2-db-sierra-leone.sql.gz"
+                                export DHIS2_IMAGE="dhis2/core:\$DHIS2_VERSION"
                                 export GIT_BRANCH=\$DHIS2_VERSION
                                 export GIT_COMMIT=\$(git rev-parse \$VERSION_NAME)
                                 echo "DHIS2 version is \$DHIS2_VERSION"
                                 echo "Git commit is \$GIT_COMMIT"
 
                                 ./dhis-2/build-docker-image.sh -t \"$version\" -r
+
+                                docker compose up -d
                             """
+
+                            catchError(message: "DHIS2 version ${version} didn't respond with 200", buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                timeout(5) {
+                                    waitFor.statusOk("localhost:8080")
+                                }
+                            }
+
+                            sh 'docker compose down --remove-orphans --volumes'
                         }
                     }
                 }


### PR DESCRIPTION
When we rebuild images with [the rebuild-image pipeline](https://github.com/dhis2/dhis2-core/blob/112bd6fb4102b07d3a737528e48711503b3d10c7/jenkinsfiles/rebuild-image), we’re checking out `master` and using the latest version of the `build-docker-image.sh` script that is now defaulting to building with Tomcat 10 as base image (updated with the recent [Spring upgrade PR](https://github.com/dhis2/dhis2-core/pull/18314)) , which isn’t going to work for any version but `master` (future `42`). This is different to building in the `dev` or `stable` pipelines, because we set the `BASE_IMAGE` variable there https://github.com/dhis2/dhis2-core/blob/112bd6fb4102b07d3a737528e48711503b3d10c7/jenkinsfiles/dev#L138 and run the pipeline from the respective version branch, not just from `master`.

## Improvements

* Remove the default value for the `BASE_IMAGE` environment variable from the script and moves the base image selection to the `rebuild-image` pipeline, so that re-building an image is consistent with initially building it upon release
* Run `docker compose up` in the `rebuild-image` pipeline as a final "smoke test" step after building, to make sure that DHIS2 boots up successfully
  * Note that I've tested the "smoke test" part with this [build](https://ci.dhis2.org/job/dhis2-core-rebuild-image/55), where I'm not actually rebuilding an image ([exiting early](https://github.com/dhis2/dhis2-core/pull/18832/files#diff-b394c41a872128b5565c97eddd2080fe614d22711b62846d96775c54362dce2fR210)), but just using an existing one for verification
  * Also made sure that the smoke test fails when a faulty DHIS2 image (40.5.0 with Tomcat 10) doesn't boot up with [this build](https://ci.dhis2.org/job/dhis2-core-rebuild-image/59/console)