### PR TITLE
fix: Incorrect follow-up value while saving working list[DHIS2-18206]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityfilter/EntityQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityfilter/EntityQueryCriteria.java
@@ -56,7 +56,7 @@ public class EntityQueryCriteria implements Serializable {
    * Property indicating whether to filter tracked entities whose enrollments are marked for
    * followup or not
    */
-  private Boolean followUp = false;
+  private Boolean followUp;
 
   /** Property indication the OU for the filter. */
   private String organisationUnit;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
@@ -97,7 +97,7 @@ class TrackedEntityFilterServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testFilterWithAndWithoutFollowUp() {
+  void testAddFilterWithAndWithoutFollowUp() {
     TrackedEntityFilter filterWithOutFollowUp = createTrackedEntityFilter('A', programA);
     TrackedEntityFilter filterWithFollowUp = createTrackedEntityFilter('B', programB);
     filterWithFollowUp.getEntityQueryCriteria().setFollowUp(true);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
@@ -97,6 +97,24 @@ class TrackedEntityFilterServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void testFilterWithAndWithoutFollowUp() {
+    TrackedEntityFilter filterWithOutFollowUp = createTrackedEntityFilter('A', programA);
+    TrackedEntityFilter filterWithFollowUp = createTrackedEntityFilter('B', programB);
+    filterWithFollowUp.getEntityQueryCriteria().setFollowUp(true);
+    long idA = trackedEntityFilterService.add(filterWithOutFollowUp);
+    long idB = trackedEntityFilterService.add(filterWithFollowUp);
+
+    TrackedEntityFilter fetchedA = trackedEntityFilterService.get(idA);
+    TrackedEntityFilter fetchedB = trackedEntityFilterService.get(idB);
+
+    assertEquals(filterWithOutFollowUp, fetchedA);
+    assertNull(fetchedA.getEntityQueryCriteria().getFollowUp());
+
+    assertEquals(filterWithFollowUp, trackedEntityFilterService.get(idB));
+    assertTrue(fetchedB.getEntityQueryCriteria().getFollowUp());
+  }
+
+  @Test
   void testDefaultPrivateAccess() {
     long idA = trackedEntityFilterService.add(createTrackedEntityFilter('A', programA));
     TrackedEntityFilter trackedEntityFilterA = trackedEntityFilterService.get(idA);


### PR DESCRIPTION
This PR addresses an issue with the CustomWorkingList feature where the backend consistently set `followup = false` during saving. The problem occurred because the client did not send any followup information, and the backend had `Boolean followup = false` as a default value. Fixed it by removing default value allowing the backend to correctly handle values provided by the client.