### PR TITLE
ci: remove compose project name option after migrating to v2 [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -89,7 +89,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -106,8 +106,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
-                                        archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose logs web > web-logs.txt"
+                                        archiveArtifacts artifacts: "web-logs.txt"
                                     }
                                 }
                             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -97,7 +97,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -114,8 +114,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
-                                        archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose logs web > web-logs.txt"
+                                        archiveArtifacts artifacts: "web-logs.txt"
                                     }
                                 }
                             }


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/18834
The pipeline build is failing after the PR above because the value we pass to the Compose `--project-name` option is not valid, as it contains a `.`, but given that we only run tests for a single Tomcat version now, we can remove the project name altogether.
