### PR TITLE
backport: ci: migrate to docker compose v2 CLI in stable and dev pipelines [skip ci]

### DIFF
--- a/.github/workflows/run-api-analytics-tests.yml
+++ b/.github/workflows/run-api-analytics-tests.yml
@@ -73,7 +73,7 @@ jobs:
         if: failure()
         run: |
           cd dhis-2/dhis-test-e2e
-          docker-compose logs web > ~/logs.txt
+          docker compose logs web > ~/logs.txt
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -90,7 +90,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker-compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -107,7 +107,7 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker-compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
                                         archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
                                     }
                                 }

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -90,7 +90,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -107,8 +107,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
-                                        archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose logs web > web-logs.txt"
+                                        archiveArtifacts artifacts: "web-logs.txt"
                                     }
                                 }
                             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -98,7 +98,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -115,8 +115,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
-                                        archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose logs web > web-logs.txt"
+                                        archiveArtifacts artifacts: "web-logs.txt"
                                     }
                                 }
                             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -98,7 +98,7 @@ pipeline {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker-compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -115,7 +115,7 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker-compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
+                                        sh "docker compose --project-name ${DOCKER_IMAGE_TAG_BASE} logs web > ${DOCKER_IMAGE_TAG_BASE}_logs.txt"
                                         archiveArtifacts artifacts: "${DOCKER_IMAGE_TAG_BASE}_logs.txt"
                                     }
                                 }


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/18834