### PR TITLE
ci: add project name opt to compose when building multiple Tomcat versions [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -88,9 +88,10 @@ pipeline {
                     stage('Run tests') {
                         steps {
                             script {
+                                projectName = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${projectName} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -107,8 +108,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose logs web > web-logs.txt"
-                                        archiveArtifacts artifacts: "web-logs.txt"
+                                        sh "docker compose --project-name ${projectName} logs web > ${projectName}-logs.txt"
+                                        archiveArtifacts artifacts: "${projectName}-logs.txt"
                                     }
                                 }
                             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -96,9 +96,10 @@ pipeline {
                     stage('Run tests') {
                         steps {
                             script {
+                                projectName = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${projectName} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -115,8 +116,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose logs web > web-logs.txt"
-                                        archiveArtifacts artifacts: "web-logs.txt"
+                                        sh "docker compose --project-name ${projectName} logs web > ${projectName}-logs.txt"
+                                        archiveArtifacts artifacts: "${projectName}-logs.txt"
                                     }
                                 }
                             }


### PR DESCRIPTION
The project name option for compose is needed in versions 41, 40 and 39, because we still build and test with two Tomcat versions there (9.0 and 8.5).