### PR TITLE
fix: Map completed data in preheat for enrollment [DHIS2-18225]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
@@ -50,6 +50,8 @@ public interface EnrollmentMapper extends PreheatMapper<Enrollment> {
   @Mapping(target = "uid")
   @Mapping(target = "code")
   @Mapping(target = "user")
+  @Mapping(target = "completedBy")
+  @Mapping(target = "completedDate")
   @Mapping(target = "program", qualifiedByName = "program")
   @Mapping(target = "trackedEntity")
   @Mapping(target = "organisationUnit")

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle;
+
+import static org.hisp.dhis.program.EnrollmentStatus.*;
+import static org.hisp.dhis.program.EnrollmentStatus.ACTIVE;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class EnrollmentImportTest extends TrackerTest {
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private EnrollmentService enrollmentService;
+
+  private User importUser;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    setUpMetadata("tracker/simple_metadata.json");
+
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
+  }
+
+  @Test
+  void shouldPopulateCompletedDataWhenCreatingAnEnrollmentWithStatusCompleted()
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(COMPLETED);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertEquals(importUser.getUsername(), enrollment.getCompletedBy());
+    assertNotNull(enrollment.getCompletedDate());
+  }
+
+  @Test
+  void shouldPopulateCompletedDateWhenCreatingAnEnrollmentWithStatusCancelled()
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(CANCELLED);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertNull(enrollment.getCompletedBy());
+    assertNotNull(enrollment.getCompletedDate());
+  }
+
+  @Test
+  void shouldNotPopulateCompletedDataWhenCreatingAnEnrollmentWithStatusActive()
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(ACTIVE);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertNull(enrollment.getCompletedBy());
+    assertNull(enrollment.getCompletedDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("statuses")
+  void shouldNotPopulateCompletedDataWhenUpdatingAnEnrollmentToActiveStatus(EnrollmentStatus status)
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(status);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    trackerObjects.getEnrollments().get(0).setStatus(ACTIVE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertNull(enrollment.getCompletedBy());
+    assertNull(enrollment.getCompletedDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("statuses")
+  void shouldPopulateCompletedDateWhenUpdatingAnEnrollmentToCancelledStatus(EnrollmentStatus status)
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(status);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    trackerObjects.getEnrollments().get(0).setStatus(CANCELLED);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertNull(enrollment.getCompletedBy());
+    assertNotNull(enrollment.getCompletedDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("statuses")
+  void shouldPopulateCompletedDataWhenUpdatingAnEnrollmentToCompletedStatus(EnrollmentStatus status)
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEnrollments().get(0).setStatus(status);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    trackerObjects.getEnrollments().get(0).setStatus(COMPLETED);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Enrollment enrollment = enrollmentService.getEnrollment("TvctPPhpD8u");
+
+    assertEquals(importUser.getUsername(), enrollment.getCompletedBy());
+    assertNotNull(enrollment.getCompletedDate());
+  }
+
+  public Stream<Arguments> statuses() {
+    return Stream.of(Arguments.of(ACTIVE), Arguments.of(CANCELLED), Arguments.of(COMPLETED));
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
@@ -79,7 +79,7 @@ class EventImportTest extends TrackerTest {
 
     assertNoErrors(importReport);
 
-    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+    Event event = eventService.getEvent(UID.of(trackerObjects.getEvents().get(0).getUid()));
 
     assertEquals(importUser.getUsername(), event.getCompletedBy());
     assertNotNull(event.getCompletedDate());
@@ -97,7 +97,7 @@ class EventImportTest extends TrackerTest {
 
     assertNoErrors(importReport);
 
-    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+    Event event = eventService.getEvent(UID.of(trackerObjects.getEvents().get(0).getUid()));
 
     assertNull(event.getCompletedBy());
     assertNull(event.getCompletedDate());
@@ -120,7 +120,7 @@ class EventImportTest extends TrackerTest {
 
     assertNoErrors(importReport);
 
-    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+    Event event = eventService.getEvent(UID.of(trackerObjects.getEvents().get(0).getUid()));
 
     assertNull(event.getCompletedBy());
     assertNull(event.getCompletedDate());
@@ -144,7 +144,7 @@ class EventImportTest extends TrackerTest {
 
     assertNoErrors(importReport);
 
-    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+    Event event = eventService.getEvent(UID.of(trackerObjects.getEvents().get(0).getUid()));
 
     assertEquals(importUser.getUsername(), event.getCompletedBy());
     assertNotNull(event.getCompletedDate());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle;
+
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class EventImportTest extends TrackerTest {
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private EventService eventService;
+
+  private User importUser;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    setUpMetadata("tracker/simple_metadata.json");
+
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
+  }
+
+  @Test
+  void shouldPopulateCompletedDataWhenCreatingAnEventWithStatusCompleted()
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+
+    assertEquals(importUser.getUsername(), event.getCompletedBy());
+    assertNotNull(event.getCompletedDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("notCompletedStatus")
+  void shouldNotPopulateCompletedDataWhenCreatingAnEventWithNotCompletedStatus(EventStatus status)
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEvents().get(0).setStatus(status);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+
+    assertNull(event.getCompletedBy());
+    assertNull(event.getCompletedDate());
+  }
+
+  @Test
+  void shouldDeleteCompletedDataWhenUpdatingAnEventWithStatusActive()
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    trackerObjects.getEvents().get(0).setStatus(EventStatus.ACTIVE);
+
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+
+    assertNull(event.getCompletedBy());
+    assertNull(event.getCompletedDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("notCompletedStatus")
+  void shouldPopulateCompletedDataWhenUpdatingAnEventWithStatusCompleted(EventStatus status)
+      throws IOException, ForbiddenException, NotFoundException {
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    TrackerObjects trackerObjects = fromJson("tracker/te_enrollment_event.json");
+    trackerObjects.getEvents().get(0).setStatus(status);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
+
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertNoErrors(importReport);
+
+    Event event = eventService.getEvent(UID.of("D9PbzJY8bJO"));
+
+    assertEquals(importUser.getUsername(), event.getCompletedBy());
+    assertNotNull(event.getCompletedDate());
+  }
+
+  public Stream<Arguments> notCompletedStatus() {
+    return Stream.of(
+        Arguments.of(EventStatus.ACTIVE),
+        Arguments.of(EventStatus.SCHEDULE),
+        Arguments.of(EventStatus.OVERDUE),
+        Arguments.of(EventStatus.SKIPPED));
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/te_enrollment_event.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/te_enrollment_event.json
@@ -1,0 +1,109 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    }
+  ],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "deleted": false,
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
+      "attributeCategoryOptions": [],
+
+      "dataValues": [],
+      "notes": []
+    }
+  ],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
Complete data (`completedDate` and `completedBy`) were set to null if an enrollment was updated without changing the status.
Mappers work under the implicit assumption that the preheat object is populated with all the necessary fields that were calculated by the system in previous imports (`created`, `createdBy`...).
That wasn't true for complete data for enrollment.

Integration tests are needed in this case to ensure that the preheat mapping and the bundle mapping work fine together.

I also created a task to review preheat mappers for tracker objects https://dhis2.atlassian.net/browse/DHIS2-18245