### PR TITLE
ci: set compose project name as env variable [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -69,6 +69,7 @@ pipeline {
                 environment {
                     DOCKER_IMAGE_NAME_BASE_FULL = "${DOCKER_IMAGE_NAME_BASE}:${DOCKER_IMAGE_TAG_BASE}"
                     DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-${DOCKER_IMAGE_TAG_BASE}" // used to test against different Tomcat variants
+                    COMPOSE_PROJECT_NAME = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                 }
 
                 stages {
@@ -88,10 +89,9 @@ pipeline {
                     stage('Run tests') {
                         steps {
                             script {
-                                projectName = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${projectName} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${COMPOSE_PROJECT_NAME} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -108,8 +108,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${projectName} logs web > ${projectName}-logs.txt"
-                                        archiveArtifacts artifacts: "${projectName}-logs.txt"
+                                        sh "docker compose --project-name ${COMPOSE_PROJECT_NAME} logs web > ${COMPOSE_PROJECT_NAME}-logs.txt"
+                                        archiveArtifacts artifacts: "${COMPOSE_PROJECT_NAME}-logs.txt"
                                     }
                                 }
                             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -80,6 +80,7 @@ pipeline {
                     BASE_IMAGE = "${DOCKER_IMAGE_NAME_BASE}:${DOCKER_IMAGE_TAG_BASE}"
                     IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME_DEV"
                     UNARCHIVED_WAR_DIR = "dhis2-war-$DOCKER_IMAGE_TAG_BASE" // this needs to be different for the two matrix stages, as they run in parallel
+                    COMPOSE_PROJECT_NAME = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                 }
 
                 stages {
@@ -96,10 +97,9 @@ pipeline {
                     stage('Run tests') {
                         steps {
                             script {
-                                projectName = "${DOCKER_IMAGE_TAG_BASE.replaceAll('\\.', '-')}"
                                 dir("dhis-2/dhis-test-e2e") {
                                     sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${projectName} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --project-name ${COMPOSE_PROJECT_NAME} --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                                 }
                             }
                         }
@@ -116,8 +116,8 @@ pipeline {
                             failure {
                                 script {
                                     dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose --project-name ${projectName} logs web > ${projectName}-logs.txt"
-                                        archiveArtifacts artifacts: "${projectName}-logs.txt"
+                                        sh "docker compose --project-name ${COMPOSE_PROJECT_NAME} logs web > ${COMPOSE_PROJECT_NAME}-logs.txt"
+                                        archiveArtifacts artifacts: "${COMPOSE_PROJECT_NAME}-logs.txt"
                                     }
                                 }
                             }


### PR DESCRIPTION
The Compose project name variable needs to be set before the "Run tests" stages steps execution, as they run in parallel and both stages modify the `projectName` variable, which needs to be unique.