### PR TITLE
fix: Add program param in attribute image endpoint [DHIS2-17173][2.41]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -139,9 +138,6 @@ public interface TrackedEntityAttributeService {
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes);
 
-  ProgramTrackedEntityAttribute getProgramTrackedEntityAttribute(
-      Program program, TrackedEntityAttribute trackedEntityAttribute);
-
   /**
    * Returns all {@link TrackedEntityAttribute} that are candidates for creating trigram indexes.
    *
@@ -173,13 +169,6 @@ public interface TrackedEntityAttributeService {
    * @return a list of attributes
    */
   List<TrackedEntityAttribute> getTrackedEntityAttributesDisplayInListNoProgram();
-
-  /**
-   * Get all attributes that user is allowed to read (through program and tracked entity type)
-   *
-   * @return a list of attributes
-   */
-  Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes();
 
   /**
    * Validate uniqueness of the tracked entity attribute value within its scope. Will return

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.MathUtils;
@@ -288,12 +287,6 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
 
   @Override
   @Transactional(readOnly = true)
-  public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes() {
-    return getAllUserReadableTrackedEntityAttributes(CurrentUserUtil.getCurrentUserDetails());
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails) {
     List<Program> programs = programService.getAllPrograms();
@@ -341,12 +334,6 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
     }
 
     return attributes;
-  }
-
-  @Override
-  public ProgramTrackedEntityAttribute getProgramTrackedEntityAttribute(
-      Program program, TrackedEntityAttribute trackedEntityAttribute) {
-    return programAttributeStore.get(program, trackedEntityAttribute);
   }
 
   @Override


### PR DESCRIPTION
As reported in https://dhis2.atlassian.net/browse/DHIS2-17173, using the old API, it's possible to retrieve attributes the user shouldn't have access to. This occurs because that endpoint returns PAs as long as the user has access to at least one program, even if the accessible program does not contain those specific PAs.

To resolve this issue, I am applying the approach we are using in the new API, where:
- If the program is supplied in the request, we return the requested attribute if it's present in the given program.
- If the program is not supplied in the request, we return the requested attribute if it's present in the tracked entity type attributes.