### PR TITLE
fix: (2.41) Add change logs when updating event data value individually [DHIS2-18138]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -112,6 +112,8 @@ public class EventManager {
       eventPersistenceService.updateEventDataValues(de, event, context);
     }
 
+    auditTrackedEntityDataValueHistory(event, context, new Date());
+
     eventPersistenceService.updateTrackedEntityInstances(context, List.of(event));
 
     executorsByPhase.get(EventProcessorPhase.UPDATE_POST).execute(context, List.of(event));

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventManagerTest.java
@@ -70,6 +70,8 @@ class EventManagerTest {
 
   @Mock List<Checker> checkersRunOnDelete;
 
+  @Mock WorkContext workContext;
+
   @Captor ArgumentCaptor<EventProcessorPhase> eventProcessorPhaseArgumentCaptor;
 
   @InjectMocks EventManager subject;
@@ -79,12 +81,15 @@ class EventManagerTest {
       throws JsonProcessingException {
 
     Event event = new Event();
-    WorkContext workContext = WorkContext.builder().build();
+    event.setUid("id");
+
     doNothing()
         .when(eventPersistenceService)
         .updateTrackedEntityInstances(any(WorkContext.class), anyList());
 
     doNothing().when(eventProcessorExecutor).execute(any(WorkContext.class), anyList());
+    when(workContext.getPersistedProgramStageInstanceMap())
+        .thenReturn(Map.of("id", new org.hisp.dhis.program.Event()));
 
     when(executorsByPhase.get(any(EventProcessorPhase.class))).thenReturn(eventProcessorExecutor);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -30,12 +30,14 @@ package org.hisp.dhis.dxf2.deprecated.tracker;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hisp.dhis.tracker.Assertions.assertTrackedEntityDataValueChangeLog;
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
 import static org.hisp.dhis.util.DateUtils.toIso8601NoTz;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -58,6 +60,7 @@ import org.hamcrest.CoreMatchers;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -88,8 +91,11 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueChangeLogQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
+import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
@@ -111,6 +117,8 @@ class EventImportTest extends TransactionalIntegrationTest {
   @Autowired private TrackedEntityTypeService trackedEntityTypeService;
 
   @Autowired private TrackedEntityInstanceService trackedEntityInstanceService;
+
+  @Autowired private TrackedEntityDataValueChangeLogService entityDataValueAuditService;
 
   @Autowired private ProgramStageDataElementService programStageDataElementService;
 
@@ -334,6 +342,114 @@ class EventImportTest extends TransactionalIntegrationTest {
         trackedEntityInstanceService.getTrackedEntityInstance(
             trackedEntityInstanceMaleA.getTrackedEntityInstance());
     assertTrue(trackedEntityInstance.getLastUpdated().compareTo(toIso8601NoTz(now)) > 0);
+  }
+
+  @Test
+  void shouldAuditChangelogWhenUpdatingEventDataValues() throws IOException {
+    String previousValueB = "10";
+    String newValueB = "15";
+    String newValueA = "20";
+    InputStream is =
+            createEventJsonInputStream(
+                    programB.getUid(),
+                    programStageB.getUid(),
+                    organisationUnitB.getUid(),
+                    trackedEntityInstanceMaleA.getTrackedEntityInstance(),
+                    dataElementB,
+                    previousValueB);
+    String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
+
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
+
+    Event ev = programStageInstanceService.getEvent(event.getUid());
+
+    assertNotNull(ev);
+    assertEquals(1, ev.getEventDataValues().size());
+
+    // add a new data value and update an existing one
+
+    DataValue dataValueA = new DataValue();
+    dataValueA.setValue(newValueA);
+    dataValueA.setDataElement(dataElementA.getUid());
+    dataValueA.setStoredBy(superUser.getName());
+
+    DataValue dataValueB = new DataValue();
+    dataValueB.setValue(newValueB);
+    dataValueB.setDataElement(dataElementB.getUid());
+    dataValueB.setStoredBy(superUser.getName());
+
+    event.setDataValues(Set.of(dataValueA, dataValueB));
+
+    eventService.updateEventDataValues(event);
+
+    List<TrackedEntityDataValueChangeLog> createdAudits =
+            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+                    new TrackedEntityDataValueChangeLogQueryParams()
+                            .setDataElements(List.of(dataElementA))
+                            .setEvents(List.of(ev))
+                            .setAuditTypes(List.of(ChangeLogType.CREATE)));
+
+    List<TrackedEntityDataValueChangeLog> updatedAudits =
+            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+                    new TrackedEntityDataValueChangeLogQueryParams()
+                            .setDataElements(List.of(dataElementB))
+                            .setEvents(List.of(ev))
+                            .setAuditTypes(List.of(ChangeLogType.UPDATE)));
+
+    assertFalse(createdAudits.isEmpty());
+    assertFalse(updatedAudits.isEmpty());
+    assertEquals(1, createdAudits.size());
+    assertEquals(1, updatedAudits.size());
+
+    assertTrackedEntityDataValueChangeLog(
+            createdAudits.get(0), dataElementA, ChangeLogType.CREATE, newValueA);
+    assertTrackedEntityDataValueChangeLog(
+            updatedAudits.get(0), dataElementB, ChangeLogType.UPDATE, previousValueB);
+  }
+
+  @Test
+  void shouldAuditChangelogWhenDeletingEventDataValue() throws IOException {
+    String previousValueB = "10";
+    InputStream is =
+            createEventJsonInputStream(
+                    programB.getUid(),
+                    programStageB.getUid(),
+                    organisationUnitB.getUid(),
+                    trackedEntityInstanceMaleA.getTrackedEntityInstance(),
+                    dataElementB,
+                    "10");
+    String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
+
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
+
+    Event ev = programStageInstanceService.getEvent(event.getUid());
+
+    assertNotNull(ev);
+    assertEquals(1, ev.getEventDataValues().size());
+
+    // delete data Element in Event Data Values by setting its value to null
+
+    DataValue dataValueB = new DataValue();
+    dataValueB.setValue(null);
+    dataValueB.setDataElement(dataElementB.getUid());
+    dataValueB.setStoredBy(superUser.getName());
+
+    event.setDataValues(Set.of(dataValueB));
+
+    eventService.updateEventDataValues(event);
+
+    List<TrackedEntityDataValueChangeLog> deleteAudits =
+            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+                    new TrackedEntityDataValueChangeLogQueryParams()
+                            .setDataElements(List.of(dataElementB))
+                            .setEvents(List.of(ev))
+                            .setAuditTypes(List.of(ChangeLogType.DELETE)));
+
+    assertFalse(deleteAudits.isEmpty());
+    assertEquals(1, deleteAudits.size());
+
+    assertTrackedEntityDataValueChangeLog(
+            deleteAudits.get(0), dataElementB, ChangeLogType.DELETE, previousValueB);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -359,9 +359,9 @@ class EventImportTest extends TransactionalIntegrationTest {
             previousValueB);
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
-    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event dxfEvent = createEvent(uid);
 
-    Event ev = programStageInstanceService.getEvent(event.getUid());
+    Event ev = programStageInstanceService.getEvent(dxfEvent.getUid());
 
     assertNotNull(ev);
     assertEquals(1, ev.getEventDataValues().size());
@@ -378,9 +378,9 @@ class EventImportTest extends TransactionalIntegrationTest {
     dataValueB.setDataElement(dataElementB.getUid());
     dataValueB.setStoredBy(superUser.getName());
 
-    event.setDataValues(Set.of(dataValueA, dataValueB));
+    dxfEvent.setDataValues(Set.of(dataValueA, dataValueB));
 
-    eventService.updateEventDataValues(event);
+    eventService.updateEventDataValues(dxfEvent);
 
     List<TrackedEntityDataValueChangeLog> createdAudits =
         entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
@@ -420,9 +420,9 @@ class EventImportTest extends TransactionalIntegrationTest {
             "10");
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
-    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event dxfEvent = createEvent(uid);
 
-    Event ev = programStageInstanceService.getEvent(event.getUid());
+    Event ev = programStageInstanceService.getEvent(dxfEvent.getUid());
 
     assertNotNull(ev);
     assertEquals(1, ev.getEventDataValues().size());
@@ -434,9 +434,9 @@ class EventImportTest extends TransactionalIntegrationTest {
     dataValueB.setDataElement(dataElementB.getUid());
     dataValueB.setStoredBy(superUser.getName());
 
-    event.setDataValues(Set.of(dataValueB));
+    dxfEvent.setDataValues(Set.of(dataValueB));
 
-    eventService.updateEventDataValues(event);
+    eventService.updateEventDataValues(dxfEvent);
 
     List<TrackedEntityDataValueChangeLog> deleteAudits =
         entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -34,10 +34,10 @@ import static org.hisp.dhis.tracker.Assertions.assertTrackedEntityDataValueChang
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
 import static org.hisp.dhis.util.DateUtils.toIso8601NoTz;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -350,13 +350,13 @@ class EventImportTest extends TransactionalIntegrationTest {
     String newValueB = "15";
     String newValueA = "20";
     InputStream is =
-            createEventJsonInputStream(
-                    programB.getUid(),
-                    programStageB.getUid(),
-                    organisationUnitB.getUid(),
-                    trackedEntityInstanceMaleA.getTrackedEntityInstance(),
-                    dataElementB,
-                    previousValueB);
+        createEventJsonInputStream(
+            programB.getUid(),
+            programStageB.getUid(),
+            organisationUnitB.getUid(),
+            trackedEntityInstanceMaleA.getTrackedEntityInstance(),
+            dataElementB,
+            previousValueB);
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
     org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
@@ -383,18 +383,18 @@ class EventImportTest extends TransactionalIntegrationTest {
     eventService.updateEventDataValues(event);
 
     List<TrackedEntityDataValueChangeLog> createdAudits =
-            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
-                    new TrackedEntityDataValueChangeLogQueryParams()
-                            .setDataElements(List.of(dataElementA))
-                            .setEvents(List.of(ev))
-                            .setAuditTypes(List.of(ChangeLogType.CREATE)));
+        entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+            new TrackedEntityDataValueChangeLogQueryParams()
+                .setDataElements(List.of(dataElementA))
+                .setEvents(List.of(ev))
+                .setAuditTypes(List.of(ChangeLogType.CREATE)));
 
     List<TrackedEntityDataValueChangeLog> updatedAudits =
-            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
-                    new TrackedEntityDataValueChangeLogQueryParams()
-                            .setDataElements(List.of(dataElementB))
-                            .setEvents(List.of(ev))
-                            .setAuditTypes(List.of(ChangeLogType.UPDATE)));
+        entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+            new TrackedEntityDataValueChangeLogQueryParams()
+                .setDataElements(List.of(dataElementB))
+                .setEvents(List.of(ev))
+                .setAuditTypes(List.of(ChangeLogType.UPDATE)));
 
     assertFalse(createdAudits.isEmpty());
     assertFalse(updatedAudits.isEmpty());
@@ -402,22 +402,22 @@ class EventImportTest extends TransactionalIntegrationTest {
     assertEquals(1, updatedAudits.size());
 
     assertTrackedEntityDataValueChangeLog(
-            createdAudits.get(0), dataElementA, ChangeLogType.CREATE, newValueA);
+        createdAudits.get(0), dataElementA, ChangeLogType.CREATE, newValueA);
     assertTrackedEntityDataValueChangeLog(
-            updatedAudits.get(0), dataElementB, ChangeLogType.UPDATE, previousValueB);
+        updatedAudits.get(0), dataElementB, ChangeLogType.UPDATE, previousValueB);
   }
 
   @Test
   void shouldAuditChangelogWhenDeletingEventDataValue() throws IOException {
     String previousValueB = "10";
     InputStream is =
-            createEventJsonInputStream(
-                    programB.getUid(),
-                    programStageB.getUid(),
-                    organisationUnitB.getUid(),
-                    trackedEntityInstanceMaleA.getTrackedEntityInstance(),
-                    dataElementB,
-                    "10");
+        createEventJsonInputStream(
+            programB.getUid(),
+            programStageB.getUid(),
+            organisationUnitB.getUid(),
+            trackedEntityInstanceMaleA.getTrackedEntityInstance(),
+            dataElementB,
+            "10");
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
     org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
@@ -439,17 +439,17 @@ class EventImportTest extends TransactionalIntegrationTest {
     eventService.updateEventDataValues(event);
 
     List<TrackedEntityDataValueChangeLog> deleteAudits =
-            entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
-                    new TrackedEntityDataValueChangeLogQueryParams()
-                            .setDataElements(List.of(dataElementB))
-                            .setEvents(List.of(ev))
-                            .setAuditTypes(List.of(ChangeLogType.DELETE)));
+        entityDataValueAuditService.getTrackedEntityDataValueChangeLogs(
+            new TrackedEntityDataValueChangeLogQueryParams()
+                .setDataElements(List.of(dataElementB))
+                .setEvents(List.of(ev))
+                .setAuditTypes(List.of(ChangeLogType.DELETE)));
 
     assertFalse(deleteAudits.isEmpty());
     assertEquals(1, deleteAudits.size());
 
     assertTrackedEntityDataValueChangeLog(
-            deleteAudits.get(0), dataElementB, ChangeLogType.DELETE, previousValueB);
+        deleteAudits.get(0), dataElementB, ChangeLogType.DELETE, previousValueB);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 import java.util.function.Supplier;
-
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
@@ -324,44 +323,45 @@ public class Assertions {
     return true;
   }
 
-
   /**
-   * assertTrackedEntityDataValueChangeLog asserts a TrackedEntityDataValueChangeLog obtained from the db and compares it with the expected value, auditType and dataElement.
+   * assertTrackedEntityDataValueChangeLog asserts a TrackedEntityDataValueChangeLog obtained from
+   * the db and compares it with the expected value, auditType and dataElement.
+   *
    * @param changeLog The TrackedEntityDataValueChangeLog entity obtained from store
    * @param expectedDataElement The ChangeLog object is expected to be for this dataElement
    * @param expectedChangeLogType The ChangeLog object is expected to have this auditType
    * @param expectedValue The ChangeLog object is expected to have this value
    */
-  public static void assertTrackedEntityDataValueChangeLog(TrackedEntityDataValueChangeLog changeLog, DataElement expectedDataElement, ChangeLogType expectedChangeLogType, String expectedValue) {
+  public static void assertTrackedEntityDataValueChangeLog(
+      TrackedEntityDataValueChangeLog changeLog,
+      DataElement expectedDataElement,
+      ChangeLogType expectedChangeLogType,
+      String expectedValue) {
     assertAll(
-            () -> assertNotNull(changeLog),
-            () ->
-                    assertEquals(
-                            expectedChangeLogType,
-                            changeLog.getAuditType(),
-                            () ->
-                                    "Expected change log type type is "
-                                            + expectedChangeLogType
-                                            + " but found "
-                                            + changeLog.getAuditType()),
-            () ->
-                    assertEquals(
-                            changeLog.getDataElement().getUid(),
-                            expectedDataElement.getUid(),
-                            () ->
-                                    "Expected dataElement is "
-                                            + expectedDataElement.getUid()
-                                            + " but found "
-                                            + changeLog.getDataElement().getUid()),
-            () ->
-                    assertEquals(
-                            expectedValue,
-                            changeLog.getValue(),
-                            () ->
-                                    "Expected value is "
-                                            + expectedValue
-                                            + " but found "
-                                            + changeLog.getValue()));
+        () -> assertNotNull(changeLog),
+        () ->
+            assertEquals(
+                expectedChangeLogType,
+                changeLog.getAuditType(),
+                () ->
+                    "Expected change log type type is "
+                        + expectedChangeLogType
+                        + " but found "
+                        + changeLog.getAuditType()),
+        () ->
+            assertEquals(
+                changeLog.getDataElement().getUid(),
+                expectedDataElement.getUid(),
+                () ->
+                    "Expected dataElement is "
+                        + expectedDataElement.getUid()
+                        + " but found "
+                        + changeLog.getDataElement().getUid()),
+        () ->
+            assertEquals(
+                expectedValue,
+                changeLog.getValue(),
+                () -> "Expected value is " + expectedValue + " but found " + changeLog.getValue()));
   }
 
   private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -40,8 +40,12 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 import java.util.function.Supplier;
+
+import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
@@ -318,6 +322,46 @@ public class Assertions {
     }
 
     return true;
+  }
+
+
+  /**
+   * assertTrackedEntityDataValueChangeLog asserts a TrackedEntityDataValueChangeLog obtained from the db and compares it with the expected value, auditType and dataElement.
+   * @param changeLog The TrackedEntityDataValueChangeLog entity obtained from store
+   * @param expectedDataElement The ChangeLog object is expected to be for this dataElement
+   * @param expectedChangeLogType The ChangeLog object is expected to have this auditType
+   * @param expectedValue The ChangeLog object is expected to have this value
+   */
+  public static void assertTrackedEntityDataValueChangeLog(TrackedEntityDataValueChangeLog changeLog, DataElement expectedDataElement, ChangeLogType expectedChangeLogType, String expectedValue) {
+    assertAll(
+            () -> assertNotNull(changeLog),
+            () ->
+                    assertEquals(
+                            expectedChangeLogType,
+                            changeLog.getAuditType(),
+                            () ->
+                                    "Expected change log type type is "
+                                            + expectedChangeLogType
+                                            + " but found "
+                                            + changeLog.getAuditType()),
+            () ->
+                    assertEquals(
+                            changeLog.getDataElement().getUid(),
+                            expectedDataElement.getUid(),
+                            () ->
+                                    "Expected dataElement is "
+                                            + expectedDataElement.getUid()
+                                            + " but found "
+                                            + changeLog.getDataElement().getUid()),
+            () ->
+                    assertEquals(
+                            expectedValue,
+                            changeLog.getValue(),
+                            () ->
+                                    "Expected value is "
+                                            + expectedValue
+                                            + " but found "
+                                            + changeLog.getValue()));
   }
 
   private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueChangeLogTest.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.tracker.imports.bundle;
 
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.Assertions.assertTrackedEntityDataValueChangeLog;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -118,46 +118,14 @@ public class TrackedEntityDataValueChangeLogTest extends TrackerTest {
                 .setAuditTypes(List.of(ChangeLogType.DELETE)));
 
     assertAll(
-        () -> assertNotNull(createdAudit),
-        () -> assertNotNull(updatedAudit),
-        () -> assertNotNull(deletedAudit));
-    assertAuditCollection(createdAudit, ChangeLogType.CREATE, ORIGINAL_VALUE);
-    assertAuditCollection(updatedAudit, ChangeLogType.UPDATE, ORIGINAL_VALUE);
-    assertAuditCollection(deletedAudit, ChangeLogType.DELETE, UPDATED_VALUE);
-  }
-
-  private void assertAuditCollection(
-      List<TrackedEntityDataValueChangeLog> audits,
-      ChangeLogType changeLogType,
-      String expectedValue) {
-    assertAll(
-        () -> assertFalse(audits.isEmpty()),
-        () ->
-            assertEquals(
-                changeLogType,
-                audits.get(0).getAuditType(),
-                () ->
-                    "Expected audit type is "
-                        + changeLogType
-                        + " but found "
-                        + audits.get(0).getAuditType()),
-        () ->
-            assertEquals(
-                audits.get(0).getDataElement().getUid(),
-                dataElement.getUid(),
-                () ->
-                    "Expected dataElement is "
-                        + dataElement.getUid()
-                        + " but found "
-                        + audits.get(0).getDataElement().getUid()),
-        () ->
-            assertEquals(
-                expectedValue,
-                audits.get(0).getValue(),
-                () ->
-                    "Expected value is "
-                        + expectedValue
-                        + " but found "
-                        + audits.get(0).getValue()));
+            () -> assertNotNull(createdAudit),
+            () -> assertNotNull(updatedAudit),
+            () -> assertNotNull(deletedAudit),
+            () -> assertFalse(createdAudit.isEmpty()),
+            () -> assertFalse(updatedAudit.isEmpty()),
+            () -> assertFalse(deletedAudit.isEmpty()));
+    assertTrackedEntityDataValueChangeLog(createdAudit.get(0),dataElement,ChangeLogType.CREATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueChangeLog(updatedAudit.get(0), dataElement,ChangeLogType.UPDATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueChangeLog(deletedAudit.get(0),  dataElement,ChangeLogType.DELETE,UPDATED_VALUE);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueChangeLogTest.java
@@ -118,14 +118,17 @@ public class TrackedEntityDataValueChangeLogTest extends TrackerTest {
                 .setAuditTypes(List.of(ChangeLogType.DELETE)));
 
     assertAll(
-            () -> assertNotNull(createdAudit),
-            () -> assertNotNull(updatedAudit),
-            () -> assertNotNull(deletedAudit),
-            () -> assertFalse(createdAudit.isEmpty()),
-            () -> assertFalse(updatedAudit.isEmpty()),
-            () -> assertFalse(deletedAudit.isEmpty()));
-    assertTrackedEntityDataValueChangeLog(createdAudit.get(0),dataElement,ChangeLogType.CREATE, ORIGINAL_VALUE);
-    assertTrackedEntityDataValueChangeLog(updatedAudit.get(0), dataElement,ChangeLogType.UPDATE, ORIGINAL_VALUE);
-    assertTrackedEntityDataValueChangeLog(deletedAudit.get(0),  dataElement,ChangeLogType.DELETE,UPDATED_VALUE);
+        () -> assertNotNull(createdAudit),
+        () -> assertNotNull(updatedAudit),
+        () -> assertNotNull(deletedAudit),
+        () -> assertFalse(createdAudit.isEmpty()),
+        () -> assertFalse(updatedAudit.isEmpty()),
+        () -> assertFalse(deletedAudit.isEmpty()));
+    assertTrackedEntityDataValueChangeLog(
+        createdAudit.get(0), dataElement, ChangeLogType.CREATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueChangeLog(
+        updatedAudit.get(0), dataElement, ChangeLogType.UPDATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueChangeLog(
+        deletedAudit.get(0), dataElement, ChangeLogType.DELETE, UPDATED_VALUE);
   }
 }


### PR DESCRIPTION
One of the deprecated APIs (`EventController @PutMapping(value = "/{uid}/{dataElementUid}"`) was used in such a way to update a single event data value (add,update or delete) within an event. This was used in the old Tracker Capture app which invoked the endpoint whenever the event data value field got onBlurred. 

This pathway did not add Audit/ChangeLog entries in the `trackedentitydatavalueaudit` table. This PR adds the required change log entries by calling the relevant method rightafter the event changes are persisted.

Although the test classes are outdated (no more in master), I refactored it a bit to move an assertion helper on a TrackedEntityDataValueChangeLog into the tracker/Assertions class which is then reused in 2 Test Classes.