### PR TITLE
fix: (2.40) Add audit change logs when updating event data value individually [DHIS2-18138]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -113,6 +113,8 @@ public class EventManager {
       eventPersistenceService.updateEventDataValues(de, event, context);
     }
 
+    auditTrackedEntityDataValueHistory(event, context, new Date());
+
     eventPersistenceService.updateTrackedEntityInstances(context, List.of(event));
 
     executorsByPhase.get(EventProcessorPhase.UPDATE_POST).execute(context, List.of(event));

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/EventManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/EventManagerTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.dxf2.events.importer.EventManager;
 import org.hisp.dhis.dxf2.events.importer.EventProcessorExecutor;
 import org.hisp.dhis.dxf2.events.importer.EventProcessorPhase;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,8 @@ class EventManagerTest {
 
   @Mock TrackedEntityDataValueAuditService entityDataValueAuditService;
 
+  @Mock WorkContext workContext;
+
   @Mock List<Checker> checkersRunOnDelete;
 
   @Mock CurrentUserService currentUserService;
@@ -82,7 +85,7 @@ class EventManagerTest {
       throws JsonProcessingException {
 
     Event event = new Event();
-    WorkContext workContext = WorkContext.builder().build();
+    event.setUid("id");
     doNothing()
         .when(eventPersistenceService)
         .updateTrackedEntityInstances(any(WorkContext.class), anyList());
@@ -90,7 +93,8 @@ class EventManagerTest {
     doNothing().when(eventProcessorExecutor).execute(any(WorkContext.class), anyList());
 
     when(executorsByPhase.get(any(EventProcessorPhase.class))).thenReturn(eventProcessorExecutor);
-
+    when(workContext.getPersistedProgramStageInstanceMap())
+        .thenReturn(Map.of("id", new ProgramStageInstance()));
     subject.updateEventDataValues(event, Set.of(), workContext);
 
     verify(eventPersistenceService, times(1))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -34,10 +34,10 @@ import static org.hisp.dhis.tracker.Assertions.assertTrackedEntityDataValueAudit
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
 import static org.hisp.dhis.util.DateUtils.getIso8601NoTz;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -60,11 +60,11 @@ import org.hibernate.SessionFactory;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -278,9 +278,10 @@ class EventImportTest extends TransactionalIntegrationTest {
             "10");
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
-    Event event = createEvent(uid);
+    Event newEvent = createEvent(uid);
 
-    ProgramStageInstance ev = programStageInstanceService.getProgramStageInstance(event.getUid());
+    ProgramStageInstance ev =
+        programStageInstanceService.getProgramStageInstance(newEvent.getUid());
 
     assertNotNull(ev);
     assertEquals(1, ev.getEventDataValues().size());
@@ -297,15 +298,15 @@ class EventImportTest extends TransactionalIntegrationTest {
     dataValueB.setDataElement(dataElementB.getUid());
     dataValueB.setStoredBy(superUser.getName());
 
-    event.setDataValues(Set.of(dataValueA, dataValueB));
+    newEvent.setDataValues(Set.of(dataValueA, dataValueB));
 
     Date now = new Date();
 
-    eventService.updateEventDataValues(event);
+    eventService.updateEventDataValues(newEvent);
 
     manager.clear();
 
-    ev = programStageInstanceService.getProgramStageInstance(event.getUid());
+    ev = programStageInstanceService.getProgramStageInstance(newEvent.getUid());
 
     assertNotNull(ev);
     assertNotNull(ev.getEventDataValues());
@@ -360,9 +361,10 @@ class EventImportTest extends TransactionalIntegrationTest {
             previousValueB);
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
-    Event event = createEvent(uid);
+    Event newEvent = createEvent(uid);
 
-    ProgramStageInstance ev = programStageInstanceService.getProgramStageInstance(event.getUid());
+    ProgramStageInstance ev =
+        programStageInstanceService.getProgramStageInstance(newEvent.getUid());
 
     assertNotNull(ev);
     assertEquals(1, ev.getEventDataValues().size());
@@ -379,9 +381,9 @@ class EventImportTest extends TransactionalIntegrationTest {
     dataValueB.setDataElement(dataElementB.getUid());
     dataValueB.setStoredBy(superUser.getName());
 
-    event.setDataValues(Set.of(dataValueA, dataValueB));
+    newEvent.setDataValues(Set.of(dataValueA, dataValueB));
 
-    eventService.updateEventDataValues(event);
+    eventService.updateEventDataValues(newEvent);
 
     List<TrackedEntityDataValueAudit> createdAudits =
         entityDataValueAuditService.getTrackedEntityDataValueAudits(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -39,7 +39,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 import java.util.function.Supplier;
-
 import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
@@ -314,42 +313,44 @@ public class Assertions {
   }
 
   /**
-   * assertTrackedEntityDataValueAudit asserts a TrackedEntityDataValueAudit obtained from the db and compares it with the expected value, auditType and dataElement.
+   * assertTrackedEntityDataValueAudit asserts a TrackedEntityDataValueAudit obtained from the db
+   * and compares it with the expected value, auditType and dataElement.
+   *
    * @param audit The TrackedEntityDataValueAudit entity obtained from persistence
    * @param expectedDataElement The audit object is expected to be for this dataElement
    * @param expectedAuditType The audit object is expected to have this auditType
    * @param expectedValue The audit object is expected to have this value
    */
-  public static void assertTrackedEntityDataValueAudit(TrackedEntityDataValueAudit audit, DataElement expectedDataElement, AuditType expectedAuditType, String expectedValue) {
+  public static void assertTrackedEntityDataValueAudit(
+      TrackedEntityDataValueAudit audit,
+      DataElement expectedDataElement,
+      AuditType expectedAuditType,
+      String expectedValue) {
     assertAll(
-            () -> assertNotNull(audit),
-            () ->
-                    assertEquals(
-                            expectedAuditType,
-                            audit.getAuditType(),
-                            () ->
-                                    "Expected audit type is "
-                                            + expectedAuditType
-                                            + " but found "
-                                            + audit.getAuditType()),
-            () ->
-                    assertEquals(
-                            audit.getDataElement().getUid(),
-                            expectedDataElement.getUid(),
-                            () ->
-                                    "Expected dataElement is "
-                                            + expectedDataElement.getUid()
-                                            + " but found "
-                                            + audit.getDataElement().getUid()),
-            () ->
-                    assertEquals(
-                            expectedValue,
-                            audit.getValue(),
-                            () ->
-                                    "Expected value is "
-                                            + expectedValue
-                                            + " but found "
-                                            + audit.getValue()));
+        () -> assertNotNull(audit),
+        () ->
+            assertEquals(
+                expectedAuditType,
+                audit.getAuditType(),
+                () ->
+                    "Expected audit type is "
+                        + expectedAuditType
+                        + " but found "
+                        + audit.getAuditType()),
+        () ->
+            assertEquals(
+                audit.getDataElement().getUid(),
+                expectedDataElement.getUid(),
+                () ->
+                    "Expected dataElement is "
+                        + expectedDataElement.getUid()
+                        + " but found "
+                        + audit.getDataElement().getUid()),
+        () ->
+            assertEquals(
+                expectedValue,
+                audit.getValue(),
+                () -> "Expected value is " + expectedValue + " but found " + audit.getValue()));
   }
 
   private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -39,6 +39,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 import java.util.function.Supplier;
+
+import org.hisp.dhis.common.AuditType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.tracker.report.Status;
 import org.hisp.dhis.tracker.report.ValidationReport;
@@ -307,6 +311,45 @@ public class Assertions {
     assertNotNull(report);
     assertFalse(
         report.hasErrors(), errorMessage("Expected no validation errors, instead got:\n", report));
+  }
+
+  /**
+   * assertTrackedEntityDataValueAudit asserts a TrackedEntityDataValueAudit obtained from the db and compares it with the expected value, auditType and dataElement.
+   * @param audit The TrackedEntityDataValueAudit entity obtained from persistence
+   * @param expectedDataElement The audit object is expected to be for this dataElement
+   * @param expectedAuditType The audit object is expected to have this auditType
+   * @param expectedValue The audit object is expected to have this value
+   */
+  public static void assertTrackedEntityDataValueAudit(TrackedEntityDataValueAudit audit, DataElement expectedDataElement, AuditType expectedAuditType, String expectedValue) {
+    assertAll(
+            () -> assertNotNull(audit),
+            () ->
+                    assertEquals(
+                            expectedAuditType,
+                            audit.getAuditType(),
+                            () ->
+                                    "Expected audit type is "
+                                            + expectedAuditType
+                                            + " but found "
+                                            + audit.getAuditType()),
+            () ->
+                    assertEquals(
+                            audit.getDataElement().getUid(),
+                            expectedDataElement.getUid(),
+                            () ->
+                                    "Expected dataElement is "
+                                            + expectedDataElement.getUid()
+                                            + " but found "
+                                            + audit.getDataElement().getUid()),
+            () ->
+                    assertEquals(
+                            expectedValue,
+                            audit.getValue(),
+                            () ->
+                                    "Expected value is "
+                                            + expectedValue
+                                            + " but found "
+                                            + audit.getValue()));
   }
 
   private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.tracker.bundle;
 
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.Assertions.assertTrackedEntityDataValueAudit;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -112,44 +112,14 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest {
                 .setAuditTypes(List.of(AuditType.DELETE)));
 
     assertAll(
-        () -> assertNotNull(createdAudit),
-        () -> assertNotNull(updatedAudit),
-        () -> assertNotNull(deletedAudit));
-    assertAuditCollection(createdAudit, AuditType.CREATE, ORIGINAL_VALUE);
-    assertAuditCollection(updatedAudit, AuditType.UPDATE, ORIGINAL_VALUE);
-    assertAuditCollection(deletedAudit, AuditType.DELETE, UPDATED_VALUE);
-  }
-
-  private void assertAuditCollection(
-      List<TrackedEntityDataValueAudit> audits, AuditType auditType, String expectedValue) {
-    assertAll(
-        () -> assertFalse(audits.isEmpty()),
-        () ->
-            assertEquals(
-                auditType,
-                audits.get(0).getAuditType(),
-                () ->
-                    "Expected audit type is "
-                        + auditType
-                        + " but found "
-                        + audits.get(0).getAuditType()),
-        () ->
-            assertEquals(
-                audits.get(0).getDataElement().getUid(),
-                dataElement.getUid(),
-                () ->
-                    "Expected dataElement is "
-                        + dataElement.getUid()
-                        + " but found "
-                        + audits.get(0).getDataElement().getUid()),
-        () ->
-            assertEquals(
-                expectedValue,
-                audits.get(0).getValue(),
-                () ->
-                    "Expected value is "
-                        + expectedValue
-                        + " but found "
-                        + audits.get(0).getValue()));
+            () -> assertNotNull(createdAudit),
+            () -> assertNotNull(updatedAudit),
+            () -> assertNotNull(deletedAudit),
+            () -> assertFalse(createdAudit.isEmpty()),
+            () -> assertFalse(updatedAudit.isEmpty()),
+            () -> assertFalse(deletedAudit.isEmpty()));
+    assertTrackedEntityDataValueAudit(createdAudit.get(0),dataElement,AuditType.CREATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueAudit(updatedAudit.get(0), dataElement,AuditType.UPDATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueAudit(deletedAudit.get(0),  dataElement,AuditType.DELETE,UPDATED_VALUE);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -112,14 +112,17 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest {
                 .setAuditTypes(List.of(AuditType.DELETE)));
 
     assertAll(
-            () -> assertNotNull(createdAudit),
-            () -> assertNotNull(updatedAudit),
-            () -> assertNotNull(deletedAudit),
-            () -> assertFalse(createdAudit.isEmpty()),
-            () -> assertFalse(updatedAudit.isEmpty()),
-            () -> assertFalse(deletedAudit.isEmpty()));
-    assertTrackedEntityDataValueAudit(createdAudit.get(0),dataElement,AuditType.CREATE, ORIGINAL_VALUE);
-    assertTrackedEntityDataValueAudit(updatedAudit.get(0), dataElement,AuditType.UPDATE, ORIGINAL_VALUE);
-    assertTrackedEntityDataValueAudit(deletedAudit.get(0),  dataElement,AuditType.DELETE,UPDATED_VALUE);
+        () -> assertNotNull(createdAudit),
+        () -> assertNotNull(updatedAudit),
+        () -> assertNotNull(deletedAudit),
+        () -> assertFalse(createdAudit.isEmpty()),
+        () -> assertFalse(updatedAudit.isEmpty()),
+        () -> assertFalse(deletedAudit.isEmpty()));
+    assertTrackedEntityDataValueAudit(
+        createdAudit.get(0), dataElement, AuditType.CREATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueAudit(
+        updatedAudit.get(0), dataElement, AuditType.UPDATE, ORIGINAL_VALUE);
+    assertTrackedEntityDataValueAudit(
+        deletedAudit.get(0), dataElement, AuditType.DELETE, UPDATED_VALUE);
   }
 }


### PR DESCRIPTION
Backport of [DHIS2-18138](https://dhis2.atlassian.net/browse/DHIS2-18138)

[DHIS2-18138]: https://dhis2.atlassian.net/browse/DHIS2-18138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ