### PR TITLE
fix: Always use system time for createdAt in events [DHIS2-18252](2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -282,7 +282,7 @@ public class EventPersister
 
     if (isNewDataValue(eventDataValue, dv)) {
       eventDataValue = new EventDataValue();
-      eventDataValue.setCreated(getFromOrNewDate(dv, DataValue::getCreatedAt));
+      eventDataValue.setCreated(new Date());
       eventDataValue.setLastUpdated(getFromOrNewDate(dv, DataValue::getUpdatedAt));
       persistedValue = dv.getValue();
       changeLogType = ChangeLogType.CREATE;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterService.java
@@ -259,7 +259,6 @@ public class EventTrackerConverterService
     for (DataValue dataValue : event.getDataValues()) {
       EventDataValue eventDataValue = new EventDataValue();
       eventDataValue.setValue(dataValue.getValue());
-      eventDataValue.setCreated(DateUtils.fromInstant(dataValue.getCreatedAt()));
       eventDataValue.setLastUpdated(now);
       eventDataValue.setProvidedElsewhere(dataValue.isProvidedElsewhere());
       // ensure dataElement is referred to by UID as multiple

--- a/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/events/events.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/events/events.json
@@ -118,7 +118,6 @@
         },
         {
           "updatedAt": "2019-03-04T15:12:59.209",
-          "createdAt": "2019-03-04T15:01:29.793",
           "dataElement": "z3Z4TD3oBCP",
           "value": "true",
           "providedElsewhere": false


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/18871 to fix https://dhis2.atlassian.net/browse/DHIS2-18252