### PR TITLE
fix: Safely serialize JSON map [DHIS2-18253] [2.40]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonAttributeValueBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonAttributeValueBinaryType.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.hibernate.jsonb.type;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,7 +70,7 @@ public class JsonAttributeValueBinaryType extends JsonBinaryType {
       return writer.writeValueAsString(attrValueMap);
 
     } catch (IOException ex) {
-      throw new RuntimeException("Failed to serialize JSON", ex);
+      throw new UncheckedIOException("Failed to serialize JSON", ex);
     }
   }
 
@@ -86,7 +87,7 @@ public class JsonAttributeValueBinaryType extends JsonBinaryType {
 
       return convertAttributeValueMapIntoSet(data);
     } catch (IOException ex) {
-      throw new RuntimeException("Failed to deserialize JSON", ex);
+      throw new UncheckedIOException("Failed to deserialize JSON", ex);
     }
   }
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonAttributeValueBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonAttributeValueBinaryType.java
@@ -58,16 +58,18 @@ public class JsonAttributeValueBinaryType extends JsonBinaryType {
       Map<String, AttributeValue> attrValueMap = new HashMap<>();
 
       for (AttributeValue attributeValue : attributeValues) {
-        if (attributeValue.getAttribute() != null) {
-          attributeValue.setAttribute(new Attribute(attributeValue.getAttribute().getUid()));
-          attrValueMap.put(attributeValue.getAttribute().getUid(), attributeValue);
+        if (attributeValue.getAttribute() != null
+            && attributeValue.getAttribute().getUid() != null) {
+          String uid = attributeValue.getAttribute().getUid();
+          attributeValue.setAttribute(new Attribute(uid));
+          attrValueMap.put(uid, attributeValue);
         }
       }
 
       return writer.writeValueAsString(attrValueMap);
 
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (IOException ex) {
+      throw new RuntimeException("Failed to serialize JSON", ex);
     }
   }
 
@@ -83,8 +85,8 @@ public class JsonAttributeValueBinaryType extends JsonBinaryType {
       Map<String, AttributeValue> data = reader.readValue(content);
 
       return convertAttributeValueMapIntoSet(data);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (IOException ex) {
+      throw new RuntimeException("Failed to deserialize JSON", ex);
     }
   }
 


### PR DESCRIPTION
This PR makes the `JsonAttributeValueBinaryType` more reliable against bad data in the `attributevalues` JSONB column in metadata tables like `organisationunit`.

A null key in the JSONB column will lead to an exception from Jackson.

```
com.fasterxml.jackson.databind.JsonMappingException: Null key for a Map not allowed in JSON
```