### PR TITLE
feat: OpenAPI considers property access [DHIS2-18265]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -44,6 +44,15 @@ import org.intellij.lang.annotations.Language;
  * @author Jan Bernitt
  */
 public @interface OpenApi {
+
+  /** Is a property output, input, input+output (explicitly) or input+output (assumed) */
+  enum Access {
+    READ,
+    WRITE,
+    READ_WRITE,
+    DEFAULT
+  }
+
   /**
    * Annotation to use as part of the OpenAPI generation to work around lack of generic types when
    * using annotations.
@@ -271,6 +280,13 @@ public @interface OpenApi {
     Class<?>[] value() default {};
 
     boolean required() default false;
+
+    /**
+     * When set to value other than the default this takes precedence over other annotations.
+     *
+     * @return the access direction for this property
+     */
+    Access access() default Access.DEFAULT;
 
     /**
      * If given, this values takes precedence over the actual initial value of a field that might be

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertGreaterOrEqual;
 import static org.hisp.dhis.test.utils.Assertions.assertLessOrEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
@@ -43,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.hisp.dhis.jsontree.JsonMixed;
+import org.hisp.dhis.jsontree.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.junit.jupiter.api.Test;
@@ -147,6 +149,28 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
             .findFirst()
             .orElse(JsonMixed.of("{}"));
     assertEquals(50, pageSize.getNumber("schema.default").integer());
+  }
+
+  @Test
+  void testGetOpenApiDocument_ReadOnly() {
+    JsonObject doc = GET("/openapi/openapi.json?domain=JobConfiguration").content();
+    JsonObject jobConfiguration = doc.getObject("components.schemas.JobConfiguration");
+    JsonObject jobConfigurationParams = doc.getObject("components.schemas.JobConfigurationParams");
+    assertTrue(jobConfiguration.isObject());
+    assertTrue(jobConfigurationParams.isObject());
+    assertTrue(
+        jobConfiguration.getObject("properties").size()
+            > jobConfigurationParams.getObject("properties").size());
+    assertTrue(
+        jobConfiguration
+            .node()
+            .find(JsonNodeType.BOOLEAN, n -> n.getPath().toString().endsWith("readOnly"))
+            .isPresent());
+    assertFalse(
+        jobConfigurationParams
+            .node()
+            .find(JsonNodeType.BOOLEAN, n -> n.getPath().toString().endsWith("readOnly"))
+            .isPresent());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -62,6 +63,7 @@ import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.Maturity;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.OpenApi.Access;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.period.Period;
 import org.springframework.http.HttpStatus;
@@ -360,6 +362,8 @@ public class Api {
 
     Boolean required;
 
+    @Nonnull Access access;
+
     /**
      * OBS! This cannot be included in {@link #toString()} because it might be a circular with the
      * {@link Schema} containing the {@link Property}.
@@ -385,11 +389,27 @@ public class Api {
 
     public Property(
         @CheckForNull AnnotatedElement source, String name, Boolean required, Schema type) {
-      this(source, name, required, type, new Maybe<>());
+      this(source, name, required, Access.DEFAULT, type, new Maybe<>());
     }
 
     Property withType(Schema type) {
-      return type == this.type ? this : new Property(source, name, required, type, description);
+      return type == this.type
+          ? this
+          : new Property(source, name, required, access, type, description);
+    }
+
+    Property withAccess(Access access) {
+      return access == this.access
+          ? this
+          : new Property(source, name, required, access, type, description);
+    }
+
+    boolean isInput() {
+      return access != Access.READ;
+    }
+
+    boolean isOutput() {
+      return access != Access.WRITE;
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
@@ -632,7 +632,8 @@ final class ApiExtractor {
             : extractSchema(endpoint, null, oneOf);
     for (OpenApi.Property p : properties) {
       obj.addProperty(
-          new Api.Property(null, p.name(), p.required(), extractSchema(endpoint, null, p.value())));
+          new Api.Property(null, p.name(), p.required(), extractSchema(endpoint, null, p.value()))
+              .withAccess(p.access()));
     }
     return obj.sealed();
   }
@@ -739,7 +740,9 @@ final class ApiExtractor {
     // the schemas map so recursive types do resolve (unless they are inlined)
     for (Property p : properties) {
       Function<Api.Schema, Api.Property> toProperty =
-          t -> new Api.Property(p.getSource(), getPropertyName(endpoint, p), p.getRequired(), t);
+          t ->
+              new Api.Property(p.getSource(), getPropertyName(endpoint, p), p.getRequired(), t)
+                  .withAccess(p.getAccess());
       Api.Property property = extractObjectProperty(endpoint, p, toProperty);
       property.getDescription().setValue(extractDescription(p.getSource()));
       schema.addProperty(property);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
@@ -354,8 +354,8 @@ public class ApiIntegrator {
           .put(schemaType, input);
     }
     input.getDirection().setValue(Api.Schema.Direction.IN);
-    output
-        .getProperties()
+    output.getProperties().stream()
+        .filter(Api.Property::isInput)
         .forEach(p -> input.getProperties().add(p.withType(generateInputReferenceSchema(p))));
     return input;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -472,6 +472,7 @@ public class OpenApiGenerator extends JsonGenerator {
                 property.getName(),
                 () -> {
                   generateSchemaOrRef(property.getType(), direction);
+                  addTrueMember("readOnly", property.getAccess() == OpenApi.Access.READ);
                   addStringMember("description", property.getDescription().orElse(NO_DESCRIPTION));
                   addStringMember("x-since", getSinceVersion(property.getSince()));
                 }));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
@@ -502,6 +502,10 @@ public interface OpenApiObject extends JsonObject {
       return getString("type").string();
     }
 
+    default boolean isReadOnly() {
+      return getBoolean("readOnly").booleanValue(false);
+    }
+
     default boolean isAnyType() {
       return "any".equalsIgnoreCase($type());
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
@@ -1247,6 +1247,7 @@ public class OpenApiRenderer {
         renderLabelledValue("enum", schema.$enum(), "", params.inlineEnumsLimit);
       return;
     }
+    if (schema.isReadOnly()) renderLabelledValue("readOnly", true);
     renderLabelledValue("format", schema.format());
     renderLabelledValue("minLength", schema.minLength());
     renderLabelledValue("maxLength", schema.maxLength());


### PR DESCRIPTION
### Summary
`@JsonProperty` has the `access` attribute which can specify read-only or write-only special cases.
OpenAPI can express a read-only schema property by marking it `readOnly:true`. 
These two needed to be connected.

In addition, to the obvious connection when generating input params schemas from output schemas the access needs to act as a filter removing all _read-only_ properties. 

To allow overrides access and specify it in added properties the `@OpenApi.Property` annotation also got an `Access` attribute.

### Manual Testing
The `/api/openapi/openapi.html?domain=JobConfiguration` is a good example. 

* compare  `/api/openapi/openapi.html?domain=JobConfiguration#JobConfiguration` and it's input version `/api/openapi/openapi.html?domain=JobConfiguration#JobConfigurationParams` and note that the that has much less properties because many are read-only
* also note that the first has these properties marked as `readOnly: true`

### Automated Testing
Added a new controller tests scenario that tests the above in the OpenAPI JSON document