### PR TITLE
ci: expect node.js on build machine [2.39]

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 concurrency:
-    group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   analyze:
     name: Analyze
@@ -27,7 +27,7 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: [ 'java' ]
+        language: ["java"]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
@@ -58,9 +58,9 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build core
-        run: mvn clean install -f ./dhis-2/pom.xml --batch-mode --no-transfer-progress -Pdev -DskipTests=true -Dmaven.javadoc.skip=true -V
+        run: mvn clean install -f ./dhis-2/pom.xml --batch-mode --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true -V
       - name: Build web
-        run: mvn clean install -f ./dhis-2/dhis-web/pom.xml --batch-mode --no-transfer-progress -Pdev -DskipTests=true -Dmaven.javadoc.skip=true -V
+        run: mvn clean install -f ./dhis-2/dhis-web/pom.xml --batch-mode --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true -V
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,8 +8,8 @@ on:
       - master
   pull_request:
 concurrency:
-    group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -21,8 +21,8 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: maven
-      - name: Test core # NOTE: dhis-2/pom.xml needs to be installed as built artifacts are needed by dhis-web
-        run: mvn clean install --threads 2C --batch-mode --no-transfer-progress --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Run unit tests # NOTE: dhis-2/pom.xml needs to be installed as built artifacts are needed by dhis-web
+        run: mvn clean install --threads 2C --batch-mode --no-transfer-progress --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty --activate-profiles unit-test
         timeout-minutes: 30
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3
@@ -69,7 +69,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -Pintegration -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty --activate-profiles integration-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure
@@ -120,7 +120,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty --activate-profiles integration-h2-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v4
         name: Upload test logs on failure
@@ -167,12 +167,11 @@ jobs:
       contains(needs.*.result, 'failure') &&
       github.ref == 'refs/heads/master'
 
-    needs: [ unit-test, integration-test, integration-h2-test ]
+    needs: [unit-test, integration-test, integration-h2-test]
     steps:
       - uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_BACKEND_WEBHOOK }}
-          SLACK_CHANNEL: 'team-backend'
+          SLACK_CHANNEL: "team-backend"
           SLACK_MESSAGE: "Latest test run on master failed and needs investigation :detective-duck:. \n Commit message: ${{ github.event.head_commit.message }}"
-          SLACK_COLOR: '#ff0000'
-
+          SLACK_COLOR: "#ff0000"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ You'll need the following software to run DHIS2 on your machine:
 
 - Java 8
 - Maven
+- Node.js at least v20 (used to bundle web apps)
 - Tomcat
 
 ## Fork

--- a/dhis-2/build-nocompr.sh
+++ b/dhis-2/build-nocompr.sh
@@ -3,5 +3,5 @@
 # Requires maven to be on the classpath
 # Invokes the dev profile which skips tests and disables compression of war artifacts for a speedy build
 
-mvn clean install --batch-mode --no-transfer-progress -Pdev
-mvn clean install --batch-mode --no-transfer-progress -Pdev -f dhis-web/pom.xml -U
+mvn clean install --batch-mode --no-transfer-progress
+mvn clean install --batch-mode --no-transfer-progress -f dhis-web/pom.xml -U

--- a/dhis-2/dhis-test-coverage/pom.xml
+++ b/dhis-2/dhis-test-coverage/pom.xml
@@ -201,7 +201,7 @@
             <goals>
               <goal>report-aggregate</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>test</phase>
           </execution>
         </executions>
       </plugin>

--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -18,56 +18,55 @@
 
   <build>
     <finalName>dhis-web-apps</finalName>
-
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin.version}</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+            <!-- this template is only needed by bundle-apps.js to generate the dhis-web-apps/index.html -->
+            <packagingExcludes>dhis-web-apps/template.html</packagingExcludes>
+            <archive>
+              <compress>true</compress>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <!-- nodejs is expected to be present to clone bundled apps -->
     <plugins>
       <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.6</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <installDirectory>target</installDirectory>
+          <executable>npm</executable>
+          <arguments>
+            <argument>run</argument>
+            <argument>bundle-apps</argument>
+          </arguments>
           <environmentVariables>
             <BUILD_DIR>${project.build.directory}</BUILD_DIR>
-            <ARTIFACT_ID>${project.artifactId}</ARTIFACT_ID>
+            <ARTIFACT_ID>dhis-web-apps</ARTIFACT_ID>
             <APPS>./apps-to-bundle.json</APPS>
             <DEFAULT_BRANCH>master</DEFAULT_BRANCH>
           </environmentVariables>
         </configuration>
         <executions>
-
           <execution>
-            <id>install node and npm</id>
+            <id>bundle-apps</id>
             <goals>
-              <goal>install-node-and-npm</goal>
+              <goal>exec</goal>
             </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <nodeVersion>v16.13.2</nodeVersion>
-            </configuration>
+            <phase>prepare-package</phase>
           </execution>
-
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-          </execution>
-
-          <execution>
-            <id>clone apps</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <arguments>run bundle-apps</arguments>
-            </configuration>
-          </execution>
-
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -7,11 +7,19 @@
   <packaging>pom</packaging>
   <name>DHIS 2</name>
 
-  <description>The District Health Information System 2 deals with
-    aggregating and reporting statistical health data. The goal is to allow users to analyze
-    and use this data to guide local action. The system is based around an goals of empowering
-    users, by allowing them to decide what to register and report data for.</description>
-  <url>http://dhis2.org</url>
+  <description>DHIS2 is a free and open-source software platform for collecting, managing,
+    analyzing, and sharing data. It supports online and offline data capture via web and mobile
+    devices, and includes built-in features for data validation and visualization. The generic DHIS2
+    data model supports both routine aggregate/statistical data collection and individual/event
+    data, and can be applied to use cases in any sector, allowing decentralized access to data
+    throughout an organizational hierarchy. DHIS2 is fully customizable through the user interface
+    without the need for coding skills, and can be extended with custom applications, scripts, and
+    integrations. Each DHIS2 instance and the data stored within it are locally owned and managed.
+
+    DHIS2 is designed and developed by the HISP Centre at University of Oslo, with the goal of
+    strengthening governance systems in low- and middle-income countries. It is shared as a Digital
+    Public Good.</description>
+  <url>https://dhis2.org</url>
 
   <organization>
     <name>UiO</name>
@@ -64,7 +72,7 @@
   <properties>
     <!-- Build Properties -->
     <rootDir/>
-    <!-- Custom source directory property, as <build><sourceDirectory> cannot 
+    <!-- Custom source directory property, as <build><sourceDirectory> cannot
       be set in a profile. See https://github.com/awhitford/lombok.maven/issues/17#issuecomment-136606104 -->
     <sourceDir>${project.basedir}/src/main/java</sourceDir>
 
@@ -78,10 +86,6 @@
     <sonar.organization>dhis2</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <surefireArgLine>-Xmx2024m --illegal-access=permit</surefireArgLine>
-
-    <!-- Needed so we can disable running tests when the default profile 
-      is used (activated by default). It does not honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->
-    <skipTests>false</skipTests>
 
     <!-- *Dependencies* -->
 
@@ -229,6 +233,7 @@
     <!-- Maven plugin versions -->
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-exec-plugin.version>3.4.1</maven-exec-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
@@ -1642,8 +1647,8 @@
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
-      <!-- Depend only on mockito-inline (includes mockito-core already) 
-        if you must use mockStatic (can you rewrite your code, so it's not necessary 
+      <!-- Depend only on mockito-inline (includes mockito-core already)
+        if you must use mockStatic (can you rewrite your code, so it's not necessary
         ;)), otherwise depend on mockito-core only -->
       <dependency>
         <groupId>org.mockito</groupId>
@@ -1901,6 +1906,16 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-report-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${maven-exec-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
@@ -2110,6 +2125,18 @@ jasperreports.version=${jasperreports.version}
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco-maven-plugin.version}</version>
+          <!-- disable the jacoco coverage agent if we skip running tests -->
+          <configuration>
+            <skip>${skipTests}</skip>
+          </configuration>
+          <executions>
+            <execution>
+              <id>prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -2228,14 +2255,6 @@ jasperreports.version=${jasperreports.version}
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
     <!-- <build><sourceDirectory> cannot be set in a profile, so it needs
@@ -2264,13 +2283,9 @@ jasperreports.version=${jasperreports.version}
   </reporting>
 
   <profiles>
-
-    <!-- Default profile will run all unit tests, not integration tests -->
+    <!-- runs all unit tests -->
     <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
+      <id>unit-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2295,10 +2310,9 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- Integration test profile, runs all integrations tests, not unit
-      tests -->
+    <!-- runs all integration tests using Postgres DB -->
     <profile>
-      <id>integration</id>
+      <id>integration-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2321,10 +2335,9 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- IntegrationH2 test profile, this runs all the integrations tests
-      with H2, but not the unit tests -->
+    <!-- runs all integrations tests using H2 in-memory DB -->
     <profile>
-      <id>integrationH2</id>
+      <id>integration-h2-test</id>
       <build>
         <plugins>
           <plugin>
@@ -2346,43 +2359,6 @@ jasperreports.version=${jasperreports.version}
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>dev</id>
-      <properties>
-        <skipTests>true</skipTests>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-              <trimStackTrace>false</trimStackTrace>
-              <argLine>@{argLine} ${surefireArgLine}</argLine>
-              <excludedGroups>integration,integrationH2</excludedGroups>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>jrebel-maven-plugin</artifactId>
-            <version>${jrebel-x-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>generate-rebel-xml</id>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration/>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>javadoc</id>
       <properties>
@@ -2410,7 +2386,5 @@ jasperreports.version=${jasperreports.version}
         </plugins>
       </build>
     </profile>
-
   </profiles>
-
 </project>

--- a/dhis-2/run-api.sh
+++ b/dhis-2/run-api.sh
@@ -50,7 +50,7 @@ fi
 mvn clean install \
     -f "$(dirname "$0")/pom.xml" \
     --batch-mode \
-    -Pdev -T 100C \
+    -T 100C \
     -DskipTests -Dmaven.test.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true
 java \
     -Ddhis2.home=$DHIS2_HOME \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,14 @@ services:
       - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
       - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
     environment:
-      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081 \
-              -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml
-              -Dcom.sun.management.jmxremote \
-              -Dcom.sun.management.jmxremote.port=9010 \
-              -Dcom.sun.management.jmxremote.local.only=false \
-              -Dcom.sun.management.jmxremote.authenticate=false \
-              -Dcom.sun.management.jmxremote.ssl=false"
+      JAVA_OPTS:
+        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081 \
+        -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml
+        -Dcom.sun.management.jmxremote \
+        -Dcom.sun.management.jmxremote.port=9010 \
+        -Dcom.sun.management.jmxremote.local.only=false \
+        -Dcom.sun.management.jmxremote.authenticate=false \
+        -Dcom.sun.management.jmxremote.ssl=false"
     depends_on:
       db:
         condition: service_healthy
@@ -34,7 +35,11 @@ services:
       POSTGRES_PASSWORD: &postgres_password dhis
       PGPASSWORD: *postgres_password # needed by psql in healthcheck
     healthcheck:
-      test: [ "CMD-SHELL", "psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command \"SELECT 'ok'\" > /dev/null" ]
+      test:
+        [
+          "CMD-SHELL",
+          'psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command "SELECT ''ok''" > /dev/null',
+        ]
       start_period: 120s
       interval: 1s
       timeout: 3s
@@ -53,4 +58,4 @@ services:
       - db-dump:/opt/dump
 
 volumes:
-  db-dump: { }
+  db-dump: {}

--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -30,14 +30,14 @@ pipeline {
                     def formatted = "${today.format('yyyyMMdd')}"
                     def source = "dhis2/core-dev:${branch}"
                     def target = "dhis2/core-canary:${branch}"
-                    
+
                     sh "docker pull ${source}"
                     sh "docker tag ${source} ${target}"
                     sh "docker tag ${source} ${target}-${formatted}"
                     withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
                         sh "docker push ${target}"
                         sh "docker push ${target}-${formatted}"
-                    }           
+                    }
                 }
             }
         }
@@ -47,8 +47,8 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress package -f dhis-2/dhis-web/pom.xml -P -default --update-snapshots'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress package -f dhis-2/dhis-web/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -37,8 +37,8 @@ pipeline {
                     gitHelper.setCommitStatus("${env.DHIS2_COMMIT_SHA}", "${env.DHIS2_REPO_URL}")
 
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress install -f dhis-2/dhis-web/pom.xml -P -default --update-snapshots'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress install -f dhis-2/dhis-web/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -26,8 +26,8 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress package -f dhis-2/dhis-web/pom.xml -P -default --update-snapshots'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress package -f dhis-2/dhis-web/pom.xml --update-snapshots'
                     }
                 }
             }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -35,8 +35,8 @@ pipeline {
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress install -f dhis-2/dhis-web/pom.xml -P -default --update-snapshots'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
+                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress install -f dhis-2/dhis-web/pom.xml --update-snapshots'
                     }
                 }
             }


### PR DESCRIPTION
backport of
* https://github.com/dhis2/dhis2-core/pull/18632 only the part of expecting Node.js to be present on the machine building DHIS2 to bundle the webapps
* https://github.com/dhis2/dhis2-core/pull/18669
* https://github.com/dhis2/dhis2-core/pull/18801

manual tests
* `./dhis-2/build-dev.sh && docker compose up` locally and check apps are bundled
* deploy PR to instance manager and check apps are bundled
* run `mvn clean test` and `mvn clean test` with individual profiles and double-check sum of tests is equal