### PR TITLE
ci: keep war/Docker image Tomcat version in sync

### DIFF
--- a/dhis-2/dhis-web-server/pom.xml
+++ b/dhis-2/dhis-web-server/pom.xml
@@ -15,7 +15,13 @@
   <properties>
     <rootDir>../</rootDir>
     <build.time>${maven.build.timestamp}</build.time>
-    <tomcat.version>10.1.28</tomcat.version>
+    <tomcat.version>10.1.30</tomcat.version>
+    <jib.version>3.4.3</jib.version>
+    <jib.from.image>tomcat:${tomcat.version}-jre17</jib.from.image>
+    <jib.to.image>dhis2/core-dev:local</jib.to.image>
+    <!-- uid=65534(nobody) gid=65534(nogroup) present in Tomcat image -->
+    <jib.container.user>65534</jib.container.user>
+    <jib.container.appRoot>/usr/local/tomcat/webapps/ROOT</jib.container.appRoot>
     <spring-boot-maven-plugin.version>3.3.4</spring-boot-maven-plugin.version>
   </properties>
 
@@ -176,6 +182,7 @@
             <failOnMissingWebXml>false</failOnMissingWebXml>
             <!-- this template is only needed by bundle-apps.js to generate the dhis-web-apps/index.html -->
             <packagingExcludes>dhis-web-apps/template.html</packagingExcludes>
+            <archiveClasses>true</archiveClasses>
             <archive>
               <compress>true</compress>
             </archive>

--- a/dhis-2/dhis-web-server/pom.xml
+++ b/dhis-2/dhis-web-server/pom.xml
@@ -16,7 +16,7 @@
     <rootDir>../</rootDir>
     <build.time>${maven.build.timestamp}</build.time>
     <tomcat.version>10.1.30</tomcat.version>
-    <jib.version>3.4.3</jib.version>
+    <jib.version>3.4.4</jib.version>
     <jib.from.image>tomcat:${tomcat.version}-jre17</jib.from.image>
     <jib.to.image>dhis2/core-dev:local</jib.to.image>
     <!-- uid=65534(nobody) gid=65534(nogroup) present in Tomcat image -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -74,15 +74,6 @@
 
     <surefireArgLine>-Xmx2024m</surefireArgLine>
 
-    <!-- *Build* -->
-    <jib.version>3.4.3</jib.version>
-    <jib.from.image>tomcat:10.1.30-jre21</jib.from.image>
-    <jib.to.image>dhis2/core-dev:local</jib.to.image>
-    <!-- uid=65534(nobody) gid=65534(nogroup) present in Tomcat image -->
-    <jib.container.user>65534</jib.container.user>
-    <jib.container.appRoot>/usr/local/tomcat/webapps/ROOT</jib.container.appRoot>
-
-    <tomcat.version>10.1.30</tomcat.version>
     <jrebel-maven-plugin.version>1.1.6</jrebel-maven-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
@@ -2170,20 +2161,6 @@ jasperreports.version=${jasperreports.version}
 
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${maven-war-plugin.version}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-          <archiveClasses>true</archiveClasses>
-          <dependentWarExcludes>**/web.xml</dependentWarExcludes>
-          <archive>
-            <compress>${useWarCompression}</compress>
-          </archive>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <version>${properties-maven-plugin.version}</version>
@@ -2206,40 +2183,6 @@ jasperreports.version=${jasperreports.version}
             </configuration>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>${cargo-maven2-plugin.version}</version>
-        <configuration>
-          <container>
-            <containerId>tomcat8x</containerId>
-            <artifactInstaller>
-              <groupId>org.apache.tomcat</groupId>
-              <artifactId>tomcat</artifactId>
-              <version>${tomcat.version}</version>
-            </artifactInstaller>
-          </container>
-          <configuration>
-            <type>standalone</type>
-            <home>${project.build.directory}/apache-tomcat-${tomcat.version}</home>
-            <properties>
-              <cargo.servlet.port>8080</cargo.servlet.port>
-              <cargo.logging>low</cargo.logging>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <groupId>${project.groupId}</groupId>
-              <artifactId>${project.artifactId}</artifactId>
-              <type>war</type>
-              <properties>
-                <context>/</context>
-              </properties>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -23,7 +23,6 @@ pipeline {
         DHIS2_VERSION = readMavenPom(file: 'dhis-2/pom.xml').getVersion()
         DOCKER_IMAGE_NAME = "${DOCKER_HUB_OWNER}/core-dev"
         DOCKER_IMAGE_TAG = "${env.GIT_BRANCH}"
-        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "tomcat:10.0-jre17"
     }
 
     stages {
@@ -54,67 +53,53 @@ pipeline {
                 RP_UUID = credentials('report-portal-access-uuid')
                 RP_ENABLE = 'true'
                 RP_ATTRIBUTES = "version:${env.GIT_BRANCH};"
-                DOCKER_IMAGE_NAME_BASE = 'tomcat'
+                DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
             }
 
-            matrix {
-                axes {
-                    axis {
-                        name 'DOCKER_IMAGE_TAG_BASE'
-                        values '10.0-jre17'
-                    }
-                }
+              stages {
+                  stage('Build Docker image') {
+                      steps {
+                          withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                              withMaven(options: [artifactsPublisher(disabled: true)]) {
+                                  sh "mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true \
+                                          --file dhis-2/dhis-web-server/pom.xml --activate-profiles jibBuild jib:build \
+                                          -Djib.to.image=${DOCKER_IMAGE_NAME_FULL} \
+                                          -Djib.container.labels=DHIS2_VERSION=${DHIS2_VERSION},DHIS2_BUILD_REVISION=${GIT_COMMIT},DHIS2_BUILD_BRANCH=${env.GIT_BRANCH}"
+                              }
+                          }
+                      }
+                  }
 
-                environment {
-                    DOCKER_IMAGE_NAME_BASE_FULL = "${DOCKER_IMAGE_NAME_BASE}:${DOCKER_IMAGE_TAG_BASE}"
-                    DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-${DOCKER_IMAGE_TAG_BASE}" // used to test against different Tomcat variants
-                }
+                  stage('Run tests') {
+                      steps {
+                          script {
+                              dir("dhis-2/dhis-test-e2e") {
+                                  sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
+                                  sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                              }
+                          }
+                      }
 
-                stages {
-                    stage('Build Docker image') {
-                        steps {
-                            withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
-                                withMaven(options: [artifactsPublisher(disabled: true)]) {
-                                    sh "mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true \
-                                            --file dhis-2/dhis-web-server/pom.xml --activate-profiles jibBuild jib:build \
-                                            -Djib.from.image=${DOCKER_IMAGE_NAME_BASE_FULL} -Djib.to.image=${DOCKER_IMAGE_NAME_FULL} \
-                                            -Djib.container.labels=DHIS2_VERSION=${DHIS2_VERSION},DHIS2_BUILD_REVISION=${GIT_COMMIT},DHIS2_BUILD_BRANCH=${env.GIT_BRANCH}"
-                                }
-                            }
-                        }
-                    }
+                      post {
+                          always {
+                              script {
+                                  dir("dhis-2/dhis-test-e2e") {
+                                      archiveArtifacts artifacts: "coverage.csv", allowEmptyArchive: true
+                                  }
+                              }
+                          }
 
-                    stage('Run tests') {
-                        steps {
-                            script {
-                                dir("dhis-2/dhis-test-e2e") {
-                                    sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
-                                }
-                            }
-                        }
-
-                        post {
-                            always {
-                                script {
-                                    dir("dhis-2/dhis-test-e2e") {
-                                        archiveArtifacts artifacts: "coverage.csv", allowEmptyArchive: true
-                                    }
-                                }
-                            }
-
-                            failure {
-                                script {
-                                    dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose logs web > web-logs.txt"
-                                        archiveArtifacts artifacts: "web-logs.txt"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+                          failure {
+                              script {
+                                  dir("dhis-2/dhis-test-e2e") {
+                                      sh "docker compose logs web > web-logs.txt"
+                                      archiveArtifacts artifacts: "web-logs.txt"
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
         }
 
         stage('Sync WAR') {
@@ -135,7 +120,8 @@ pipeline {
 
         stage('Publish image') {
             environment {
-                BASE_IMAGE = "$DOCKER_IMAGE_NAME_PUBLISH_SOURCE"
+                // THIS MUST be kept in sync with the jib.from.image in ../dhis-2/dhis-web-server/pom.xml
+                BASE_IMAGE = "tomcat:10.1.30-jre17"
                 IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME"
             }
 

--- a/jenkinsfiles/rebuild-image
+++ b/jenkinsfiles/rebuild-image
@@ -40,7 +40,8 @@ pipeline {
                         env.VERSIONS_TO_REBUILD.tokenize(" ").each { version ->
                             def majorVersion = version.split('\\.')[0].toInteger()
                             if (majorVersion >= 42) {
-                                env.BASE_IMAGE = "tomcat:10.0-jre17"
+                                // THIS MUST be kept in sync with the jib.from.image in ../dhis-2/dhis-web-server/pom.xml
+                                env.BASE_IMAGE = "tomcat:10.1.30-jre17"
                             } else if (majorVersion == 41) {
                                 env.BASE_IMAGE = "tomcat:9.0-jre17"
                             } else {

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -35,8 +35,10 @@ pipeline {
         DOCKER_IMAGE_NAME_DEV = "${DOCKER_HUB_OWNER}/core-dev"
         DOCKER_IMAGE_NAME = "${DOCKER_HUB_OWNER}/core"
         DOCKER_IMAGE_TAG = "${env.DHIS2_VERSION.replace('SNAPSHOT', 'rc')}"
-        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "tomcat:10.0-jre17" // source of image to publish to Dockerhub (one of the matrix axes)
         DOCKER_IMAGE_NAME_PUBLISH_TARGET = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" // used to publish to Dockerhub
+        // THIS MUST be kept in sync with the jib.from.image in ../dhis-2/dhis-web-server/pom.xml
+        BASE_IMAGE = "tomcat:10.1.30-jre17"
+        IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME"
     }
 
     stages {
@@ -63,60 +65,44 @@ pipeline {
                 RP_UUID = credentials('report-portal-access-uuid')
                 RP_ENABLE = 'true'
                 RP_ATTRIBUTES = "version:${env.GIT_BRANCH};"
-                DOCKER_IMAGE_NAME_BASE = 'tomcat'
+                DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME_DEV}:${DOCKER_IMAGE_TAG}"
             }
 
-            matrix {
-                axes {
-                    axis {
-                        name 'DOCKER_IMAGE_TAG_BASE'
-                        values '10.0-jre17'
+            stages {
+                stage('Build Docker image') {
+                    steps {
+                        withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                            withMaven(options: [artifactsPublisher(disabled: true)]) {
+                                sh './dhis-2/build-docker-image.sh -t "${DOCKER_IMAGE_TAG}" -d'
+                            }
+                        }
                     }
                 }
 
-                environment {
-                    DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME_DEV}:${DOCKER_IMAGE_TAG}-${DOCKER_IMAGE_TAG_BASE}" // used to test against different Tomcat variants
-                    BASE_IMAGE = "${DOCKER_IMAGE_NAME_BASE}:${DOCKER_IMAGE_TAG_BASE}"
-                    IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME_DEV"
-                    UNARCHIVED_WAR_DIR = "dhis2-war-$DOCKER_IMAGE_TAG_BASE" // this needs to be different for the two matrix stages, as they run in parallel
-                }
-
-                stages {
-                    stage('Build Docker image') {
-                        steps {
-                            withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
-                                withMaven(options: [artifactsPublisher(disabled: true)]) {
-                                    sh './dhis-2/build-docker-image.sh -t "${DOCKER_IMAGE_TAG}-${DOCKER_IMAGE_TAG_BASE}" -d'
-                                }
+                stage('Run tests') {
+                    steps {
+                        script {
+                            dir("dhis-2/dhis-test-e2e") {
+                                sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
+                                sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
                             }
                         }
                     }
 
-                    stage('Run tests') {
-                        steps {
+                    post {
+                        always {
                             script {
                                 dir("dhis-2/dhis-test-e2e") {
-                                    sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
-                                    sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                                    archiveArtifacts artifacts: "coverage.csv", allowEmptyArchive: true
                                 }
                             }
                         }
 
-                        post {
-                            always {
-                                script {
-                                    dir("dhis-2/dhis-test-e2e") {
-                                        archiveArtifacts artifacts: "coverage.csv", allowEmptyArchive: true
-                                    }
-                                }
-                            }
-
-                            failure {
-                                script {
-                                    dir("dhis-2/dhis-test-e2e") {
-                                        sh "docker compose logs web > web-logs.txt"
-                                        archiveArtifacts artifacts: "web-logs.txt"
-                                    }
+                        failure {
+                            script {
+                                dir("dhis-2/dhis-test-e2e") {
+                                    sh "docker compose logs web > web-logs.txt"
+                                    archiveArtifacts artifacts: "web-logs.txt"
                                 }
                             }
                         }
@@ -126,11 +112,6 @@ pipeline {
         }
 
         stage('Publish images') {
-            environment {
-                BASE_IMAGE = "$DOCKER_IMAGE_NAME_PUBLISH_SOURCE"
-                IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME"
-            }
-
             steps {
                 script {
                     // Remove -rc suffix in case it's there, will be added later if needed.


### PR DESCRIPTION
We are only building/testing against one version of Tomcat on master since https://github.com/dhis2/dhis2-core/pull/18787

* remove the Tomcat matrix remnants from the jenkins pipeline (used before https://github.com/dhis2/dhis2-core/pull/18787)
* undo move of jib/tomcat version related properties done in https://github.com/dhis2/dhis2-core/pull/17040 back to the dhis-web-server/pom.xml. Like any other var its best to keep its scope minimal. These properties are not used anywhere else. Having them in the root makes it complex to override and understand where the actual values are coming from in the build of the war/Docker image.
* remove unused plugin `cargo-maven2-plugin`
* keep version of our embedded tomcat and Docker base image in sync by reusing the `tomcat.version` property

Tests
* `./dhis-2/run-api.sh` - running embedded Tomcat
* `./dhis-2/build-dev.sh` - building and running Docker image locally
* deployed PR using IM