### PR TITLE
chore: Use UID in event exporter [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
@@ -41,9 +41,9 @@ public class AssignedUserQueryParam {
   public static final AssignedUserQueryParam ALL =
       new AssignedUserQueryParam(AssignedUserSelectionMode.ALL, Collections.emptySet(), null);
 
-  private final AssignedUserSelectionMode mode;
+  AssignedUserSelectionMode mode;
 
-  private final Set<String> assignedUsers;
+  Set<UID> assignedUsers;
 
   /**
    * Non-empty assigned users are only allowed with mode PROVIDED (or null).
@@ -51,8 +51,7 @@ public class AssignedUserQueryParam {
    * @param mode assigned user mode
    * @param assignedUsers assigned user uids
    */
-  public AssignedUserQueryParam(
-      AssignedUserSelectionMode mode, Set<String> assignedUsers, String userUid) {
+  public AssignedUserQueryParam(AssignedUserSelectionMode mode, Set<UID> assignedUsers, UID user) {
     if (mode == AssignedUserSelectionMode.PROVIDED
         && (assignedUsers == null || assignedUsers.isEmpty())) {
       throw new IllegalQueryException(
@@ -69,7 +68,7 @@ public class AssignedUserQueryParam {
 
     if (mode == AssignedUserSelectionMode.CURRENT) {
       this.mode = AssignedUserSelectionMode.PROVIDED;
-      this.assignedUsers = Collections.singleton(userUid);
+      this.assignedUsers = Collections.singleton(user);
     } else if ((mode == null || mode == AssignedUserSelectionMode.PROVIDED)
         && (assignedUsers != null && !assignedUsers.isEmpty())) {
       this.mode = AssignedUserSelectionMode.PROVIDED;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -39,6 +39,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserDetails;
 
 /**
@@ -78,11 +79,19 @@ public final class UID implements Serializable {
   }
 
   public static UID of(@Nonnull UserDetails currentUser) {
+    // TODO:(DHIS2-18296) Refactor SystemUser to use a valid uid
+    if (currentUser instanceof SystemUser) {
+      return new UID("systemUser1");
+    }
     return new UID(currentUser.getUid());
   }
 
   public static UID of(@CheckForNull UidObject object) {
     return object == null ? null : new UID(object.getUid());
+  }
+
+  public static Set<UID> of(@Nonnull String... values) {
+    return Stream.of(values).map(UID::of).collect(toUnmodifiableSet());
   }
 
   public static Set<UID> of(@Nonnull Collection<String> values) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AssignedUserQueryParamTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AssignedUserQueryParamTest.java
@@ -44,11 +44,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class AssignedUserQueryParamTest {
-  public static final String CURRENT_USER_UID = "Kj6vYde4LHh";
+  public static final UID CURRENT_USER_UID = UID.of("Kj6vYde4LHh");
 
-  public static final String NON_CURRENT_USER_UID = "f1AyMswryyX";
+  public static final UID NON_CURRENT_USER_UID = UID.of("f1AyMswryyX");
 
-  public static final Set<String> NON_CURRENT_USER_UIDS = Set.of(NON_CURRENT_USER_UID);
+  public static final Set<UID> NON_CURRENT_USER_UIDS = Set.of(NON_CURRENT_USER_UID);
 
   @Test
   void testUserWithAssignedUsersGivenUsersAndModeProvided() {
@@ -74,7 +74,7 @@ class AssignedUserQueryParamTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void testUserWithAssignedUsersGivenNoModeAndNoUsers(Set<String> users) {
+  void testUserWithAssignedUsersGivenNoModeAndNoUsers(Set<UID> users) {
 
     AssignedUserQueryParam param = new AssignedUserQueryParam(null, users, CURRENT_USER_UID);
 
@@ -85,7 +85,7 @@ class AssignedUserQueryParamTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void testUserWithAssignedUsersFailsGivenNoUsersAndProvided(Set<String> users) {
+  void testUserWithAssignedUsersFailsGivenNoUsersAndProvided(Set<UID> users) {
 
     assertThrows(
         IllegalQueryException.class,
@@ -94,7 +94,7 @@ class AssignedUserQueryParamTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void testUserWithAssignedUsersGivenCurrentUserAndModeCurrentAndUsersNull(Set<String> users) {
+  void testUserWithAssignedUsersGivenCurrentUserAndModeCurrentAndUsersNull(Set<UID> users) {
     AssignedUserQueryParam param = new AssignedUserQueryParam(CURRENT, users, CURRENT_USER_UID);
 
     assertEquals(PROVIDED, param.getMode());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -244,10 +244,10 @@ class DefaultEventService implements EventService {
 
   @Override
   public RelationshipItem getEventInRelationshipItem(
-      @Nonnull String uid, @Nonnull EventParams eventParams) throws NotFoundException {
+      @Nonnull UID uid, @Nonnull EventParams eventParams) throws NotFoundException {
     RelationshipItem relationshipItem = new RelationshipItem();
 
-    Event event = manager.get(Event.class, uid);
+    Event event = manager.get(Event.class, uid.getValue());
     if (event == null) {
       throw new NotFoundException(Event.class, uid);
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -55,9 +55,9 @@ import org.hisp.dhis.tracker.export.Order;
 @Builder(toBuilder = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EventOperationParams {
-  private String programUid;
+  private UID program;
 
-  private String programStageUid;
+  private UID programStage;
 
   private EnrollmentStatus enrollmentStatus;
 
@@ -65,15 +65,15 @@ public class EventOperationParams {
 
   private Boolean followUp;
 
-  private String orgUnitUid;
+  private UID orgUnit;
 
   private OrganisationUnitSelectionMode orgUnitMode;
 
   private AssignedUserSelectionMode assignedUserMode;
 
-  private Set<String> assignedUsers;
+  private Set<UID> assignedUsers;
 
-  private String trackedEntityUid;
+  private UID trackedEntity;
 
   private Date occurredAfter;
 
@@ -100,9 +100,9 @@ public class EventOperationParams {
 
   private Date enrollmentOccurredAfter;
 
-  private String attributeCategoryCombo;
+  private UID attributeCategoryCombo;
 
-  @Builder.Default private Set<String> attributeCategoryOptions = Collections.emptySet();
+  @Builder.Default private Set<UID> attributeCategoryOptions = Collections.emptySet();
 
   private CategoryOptionCombo categoryOptionCombo;
 
@@ -126,7 +126,7 @@ public class EventOperationParams {
 
   private boolean includeAllDataElements;
 
-  @Builder.Default private Set<String> events = new HashSet<>();
+  @Builder.Default private Set<UID> events = new HashSet<>();
 
   /** Data element filters per data element UID. */
   @Builder.Default private Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
@@ -136,16 +136,12 @@ public class EventOperationParams {
 
   private boolean includeDeleted;
 
-  private Set<String> accessiblePrograms;
-
-  private Set<String> accessibleProgramStages;
-
   private boolean synchronizationQuery;
 
   /** Indicates a point in the time used to decide the data that should not be synchronized */
   private Date skipChangedBefore;
 
-  private Set<String> enrollments;
+  private Set<UID> enrollments;
 
   private EventParams eventParams;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -123,7 +124,7 @@ class EventQueryParams {
 
   private boolean includeAllDataElements;
 
-  private Set<String> events = new HashSet<>();
+  private Set<UID> events = new HashSet<>();
 
   /** Each attribute will affect the final SQL query. Some attributes are filtered on. */
   private final Map<TrackedEntityAttribute, List<QueryFilter>> attributes = new HashMap<>();
@@ -138,16 +139,16 @@ class EventQueryParams {
 
   private boolean includeDeleted;
 
-  private Set<String> accessiblePrograms;
+  private Set<UID> accessiblePrograms;
 
-  private Set<String> accessibleProgramStages;
+  private Set<UID> accessibleProgramStages;
 
   private boolean synchronizationQuery;
 
   /** Indicates a point in the time used to decide the data that should not be synchronized */
   private Date skipChangedBefore;
 
-  private Set<String> enrollments;
+  private Set<UID> enrollments;
 
   @Getter private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
@@ -441,11 +442,11 @@ class EventQueryParams {
     return this;
   }
 
-  public Set<String> getEvents() {
+  public Set<UID> getEvents() {
     return events;
   }
 
-  public EventQueryParams setEvents(Set<String> events) {
+  public EventQueryParams setEvents(Set<UID> events) {
     this.events = events;
     return this;
   }
@@ -490,20 +491,20 @@ class EventQueryParams {
     return this.includeDeleted;
   }
 
-  public Set<String> getAccessiblePrograms() {
+  public Set<UID> getAccessiblePrograms() {
     return accessiblePrograms;
   }
 
-  public EventQueryParams setAccessiblePrograms(Set<String> accessiblePrograms) {
+  public EventQueryParams setAccessiblePrograms(Set<UID> accessiblePrograms) {
     this.accessiblePrograms = accessiblePrograms;
     return this;
   }
 
-  public Set<String> getAccessibleProgramStages() {
+  public Set<UID> getAccessibleProgramStages() {
     return accessibleProgramStages;
   }
 
-  public EventQueryParams setAccessibleProgramStages(Set<String> accessibleProgramStages) {
+  public EventQueryParams setAccessibleProgramStages(Set<UID> accessibleProgramStages) {
     this.accessibleProgramStages = accessibleProgramStages;
     return this;
   }
@@ -530,11 +531,11 @@ class EventQueryParams {
     return this;
   }
 
-  public Set<String> getEnrollments() {
+  public Set<UID> getEnrollments() {
     return enrollments;
   }
 
-  public EventQueryParams setEnrollments(Set<String> enrollments) {
+  public EventQueryParams setEnrollments(Set<UID> enrollments) {
     this.enrollments = enrollments;
     return this;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -82,7 +82,7 @@ public interface EventService {
   Page<Event> getEvents(EventOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException;
 
-  RelationshipItem getEventInRelationshipItem(String uid, EventParams eventParams)
+  RelationshipItem getEventInRelationshipItem(UID uid, EventParams eventParams)
       throws NotFoundException;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -1061,13 +1062,13 @@ class JdbcEventStore implements EventStore {
     if (params.getEvents() != null
         && !params.getEvents().isEmpty()
         && !params.hasDataElementFilter()) {
-      mapSqlParameterSource.addValue(COLUMN_EVENT_UID, params.getEvents());
+      mapSqlParameterSource.addValue(COLUMN_EVENT_UID, UID.toValueSet(params.getEvents()));
       fromBuilder.append(hlp.whereAnd()).append(" (ev.uid in (").append(":ev_uid").append(")) ");
     }
 
     if (params.getAssignedUserQueryParam().hasAssignedUsers()) {
       mapSqlParameterSource.addValue(
-          "au_uid", params.getAssignedUserQueryParam().getAssignedUsers());
+          "au_uid", UID.toValueSet(params.getAssignedUserQueryParam().getAssignedUsers()));
 
       fromBuilder.append(hlp.whereAnd()).append(" (au.uid in (").append(":au_uid").append(")) ");
     }
@@ -1087,7 +1088,9 @@ class JdbcEventStore implements EventStore {
     if (params.hasSecurityFilter()) {
       mapSqlParameterSource.addValue(
           "program_uid",
-          params.getAccessiblePrograms().isEmpty() ? null : params.getAccessiblePrograms());
+          params.getAccessiblePrograms().isEmpty()
+              ? null
+              : UID.toValueSet(params.getAccessiblePrograms()));
 
       fromBuilder
           .append(hlp.whereAnd())
@@ -1099,7 +1102,7 @@ class JdbcEventStore implements EventStore {
           "programstage_uid",
           params.getAccessibleProgramStages().isEmpty()
               ? null
-              : params.getAccessibleProgramStages());
+              : UID.toValueSet(params.getAccessibleProgramStages()));
 
       fromBuilder
           .append(hlp.whereAnd())
@@ -1113,7 +1116,7 @@ class JdbcEventStore implements EventStore {
     }
 
     if (!CollectionUtils.isEmpty(params.getEnrollments())) {
-      mapSqlParameterSource.addValue("enrollment_uid", params.getEnrollments());
+      mapSqlParameterSource.addValue("enrollment_uid", UID.toValueSet(params.getEnrollments()));
 
       fromBuilder.append(hlp.whereAnd()).append(" (en.uid in (:enrollment_uid)) ");
     }
@@ -1587,11 +1590,13 @@ class JdbcEventStore implements EventStore {
       params.setAccessiblePrograms(
           manager.getDataReadAll(Program.class).stream()
               .map(Program::getUid)
+              .map(UID::of)
               .collect(Collectors.toSet()));
 
       params.setAccessibleProgramStages(
           manager.getDataReadAll(ProgramStage.class).stream()
               .map(ProgramStage::getUid)
+              .map(UID::of)
               .collect(Collectors.toSet()));
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -451,7 +451,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     } else if (item.getEvent() != null) {
       result =
           eventService.getEventInRelationshipItem(
-              item.getEvent().getUid(), EventParams.TRUE.withIncludeRelationships(false));
+              UID.of(item.getEvent()), EventParams.TRUE.withIncludeRelationships(false));
     }
 
     return result;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.event.EventStatus;
@@ -845,7 +846,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
           .append("SELECT userinfoid AS userid ")
           .append("FROM userinfo ")
           .append("WHERE uid IN (")
-          .append(encodeAndQuote(params.getAssignedUserQueryParam().getAssignedUsers()))
+          .append(
+              encodeAndQuote(UID.toValueSet(params.getAssignedUserQueryParam().getAssignedUsers())))
           .append(") ")
           .append(") AU ON AU.userid = EV.assigneduserid");
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
@@ -211,7 +212,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
                   EventOperationParams.builder()
                       .eventParams(EventParams.TRUE)
                       .orgUnitMode(ACCESSIBLE)
-                      .enrollments(Set.of(enrollmentUid))
+                      .enrollments(Set.of(UID.of(enrollmentUid)))
                       .build())
               .stream()
               .filter(e -> bundle.findEventByUid(e.getUid()).isEmpty());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -112,8 +112,7 @@ class DeduplicationHelperTest extends TestBase {
     List<String> relationshipUids =
         List.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
     List<String> attributeUids = List.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
-    Set<UID> enrollmentUids =
-        Set.of(UID.of(CodeGenerator.generateUid()), UID.of(CodeGenerator.generateUid()));
+    Set<UID> enrollmentUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
 
     organisationUnitA = createOrganisationUnit('A');
     organisationUnitB = createOrganisationUnit('B');

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -131,14 +131,12 @@ class EventOperationParamsMapperTest {
 
   @BeforeEach
   public void setUp() {
-    String orgUnitId = "orgUnitId";
-    OrganisationUnit orgUnit = createOrgUnit("orgUnit", orgUnitId);
+    OrganisationUnit orgUnit = createOrgUnit("orgUnit");
     orgUnit.setChildren(
-        Set.of(
-            createOrgUnit("captureScopeChild", "captureScopeChildUid"),
-            createOrgUnit("searchScopeChild", "searchScopeChildUid")));
+        Set.of(createOrgUnit("captureScopeChild"), createOrgUnit("searchScopeChild")));
 
     User testUser = new User();
+    testUser.setUid(CodeGenerator.generateUid());
     testUser.setUsername("test");
     testUser.setOrganisationUnits(Set.of(orgUnit));
     user = UserDetails.fromUser(testUser);
@@ -157,7 +155,7 @@ class EventOperationParamsMapperTest {
     ProgramStage programStage = new ProgramStage();
     programStage.setUid("PlZSBEN7iZd");
     EventOperationParams eventOperationParams =
-        eventBuilder.programStageUid(programStage.getUid()).build();
+        eventBuilder.programStage(UID.of(programStage)).build();
 
     when(aclService.canDataRead(user, programStage)).thenReturn(false);
     when(programStageService.getProgramStage("PlZSBEN7iZd")).thenReturn(programStage);
@@ -171,7 +169,7 @@ class EventOperationParamsMapperTest {
   @Test
   void shouldFailWithBadRequestExceptionWhenMappingWithUnknownProgramStage() {
     EventOperationParams eventOperationParams =
-        EventOperationParams.builder().programStageUid("NeU85luyD4w").build();
+        EventOperationParams.builder().programStage(UID.of("NeU85luyD4w")).build();
 
     Exception exception =
         assertThrows(BadRequestException.class, () -> mapper.map(eventOperationParams, user));
@@ -184,8 +182,8 @@ class EventOperationParamsMapperTest {
       shouldFailWithForbiddenExceptionWhenUserHasNoAccessToCategoryComboGivenAttributeCategoryOptions() {
     EventOperationParams eventOperationParams =
         eventBuilder
-            .attributeCategoryCombo("NeU85luyD4w")
-            .attributeCategoryOptions(Set.of("tqrzUqNMHib", "bT6OSf4qnnk"))
+            .attributeCategoryCombo(UID.of("NeU85luyD4w"))
+            .attributeCategoryOptions(UID.of("tqrzUqNMHib", "bT6OSf4qnnk"))
             .build();
     CategoryOptionCombo combo = new CategoryOptionCombo();
     combo.setUid("uid");
@@ -208,8 +206,8 @@ class EventOperationParamsMapperTest {
       throws BadRequestException, ForbiddenException {
     EventOperationParams operationParams =
         eventBuilder
-            .attributeCategoryCombo("NeU85luyD4w")
-            .attributeCategoryOptions(Set.of("tqrzUqNMHib", "bT6OSf4qnnk"))
+            .attributeCategoryCombo(UID.of("NeU85luyD4w"))
+            .attributeCategoryOptions(UID.of("tqrzUqNMHib", "bT6OSf4qnnk"))
             .build();
     CategoryOptionCombo combo = new CategoryOptionCombo();
     combo.setUid("uid");
@@ -228,14 +226,14 @@ class EventOperationParamsMapperTest {
   void testMappingAssignedUser() throws BadRequestException, ForbiddenException {
     EventOperationParams operationParams =
         eventBuilder
-            .assignedUsers(Set.of("IsdLBTOBzMi", "l5ab8q5skbB"))
+            .assignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"))
             .assignedUserMode(AssignedUserSelectionMode.PROVIDED)
             .build();
 
     EventQueryParams queryParams = mapper.map(operationParams, user);
 
     assertContainsOnly(
-        Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+        UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
         queryParams.getAssignedUserQueryParam().getAssignedUsers());
     assertEquals(
         AssignedUserSelectionMode.PROVIDED, queryParams.getAssignedUserQueryParam().getMode());
@@ -420,16 +418,18 @@ class EventOperationParamsMapperTest {
       OrganisationUnitSelectionMode orgUnitMode, AccessLevel accessLevel)
       throws ForbiddenException, BadRequestException {
     Program program = new Program();
+    program.setUid(CodeGenerator.generateUid());
     program.setAccessLevel(accessLevel);
 
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit", "uid5");
+    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit");
+    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit");
     searchScopeOrgUnit.setChildren(Set.of(searchScopeChildOrgUnit));
     searchScopeChildOrgUnit.setParent(searchScopeOrgUnit);
 
     User user = new User();
+    user.setUid(CodeGenerator.generateUid());
     user.setUsername("testB");
-    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit", "uid")));
+    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit")));
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
 
     when(organisationUnitService.getOrganisationUnit(searchScopeChildOrgUnit.getUid()))
@@ -437,8 +437,8 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams =
         eventBuilder
-            .programUid(program.getUid())
-            .orgUnitUid(searchScopeChildOrgUnit.getUid())
+            .program(UID.of(program))
+            .orgUnit(UID.of(searchScopeChildOrgUnit))
             .orgUnitMode(orgUnitMode)
             .build();
 
@@ -450,16 +450,18 @@ class EventOperationParamsMapperTest {
   void shouldMapOrgUnitWhenModeAllProgramProvidedAndRequestedOrgUnitInSearchScope()
       throws ForbiddenException, BadRequestException {
     Program program = new Program();
+    program.setUid(CodeGenerator.generateUid());
     program.setAccessLevel(OPEN);
 
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit", "uid5");
+    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit");
+    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit");
     searchScopeOrgUnit.setChildren(Set.of(searchScopeChildOrgUnit));
     searchScopeChildOrgUnit.setParent(searchScopeOrgUnit);
 
     User user = new User();
+    user.setUid(CodeGenerator.generateUid());
     user.setUsername("testB");
-    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit", "uid")));
+    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit")));
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
     UserRole userRole = new UserRole();
     userRole.setAuthorities(Set.of(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
@@ -470,8 +472,8 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams =
         eventBuilder
-            .programUid(program.getUid())
-            .orgUnitUid(searchScopeChildOrgUnit.getUid())
+            .program(UID.of(program))
+            .orgUnit(UID.of(searchScopeChildOrgUnit))
             .orgUnitMode(ALL)
             .build();
 
@@ -483,14 +485,10 @@ class EventOperationParamsMapperTest {
   @EnumSource(value = OrganisationUnitSelectionMode.class)
   void shouldFailWhenRequestedOrgUnitOutsideOfSearchScope(
       OrganisationUnitSelectionMode orgUnitMode) {
-    String orgUnitId = "orgUnitId";
-    OrganisationUnit orgUnit = createOrgUnit(orgUnitId, orgUnitId);
-    when(organisationUnitService.getOrganisationUnit(orgUnitId)).thenReturn(orgUnit);
+    OrganisationUnit orgUnit = createOrgUnit("name");
+    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
     EventOperationParams operationParams =
-        EventOperationParams.builder()
-            .orgUnitUid(orgUnit.getUid())
-            .orgUnitMode(orgUnitMode)
-            .build();
+        EventOperationParams.builder().orgUnit(UID.of(orgUnit)).orgUnitMode(orgUnitMode).build();
 
     ForbiddenException exception =
         assertThrows(
@@ -506,6 +504,7 @@ class EventOperationParamsMapperTest {
   void shouldMapOrgUnitAndModeWhenModeAllAndUserIsAuthorized(String userName)
       throws ForbiddenException, BadRequestException {
     User mappedUser = userMap.get(userName);
+    mappedUser.setUid(CodeGenerator.generateUid());
     mappedUser.setUsername(userName);
 
     EventOperationParams operationParams = eventBuilder.orgUnitMode(ALL).build();
@@ -519,6 +518,7 @@ class EventOperationParamsMapperTest {
   void shouldIncludeRelationshipsWhenFieldPathIncludeRelationships()
       throws BadRequestException, ForbiddenException {
     User mappedUser = userMap.get("admin");
+    mappedUser.setUid(CodeGenerator.generateUid());
     mappedUser.setUsername("admin");
 
     EventOperationParams operationParams =
@@ -531,6 +531,7 @@ class EventOperationParamsMapperTest {
   void shouldNotIncludeRelationshipsWhenFieldPathDoNotIncludeRelationships()
       throws BadRequestException, ForbiddenException {
     User mappedUser = userMap.get("admin");
+    mappedUser.setUid(CodeGenerator.generateUid());
     mappedUser.setUsername("admin");
 
     EventOperationParams operationParams =
@@ -548,9 +549,9 @@ class EventOperationParamsMapperTest {
     return user;
   }
 
-  private OrganisationUnit createOrgUnit(String name, String uid) {
+  private OrganisationUnit createOrgUnit(String name) {
     OrganisationUnit orgUnit = new OrganisationUnit(name);
-    orgUnit.setUid(uid);
+    orgUnit.setUid(CodeGenerator.generateUid());
     return orgUnit;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -138,6 +138,7 @@ class TrackedEntityOperationParamsMapperTest {
     orgUnit2 = new OrganisationUnit("orgUnit2");
     orgUnit2.setUid(ORG_UNIT_2_UID);
     User testUser = new User();
+    testUser.setUid(CodeGenerator.generateUid());
     testUser.setOrganisationUnits(Set.of(orgUnit1, orgUnit2));
     user = UserDetails.fromUser(testUser);
 
@@ -188,7 +189,8 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
             .assignedUserQueryParam(
-                new AssignedUserQueryParam(AssignedUserSelectionMode.CURRENT, null, user.getUid()))
+                new AssignedUserQueryParam(
+                    AssignedUserSelectionMode.CURRENT, null, UID.of(user.getUid())))
             .orgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
             .followUp(true)
@@ -416,14 +418,14 @@ class TrackedEntityOperationParamsMapperTest {
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
                     AssignedUserSelectionMode.PROVIDED,
-                    Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
-                    user.getUid()))
+                    UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+                    UID.of(user.getUid())))
             .build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
 
     assertContainsOnly(
-        Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+        UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
         params.getAssignedUserQueryParam().getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserQueryParam().getMode());
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/indicator/IndicatorMergeProcessorTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/indicator/IndicatorMergeProcessorTest.java
@@ -143,7 +143,7 @@ class IndicatorMergeProcessorTest extends PostgresIntegrationTestBase {
 
     // given merge params with an invalid source indicator
     MergeParams params = new MergeParams();
-    params.setSources(Set.of(UID.of(validSource1.getUid()), UID.of("Uid00000011")));
+    params.setSources(UID.of(validSource1.getUid(), "Uid00000011"));
     params.setTarget(UID.of(validTarget.getUid()));
     params.setMergeType(MergeType.INDICATOR);
 
@@ -219,7 +219,7 @@ class IndicatorMergeProcessorTest extends PostgresIntegrationTestBase {
 
     // given merge params with a target indicator and source indicators
     MergeParams params = new MergeParams();
-    params.setSources(Set.of(UID.of(validSource1.getUid()), UID.of(validSource2.getUid())));
+    params.setSources(UID.of(validSource1.getUid(), validSource2.getUid()));
     params.setTarget(UID.of(validTarget.getUid()));
     params.setDeleteSources(true);
     params.setMergeType(MergeType.INDICATOR);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -43,7 +43,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -687,8 +686,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .events(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"))
+            .orgUnit(UID.of(orgUnit))
+            .events(UID.of("pTzf9KYMk72", "D9PbzJY8bJM"))
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -713,10 +712,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldReturnPaginatedEventsWithTotalPages()
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
-        eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programStageUid(programStage.getUid())
-            .build();
+        eventParamsBuilder.orgUnit(UID.of(orgUnit)).programStage(UID.of(programStage)).build();
 
     Page<Event> page = eventService.getEvents(params, new PageParams(1, 2, true));
 
@@ -734,8 +730,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programUid(program.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .program(UID.of(program))
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -764,8 +760,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programUid(program.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .program(UID.of(program))
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -788,7 +784,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .map(Event::getUid)
             .toList();
 
-    EventOperationParams params = eventParamsBuilder.orgUnitUid(orgUnit.getUid()).build();
+    EventOperationParams params = eventParamsBuilder.orgUnit(UID.of(orgUnit)).build();
 
     List<String> events = getEvents(params);
 
@@ -811,7 +807,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnitMode(ACCESSIBLE)
-            .events(Set.of("pTzf9KYMk72", "QRYjLTiJTrA"))
+            .events(UID.of("pTzf9KYMk72", "QRYjLTiJTrA"))
             .orderBy("enrollment.program.uid", SortDirection.ASC)
             .build();
 
@@ -838,7 +834,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnitMode(ACCESSIBLE)
-            .events(Set.of("pTzf9KYMk72", "QRYjLTiJTrA"))
+            .events(UID.of("pTzf9KYMk72", "QRYjLTiJTrA"))
             .orderBy("enrollment.program.uid", SortDirection.DESC)
             .build();
 
@@ -852,7 +848,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
@@ -866,7 +862,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
@@ -880,9 +876,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .events(
-                Set.of(
+                UID.of(
                     "pTzf9KYMk72",
                     "D9PbzJY8bJM")) // EV pTzf9KYMk72 => TE QS6w44flWAf without attribute
             // notUpdated0
@@ -899,7 +895,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
@@ -910,11 +906,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByMultipleAttributesAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByMultipleAttributesAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
@@ -923,9 +918,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), uids(events));
     List<String> trackedEntities =
-        events.stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+        events.stream().map(event -> event.getEnrollment().getTrackedEntity().getUid()).toList();
     assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
   }
 
@@ -934,7 +927,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
@@ -961,7 +954,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid("uoNW0E3xXUy")
+            .orgUnit(UID.of("uoNW0E3xXUy"))
             .orderBy("programStage.uid", SortDirection.DESC)
             .build();
 
@@ -975,7 +968,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid("uoNW0E3xXUy")
+            .orgUnit(UID.of("uoNW0E3xXUy"))
             .orderBy("programStage.uid", SortDirection.ASC)
             .build();
 
@@ -989,7 +982,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("enrollment.trackedEntity.uid", SortDirection.DESC)
             .build();
 
@@ -1003,7 +996,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("enrollment.trackedEntity.uid", SortDirection.ASC)
             .build();
 
@@ -1017,8 +1010,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
-            .events(Set.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
+            .orgUnit(UID.of("DiszpKrYNg8"))
+            .events(UID.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
             .orderBy("attributeOptionCombo.uid", SortDirection.DESC)
             .build();
 
@@ -1032,8 +1025,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
-            .events(Set.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
+            .orgUnit(UID.of("DiszpKrYNg8"))
+            .events(UID.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
             .orderBy("attributeOptionCombo.uid", SortDirection.ASC)
             .build();
 
@@ -1047,7 +1040,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -1061,7 +1054,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("occurredDate", SortDirection.ASC)
             .build();
 
@@ -1075,8 +1068,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programStageUid(programStage.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .programStage(UID.of(programStage))
             .orderBy("createdAtClient", SortDirection.ASC)
             .build();
 
@@ -1090,8 +1083,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programStageUid(programStage.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .programStage(UID.of(programStage))
             .orderBy("createdAtClient", SortDirection.DESC)
             .build();
 
@@ -1105,8 +1098,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programStageUid(programStage.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .programStage(UID.of(programStage))
             .orderBy("lastUpdatedAtClient", SortDirection.ASC)
             .build();
 
@@ -1120,8 +1113,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
-            .programStageUid(programStage.getUid())
+            .orgUnit(UID.of(orgUnit))
+            .programStage(UID.of(programStage))
             .orderBy("lastUpdatedAtClient", SortDirection.DESC)
             .build();
 
@@ -1135,7 +1128,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
@@ -1150,7 +1143,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
@@ -1165,7 +1158,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("scheduledDate", SortDirection.DESC)
             .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
@@ -1181,7 +1174,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .build();
@@ -1196,9 +1189,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .events(
-                Set.of(
+                UID.of(
                     "pTzf9KYMk72", // EV pTzf9KYMk72 without data element DATAEL00002
                     "D9PbzJY8bJM"))
             // notUpdated0
@@ -1236,7 +1229,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
-    eventParamsBuilder.orgUnitUid(orgUnit.getUid());
+    eventParamsBuilder.orgUnit(UID.of(orgUnit));
     eventParamsBuilder.orderBy(field, SortDirection.DESC);
 
     List<String> events = getEvents(eventParamsBuilder.build());
@@ -1250,7 +1243,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
-    eventParamsBuilder.orgUnitUid(orgUnit.getUid());
+    eventParamsBuilder.orgUnit(UID.of(orgUnit));
     eventParamsBuilder.orderBy(field, SortDirection.ASC);
 
     List<String> events = getEvents(eventParamsBuilder.build());
@@ -1282,7 +1275,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
 
     eventParamsBuilder.orgUnitMode(DESCENDANTS);
-    eventParamsBuilder.orgUnitUid("RojfDTBhoGC");
+    eventParamsBuilder.orgUnit(UID.of("RojfDTBhoGC"));
     eventParamsBuilder.orderBy(field, SortDirection.DESC);
 
     List<String> events = getEvents(eventParamsBuilder.build());
@@ -1296,7 +1289,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
 
     eventParamsBuilder.orgUnitMode(DESCENDANTS);
-    eventParamsBuilder.orgUnitUid("RojfDTBhoGC");
+    eventParamsBuilder.orgUnit(UID.of("RojfDTBhoGC"));
     eventParamsBuilder.orderBy(field, SortDirection.ASC);
 
     List<String> events = getEvents(eventParamsBuilder.build());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -46,15 +46,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
@@ -115,12 +114,12 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramClosedOuModeDescendantsAndOrgUnitInCaptureScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid("pcxIanBWlSY")
-            .orgUnitUid(orgUnit.getUid())
+            .program(UID.of("pcxIanBWlSY"))
+            .orgUnit(UID.of(orgUnit))
             .orgUnitMode(DESCENDANTS)
             .build();
 
@@ -141,10 +140,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeDescendantsAndOrgUnitInSearchScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnitUid(orgUnit.getUid()).orgUnitMode(DESCENDANTS).build();
+        operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(DESCENDANTS).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -165,12 +164,12 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramClosedOuModeChildrenAndOrgUnitInCaptureScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid("pcxIanBWlSY")
-            .orgUnitUid(orgUnit.getUid())
+            .program(UID.of("pcxIanBWlSY"))
+            .orgUnit(UID.of(orgUnit))
             .orgUnitMode(CHILDREN)
             .build();
 
@@ -191,10 +190,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeChildrenAndOrgUnitInSearchScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnitUid(orgUnit.getUid()).orgUnitMode(CHILDREN).build();
+        operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(CHILDREN).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -211,8 +210,8 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid(program.getUid())
-            .orgUnitUid("DiszpKrYNg8")
+            .program(UID.of(program))
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(DESCENDANTS)
             .build();
 
@@ -227,8 +226,8 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid("pcxIanBWlSY")
-            .orgUnitUid("DiszpKrYNg8")
+            .program(UID.of("pcxIanBWlSY"))
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(DESCENDANTS)
             .build();
 
@@ -240,12 +239,12 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramClosedOuModeSelectedAndOrgUnitInCaptureScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid("pcxIanBWlSY")
-            .orgUnitUid("uoNW0E3xXUy")
+            .program(UID.of("pcxIanBWlSY"))
+            .orgUnit(UID.of("uoNW0E3xXUy"))
             .orgUnitMode(SELECTED)
             .build();
 
@@ -266,10 +265,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeSelectedAndOrgUnitInSearchScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("nIidJVYpQQK"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnitUid("DiszpKrYNg8").orgUnitMode(SELECTED).build();
+        operationParamsBuilder.orgUnit(UID.of("DiszpKrYNg8")).orgUnitMode(SELECTED).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -284,10 +283,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeSelectedAndOrgUnitInCaptureScope()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnitUid("RojfDTBhoGC").orgUnitMode(SELECTED).build();
+        operationParamsBuilder.orgUnit(UID.of("RojfDTBhoGC")).orgUnitMode(SELECTED).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -302,12 +301,12 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnNoEventsWhenProgramOpenOuModeSelectedAndNoProgramEvents()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .programUid("shPjYNifvMK")
-            .orgUnitUid(orgUnit.getUid())
+            .program(UID.of("shPjYNifvMK"))
+            .orgUnit(UID.of(orgUnit))
             .orgUnitMode(SELECTED)
             .build();
 
@@ -318,10 +317,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramClosedOuModeAccessible()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.programUid("pcxIanBWlSY").orgUnitMode(ACCESSIBLE).build();
+        operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(ACCESSIBLE).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -339,10 +338,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramOpenOuModeAccessible()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.programUid(program.getUid()).orgUnitMode(ACCESSIBLE).build();
+        operationParamsBuilder.program(UID.of(program)).orgUnitMode(ACCESSIBLE).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -360,10 +359,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenProgramClosedOuModeCapture()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.programUid("pcxIanBWlSY").orgUnitMode(CAPTURE).build();
+        operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(CAPTURE).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -381,10 +380,10 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnAccessibleOrgUnitEventsWhenNoOrgUnitSpecified()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.programUid("pcxIanBWlSY").orgUnitMode(ACCESSIBLE).build();
+        operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(ACCESSIBLE).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -403,16 +402,16 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsNonSuperUserIsOwnerOrHasUserAccess()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     // given events have a COC which has a CO which the
     // user owns yMj2MnmNI8L and has user read access to OUUdG3sdOqb
     injectSecurityContextUser(userService.getUser("o1HMTIzBGo7"));
 
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
-            .events(Set.of("lumVtWwwy0O", "cadc5eGj0j7"))
+            .events(UID.of("lumVtWwwy0O", "cadc5eGj0j7"))
             .build();
 
     List<Event> events = eventService.getEvents(params);
@@ -430,24 +429,23 @@ class AclEventExporterTest extends TrackerTest {
                                 String.format(
                                     "got category options %s",
                                     e.getAttributeOptionCombo().getCategoryOptions())))
-            .collect(Collectors.toList());
+            .toList();
     assertAll(
         "all events should have the optionSize set which is the number of COs in the COC",
         executables);
   }
 
   @Test
-  void shouldReturnNoEventsGivenUserHasNoAccess()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnNoEventsGivenUserHasNoAccess() throws ForbiddenException, BadRequestException {
     // given events have a COC which has a CO (OUUdG3sdOqb/yMj2MnmNI8L) which are not publicly
     // readable, user is not the owner and has no user access
     injectSecurityContextUser(userService.getUser("CYVgFNKCaUS"));
 
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
-            .events(Set.of("lumVtWwwy0O", "cadc5eGj0j7"))
+            .events(UID.of("lumVtWwwy0O", "cadc5eGj0j7"))
             .build();
 
     List<String> events = getEvents(params);
@@ -457,7 +455,7 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnAllEventsWhenOrgUnitModeAllAndNoOrgUnitProvided()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("lPaILkLkgOM"));
 
     EventOperationParams params = operationParamsBuilder.orgUnitMode(ALL).build();
@@ -481,11 +479,11 @@ class AclEventExporterTest extends TrackerTest {
 
   @Test
   void shouldIgnoreRequestedOrgUnitAndReturnAllEventsWhenOrgUnitModeAllAndOrgUnitProvided()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("lPaILkLkgOM"));
 
     EventOperationParams params =
-        operationParamsBuilder.orgUnitUid("uoNW0E3xXUy").orgUnitMode(ALL).build();
+        operationParamsBuilder.orgUnit(UID.of("uoNW0E3xXUy")).orgUnitMode(ALL).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -507,7 +505,7 @@ class AclEventExporterTest extends TrackerTest {
   @Test
   void
       shouldReturnOnlyVisibleEventsInSearchAndCaptureScopeWhenNoProgramPresentOrgUnitModeAccessible()
-          throws ForbiddenException, BadRequestException, NotFoundException {
+          throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("nIidJVYpQQK"));
 
     EventOperationParams params = operationParamsBuilder.orgUnitMode(ACCESSIBLE).build();
@@ -537,7 +535,7 @@ class AclEventExporterTest extends TrackerTest {
   }
 
   private List<String> getEvents(EventOperationParams params)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     return uids(eventService.getEvents(params));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -57,11 +57,11 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -136,16 +136,16 @@ class EventExporterTest extends TrackerTest {
     injectSecurityContextUser(importUser);
 
     operationParamsBuilder = EventOperationParams.builder().eventParams(EventParams.FALSE);
-    operationParamsBuilder.orgUnitUid(orgUnit.getUid()).orgUnitMode(SELECTED);
+    operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(SELECTED);
   }
 
   @Test
   void shouldExportEventAndMapAssignedUserWhenAssignedUserIsNotNull()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .trackedEntityUid(trackedEntity.getUid())
-            .enrollments(Set.of("TvctPPhpD8z"))
+            .trackedEntity(UID.of(trackedEntity))
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
             .build();
 
     List<Event> events = eventService.getEvents(params);
@@ -155,10 +155,12 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsWithRelationships()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnEventsWithRelationships() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        operationParamsBuilder.events(Set.of("pTzf9KYMk72")).eventParams(EventParams.TRUE).build();
+        operationParamsBuilder
+            .events(Set.of(UID.of("pTzf9KYMk72")))
+            .eventParams(EventParams.TRUE)
+            .build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -171,9 +173,9 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsWithNotes()
-      throws ForbiddenException, BadRequestException, NotFoundException {
-    EventOperationParams params = operationParamsBuilder.events(Set.of("pTzf9KYMk72")).build();
+  void shouldReturnEventsWithNotes() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder.events(Set.of(UID.of("pTzf9KYMk72"))).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -186,9 +188,8 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testExportEvents() throws ForbiddenException, BadRequestException, NotFoundException {
-    EventOperationParams params =
-        operationParamsBuilder.programStageUid(programStage.getUid()).build();
+  void testExportEvents() throws ForbiddenException, BadRequestException {
+    EventOperationParams params = operationParamsBuilder.programStage(UID.of(programStage)).build();
 
     List<String> events = getEvents(params);
 
@@ -196,12 +197,11 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testExportEventsWhenFilteringByEnrollment()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void testExportEventsWhenFilteringByEnrollment() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .trackedEntityUid(trackedEntity.getUid())
-            .enrollments(Set.of("TvctPPhpD8z"))
+            .trackedEntity(UID.of(trackedEntity))
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
             .build();
 
     List<String> events = getEvents(params);
@@ -211,11 +211,11 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWithExecutionAndUpdateDates()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .occurredAfter(getDate(2018, 1, 1))
             .occurredBefore(getDate(2020, 1, 29))
             .skipChangedBefore(getDate(2018, 1, 1))
@@ -227,12 +227,11 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testExportEventsWithLastUpdateDuration()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void testExportEventsWithLastUpdateDuration() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .updatedWithin("1d")
             .build();
 
@@ -243,11 +242,11 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsIfItOccurredBetweenPassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .occurredBefore(Date.from(getDate(2020, 1, 28).toInstant().plus(1, ChronoUnit.HOURS)))
             .occurredAfter(Date.from(getDate(2020, 1, 28).toInstant().minus(1, ChronoUnit.HOURS)))
             .build();
@@ -259,11 +258,11 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsIfItOccurredAtTheSameDateAndTimeOfOccurredBeforePassed()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .occurredBefore(getDate(2020, 1, 28))
             .build();
 
@@ -274,11 +273,11 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsIfItOccurredAtTheSameDateAndTimeOfOccurredAfterPassed()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .occurredAfter(getDate(2020, 1, 28))
             .build();
 
@@ -288,13 +287,12 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testExportEventsWithLastUpdateDates()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void testExportEventsWithLastUpdateDates() throws ForbiddenException, BadRequestException {
     Date date = new Date();
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
             .updatedAfter(
                 Date.from(
                     date.toInstant()
@@ -316,9 +314,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWithDatesIncludingTimeStamp()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        operationParamsBuilder.orgUnitMode(ACCESSIBLE).events(Set.of("pTzf9KYMk72")).build();
+        operationParamsBuilder
+            .orgUnitMode(ACCESSIBLE)
+            .events(Set.of(UID.of("pTzf9KYMk72")))
+            .build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -347,12 +348,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsLike()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00001");
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of("DATAEL00001", List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
@@ -366,13 +367,13 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithStatusFilter()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00001");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
             .dataElementFilters(
                 Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
@@ -385,13 +386,13 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithProgramTypeFilter()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00001");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .programType(ProgramType.WITH_REGISTRATION)
             .dataElementFilters(
                 Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
@@ -404,13 +405,13 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsEqual()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00001");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(),
@@ -424,13 +425,13 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsIn()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement datael00001 = dataElement("DATAEL00001");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
                     datael00001.getUid(),
@@ -444,16 +445,16 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithCategoryOptionSuperUser()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00001");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
-            .programUid(program.getUid())
-            .attributeCategoryCombo("bjDvmb4bfuf")
-            .attributeCategoryOptions(Set.of("xYerKDKCefk"))
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
+            .program(UID.of(program))
+            .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
+            .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00001"))))
@@ -465,14 +466,13 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsGivenCategoryOptionCombo()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnEventsGivenCategoryOptionCombo() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
-            .attributeCategoryCombo("O4VaNks6tta")
-            .attributeCategoryOptions(Set.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
+            .attributeCategoryCombo(UID.of("O4VaNks6tta"))
+            .attributeCategoryOptions(UID.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
             .build();
 
     List<Event> events = eventService.getEvents(params);
@@ -495,7 +495,7 @@ class EventExporterTest extends TrackerTest {
                                         e.getAttributeOptionCombo().getCategoryOptions().stream()
                                             .map(CategoryOption::getUid)
                                             .collect(Collectors.toSet()))))
-            .collect(Collectors.toList());
+            .toList();
     assertAll("all events should have the same category option combo and options", executables);
   }
 
@@ -505,10 +505,10 @@ class EventExporterTest extends TrackerTest {
     idSchemes.setCategoryOptionComboIdScheme("ATTRIBUTE:GOLswS44mh8");
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
             .idSchemes(idSchemes)
-            .events(Set.of("kWjSezkXHVp"))
+            .events(Set.of(UID.of("kWjSezkXHVp")))
             .build();
 
     IllegalStateException ex =
@@ -518,8 +518,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsGivenIdSchemeCode()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnEventsGivenIdSchemeCode() throws ForbiddenException, BadRequestException {
     IdSchemes idSchemes = new IdSchemes();
     idSchemes.setProgramIdScheme("code");
     idSchemes.setProgramStageIdScheme("code");
@@ -528,11 +527,11 @@ class EventExporterTest extends TrackerTest {
 
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
             .idSchemes(idSchemes)
-            .attributeCategoryCombo("O4VaNks6tta")
-            .attributeCategoryOptions(Set.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
+            .attributeCategoryCombo(UID.of("O4VaNks6tta"))
+            .attributeCategoryOptions(UID.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
             .build();
 
     List<Event> events = eventService.getEvents(params);
@@ -566,13 +565,12 @@ class EventExporterTest extends TrackerTest {
                                         e.getAttributeOptionCombo().getCategoryOptions().stream()
                                             .map(CategoryOption::getUid)
                                             .collect(Collectors.toSet()))))
-            .collect(Collectors.toList());
+            .toList();
     assertAll("all events should have the same category option combo and options", executables);
   }
 
   @Test
-  void shouldReturnEventsGivenIdSchemeAttribute()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnEventsGivenIdSchemeAttribute() throws ForbiddenException, BadRequestException {
     IdSchemes idSchemes = new IdSchemes();
     idSchemes.setProgramIdScheme("ATTRIBUTE:j45AR9cBQKc");
     idSchemes.setProgramStageIdScheme("ATTRIBUTE:j45AR9cBQKc");
@@ -580,11 +578,11 @@ class EventExporterTest extends TrackerTest {
     idSchemes.setCategoryOptionComboIdScheme("ATTRIBUTE:j45AR9cBQKc");
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid("DiszpKrYNg8")
+            .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(SELECTED)
             .idSchemes(idSchemes)
-            .attributeCategoryCombo("O4VaNks6tta")
-            .attributeCategoryOptions(Set.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
+            .attributeCategoryCombo(UID.of("O4VaNks6tta"))
+            .attributeCategoryOptions(UID.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
             .build();
 
     List<Event> events = eventService.getEvents(params);
@@ -623,24 +621,24 @@ class EventExporterTest extends TrackerTest {
                                         e.getAttributeOptionCombo().getCategoryOptions().stream()
                                             .map(CategoryOption::getUid)
                                             .collect(Collectors.toSet()))))
-            .collect(Collectors.toList());
+            .toList();
     assertAll("all events should have the same category option combo and options", executables);
   }
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithCategoryOptionNotSuperUser()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(
         createAndAddUser(false, "user", Set.of(orgUnit), Set.of(orgUnit), "F_EXPORT_DATA"));
     DataElement dataElement = dataElement("DATAEL00002");
 
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
-            .programUid(program.getUid())
-            .attributeCategoryCombo("bjDvmb4bfuf")
-            .attributeCategoryOptions(Set.of("xYerKDKCefk"))
+            .enrollments(Set.of(UID.of("TvctPPhpD8z")))
+            .programStage(UID.of(programStage))
+            .program(UID.of(program))
+            .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
+            .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00002"))))
@@ -653,12 +651,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetEqual()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00005");
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
             .build();
@@ -670,12 +668,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetIn()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00005");
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(),
@@ -689,12 +687,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetLike()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00005");
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ"))
-            .programStageUid(programStage.getUid())
+            .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
             .build();
@@ -706,12 +704,12 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEventsWhenFilteringByNumericDataElements()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00006");
     EventOperationParams params =
         operationParamsBuilder
-            .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStageUid(programStage.getUid())
+            .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
+            .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(),
@@ -727,7 +725,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testEnrollmentEnrolledBeforeSetToBeforeFirstEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledBefore(parseDate("2021-02-27T12:05:00.000"))
@@ -736,14 +734,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertIsEmpty(enrollments);
   }
 
   @Test
   void testEnrollmentEnrolledBeforeEqualToFirstEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledBefore(parseDate("2021-02-28T12:05:00.000"))
@@ -752,14 +750,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("nxP7UnKhomJ"), enrollments);
   }
 
   @Test
   void testEnrollmentEnrolledBeforeSetToAfterFirstEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledBefore(parseDate("2021-02-28T13:05:00.000"))
@@ -768,14 +766,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("nxP7UnKhomJ"), enrollments);
   }
 
   @Test
   void testEnrollmentEnrolledAfterSetToBeforeLastEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledAfter(parseDate("2021-03-27T12:05:00.000"))
@@ -784,14 +782,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("TvctPPhpD8z"), enrollments);
   }
 
   @Test
   void testEnrollmentEnrolledAfterEqualToLastEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledAfter(parseDate("2021-03-28T12:05:00.000"))
@@ -800,14 +798,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("TvctPPhpD8z"), enrollments);
   }
 
   @Test
   void testEnrollmentEnrolledAfterSetToAfterLastEnrolledAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentEnrolledAfter(parseDate("2021-03-28T13:05:00.000"))
@@ -816,14 +814,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertIsEmpty(enrollments);
   }
 
   @Test
   void testEnrollmentOccurredBeforeSetToBeforeFirstOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredBefore(parseDate("2021-02-27T12:05:00.000"))
@@ -832,14 +830,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertIsEmpty(enrollments);
   }
 
   @Test
   void testEnrollmentOccurredBeforeEqualToFirstOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredBefore(parseDate("2021-02-28T12:05:00.000"))
@@ -848,14 +846,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("nxP7UnKhomJ"), enrollments);
   }
 
   @Test
   void testEnrollmentOccurredBeforeSetToAfterFirstOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredBefore(parseDate("2021-02-28T13:05:00.000"))
@@ -864,14 +862,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("nxP7UnKhomJ"), enrollments);
   }
 
   @Test
   void testEnrollmentOccurredAfterSetToBeforeLastOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredAfter(parseDate("2021-03-27T12:05:00.000"))
@@ -880,14 +878,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("TvctPPhpD8z"), enrollments);
   }
 
   @Test
   void testEnrollmentOccurredAfterEqualToLastOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredAfter(parseDate("2021-03-28T12:05:00.000"))
@@ -896,7 +894,7 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("TvctPPhpD8z"), enrollments);
   }
@@ -904,27 +902,26 @@ class EventExporterTest extends TrackerTest {
   @Test
   void
       shouldFilterOutEventsWithATrackedEntityWithoutThatAttributeWhenFilterAttributeHasNoQueryFilter()
-          throws ForbiddenException, BadRequestException, NotFoundException {
+          throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .attributeFilters(Map.of("notUpdated0", List.of()))
             .build();
 
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("dUE514NMOlo"), trackedEntities);
   }
 
   @Test
-  void testEnrollmentFilterNumericAttributes()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void testEnrollmentFilterNumericAttributes() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
                     "numericAttr",
@@ -936,17 +933,16 @@ class EventExporterTest extends TrackerTest {
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("dUE514NMOlo"), trackedEntities);
   }
 
   @Test
-  void testEnrollmentFilterAttributes()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void testEnrollmentFilterAttributes() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of("toUpdate000", List.of(new QueryFilter(QueryOperator.EQ, "summer day"))))
             .build();
@@ -954,17 +950,17 @@ class EventExporterTest extends TrackerTest {
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("QS6w44flWAf"), trackedEntities);
   }
 
   @Test
   void testEnrollmentFilterAttributesWithMultipleFiltersOnDifferentAttributes()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
                     "toUpdate000",
@@ -976,17 +972,17 @@ class EventExporterTest extends TrackerTest {
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("dUE514NMOlo"), trackedEntities);
   }
 
   @Test
   void testEnrollmentFilterAttributesWithMultipleFiltersOnTheSameAttribute()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnitUid(orgUnit.getUid())
+            .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
                     "toUpdate000",
@@ -998,14 +994,14 @@ class EventExporterTest extends TrackerTest {
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertContainsOnly(List.of("dUE514NMOlo"), trackedEntities);
   }
 
   @Test
   void testEnrollmentOccurredAfterSetToAfterLastOccurredAtDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
             .enrollmentOccurredAfter(parseDate("2021-03-28T13:05:00.000"))
@@ -1014,14 +1010,14 @@ class EventExporterTest extends TrackerTest {
     List<String> enrollments =
         eventService.getEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+            .toList();
 
     assertIsEmpty(enrollments);
   }
 
   @Test
   void shouldReturnNoEventsWhenParamStartDueDateLaterThanEventDueDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder.scheduledAfter(parseDate("2021-02-28T13:05:00.000")).build();
 
@@ -1032,7 +1028,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenParamStartDueDateEarlierThanEventsDueDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder.scheduledAfter(parseDate("2018-02-28T13:05:00.000")).build();
 
@@ -1043,7 +1039,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnNoEventsWhenParamEndDueDateEarlierThanEventDueDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder.scheduledBefore(parseDate("2018-02-28T13:05:00.000")).build();
 
@@ -1054,7 +1050,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWhenParamEndDueDateLaterThanEventsDueDate()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder.scheduledBefore(parseDate("2021-02-28T13:05:00.000")).build();
 
@@ -1083,7 +1079,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   private List<String> getEvents(EventOperationParams params)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     return uids(eventService.getEvents(params));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -1091,7 +1092,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
-            .assignedUserQueryParam(new AssignedUserQueryParam(null, null, user.getUid()))
+            .assignedUserQueryParam(new AssignedUserQueryParam(null, null, UID.of(user)))
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .programUid(programA.getUid())
             .eventStartDate(Date.from(Instant.now().minus(10, ChronoUnit.DAYS)))

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -649,7 +649,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .programUid(eventProgram.getUid())
+                .program(UID.of(eventProgram))
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());
@@ -730,8 +730,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .trackedEntityUid(trackedEntity.getUid())
-                .programUid(trackerProgram.getUid())
+                .trackedEntity(UID.of(trackedEntity))
+                .program(UID.of(trackerProgram))
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());
@@ -798,8 +798,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .trackedEntityUid(trackedEntity.getUid())
-                .programUid(trackerProgram.getUid())
+                .trackedEntity(UID.of(trackedEntity))
+                .program(UID.of(trackerProgram))
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -125,15 +125,15 @@ class EventRequestParamsMapper {
 
     EventOperationParamsBuilder builder =
         EventOperationParams.builder()
-            .programUid(applyIfNotNull(eventRequestParams.getProgram(), UID::getValue))
-            .programStageUid(applyIfNotNull(eventRequestParams.getProgramStage(), UID::getValue))
-            .orgUnitUid(applyIfNotNull(eventRequestParams.getOrgUnit(), UID::getValue))
-            .trackedEntityUid(applyIfNotNull(eventRequestParams.getTrackedEntity(), UID::getValue))
+            .program(eventRequestParams.getProgram())
+            .programStage(eventRequestParams.getProgramStage())
+            .orgUnit(eventRequestParams.getOrgUnit())
+            .trackedEntity(eventRequestParams.getTrackedEntity())
             .enrollmentStatus(enrollmentStatus)
             .followUp(eventRequestParams.getFollowUp())
             .orgUnitMode(orgUnitMode)
             .assignedUserMode(eventRequestParams.getAssignedUserMode())
-            .assignedUsers(UID.toValueSet(assignedUsers))
+            .assignedUsers(assignedUsers)
             .occurredAfter(
                 applyIfNotNull(eventRequestParams.getOccurredAfter(), StartDateTime::toDate))
             .occurredBefore(
@@ -160,15 +160,15 @@ class EventRequestParamsMapper {
                 applyIfNotNull(
                     eventRequestParams.getEnrollmentOccurredAfter(), StartDateTime::toDate))
             .eventStatus(eventRequestParams.getStatus())
-            .attributeCategoryCombo(applyIfNotNull(attributeCategoryCombo, UID::getValue))
-            .attributeCategoryOptions(UID.toValueSet(attributeCategoryOptions))
+            .attributeCategoryCombo(attributeCategoryCombo)
+            .attributeCategoryOptions(attributeCategoryOptions)
             .idSchemes(eventRequestParams.getIdSchemes())
             .includeAttributes(false)
             .includeAllDataElements(false)
             .dataElementFilters(dataElementFilters)
             .attributeFilters(attributeFilters)
-            .events(UID.toValueSet(eventUids))
-            .enrollments(UID.toValueSet(eventRequestParams.getEnrollments()))
+            .events(eventUids)
+            .enrollments(eventRequestParams.getEnrollments())
             .includeDeleted(eventRequestParams.isIncludeDeleted())
             .eventParams(eventsMapper.map(eventRequestParams.getFields()));
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -162,9 +162,7 @@ class TrackedEntityRequestParamsMapper {
                     trackedEntityRequestParams.getEventOccurredBefore(), EndDateTime::toDate))
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
-                    trackedEntityRequestParams.getAssignedUserMode(),
-                    UID.toValueSet(assignedUsers),
-                    user.getUid()))
+                    trackedEntityRequestParams.getAssignedUserMode(), assignedUsers, UID.of(user)))
             .trackedEntityUids(UID.toValueSet(trackedEntities))
             .filters(filters)
             .includeDeleted(trackedEntityRequestParams.isIncludeDeleted())

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -186,7 +186,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(program.getUid(), params.getProgramUid());
+    assertEquals(UID.of(program), params.getProgram());
   }
 
   @Test
@@ -232,7 +232,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(orgUnit.getUid(), params.getOrgUnitUid());
+    assertEquals(UID.of(orgUnit), params.getOrgUnit());
   }
 
   @Test
@@ -242,7 +242,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals("qnR1RK4cTIZ", params.getTrackedEntityUid());
+    assertEquals(UID.of("qnR1RK4cTIZ"), params.getTrackedEntity());
   }
 
   @Test
@@ -358,7 +358,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(Set.of("NQnuK2kLm6e"), params.getEnrollments());
+    assertEquals(Set.of(UID.of("NQnuK2kLm6e")), params.getEnrollments());
   }
 
   @Test
@@ -368,17 +368,17 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(Set.of("XKrcfuM4Hcw", "M4pNmLabtXl"), params.getEvents());
+    assertEquals(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"), params.getEvents());
   }
 
   @Test
   void testMappingEvents() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setEvents(Set.of(UID.of("XKrcfuM4Hcw"), UID.of("M4pNmLabtXl")));
+    eventRequestParams.setEvents(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"));
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(Set.of("XKrcfuM4Hcw", "M4pNmLabtXl"), params.getEvents());
+    assertEquals(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"), params.getEvents());
   }
 
   @Test
@@ -398,19 +398,19 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertContainsOnly(Set.of("IsdLBTOBzMi", "l5ab8q5skbB"), params.getAssignedUsers());
+    assertContainsOnly(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"), params.getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserMode());
   }
 
   @Test
   void testMappingAssignedUsers() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setAssignedUsers(Set.of(UID.of("IsdLBTOBzMi"), UID.of("l5ab8q5skbB")));
+    eventRequestParams.setAssignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"));
     eventRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertContainsOnly(Set.of("IsdLBTOBzMi", "l5ab8q5skbB"), params.getAssignedUsers());
+    assertContainsOnly(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"), params.getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserMode());
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -271,22 +271,21 @@ class TrackedEntityRequestParamsMapperTest {
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
     assertContainsOnly(
-        Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+        UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
         params.getAssignedUserQueryParam().getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserQueryParam().getMode());
   }
 
   @Test
   void testMappingAssignedUsers() throws BadRequestException {
-    trackedEntityRequestParams.setAssignedUsers(
-        Set.of(UID.of("IsdLBTOBzMi"), UID.of("l5ab8q5skbB")));
+    trackedEntityRequestParams.setAssignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"));
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
     assertContainsOnly(
-        Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
+        UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
         params.getAssignedUserQueryParam().getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserQueryParam().getMode());
   }


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UID in EventService and propagate the change until the generic stores.
Use UID in EventOperationParams and propagate until the generic stores and until tracker stores when building the queries.
EventRequestParams are already using UIDs.
EventOperationParams are now using UIDs. `dataElementFilters` and `attributeFilters` are going to be changed in next PR.
EventQueryParams is using hibernate object to build the query. A few fields are using UID and they are passed to the store and the value is used to build the query.

There is a quick fix in `UID` object to make tests work with `SystemUser`. It will be fix soon in https://dhis2.atlassian.net/browse/DHIS2-18296

Next steps*

Harmonize UID in Filters
Harmonize UID in TrackedEntity
Harmonize UID in Relationship
Harmonize UID in OperationsParamsValidator
Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages