### PR TITLE
feat: scope based global navigation [DHIS2-18266]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -163,19 +163,6 @@ public @interface OpenApi {
     String value();
   }
 
-  @Inherited
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target(ElementType.TYPE)
-  @interface Team {
-
-    /**
-     * Names are case-insensitive, e.g. "Tracker" is the same as "tracker"
-     *
-     * @return name of the team that supports the annotated element
-     */
-    String value();
-  }
-
   /**
    * Can be used to annotate endpoint methods to constraint which concrete {@link EntityType}s will
    * support the annotated endpoint method.
@@ -198,6 +185,10 @@ public @interface OpenApi {
     Class<?>[] excludes() default {};
   }
 
+  /**
+   * Used to classify the contents of a controller so that the entire API can be split by the
+   * different classifiers.
+   */
   @Target({ElementType.METHOD, ElementType.TYPE})
   @Retention(RetentionPolicy.RUNTIME)
   @interface Document {
@@ -218,9 +209,13 @@ public @interface OpenApi {
      * named of the domain class. That is the {@link Class#getSimpleName()} unless the class is
      * annotated and named via {@link Shared}.
      *
+     * <p>Unless overridden by {@link #classifiers()} this is also the classifier value for {@code
+     * entity}.
+     *
      * @return the class that represents the domain for the annotated controller {@link Class} or
      *     endpoint {@link java.lang.reflect.Method}.
      */
+    // TODO rename to entity() (extra PR)
     Class<?> domain() default EntityType.class;
 
     /**
@@ -230,6 +225,17 @@ public @interface OpenApi {
      * @return type of group used
      */
     String group() default "";
+
+    /**
+     *
+     *
+     * <pre>
+     *   {"team:tracker", "purpose:metadata", "path:/openapi"}
+     * </pre>
+     *
+     * @return the scope classifiers that describe the annotated controller
+     */
+    String[] classifiers() default {};
   }
 
   @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/BadRequestException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/BadRequestException.java
@@ -37,11 +37,11 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
 @Accessors(chain = true)
-@OpenApi.Response(status = BAD_REQUEST, value = BasicWebMessage.class)
+@OpenApi.Response(status = BAD_REQUEST, value = WebResponse.class)
 @SuppressWarnings({"java:S1165", "java:S1948"})
 public final class BadRequestException extends Exception implements Error {
   public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ConflictException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ConflictException.java
@@ -36,11 +36,11 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
 @Accessors(chain = true)
-@OpenApi.Response(status = CONFLICT, value = BasicWebMessage.class)
+@OpenApi.Response(status = CONFLICT, value = WebResponse.class)
 @SuppressWarnings({"java:S1165", "java:S1948"})
 public final class ConflictException extends Exception implements Error {
   public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
@@ -35,11 +35,11 @@ import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
 @Accessors(chain = true)
-@OpenApi.Response(status = FORBIDDEN, value = BasicWebMessage.class)
+@OpenApi.Response(status = FORBIDDEN, value = WebResponse.class)
 public final class ForbiddenException extends Exception implements Error {
   public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)
       throws ForbiddenException {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/HiddenNotFoundException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/HiddenNotFoundException.java
@@ -35,11 +35,11 @@ import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
 @Accessors(chain = true)
-@OpenApi.Response(status = OK, value = BasicWebMessage.class)
+@OpenApi.Response(status = OK, value = WebResponse.class)
 public final class HiddenNotFoundException extends Exception implements Error {
   public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)
       throws HiddenNotFoundException {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/NotFoundException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/NotFoundException.java
@@ -35,11 +35,11 @@ import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
 @Accessors(chain = true)
-@OpenApi.Response(status = NOT_FOUND, value = BasicWebMessage.class)
+@OpenApi.Response(status = NOT_FOUND, value = WebResponse.class)
 public final class NotFoundException extends Exception implements Error {
   public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)
       throws NotFoundException {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webmessage/WebResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webmessage/WebResponse.java
@@ -45,7 +45,7 @@ import org.hisp.dhis.feedback.Status;
  */
 @Getter
 @OpenApi.Kind("WebMessageResponse")
-public class BasicWebMessage {
+public class WebResponse {
 
   /**
    * Message status, currently two statuses are available: OK, ERROR. Default value is OK.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessage.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.predictor.PredictionSummary;
 import org.hisp.dhis.webapi.controller.tracker.imports.TrackerJobWebMessageResponse;
-import org.hisp.dhis.webmessage.BasicWebMessage;
 import org.hisp.dhis.webmessage.WebMessageResponse;
+import org.hisp.dhis.webmessage.WebResponse;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -72,7 +72,7 @@ import org.springframework.http.HttpStatus;
   "devMessage",
   "response"
 })
-public class WebMessage extends BasicWebMessage {
+public class WebMessage extends WebResponse {
 
   /** HTTP status. */
   private HttpStatus httpStatus = HttpStatus.OK;

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/jsonpatch/JsonPatchException.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/jsonpatch/JsonPatchException.java
@@ -30,12 +30,12 @@ package org.hisp.dhis.commons.jackson.jsonpatch;
 import static org.hisp.dhis.common.OpenApi.Response.Status.BAD_REQUEST;
 
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.webmessage.BasicWebMessage;
+import org.hisp.dhis.webmessage.WebResponse;
 
 /**
  * @author Morten Olav Hansen
  */
-@OpenApi.Response(status = BAD_REQUEST, value = BasicWebMessage.class)
+@OpenApi.Response(status = BAD_REQUEST, value = WebResponse.class)
 public class JsonPatchException extends Exception {
   public JsonPatchException(String message) {
     super(message);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -81,7 +81,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testGetOpenApiDocument_PathFilter() {
-    JsonObject doc = GET("/openapi/openapi.json?path=/api/users").content();
+    JsonObject doc = GET("/openapi/openapi.json?scope=path./api/users").content();
     assertTrue(doc.isObject());
     assertTrue(
         doc.getObject("paths")
@@ -96,7 +96,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testGetOpenApiDocument_DomainFilter() {
-    JsonObject doc = GET("/openapi/openapi.json?domain=User").content();
+    JsonObject doc = GET("/openapi/openapi.json?scope=entity.User").content();
     assertTrue(doc.isObject());
     assertTrue(
         doc.getObject("paths")
@@ -112,7 +112,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testGetOpenApiDocumentHtml_DomainFilter() {
     String html =
-        GET("/openapi/openapi.html?domain=DataElement", Accept(TEXT_HTML_VALUE))
+        GET("/openapi/openapi.html?scope=entity.DataElement", Accept(TEXT_HTML_VALUE))
             .content(TEXT_HTML_VALUE);
     assertContains("#DataElement", html);
   }
@@ -120,7 +120,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testGetOpenApiDocument_DefaultValue() {
     // defaults in parameter objects (from Property analysis)
-    JsonObject users = GET("/openapi/openapi.json?path=/api/users").content();
+    JsonObject users = GET("/openapi/openapi.json?scope=path./api/users").content();
     JsonObject sharedParams = users.getObject("components.parameters");
     assertEquals(50, sharedParams.getNumber("{GistParams.pageSize}.schema.default").integer());
     assertEquals(
@@ -128,7 +128,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
     assertTrue(sharedParams.getBoolean("{GistParams.translate}.schema.default").booleanValue());
 
     // defaults in individual parameters (from endpoint method parameter analysis)
-    JsonObject fileResources = GET("/openapi/openapi.json?path=/api/fileResources").content();
+    JsonObject fileResources = GET("/openapi/openapi.json?scope=path./api/fileResources").content();
     JsonObject domain =
         fileResources
             .get("paths./api/fileResources/.post.parameters")
@@ -139,7 +139,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
             .orElse(JsonMixed.of("{}"));
     assertEquals("DATA_VALUE", domain.getString("schema.default").string());
 
-    JsonObject audits = GET("/openapi/openapi.json?path=/api/audits").content();
+    JsonObject audits = GET("/openapi/openapi.json?scope=path./api/audits").content();
     JsonObject pageSize =
         audits
             .getArray("paths./api/audits/trackedEntityAttributeValue.get.parameters")
@@ -153,7 +153,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testGetOpenApiDocument_ReadOnly() {
-    JsonObject doc = GET("/openapi/openapi.json?domain=JobConfiguration").content();
+    JsonObject doc = GET("/openapi/openapi.json?scope=entity.JobConfiguration").content();
     JsonObject jobConfiguration = doc.getObject("components.schemas.JobConfiguration");
     JsonObject jobConfigurationParams = doc.getObject("components.schemas.JobConfigurationParams");
     assertTrue(jobConfiguration.isObject());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -73,6 +73,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/jobConfigurations")
 @RequiredArgsConstructor
+@OpenApi.Document(classifiers = {"team:platform", "purpose:operation"})
 public class JobConfigurationController extends AbstractCrudController<JobConfiguration> {
 
   private final JobConfigurationService jobConfigurationService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
@@ -94,6 +94,8 @@ public class Api {
     Schema generate(Endpoint endpoint, Type source, Class<?>... args);
   }
 
+  Set<Class<?>> context;
+
   /** Can be set to enable debug mode */
   Maybe<Boolean> debug = new Maybe<>(false);
 
@@ -190,7 +192,7 @@ public class Api {
     @ToString.Exclude @EqualsAndHashCode.Include Class<?> entityType;
 
     String name;
-    Class<?> domain;
+    Map<String, String> classifiers = new TreeMap<>();
     List<String> paths = new ArrayList<>();
     List<Endpoint> endpoints = new ArrayList<>();
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiClassification.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiClassification.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.openapi;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Comparator.comparingInt;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * The aggregated classifiers map for a set of given controller {@link Class}es.
+ *
+ * @author Jan Bernitt
+ * @since 2.42
+ */
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public final class ApiClassification {
+
+  /**
+   * All controllers considered in the classification. This is the basis of the analysis and
+   * therefore also the key or identity of a classification.
+   */
+  @EqualsAndHashCode.Include private final Set<Class<?>> controllers;
+
+  @Getter private final Map<String, Set<String>> classifiers;
+
+  private static final Map<Set<Class<?>>, ApiClassification> CACHE = new ConcurrentHashMap<>();
+
+  static ApiClassification of(Set<Class<?>> controllers) {
+    return CACHE.computeIfAbsent(controllers, ApiClassification::create);
+  }
+
+  private static ApiClassification create(Set<Class<?>> controllers) {
+    TreeMap<String, Set<String>> classifiers = new TreeMap<>();
+    controllers.forEach(
+        c ->
+            OpenApiAnnotations.getClassifiers(c)
+                .forEach(
+                    (classifier, value) ->
+                        classifiers.computeIfAbsent(classifier, k -> new TreeSet<>()).add(value)));
+    LinkedHashMap<String, Set<String>> sortedBySize =
+        classifiers.entrySet().stream()
+            .sorted(comparingInt(e -> e.getValue().size()))
+            .collect(
+                toMap(
+                    Map.Entry::getKey,
+                    e -> unmodifiableSet(e.getValue()),
+                    (x, y) -> y,
+                    LinkedHashMap::new));
+    return new ApiClassification(controllers, unmodifiableMap(sortedBySize));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
@@ -67,8 +67,6 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.Maturity;
 import org.hisp.dhis.common.OpenApi;
@@ -108,7 +106,6 @@ import org.springframework.web.servlet.view.RedirectView;
  *
  * @author Jan Bernitt
  */
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 final class ApiExtractor {
   /**
    * The included classes can be filtered based on REST API resource path or {@link
@@ -116,42 +113,26 @@ final class ApiExtractor {
    * will not be considered for this filter.
    *
    * @param controllers controllers all potential controllers
-   * @param paths filter based on resource path (empty includes all)
-   * @param domains filter based on {@link OpenApi.Document#domain()} (empty includes all)
+   * @param filters the scope filter used (empty includes all)
    */
-  record Scope(
-      @Nonnull Set<Class<?>> controllers,
-      @Nonnull Set<String> paths,
-      @Nonnull Set<String> domains) {
+  record Scope(@Nonnull Set<Class<?>> controllers, @Nonnull Map<String, Set<String>> filters) {
 
     boolean includes(Class<?> controller) {
       if (!isControllerType(controller)) return false;
       if (!controllers.contains(controller)) return false;
-      if (paths.isEmpty() && domains.isEmpty()) return true;
-      if (!paths.isEmpty() && paths(controller).noneMatch(paths::contains)) return false;
-      Class<?> domain = OpenApiAnnotations.getDomain(controller);
-      return domains.isEmpty()
-          || domains.contains(domain.getName())
-          || domains.contains(domain.getSimpleName());
+      if (filters.isEmpty()) return true;
+      Map<String, String> present = OpenApiAnnotations.getClassifiers(controller);
+      for (Map.Entry<String, Set<String>> filter : filters.entrySet()) {
+        String value = present.get(filter.getKey());
+        if (value != null && filter.getValue().contains(value)) return true;
+      }
+      return false;
     }
 
     private static boolean isControllerType(Class<?> source) {
       return (source.isAnnotationPresent(RestController.class)
               || source.isAnnotationPresent(Controller.class))
           && !source.isAnnotationPresent(OpenApi.Ignore.class);
-    }
-
-    private static Stream<String> paths(Class<?> controller) {
-      RequestMapping a = controller.getAnnotation(RequestMapping.class);
-      return a == null
-          ? Stream.empty()
-          : stream(firstNonEmpty(a.value(), a.path()))
-              .flatMap(path -> Stream.of(path, normalisePath(path)));
-    }
-
-    @Nonnull
-    private static String normalisePath(@Nonnull String path) {
-      return path.startsWith("/api/") ? path.substring(4) : path;
     }
   }
 
@@ -187,7 +168,12 @@ final class ApiExtractor {
   }
 
   private final Configuration config;
-  private final Api api = new Api();
+  private final Api api;
+
+  private ApiExtractor(Configuration config) {
+    this.config = config;
+    this.api = new Api(config.scope.controllers);
+  }
 
   private void extractApi() {
     config.scope.controllers.stream()
@@ -204,8 +190,10 @@ final class ApiExtractor {
             n -> !n.isEmpty(),
             () -> source.getSimpleName().replace("Controller", ""));
     Class<?> entityClass = OpenApiAnnotations.getEntityType(source);
-    Class<?> domain = OpenApiAnnotations.getDomain(source);
-    Api.Controller controller = new Api.Controller(api, source, entityClass, name, domain);
+    Api.Controller controller = new Api.Controller(api, source, entityClass, name);
+    Map<String, String> classifiers = controller.getClassifiers();
+    classifiers.putAll(OpenApiAnnotations.getClassifiers(source));
+
     whenAnnotated(
         source, RequestMapping.class, a -> controller.getPaths().addAll(List.of(a.value())));
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -190,7 +190,7 @@ public class OpenApiController {
 
     StringWriter json = new StringWriter();
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path./" + path));
+    scope.setScope(Set.of("path./api/" + path));
     writeDocument(
         request, generation, scope, () -> new PrintWriter(json), OpenApiGenerator::generateJson);
 
@@ -213,7 +213,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path./" + path));
+    scope.setScope(Set.of("path./api/" + path));
     writeDocument(
         request, generation, scope, getYamlWriter(response), OpenApiGenerator::generateYaml);
   }
@@ -247,7 +247,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path./" + path));
+    scope.setScope(Set.of("path./api/" + path));
     writeDocument(
         request, generation, scope, getJsonWriter(response), OpenApiGenerator::generateJson);
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -190,7 +190,7 @@ public class OpenApiController {
 
     StringWriter json = new StringWriter();
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path:/" + path));
+    scope.setScope(Set.of("path./" + path));
     writeDocument(
         request, generation, scope, () -> new PrintWriter(json), OpenApiGenerator::generateJson);
 
@@ -213,7 +213,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path:/" + path));
+    scope.setScope(Set.of("path./" + path));
     writeDocument(
         request, generation, scope, getYamlWriter(response), OpenApiGenerator::generateYaml);
   }
@@ -247,7 +247,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setScope(Set.of("path:/" + path));
+    scope.setScope(Set.of("path./" + path));
     writeDocument(
         request, generation, scope, getJsonWriter(response), OpenApiGenerator::generateJson);
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -38,6 +38,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.lang.ref.SoftReference;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -87,15 +90,13 @@ public class OpenApiController {
   @Data
   @OpenApi.Shared
   public static class OpenApiScopeParams {
-    @OpenApi.Description("When specified only operations matching the path are included.")
-    Set<String> path = Set.of();
-
-    @OpenApi.Description("When specified only operations matching the domain are included.")
-    Set<String> domain = Set.of();
+    @OpenApi.Description(
+        "When given only operations in controllers matching the scope are considered")
+    Set<String> scope = Set.of();
 
     @OpenApi.Ignore
     boolean isCachable() {
-      return path.isEmpty() && domain.isEmpty();
+      return scope.isEmpty();
     }
   }
 
@@ -189,7 +190,7 @@ public class OpenApiController {
 
     StringWriter json = new StringWriter();
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setPath(Set.of("/" + path));
+    scope.setScope(Set.of("path:/" + path));
     writeDocument(
         request, generation, scope, () -> new PrintWriter(json), OpenApiGenerator::generateJson);
 
@@ -212,7 +213,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setPath(Set.of("/" + path));
+    scope.setScope(Set.of("path:/" + path));
     writeDocument(
         request, generation, scope, getYamlWriter(response), OpenApiGenerator::generateYaml);
   }
@@ -246,7 +247,7 @@ public class OpenApiController {
     if (notModified(request, response, generation)) return;
 
     OpenApiScopeParams scope = new OpenApiScopeParams();
-    scope.setPath(Set.of("/" + path));
+    scope.setScope(Set.of("path:/" + path));
     writeDocument(
         request, generation, scope, getJsonWriter(response), OpenApiGenerator::generateJson);
   }
@@ -313,10 +314,16 @@ public class OpenApiController {
 
   @Nonnull
   private Api getApiUncached(OpenApiGenerationParams generation, OpenApiScopeParams scope) {
+    Map<String, Set<String>> filters = new HashMap<>();
+    for (String s : scope.scope) {
+      String key = s.substring(0, s.indexOf('.'));
+      String value = s.substring(s.indexOf('.') + 1);
+      filters.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+    }
     Api api =
         ApiExtractor.extractApi(
             new ApiExtractor.Configuration(
-                new ApiExtractor.Scope(getAllControllerClasses(), scope.path, scope.domain),
+                new ApiExtractor.Scope(getAllControllerClasses(), filters),
                 generation.expandedRefs));
     ApiIntegrator.integrateApi(
         api,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -171,6 +171,12 @@ public class OpenApiGenerator extends JsonGenerator {
                       addStringMember("url", info.contactUrl);
                       addStringMember("email", info.contactEmail);
                     });
+                addObjectMember(
+                    "x-navigation",
+                    () ->
+                        ApiClassification.of(api.getContext())
+                            .getClassifiers()
+                            .forEach(this::addArrayMember));
               });
           addArrayMember(
               "tags",
@@ -231,7 +237,9 @@ public class OpenApiGenerator extends JsonGenerator {
           addStringMember("x-since", getSinceVersion(endpoint.getSince()));
           addStringMultilineMember("description", endpoint.getDescription().orElse(NO_DESCRIPTION));
           addStringMember("operationId", getUniqueOperationId(endpoint));
-          addStringMember("x-package", endpoint.getIn().getDomain().getSimpleName());
+          addObjectMember(
+              "x-classifiers",
+              () -> endpoint.getIn().getClassifiers().forEach(this::addStringMember));
           addStringMember("x-group", endpoint.getGroup());
           addInlineArrayMember("x-auth", endpoint.getAuthorities());
           addInlineArrayMember("tags", List.of()); // TODO add tag support again

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
@@ -30,12 +30,14 @@ package org.hisp.dhis.webapi.openapi;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonMultiMap;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.jsontree.JsonValue;
@@ -118,6 +120,23 @@ public interface OpenApiObject extends JsonObject {
     @Required
     default String version() {
       return getString("version").string();
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     *   {
+     *   "path": ["/foo", "/bar", ...],
+     *   "entity": ["DataElement", ...],
+     *   ...
+     *   }
+     * </pre>
+     *
+     * @return all possible values for each classification
+     */
+    default JsonMultiMap<JsonString> x_navigation() {
+      return getMultiMap("x-navigation", JsonString.class);
     }
   }
 
@@ -225,8 +244,12 @@ public interface OpenApiObject extends JsonObject {
           : path.substring(1);
     }
 
-    default String x_package() {
-      return getString("x-package").string();
+    default Map<String, String> x_classifiers() {
+      return getMap("x-classifiers", JsonString.class).toMap(JsonString::string);
+    }
+
+    default String x_entity() {
+      return x_classifiers().get("entity");
     }
 
     default String x_group() {
@@ -472,6 +495,7 @@ public interface OpenApiObject extends JsonObject {
     }
 
     default boolean isShared() {
+      if (!exists()) return false;
       String path = node().getPath().toString();
       return path.substring(0, path.lastIndexOf('.')).equals(".components.schemas");
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
@@ -478,7 +478,6 @@ public class OpenApiRenderer {
     const id = 'hk_'+location.hash.substring(1);
     if (document.getElementById(id) != null) return;
     const a = document.createElement('a');
-    a.appendChild(document.createTextNode(" + "))
     const hotkeys = document.getElementById("hotkeys");
     hotkeys.appendChild(a);
     const fn = document.createElement('kbd');
@@ -487,7 +486,7 @@ public class OpenApiRenderer {
       hotkeys.firstChild.nextSibling.remove();
       n = 1;
     }
-    fn.appendChild(document.createTextNode(""+ n));
+    fn.appendChild(document.createTextNode("Ctrl+"+ n));
     fn.id = 'hk'+n;
     a.appendChild(fn);
     a.appendChild(document.createTextNode(" "+location.hash+" "));
@@ -681,13 +680,7 @@ public class OpenApiRenderer {
   }
 
   private void renderHotkeysMenu() {
-    renderMenuGroup(
-        "hotkeys",
-        () -> {
-          appendTag("kbd", "Ctrl");
-          appendRaw(" Hotkeys");
-        },
-        () -> {});
+    renderMenuGroup("hotkeys", () -> appendRaw(" Hotkeys"), () -> {});
   }
 
   private void renderDisplayMenu() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
@@ -114,7 +114,7 @@ public class OpenApiRenderer {
        --color-tooltiptext: #eee;
        --color-tooltipborder: lightgray;
        --color-target: black;
-       --width-nav: 320px;
+       --width-nav: 360px;
    }
   html {
     background-color: var(--bg-page);
@@ -136,7 +136,7 @@ public class OpenApiRenderer {
   h4 { font-weight: normal; padding: 0 1em; }
   nav > summary { margin: 1em 0 0.5em 0; font-weight: normal; font-size: 85%; }
 
-  h2 a[target="_blank"] { text-decoration: none; margin-left: 0.5em; }
+  h2 a[target="_blank"] { text-decoration: none; margin-right: 2em; float: right; }
   a[href^="#"] { text-decoration: none; }
   a[title="permalink"] { position: absolute;  right: 1em; display: inline-block; width: 24px; height: 24px;
     text-align: center; vertical-align: middle; border-radius: 50%; line-height: 24px; color: dimgray; margin-top: -0.125rem; }
@@ -171,7 +171,6 @@ public class OpenApiRenderer {
       box-sizing: border-box;
       padding: 10px;
       text-align: center;
-      border-bottom: 5px solid #147cd7;
       background-color: snow;
       background-image: url('/../favicon.ico');
       background-repeat: no-repeat;
@@ -186,6 +185,11 @@ public class OpenApiRenderer {
         padding-right: 1rem;
         box-sizing: border-box;
   }
+  #scope div { display: inline-grid; grid-template-columns: 4fr 6fr 1fr 1fr; padding: 0.25em 0.5em; }
+  #scope select { max-width: 140px; }
+  #scope label { text-transform: capitalize; }
+  #scope input { margin-left: 0.5em; }
+
   body > section { margin-left: var(--width-nav); padding-top: 65px; padding-bottom: 1em; position: relative; }
   body > section > details { margin-top: 10px; }
   body > section > details > summary { padding: 0.5em 1em; }
@@ -196,13 +200,14 @@ public class OpenApiRenderer {
     margin-left: 2rem;
   }
   body > nav details {
-    padding: 0.5rem 0 0 1rem;
+    padding: 0.5rem 0 0 0.5rem;
   }
   body > nav > details > summary {
       background-color: #147cd7;
       color: snow;
       margin-left: -1rem;
       padding-left: 1rem;
+      border-radius: 0 4px 4px 0;
   }
   body > section details:not(.button) > summary:before {
       content: '⊕';
@@ -445,8 +450,28 @@ public class OpenApiRenderer {
 
   function addUrlParameter(name, value) {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set(name, value)
+    if (value === '' || value == null) {
+      searchParams.delete(name);
+    } else {
+      searchParams.set(name, value);
+    }
     window.location.search = searchParams.toString()
+  }
+
+  function modifyLocationSearch(button) {
+    const select = button.parentElement.querySelector('select');
+    const value = select.value;
+    if (value === '') return;
+    const key = select.getAttribute("data-key");
+    const params = new URLSearchParams(window.location.search);
+    const scope = key + '.' + value
+    if (button.value === '+') {
+      if (!params.has('scope', scope)) params.append('scope', scope);
+    } else {
+      params.set('scope', scope);
+    }
+    window.location.hash = '';
+    window.location.search = params.toString();
   }
 
   function addHashHotkey() {
@@ -517,51 +542,51 @@ public class OpenApiRenderer {
   /*
   Reorganizing...
    */
-  record PackageItem(String domain, Map<String, GroupItem> groups) {}
+  record OperationsItem(String entity, Map<String, OperationsGroupItem> groups) {}
 
-  record GroupItem(String domain, String group, List<OperationObject> operations) {}
+  record OperationsGroupItem(String entity, String group, List<OperationObject> operations) {}
 
-  record KindItem(String kind, List<SchemaObject> schemas) {}
+  record SchemasItem(String kind, List<SchemaObject> schemas) {}
 
   private static final Comparator<OperationObject> SORT_BY_METHOD =
       comparing(OperationObject::operationMethod)
           .thenComparing(OperationObject::operationPath)
           .thenComparing(OperationObject::operationId);
 
-  private List<PackageItem> groupPackages() {
-    Map<String, PackageItem> packages = new TreeMap<>();
+  private List<OperationsItem> groupedOperations() {
+    Map<String, OperationsItem> byEntity = new TreeMap<>();
     Consumer<OperationObject> add =
         op -> {
-          String domain = op.x_package();
+          String entity = op.x_entity();
           String group = op.x_group();
-          packages
-              .computeIfAbsent(domain, pkg -> new PackageItem(pkg, new TreeMap<>()))
+          byEntity
+              .computeIfAbsent(entity, e -> new OperationsItem(e, new TreeMap<>()))
               .groups()
-              .computeIfAbsent(group, g -> new GroupItem(domain, g, new ArrayList<>()))
+              .computeIfAbsent(group, g -> new OperationsGroupItem(entity, g, new ArrayList<>()))
               .operations()
               .add(op);
         };
     api.operations().forEach(add);
     if (params.sortEndpointsByMethod)
-      packages
+      byEntity
           .values()
           .forEach(p -> p.groups().values().forEach(g -> g.operations().sort(SORT_BY_METHOD)));
-    return List.copyOf(packages.values());
+    return List.copyOf(byEntity.values());
   }
 
-  private List<KindItem> groupKinds() {
-    Map<String, KindItem> kinds = new TreeMap<>();
+  private List<SchemasItem> groupedSchemas() {
+    Map<String, SchemasItem> byKind = new TreeMap<>();
     api.components()
         .schemas()
         .forEach(
             (name, schema) -> {
               String kind = schema.x_kind();
-              kinds
-                  .computeIfAbsent(kind, key -> new KindItem(key, new ArrayList<>()))
+              byKind
+                  .computeIfAbsent(kind, k -> new SchemasItem(k, new ArrayList<>()))
                   .schemas()
                   .add(schema);
             });
-    return List.copyOf(kinds.values());
+    return List.copyOf(byKind.values());
   }
 
   /*
@@ -621,74 +646,103 @@ public class OpenApiRenderer {
         "nav",
         () -> {
           renderPageHeader();
-          renderMenuGroup(
-              "hotkeys",
-              () -> {
-                appendTag("kbd", "Ctrl");
-                appendRaw(" Hotkeys");
-              },
-              () -> {});
-          renderMenuGroup(
-              null,
-              () -> appendRaw("Filters"),
-              () -> {
-                renderMenuItem(
-                    "HTTP Methods",
-                    () -> {
-                      renderToggleButton("GET", "GET", "get-", false);
-                      renderToggleButton("POST", "POST", "post-", false);
-                      renderToggleButton("PUT", "PUT", "put-", false);
-                      renderToggleButton("PATCH", "PATCH", "patch-", false);
-                      renderToggleButton("DELETE", "DELETE", "delete-", false);
-                    });
-
-                renderMenuItem(
-                    "HTTP Status",
-                    () -> {
-                      for (int statusCode : new int[] {200, 201, 202, 204}) {
-                        renderToggleButton(
-                            statusCode + " " + statusCodeName(statusCode),
-                            "status status2xx status" + statusCode,
-                            "status" + statusCode + "-",
-                            true);
-                      }
-                    });
-
-                renderMenuItem(
-                    "HTTP Content-Type",
-                    () -> {
-                      for (String mime : new String[] {"json", "xml", "csv"})
-                        renderToggleButton(mime.toUpperCase(), mime, mime + "-", true);
-                    });
-
-                renderMenuItem(
-                    "Maturity",
-                    () -> {
-                      renderToggleButton("&#129514; Alpha", "alpha", "alpha-", false);
-                      renderToggleButton("&#128295; Beta", "beta", "beta-", false);
-                      renderToggleButton("&#128737;&#65039; Stable", "stable", "stable-", false);
-                      renderToggleButton("Unspecified", "open", "open-", false);
-                      renderToggleButton("@Deprecated", "deprecated", "deprecated-", true);
-                    });
-              });
-
-          renderMenuGroup(
-              null,
-              () -> appendRaw("View"),
-              () -> {
-                renderMenuItem(
-                    "Summaries",
-                    () -> {
-                      renderToggleButton("Show request info", "request", "request-", false);
-                      renderToggleButton("Show response info", "response", "response-", false);
-                      renderToggleButton("Show content info", "content", "content-", false);
-                    });
-                renderMenuItem(
-                    "Details",
-                    () -> renderToggleButton("Abbr. Descriptions", "desc", "desc-", false));
-              });
+          renderScopeMenu();
+          renderDisplayMenu();
+          renderHotkeysMenu();
         });
-    // TODO bring back tags as actual tags usable as filters
+  }
+
+  private void renderScopeMenu() {
+    renderMenuGroup(
+        "scope",
+        () -> appendRaw("Scope"),
+        () -> {
+          api.info().x_navigation().forEach(this::renderScopeMenuItem);
+          appendInputButton("Full API (single page)", "addUrlParameter('scope', '')");
+          appendInputButton("+ &#128435;", "addUrlParameter('source', 'true')");
+        });
+  }
+
+  private void renderScopeMenuItem(String classifier, JsonList<JsonString> values) {
+    appendTag(
+        "div",
+        () -> {
+          appendTag("label", classifier);
+          appendTag(
+              "select",
+              Map.of("data-key", classifier),
+              () -> {
+                appendTag("option", Map.of("value", ""), "(select and click go or +)");
+                values.forEach(v -> appendTag("option", Map.of("value", v.string()), v.string()));
+              });
+          appendInputButton("go", "modifyLocationSearch(this)");
+          appendInputButton("+", "modifyLocationSearch(this)");
+        });
+  }
+
+  private void renderHotkeysMenu() {
+    renderMenuGroup(
+        "hotkeys",
+        () -> {
+          appendTag("kbd", "Ctrl");
+          appendRaw(" Hotkeys");
+        },
+        () -> {});
+  }
+
+  private void renderDisplayMenu() {
+    renderMenuGroup(
+        null,
+        () -> appendRaw("Display"),
+        () -> {
+          renderMenuItem(
+              "HTTP Methods",
+              () -> {
+                renderToggleButton("GET", "GET", "get-", false);
+                renderToggleButton("POST", "POST", "post-", false);
+                renderToggleButton("PUT", "PUT", "put-", false);
+                renderToggleButton("PATCH", "PATCH", "patch-", false);
+                renderToggleButton("DELETE", "DELETE", "delete-", false);
+              });
+
+          renderMenuItem(
+              "HTTP Status",
+              () -> {
+                for (int statusCode : new int[] {200, 201, 202, 204}) {
+                  renderToggleButton(
+                      statusCode + " " + statusCodeName(statusCode),
+                      "status status2xx status" + statusCode,
+                      "status" + statusCode + "-",
+                      true);
+                }
+              });
+
+          renderMenuItem(
+              "HTTP Content-Type",
+              () -> {
+                for (String mime : new String[] {"json", "xml", "csv"})
+                  renderToggleButton(mime.toUpperCase(), mime, mime + "-", true);
+              });
+
+          renderMenuItem(
+              "Maturity",
+              () -> {
+                renderToggleButton("&#129514; Alpha", "alpha", "alpha-", false);
+                renderToggleButton("&#128295; Beta", "beta", "beta-", false);
+                renderToggleButton("&#128737;&#65039; Stable", "stable", "stable-", false);
+                renderToggleButton("Unspecified", "open", "open-", false);
+                renderToggleButton("@Deprecated", "deprecated", "deprecated-", true);
+              });
+          renderMenuItem(
+              "Summaries",
+              () -> {
+                renderToggleButton("Show request info", "request", "request-", false);
+                renderToggleButton("Show response info", "response", "response-", false);
+                renderToggleButton("Show content info", "content", "content-", false);
+              });
+          renderMenuItem(
+              "Details", () -> renderToggleButton("Abbr. Descriptions", "desc", "desc-", false));
+        });
   }
 
   private void renderMenuGroup(String id, Runnable renderSummary, Runnable renderBody) {
@@ -720,12 +774,12 @@ public class OpenApiRenderer {
   }
 
   private void renderPaths() {
-    List<PackageItem> packages = groupPackages();
+    List<OperationsItem> packages = groupedOperations();
     appendTag("section", () -> packages.forEach(this::renderPathPackage));
   }
 
-  private void renderPathPackage(PackageItem pkg) {
-    String id = "-" + pkg.domain();
+  private void renderPathPackage(OperationsItem pkg) {
+    String id = "-" + pkg.entity();
     appendDetails(
         id,
         false,
@@ -736,22 +790,17 @@ public class OpenApiRenderer {
         });
   }
 
-  private void renderPathPackageSummary(PackageItem pkg) {
+  private void renderPathPackageSummary(OperationsItem pkg) {
     appendTag(
         "h2",
         () -> {
-          appendRaw(toWords(pkg.domain()));
-          appendA("/api/openapi/openapi.html?domain=" + pkg.domain, true, "&#x1F5D7;");
-          appendRaw(" | ");
-          appendA(
-              "/api/openapi/openapi.html?source=true&domain=" + pkg.domain,
-              true,
-              "&#x1F5D7; + &#128435;");
+          appendRaw(toWords(pkg.entity()));
+          appendA("/api/openapi/openapi.html?scope=entity." + pkg.entity, true, "&#x1F5D7;");
         });
   }
 
-  private void renderPathGroup(GroupItem group) {
-    String id = "-" + group.domain() + "-" + group.group();
+  private void renderPathGroup(OperationsGroupItem group) {
+    String id = "-" + group.entity() + "-" + group.group();
     appendDetails(
         id,
         true,
@@ -762,7 +811,7 @@ public class OpenApiRenderer {
         });
   }
 
-  private void renderPathGroupSummary(GroupItem group) {
+  private void renderPathGroupSummary(OperationsGroupItem group) {
     appendTag("h3", Map.of("class", group.group()), group.group());
 
     group.operations().stream()
@@ -1198,7 +1247,7 @@ public class OpenApiRenderer {
     appendTag(
         "section",
         () -> {
-          for (KindItem kind : groupKinds()) {
+          for (SchemasItem kind : groupedSchemas()) {
             String id = "--" + kind.kind;
             appendDetails(
                 id,
@@ -1355,6 +1404,10 @@ public class OpenApiRenderer {
         });
   }
 
+  private void appendInputButton(String text, String onclick) {
+    appendTag("input", Map.of("type", "button", "value", text, "onclick", onclick));
+  }
+
   private void appendA(String href, boolean blank, String text) {
     String target = blank ? "_blank" : "";
     String title = "#".equals(text) ? "permalink" : "";
@@ -1387,6 +1440,10 @@ public class OpenApiRenderer {
 
   private void appendTag(String name, Runnable body) {
     appendTag(name, Map.of(), body);
+  }
+
+  private void appendTag(String name, Map<String, String> attributes) {
+    appendTag(name, attributes, () -> {});
   }
 
   private void appendTag(String name, Map<String, String> attributes, Runnable body) {


### PR DESCRIPTION
### Summary
Provides scopes as a universal concept for global navigation.

The PR mainly provides the machinery behind the menu shown below

![DHIS2-API-2-42-10-23-2024_07_27_PM](https://github.com/user-attachments/assets/c938d338-6055-47d8-8177-80b67d3e8bf4)


### Scopes + Classifiers
The main new concept are scopes. Each controller class is associated with a key-value set of classifiers. 
The `@OpenAPI.Document.classifiers()` annotation is used to add more classifiers to a controller class.
Based on these users can then compose a scope by specifying the classifiers to include. 

In the URL this is now given as a single parameter `scope`. A scope value has a classifier name and value; for example, `scope=entity.DataElement`. The `.` is used as separator as most other symbols are URL escaped making it hard to read if added to the parameters using JS.

While the scope entirely depends on the classifiers some classifiers are pre-filled from other properties for convenience but they can be overridden by specifying them explicitly.  

### Usage (Developers)
To classify a controller it is annotated like this
```java
@OpenApi.Document(classifiers = {"team:platform", "purpose:operation"})
```
To add a new way of classifying controller the only work is to add a classifier value. For example, when adding `"utilization:frequent"` a new row would appear in the _Scope_ menu shown above that has this option and when selected the annotated controller would be included in the scope.

### Next
I left a **TODO** on purpose to rename a property as that will affect many controllers. That PR can also be used to add more `classifiers` values to most controller. In this PR I only used it on one to verify that it works. 

### Automatic Testing
Existing tests were adjusted to use the new `scope` URL parameter instead of the now obsolete `domain` and `path`.
