### PR TITLE
chore: Use UID in event filters [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -129,10 +129,10 @@ public class EventOperationParams {
   @Builder.Default private Set<UID> events = new HashSet<>();
 
   /** Data element filters per data element UID. */
-  @Builder.Default private Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
+  @Builder.Default private Map<UID, List<QueryFilter>> dataElementFilters = new HashMap<>();
 
   /** Tracked entity attribute filters per attribute UID. */
-  @Builder.Default private Map<String, List<QueryFilter>> attributeFilters = new HashMap<>();
+  @Builder.Default private Map<UID, List<QueryFilter>> attributeFilters = new HashMap<>();
 
   private boolean includeDeleted;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -197,10 +197,10 @@ class EventOperationParamsMapper {
   }
 
   private void mapDataElementFilters(
-      EventQueryParams params, Map<String, List<QueryFilter>> dataElementFilters)
+      EventQueryParams params, Map<UID, List<QueryFilter>> dataElementFilters)
       throws BadRequestException {
-    for (Entry<String, List<QueryFilter>> dataElementFilter : dataElementFilters.entrySet()) {
-      DataElement de = dataElementService.getDataElement(dataElementFilter.getKey());
+    for (Entry<UID, List<QueryFilter>> dataElementFilter : dataElementFilters.entrySet()) {
+      DataElement de = dataElementService.getDataElement(dataElementFilter.getKey().getValue());
       if (de == null) {
         throw new BadRequestException(
             String.format(
@@ -215,11 +215,12 @@ class EventOperationParamsMapper {
   }
 
   private void mapAttributeFilters(
-      EventQueryParams params, Map<String, List<QueryFilter>> attributeFilters)
+      EventQueryParams params, Map<UID, List<QueryFilter>> attributeFilters)
       throws BadRequestException {
-    for (Map.Entry<String, List<QueryFilter>> attributeFilter : attributeFilters.entrySet()) {
+    for (Map.Entry<UID, List<QueryFilter>> attributeFilter : attributeFilters.entrySet()) {
       TrackedEntityAttribute tea =
-          trackedEntityAttributeService.getTrackedEntityAttribute(attributeFilter.getKey());
+          trackedEntityAttributeService.getTrackedEntityAttribute(
+              attributeFilter.getKey().getValue());
       if (tea == null) {
         throw new BadRequestException(
             String.format(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -252,9 +252,9 @@ class EventOperationParamsMapperTest {
         eventBuilder
             .attributeFilters(
                 Map.of(
-                    TEA_1_UID,
+                    UID.of(TEA_1_UID),
                     List.of(new QueryFilter(QueryOperator.EQ, "2")),
-                    TEA_2_UID,
+                    UID.of(TEA_2_UID),
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
@@ -273,11 +273,12 @@ class EventOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenAttributeInGivenAttributeFilterDoesNotExist() {
-    String filterName = "filter";
+    UID filterName = UID.of(CodeGenerator.generateUid());
     EventOperationParams operationParams =
         eventBuilder.attributeFilters(Map.of(filterName, List.of())).build();
 
-    when(trackedEntityAttributeService.getTrackedEntityAttribute(filterName)).thenReturn(null);
+    when(trackedEntityAttributeService.getTrackedEntityAttribute(filterName.getValue()))
+        .thenReturn(null);
 
     Exception exception =
         assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
@@ -364,9 +365,9 @@ class EventOperationParamsMapperTest {
         eventBuilder
             .dataElementFilters(
                 Map.of(
-                    DE_1_UID,
+                    UID.of(DE_1_UID),
                     List.of(new QueryFilter(QueryOperator.EQ, "2")),
-                    DE_2_UID,
+                    UID.of(DE_2_UID),
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
@@ -385,11 +386,11 @@ class EventOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenDataElementInGivenDataElementFilterDoesNotExist() {
-    String filterName = "filter";
+    UID filterName = UID.of(CodeGenerator.generateUid());
     EventOperationParams operationParams =
         eventBuilder.dataElementFilters(Map.of(filterName, List.of())).build();
 
-    when(dataElementService.getDataElement(filterName)).thenReturn(null);
+    when(dataElementService.getDataElement(filterName.getValue())).thenReturn(null);
 
     Exception exception =
         assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -349,13 +349,13 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsLike()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(UID.of(programStage))
             .dataElementFilters(
-                Map.of("DATAEL00001", List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -368,7 +368,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithStatusFilter()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -376,7 +376,7 @@ class EventExporterTest extends TrackerTest {
             .programStage(UID.of(programStage))
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -387,7 +387,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithProgramTypeFilter()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -395,7 +395,7 @@ class EventExporterTest extends TrackerTest {
             .programStage(UID.of(programStage))
             .programType(ProgramType.WITH_REGISTRATION)
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -406,7 +406,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsEqual()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -414,7 +414,7 @@ class EventExporterTest extends TrackerTest {
             .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
-                    dataElement.getUid(),
+                    UID.of(dataElement),
                     List.of(new QueryFilter(QueryOperator.LIKE, "%value00001%"))))
             .build();
 
@@ -426,7 +426,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsIn()
       throws ForbiddenException, BadRequestException {
-    DataElement datael00001 = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -434,7 +434,7 @@ class EventExporterTest extends TrackerTest {
             .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
-                    datael00001.getUid(),
+                    UID.of(dataElement),
                     List.of(new QueryFilter(QueryOperator.IN, "value00001;value00002"))))
             .build();
 
@@ -446,7 +446,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithCategoryOptionSuperUser()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00001");
+    DataElement dataElement = dataElement(UID.of("DATAEL00001"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -457,7 +457,7 @@ class EventExporterTest extends TrackerTest {
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
                 Map.of(
-                    dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00001"))))
+                    UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00001"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -630,7 +630,7 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(
         createAndAddUser(false, "user", Set.of(orgUnit), Set.of(orgUnit), "F_EXPORT_DATA"));
-    DataElement dataElement = dataElement("DATAEL00002");
+    DataElement dataElement = dataElement(UID.of("DATAEL00002"));
 
     EventOperationParams params =
         operationParamsBuilder
@@ -641,7 +641,7 @@ class EventExporterTest extends TrackerTest {
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
                 Map.of(
-                    dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00002"))))
+                    UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00002"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -652,13 +652,13 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetEqual()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00005");
+    DataElement dataElement = dataElement(UID.of("DATAEL00005"));
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(UID.of(programStage))
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
+                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -669,14 +669,14 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetIn()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00005");
+    DataElement dataElement = dataElement(UID.of("DATAEL00005"));
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
-                    dataElement.getUid(),
+                    UID.of(dataElement),
                     List.of(new QueryFilter(QueryOperator.IN, "option1;option2"))))
             .build();
 
@@ -688,13 +688,13 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByDataElementsWithOptionSetLike()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00005");
+    DataElement dataElement = dataElement(UID.of("DATAEL00005"));
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(UID.of(programStage))
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
+                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -705,14 +705,14 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testExportEventsWhenFilteringByNumericDataElements()
       throws ForbiddenException, BadRequestException {
-    DataElement dataElement = dataElement("DATAEL00006");
+    DataElement dataElement = dataElement(UID.of("DATAEL00006"));
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(UID.of(programStage))
             .dataElementFilters(
                 Map.of(
-                    dataElement.getUid(),
+                    UID.of(dataElement),
                     List.of(
                         new QueryFilter(QueryOperator.LT, "77"),
                         new QueryFilter(QueryOperator.GT, "8"))))
@@ -906,7 +906,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .orgUnit(UID.of(orgUnit))
-            .attributeFilters(Map.of("notUpdated0", List.of()))
+            .attributeFilters(Map.of(UID.of("notUpdated0"), List.of()))
             .build();
 
     List<String> trackedEntities =
@@ -924,7 +924,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
-                    "numericAttr",
+                    UID.of("numericAttr"),
                     List.of(
                         new QueryFilter(QueryOperator.LT, "77"),
                         new QueryFilter(QueryOperator.GT, "8"))))
@@ -944,7 +944,9 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .orgUnit(UID.of(orgUnit))
             .attributeFilters(
-                Map.of("toUpdate000", List.of(new QueryFilter(QueryOperator.EQ, "summer day"))))
+                Map.of(
+                    UID.of("toUpdate000"),
+                    List.of(new QueryFilter(QueryOperator.EQ, "summer day"))))
             .build();
 
     List<String> trackedEntities =
@@ -963,9 +965,9 @@ class EventExporterTest extends TrackerTest {
             .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
-                    "toUpdate000",
+                    UID.of("toUpdate000"),
                     List.of(new QueryFilter(QueryOperator.EQ, "rainy day")),
-                    "notUpdated0",
+                    UID.of("notUpdated0"),
                     List.of(new QueryFilter(QueryOperator.EQ, "winter day"))))
             .build();
 
@@ -985,7 +987,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnit(UID.of(orgUnit))
             .attributeFilters(
                 Map.of(
-                    "toUpdate000",
+                    UID.of("toUpdate000"),
                     List.of(
                         new QueryFilter(QueryOperator.LIKE, "day"),
                         new QueryFilter(QueryOperator.LIKE, "in"))))
@@ -1064,8 +1066,8 @@ class EventExporterTest extends TrackerTest {
     assertEquals(expectedLastUpdatedBy, actual.getLastUpdatedBy());
   }
 
-  private DataElement dataElement(String uid) {
-    return dataElementService.getDataElement(uid);
+  private DataElement dataElement(UID uid) {
+    return dataElementService.getDataElement(uid.getValue());
   }
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -278,9 +278,8 @@ public class RequestParamsValidator {
    *
    * @return filters by UIDs
    */
-  public static Map<String, List<QueryFilter>> parseFilters(String input)
-      throws BadRequestException {
-    Map<String, List<QueryFilter>> result = new HashMap<>();
+  public static Map<UID, List<QueryFilter>> parseFilters(String input) throws BadRequestException {
+    Map<UID, List<QueryFilter>> result = new HashMap<>();
     if (StringUtils.isBlank(input)) {
       return result;
     }
@@ -298,17 +297,17 @@ public class RequestParamsValidator {
    *
    * @throws BadRequestException filter is neither multiple nor single operator:value format
    */
-  private static void parseSanitizedFilters(Map<String, List<QueryFilter>> result, String input)
+  private static void parseSanitizedFilters(Map<UID, List<QueryFilter>> result, String input)
       throws BadRequestException {
     int uidIndex = input.indexOf(DIMENSION_NAME_SEP) + 1;
 
     if (uidIndex == 0 || input.length() == uidIndex) {
-      String uid = input.replace(DIMENSION_NAME_SEP, "");
+      UID uid = UID.of(input.replace(DIMENSION_NAME_SEP, ""));
       result.putIfAbsent(uid, new ArrayList<>());
       return;
     }
 
-    String uid = input.substring(0, uidIndex - 1);
+    UID uid = UID.of(input.substring(0, uidIndex - 1));
     result.putIfAbsent(uid, new ArrayList<>());
 
     String[] filters = FILTER_ITEM_SPLIT.split(input.substring(uidIndex));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -107,9 +107,8 @@ class EventRequestParamsMapper {
             "event", eventRequestParams.getEvent(), "events", eventRequestParams.getEvents());
 
     validateFilter(eventRequestParams.getFilter(), eventUids);
-    Map<String, List<QueryFilter>> dataElementFilters =
-        parseFilters(eventRequestParams.getFilter());
-    Map<String, List<QueryFilter>> attributeFilters =
+    Map<UID, List<QueryFilter>> dataElementFilters = parseFilters(eventRequestParams.getFilter());
+    Map<UID, List<QueryFilter>> attributeFilters =
         parseFilters(eventRequestParams.getFilterAttributes());
 
     Set<UID> assignedUsers =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValida
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserQueryParam;
@@ -123,7 +124,7 @@ class TrackedEntityRequestParamsMapper {
     validateOrderParams(trackedEntityRequestParams.getOrder(), ORDERABLE_FIELD_NAMES, "attribute");
     validateRequestParams(trackedEntityRequestParams, trackedEntities);
 
-    Map<String, List<QueryFilter>> filters = parseFilters(trackedEntityRequestParams.getFilter());
+    Map<UID, List<QueryFilter>> filters = parseFilters(trackedEntityRequestParams.getFilter());
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
@@ -164,7 +165,8 @@ class TrackedEntityRequestParamsMapper {
                 new AssignedUserQueryParam(
                     trackedEntityRequestParams.getAssignedUserMode(), assignedUsers, UID.of(user)))
             .trackedEntityUids(UID.toValueSet(trackedEntities))
-            .filters(filters)
+            .filters(
+                filters.keySet().stream().collect(Collectors.toMap(UID::getValue, filters::get)))
             .includeDeleted(trackedEntityRequestParams.isIncludeDeleted())
             .potentialDuplicate(trackedEntityRequestParams.getPotentialDuplicate())
             .trackedEntityParams(fieldsParamMapper.map(fields));

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
@@ -66,11 +66,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 /** Tests {@link RequestParamsValidator}. */
 class RequestParamsValidatorTest {
 
-  private static final String TEA_1_UID = "TvjwTPToKHO";
+  private static final UID TEA_1_UID = UID.of("TvjwTPToKHO");
 
-  private static final String TEA_2_UID = "cy2oRh2sNr6";
+  private static final UID TEA_2_UID = UID.of("cy2oRh2sNr6");
 
-  public static final String TEA_3_UID = "cy2oRh2sNr7";
+  public static final UID TEA_3_UID = UID.of("cy2oRh2sNr7");
 
   private static final OrganisationUnit orgUnit = new OrganisationUnit();
 
@@ -145,7 +145,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFilters() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters =
+    Map<UID, List<QueryFilter>> filters =
         parseFilters(TEA_1_UID + ":lt:20:gt:10," + TEA_2_UID + ":like:foo");
 
     assertEquals(
@@ -160,7 +160,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFiltersGivenRepeatedUID() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters =
+    Map<UID, List<QueryFilter>> filters =
         parseFilters(TEA_1_UID + ":lt:20," + TEA_2_UID + ":like:foo," + TEA_1_UID + ":gt:10");
 
     assertEquals(
@@ -175,21 +175,21 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFiltersOnlyContainingAnIdentifier() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = parseFilters(TEA_1_UID);
+    Map<UID, List<QueryFilter>> filters = parseFilters(TEA_1_UID.getValue());
 
     assertEquals(Map.of(TEA_1_UID, List.of()), filters);
   }
 
   @Test
   void shouldParseFiltersWithIdentifierAndTrailingColon() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = parseFilters(TEA_1_UID + ":");
+    Map<UID, List<QueryFilter>> filters = parseFilters(TEA_1_UID.getValue() + ":");
 
     assertEquals(Map.of(TEA_1_UID, List.of()), filters);
   }
 
   @Test
   void shouldParseFiltersGivenBlankInput() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = parseFilters(" ");
+    Map<UID, List<QueryFilter>> filters = parseFilters(" ");
 
     assertTrue(filters.isEmpty());
   }
@@ -210,7 +210,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFiltersWithFilterNameHasSeparationCharInIt() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = parseFilters(TEA_2_UID + ":like:project/:x/:eq/:2");
+    Map<UID, List<QueryFilter>> filters = parseFilters(TEA_2_UID + ":like:project/:x/:eq/:2");
 
     assertEquals(
         Map.of(TEA_2_UID, List.of(new QueryFilter(QueryOperator.LIKE, "project:x:eq:2"))), filters);
@@ -227,7 +227,7 @@ class RequestParamsValidatorTest {
   @Test
   void shouldParseFilterWhenFilterHasDatesFormatDateWithMilliSecondsAndTimeZone()
       throws BadRequestException {
-    Map<String, List<QueryFilter>> filters =
+    Map<UID, List<QueryFilter>> filters =
         parseFilters(
             TEA_1_UID
                 + ":ge:2020-01-01T00/:00/:00.001 +05/:30:le:2021-01-01T00/:00/:00.001 +05/:30");
@@ -243,7 +243,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFilterWhenFilterHasMultipleOperatorAndTextRange() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters =
+    Map<UID, List<QueryFilter>> filters =
         parseFilters(TEA_1_UID + ":sw:project/:x:ew:project/:le/:");
 
     assertEquals(
@@ -257,7 +257,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFilterWhenMultipleFiltersAreMixedCommaAndSlash() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters =
+    Map<UID, List<QueryFilter>> filters =
         parseFilters(
             TEA_1_UID
                 + ":eq:project///,/,//"
@@ -278,7 +278,7 @@ class RequestParamsValidatorTest {
 
   @Test
   void shouldParseFilterWhenFilterHasMultipleOperatorWithFinalColon() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = parseFilters(TEA_1_UID + ":like:value1/::like:value2");
+    Map<UID, List<QueryFilter>> filters = parseFilters(TEA_1_UID + ":like:value1/::like:value2");
 
     assertEquals(
         Map.of(
@@ -331,9 +331,7 @@ class RequestParamsValidatorTest {
   void shouldPassWhenTrackedEntitySuppliedAndOrgUnitModeRequiresOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
     assertDoesNotThrow(
-        () ->
-            validateOrgUnitModeForTrackedEntities(
-                emptySet(), orgUnitMode, Set.of(UID.of(TEA_1_UID))));
+        () -> validateOrgUnitModeForTrackedEntities(emptySet(), orgUnitMode, Set.of(TEA_1_UID)));
   }
 
   @ParameterizedTest

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -95,15 +95,15 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 class EventRequestParamsMapperTest {
 
-  private static final String DE_1_UID = "OBzmpRP6YUh";
+  private static final UID DE_1_UID = UID.of("OBzmpRP6YUh");
 
-  private static final String DE_2_UID = "KSd4PejqBf9";
+  private static final UID DE_2_UID = UID.of("KSd4PejqBf9");
 
-  private static final String TEA_1_UID = "TvjwTPToKHO";
+  private static final UID TEA_1_UID = UID.of("TvjwTPToKHO");
 
-  private static final String TEA_2_UID = "cy2oRh2sNr6";
+  private static final UID TEA_2_UID = UID.of("cy2oRh2sNr6");
 
-  private static final String PROGRAM_UID = "PlZSBEN7iZd";
+  private static final UID PROGRAM_UID = UID.of("PlZSBEN7iZd");
 
   @Mock private UserService userService;
 
@@ -136,8 +136,8 @@ class EventRequestParamsMapperTest {
     when(userService.getUserByUsername(null)).thenReturn(user);
 
     program = new Program();
-    program.setUid(PROGRAM_UID);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    program.setUid(PROGRAM_UID.getValue());
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
 
     ProgramStage programStage = new ProgramStage();
@@ -153,18 +153,18 @@ class EventRequestParamsMapperTest {
     when(trackedEntityService.getTrackedEntity("qnR1RK4cTIZ", null, FALSE))
         .thenReturn(trackedEntity);
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
-    tea1.setUid(TEA_1_UID);
+    tea1.setUid(TEA_1_UID.getValue());
     TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
-    tea2.setUid(TEA_2_UID);
+    tea2.setUid(TEA_2_UID.getValue());
     when(attributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1, tea2));
-    when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
+    when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(tea1);
 
     DataElement de1 = new DataElement();
-    de1.setUid(DE_1_UID);
-    when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
+    de1.setUid(DE_1_UID.getValue());
+    when(dataElementService.getDataElement(DE_1_UID.getValue())).thenReturn(de1);
     DataElement de2 = new DataElement();
-    de2.setUid(DE_2_UID);
-    when(dataElementService.getDataElement(DE_2_UID)).thenReturn(de2);
+    de2.setUid(DE_2_UID.getValue());
+    when(dataElementService.getDataElement(DE_2_UID.getValue())).thenReturn(de2);
   }
 
   @Test
@@ -182,7 +182,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingProgram() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setProgram(UID.of(PROGRAM_UID));
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
@@ -433,9 +433,9 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
+    Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
-    Map<String, List<QueryFilter>> expected =
+    Map<UID, List<QueryFilter>> expected =
         Map.of(
             DE_1_UID,
             List.of(new QueryFilter(QueryOperator.EQ, "2")),
@@ -451,9 +451,9 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
+    Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
-    Map<String, List<QueryFilter>> expected =
+    Map<UID, List<QueryFilter>> expected =
         Map.of(
             DE_1_UID,
             List.of(
@@ -467,7 +467,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
+    Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
 
     assertNotNull(dataElementFilters);
     assertTrue(dataElementFilters.isEmpty());
@@ -480,9 +480,9 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
+    Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
-    Map<String, List<QueryFilter>> expected =
+    Map<UID, List<QueryFilter>> expected =
         Map.of(
             TEA_1_UID,
             List.of(new QueryFilter(QueryOperator.EQ, "2")),
@@ -498,9 +498,9 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
+    Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
-    Map<String, List<QueryFilter>> expected =
+    Map<UID, List<QueryFilter>> expected =
         Map.of(
             TEA_1_UID,
             List.of(
@@ -511,13 +511,13 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAttributeFiltersWhenOnlyGivenUID() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setFilterAttributes(TEA_1_UID);
+    eventRequestParams.setFilterAttributes(TEA_1_UID.getValue());
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
+    Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
-    Map<String, List<QueryFilter>> expected = Map.of(TEA_1_UID, List.of());
+    Map<UID, List<QueryFilter>> expected = Map.of(TEA_1_UID, List.of());
     assertEquals(expected, attributeFilters);
   }
 
@@ -527,7 +527,7 @@ class EventRequestParamsMapperTest {
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    Map<String, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
+    Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
 
     assertNotNull(attributeFilters);
     assertTrue(attributeFilters.isEmpty());


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UIDs in EventOperationParams for  `dataElementFilters` and `attributeFilters` fields.

Next steps*
 
Harmonize UID in Relationship
Harmonize UID in TrackedEntity
Harmonize UID in OperationsParamsValidator
Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages