### PR TITLE
chore: Make SystemUser return valid uid [DHIS2-18296]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -39,8 +39,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.hisp.dhis.user.SystemUser;
-import org.hisp.dhis.user.UserDetails;
 
 /**
  * UID represents an alphanumeric string of 11 characters starting with a letter.
@@ -80,14 +78,6 @@ public final class UID implements Serializable {
   @JsonCreator
   public static UID of(@Nonnull String value) {
     return new UID(value);
-  }
-
-  public static UID of(@Nonnull UserDetails currentUser) {
-    // TODO:(DHIS2-18296) Refactor SystemUser to use a valid uid
-    if (currentUser instanceof SystemUser) {
-      return new UID("systemUser1");
-    }
-    return new UID(currentUser.getUid());
   }
 
   public static UID of(@CheckForNull UidObject object) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -90,7 +90,7 @@ public class SystemUser implements UserDetails {
 
   @Override
   public String getUid() {
-    return "system-process";
+    return "XXXXXSystem";
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -35,11 +35,13 @@ import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UidObject;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.user.UserDetailsImpl.UserDetailsImplBuilder;
 import org.springframework.security.core.GrantedAuthority;
 
-public interface UserDetails extends org.springframework.security.core.userdetails.UserDetails {
+public interface UserDetails
+    extends org.springframework.security.core.userdetails.UserDetails, UidObject {
 
   // TODO MAS: This is a workaround and usually indicated a design flaw, and that we should refactor
   // to use UserDetails higher up in the layers.
@@ -195,6 +197,7 @@ public interface UserDetails extends org.springframework.security.core.userdetai
 
   boolean isSuper();
 
+  @Override
   String getUid();
 
   Long getId();


### PR DESCRIPTION
This PR is making interface `UserDetails` extending the `UidObject` interface and making `SystemUser` return a valid uid string for method `getUid`.
I choose the string `XXXXXSystem` as uid for `SystemUser` but I am open to suggestions.
I just remove from `UID` object the quick fix I introduced in a previous [PR](https://github.com/dhis2/dhis2-core/pull/18902) to make tests pass.
