### PR TITLE
fix: system setting check for email configured

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -727,7 +727,7 @@ public non-sealed interface SystemSettings extends Settings {
   */
 
   default boolean isEmailConfigured() {
-    return !getEmailHostName().isBlank() && getEmailUsername().isBlank();
+    return !getEmailHostName().isBlank() && !getEmailUsername().isBlank();
   }
 
   default boolean isHideUnapprovedDataInAnalytics() {

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -222,4 +222,13 @@ class SystemSettingsTest {
     assertFalse(settings.isValid("keyLastMonitoringRun", "hello"));
     assertFalse(settings.isValid("keyLastMonitoringRun", "true"));
   }
+
+  @Test
+  void testEmailIsConfigured() {
+    SystemSettings settings = SystemSettings.of(Map.of());
+    assertFalse(settings.isEmailConfigured());
+    settings =
+        SystemSettings.of(Map.of("keyEmailHostName", "localhost", "keyEmailUsername", "user"));
+    assertTrue(settings.isEmailConfigured());
+  }
 }


### PR DESCRIPTION
## Summary
Small fix for a check that checks if an email server is properly configured. Recent changes to the SystemSettings inverted one part of the if condition.

### Automatic test
SystemSettingTest#testEmailIsConfigured()

### Manual test
1. Go to the "System Settings" app
2. Go to "Email" settings in the left pane meny
3. Enter any valid hostname (we don't need an actual one, just need to have valid syntax) and same with the username.
4. Press "Send me a test email"
5. This should result in an error saying: "Could not send test email, no email configured for current user" if you are using the default admin user which do not have an email configured. The error should NOT say: "SMTP server not configured", as described in the Jira. If you configure a real SMTP server and add a real email to the user you are testing with, it should work without an error.

### Jira
[DHIS2-18244](https://dhis2.atlassian.net/browse/DHIS2-18244)




[DHIS2-18244]: https://dhis2.atlassian.net/browse/DHIS2-18244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ