### PR TITLE
fix: (2.40) Incorrect follow-up value while saving program working list[DHIS2-18279]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
@@ -100,5 +100,5 @@ public class ProgramStageQueryCriteria implements Serializable {
   @JsonProperty private List<AttributeValueFilter> attributeValueFilters = Collections.emptyList();
 
   /** Property to filter events based on {@link org.hisp.dhis.program.ProgramInstance#followup property */
-  @JsonProperty private boolean followUp;
+  @JsonProperty private Boolean followUp;
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
@@ -49,7 +49,7 @@ public interface JsonProgramStageQueryCriteria extends JsonObject {
     return get("eventOccurredAt").as(JsonDatePeriod.class);
   }
 
-  default boolean getFollowUp() {
+  default Boolean getFollowUp() {
     return getBoolean("followUp").booleanValue();
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -29,9 +29,9 @@ package org.hisp.dhis.webapi.controller.programstageworkinglist;
 
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
@@ -349,7 +349,7 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
     // Assert that the followUp is null (not saved as false)
     JsonProgramStageQueryCriteria criteria = workingList.getProgramStageQueryCriteria();
     assertFalse(criteria.isEmpty());
-    assertNull(criteria.getFollowUp(), "FollowUp should be null when not configured");
+    assertHasMember(criteria, "followUp");
   }
 
   private String createWorkingList(String workingListName) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.webapi.controller.programstageworkinglist;
 
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -349,7 +349,7 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
     // Assert that the followUp is null (not saved as false)
     JsonProgramStageQueryCriteria criteria = workingList.getProgramStageQueryCriteria();
     assertFalse(criteria.isEmpty());
-    assertHasMember(criteria, "followUp");
+    assertHasNoMember(criteria, "followUp");
   }
 
   private String createWorkingList(String workingListName) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -321,6 +321,36 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
     assertTrue(programStageQueryCriteria.getFollowUp());
   }
 
+  @Test
+  void shouldNotSaveFollowUpAsFalseWhenNotConfigured() {
+    String workingListId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programStageWorkingLists",
+                String.format(
+                    "{"
+                        + "'program': {'id': '%s'},"
+                        + "'programStage': {'id': '%s'},"
+                        + "'name':'workingListWithoutFollowUp',"
+                        + "'programStageQueryCriteria': {"
+                        + "'displayColumnOrder': ['w75KJ2mc4zz'],"
+                        + "'order': 'createdAt:desc'"
+                        + "}"
+                        + "}",
+                    programId, programStageId)));
+
+    JsonWorkingList workingList =
+        GET("/programStageWorkingLists/{id}", workingListId).content().as(JsonWorkingList.class);
+
+    assertFalse(workingList.isEmpty());
+
+    // Assert that the followUp is null (not saved as false)
+    JsonProgramStageQueryCriteria criteria = workingList.getProgramStageQueryCriteria();
+    assertFalse(criteria.isEmpty());
+    assertEquals(null, criteria.getFollowUp(), "FollowUp should be null when not configured");
+  }
+
   private String createWorkingList(String workingListName) {
     return assertStatus(
         HttpStatus.CREATED,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
@@ -348,7 +349,7 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
     // Assert that the followUp is null (not saved as false)
     JsonProgramStageQueryCriteria criteria = workingList.getProgramStageQueryCriteria();
     assertFalse(criteria.isEmpty());
-    assertEquals(null, criteria.getFollowUp(), "FollowUp should be null when not configured");
+    assertNull(criteria.getFollowUp(), "FollowUp should be null when not configured");
   }
 
   private String createWorkingList(String workingListName) {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-18279

This PR refactors the `ProgramStageQueryCriteria` class to change the `followUp` field from a `boolean` primitive to the `Boolean` wrapper type. This update allows `followUp` to hold three possible states: true, false, and null.
