### PR TITLE
chore: Use UID in relationship exporter [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
@@ -272,7 +272,7 @@ public class DeduplicationHelper {
     }
 
     List<RelationshipType> relationshipTypes =
-        relationshipService.getRelationships(mergeObject.getRelationships()).stream()
+        relationshipService.getRelationships(UID.of(mergeObject.getRelationships())).stream()
             .map(Relationship::getRelationshipType)
             .distinct()
             .toList();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -76,12 +77,12 @@ public class DefaultRelationshipService implements RelationshipService {
   }
 
   @Override
-  public Relationship getRelationship(@Nonnull String uid)
+  public Relationship getRelationship(@Nonnull UID relationshipUid)
       throws ForbiddenException, NotFoundException {
-    Relationship relationship = relationshipStore.getByUid(uid);
+    Relationship relationship = relationshipStore.getByUid(relationshipUid.getValue());
 
     if (relationship == null) {
-      throw new NotFoundException(Relationship.class, uid);
+      throw new NotFoundException(Relationship.class, relationshipUid);
     }
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
@@ -94,10 +95,10 @@ public class DefaultRelationshipService implements RelationshipService {
   }
 
   @Override
-  public List<Relationship> getRelationships(@Nonnull List<String> uids)
+  public List<Relationship> getRelationships(@Nonnull Set<UID> uids)
       throws ForbiddenException, NotFoundException {
     List<Relationship> relationships = new ArrayList<>();
-    for (String uid : uids) {
+    for (UID uid : uids) {
       relationships.add(getRelationship(uid));
     }
     return relationships;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -77,12 +77,12 @@ public class DefaultRelationshipService implements RelationshipService {
   }
 
   @Override
-  public Relationship getRelationship(@Nonnull UID relationshipUid)
+  public Relationship getRelationship(@Nonnull UID uid)
       throws ForbiddenException, NotFoundException {
-    Relationship relationship = relationshipStore.getByUid(relationshipUid.getValue());
+    Relationship relationship = relationshipStore.getByUid(uid.getValue());
 
     if (relationship == null) {
-      throw new NotFoundException(Relationship.class, relationshipUid);
+      throw new NotFoundException(Relationship.class, uid);
     }
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export.relationship;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -47,13 +48,13 @@ public interface RelationshipService {
   Page<Relationship> getRelationships(RelationshipOperationParams params, PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException;
 
-  Relationship getRelationship(String uid) throws ForbiddenException, NotFoundException;
+  Relationship getRelationship(UID uid) throws ForbiddenException, NotFoundException;
 
   /**
    * Get relationships matching given {@code UID}s under the privileges of the currently
    * authenticated user.
    */
-  List<Relationship> getRelationships(@Nonnull List<String> uids)
+  List<Relationship> getRelationships(@Nonnull Set<UID> uids)
       throws ForbiddenException, NotFoundException;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -109,8 +109,7 @@ class DeduplicationHelperTest extends TestBase {
 
   @BeforeEach
   public void setUp() throws ForbiddenException, NotFoundException {
-    List<String> relationshipUids =
-        List.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
+    Set<UID> relationshipUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
     List<String> attributeUids = List.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
     Set<UID> enrollmentUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
 
@@ -124,7 +123,7 @@ class DeduplicationHelperTest extends TestBase {
     enrollment = createEnrollment(createProgram('A'), getTrackedEntityA(), organisationUnitA);
     mergeObject =
         MergeObject.builder()
-            .relationships(relationshipUids)
+            .relationships(UID.toValueList(relationshipUids))
             .trackedEntityAttributes(attributeUids)
             .enrollments(UID.toValueList(enrollmentUids))
             .build();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerCreateRelationshipSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerCreateRelationshipSMSTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.http.HttpStatus;
@@ -197,7 +198,7 @@ class TrackerCreateRelationshipSMSTest extends PostgresControllerIntegrationTest
         () -> assertEquals(originator, sms.getOriginator()),
         () -> assertEquals(user, sms.getCreatedBy()),
         () -> {
-          Relationship relationship = relationshipService.getRelationship(relationshipUid);
+          Relationship relationship = relationshipService.getRelationship(UID.of(relationshipUid));
           assertAll(
               () -> assertEquals(relationshipUid, relationship.getUid()),
               () -> assertEquals(event1, relationship.getFrom().getEvent()),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -138,8 +138,7 @@ class RelationshipsExportController {
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
           List<FieldPath> fields)
       throws NotFoundException, ForbiddenException {
-    Relationship relationship =
-        RELATIONSHIP_MAPPER.from(relationshipService.getRelationship(uid.getValue()));
+    Relationship relationship = RELATIONSHIP_MAPPER.from(relationshipService.getRelationship(uid));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(relationship, fields));
   }


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UID in RelationshipService and propagate the change until the generic stores.

Next steps*

Harmonize UID in TrackedEntity
Harmonize UID in OperationsParamsValidator
Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages