### PR TITLE
chore: Use UID in trackedEntity exporter [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.webmessage.WebResponse;
 
 @Getter
@@ -61,6 +62,10 @@ public final class ForbiddenException extends Exception implements Error {
 
   public ForbiddenException(Class<?> type, String uid) {
     this("User has no access to " + type.getSimpleName() + ":" + uid);
+  }
+
+  public ForbiddenException(Class<?> type, UID uid) {
+    this(type, uid.getValue());
   }
 
   public ForbiddenException(ErrorCode code, Object... args) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -230,7 +230,7 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   public List<Enrollment> getEnrollments(@Nonnull EnrollmentOperationParams params)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 
     return getEnrollments(
@@ -243,7 +243,7 @@ class DefaultEnrollmentService implements EnrollmentService {
   @Override
   public Page<Enrollment> getEnrollments(
       @Nonnull EnrollmentOperationParams params, PageParams pageParams)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 
     Page<Enrollment> enrollmentsPage = enrollmentStore.getEnrollments(queryParams, pageParams);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -50,11 +50,11 @@ public interface EnrollmentService {
 
   /** Get all enrollments matching given params. */
   List<Enrollment> getEnrollments(EnrollmentOperationParams params)
-      throws BadRequestException, ForbiddenException, NotFoundException;
+      throws BadRequestException, ForbiddenException;
 
   /** Get a page of enrollments matching given params. */
   Page<Enrollment> getEnrollments(EnrollmentOperationParams params, PageParams pageParams)
-      throws BadRequestException, ForbiddenException, NotFoundException;
+      throws BadRequestException, ForbiddenException;
 
   /**
    * Get event matching given {@code UID} under the privileges the user in the context. This method

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -59,8 +59,7 @@ class RelationshipOperationParamsMapper {
 
     IdentifiableObject entity =
         switch (params.getType()) {
-          case TRACKED_ENTITY ->
-              trackedEntityService.getTrackedEntity(params.getIdentifier().getValue());
+          case TRACKED_ENTITY -> trackedEntityService.getTrackedEntity(params.getIdentifier());
           case ENROLLMENT -> enrollmentService.getEnrollment(params.getIdentifier());
           case EVENT -> eventService.getEvent(params.getIdentifier());
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -122,8 +122,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
       TrackedEntityChangeLogOperationParams operationParams,
       PageParams pageParams)
       throws NotFoundException, ForbiddenException, BadRequestException {
-    TrackedEntity trackedEntity =
-        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue());
+    TrackedEntity trackedEntity = trackedEntityService.getTrackedEntity(trackedEntityUid);
     if (trackedEntity == null) {
       throw new NotFoundException(TrackedEntity.class, trackedEntityUid.getValue());
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -213,7 +212,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  public TrackedEntity getTrackedEntity(@Nonnull String uid)
+  public TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException {
     UserDetails currentUser = getCurrentUserDetails();
     TrackedEntity trackedEntity =
@@ -229,14 +228,14 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public TrackedEntity getTrackedEntity(
-      @Nonnull String uid,
-      @CheckForNull String programIdentifier,
+      @Nonnull UID trackedEntityUid,
+      @CheckForNull UID programIdentifier,
       @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException {
     Program program = null;
 
-    if (StringUtils.isNotEmpty(programIdentifier)) {
-      program = programService.getProgram(programIdentifier);
+    if (programIdentifier != null) {
+      program = programService.getProgram(programIdentifier.getValue());
       if (program == null) {
         throw new NotFoundException(Program.class, programIdentifier);
       }
@@ -244,12 +243,12 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     TrackedEntity trackedEntity;
     if (program != null) {
-      trackedEntity = getTrackedEntity(uid, program, params);
+      trackedEntity = getTrackedEntity(trackedEntityUid.getValue(), program, params);
 
       if (params.isIncludeProgramOwners()) {
         Set<TrackedEntityProgramOwner> filteredProgramOwners =
             trackedEntity.getProgramOwners().stream()
-                .filter(te -> te.getProgram().getUid().equals(programIdentifier))
+                .filter(te -> te.getProgram().getUid().equals(programIdentifier.getValue()))
                 .collect(Collectors.toSet());
         trackedEntity.setProgramOwners(filteredProgramOwners);
       }
@@ -257,7 +256,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UserDetails userDetails = getCurrentUserDetails();
 
       trackedEntity =
-          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, null, false);
+          mapTrackedEntity(
+              getTrackedEntity(trackedEntityUid, userDetails), params, userDetails, null, false);
 
       mapTrackedEntityTypeAttributes(trackedEntity);
     }
@@ -304,9 +304,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
    * @throws NotFoundException if TE does not exist
    * @throws ForbiddenException if TE is not accessible
    */
-  private TrackedEntity getTrackedEntity(String uid, UserDetails userDetails)
+  private TrackedEntity getTrackedEntity(UID uid, UserDetails userDetails)
       throws NotFoundException, ForbiddenException {
-    TrackedEntity trackedEntity = trackedEntityStore.getByUid(uid);
+    TrackedEntity trackedEntity = trackedEntityStore.getByUid(uid.getValue());
     trackedEntityAuditService.addTrackedEntityAudit(trackedEntity, getCurrentUsername(), READ);
     if (trackedEntity == null) {
       throw new NotFoundException(TrackedEntity.class, uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -469,7 +469,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       trackedEntity
           .append(whereAnd.whereAnd())
           .append("TE.uid IN (")
-          .append(encodeAndQuote(params.getTrackedEntityUids()))
+          .append(encodeAndQuote(UID.toValueSet(params.getTrackedEntities())))
           .append(") ");
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -44,7 +44,13 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.export.Order;
 
 @Getter
@@ -58,16 +64,16 @@ public class TrackedEntityOperationParams {
   @Builder.Default private TrackedEntityParams trackedEntityParams = TrackedEntityParams.FALSE;
 
   /** Tracked entity attribute filters per attribute UID. */
-  @Builder.Default private Map<String, List<QueryFilter>> filters = new HashMap<>();
+  @Builder.Default private Map<UID, List<QueryFilter>> filters = new HashMap<>();
 
   /**
    * Organisation units for which instances in the response were registered at. Is related to the
    * specified OrganisationUnitMode.
    */
-  @Builder.Default private Set<String> organisationUnits = new HashSet<>();
+  @Builder.Default private Set<UID> organisationUnits = new HashSet<>();
 
   /** Program for which instances in the response must be enrolled in. */
-  private String programUid;
+  private UID program;
 
   /** Status of a tracked entities enrollment into a given program. */
   private EnrollmentStatus enrollmentStatus;
@@ -97,7 +103,7 @@ public class TrackedEntityOperationParams {
   private Date programIncidentEndDate;
 
   /** Tracked entity type to fetch. */
-  private String trackedEntityTypeUid;
+  private UID trackedEntityType;
 
   private OrganisationUnitSelectionMode orgUnitMode;
 
@@ -105,10 +111,10 @@ public class TrackedEntityOperationParams {
   private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
   /** Set of te uids to explicitly select. */
-  @Builder.Default private Set<String> trackedEntityUids = new HashSet<>();
+  @Builder.Default private Set<UID> trackedEntities = new HashSet<>();
 
   /** ProgramStage to be used in conjunction with eventstatus. */
-  private String programStageUid;
+  private UID programStage;
 
   /** Status of any events in the specified program. */
   private EventStatus eventStatus;
@@ -183,6 +189,69 @@ public class TrackedEntityOperationParams {
 
     public TrackedEntityOperationParamsBuilder orderBy(UID uid, SortDirection direction) {
       this.order.add(new Order(uid, direction));
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder program(UID uid) {
+      this.program = uid;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder program(Program program) {
+      this.program = UID.of(program);
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder programStage(UID uid) {
+      this.programStage = uid;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder programStage(ProgramStage programStage) {
+      this.programStage = UID.of(programStage);
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder trackedEntityType(UID uid) {
+      this.trackedEntityType = uid;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder trackedEntityType(
+        TrackedEntityType trackedEntityType) {
+      this.trackedEntityType = UID.of(trackedEntityType);
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder trackedEntities(Set<UID> uids) {
+      this.trackedEntities$value = uids;
+      this.trackedEntities$set = true;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder trackedEntities(TrackedEntity... trackedEntities) {
+      this.trackedEntities$value = UID.of(trackedEntities);
+      this.trackedEntities$set = true;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder organisationUnits(Set<UID> uids) {
+      this.organisationUnits$value = uids;
+      this.organisationUnits$set = true;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder organisationUnits(
+        OrganisationUnit... organisationUnits) {
+      this.organisationUnits$value = UID.of(organisationUnits);
+      this.organisationUnits$set = true;
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder filter(
+        TrackedEntityAttribute attribute, List<QueryFilter> queryFilters) {
+      this.filters$value = Map.of(UID.of(attribute), queryFilters);
+      this.filters$set = true;
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.export.OperationsParamsValidator;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,18 +92,23 @@ class TrackedEntityOperationParamsMapper {
   public TrackedEntityQueryParams map(
       TrackedEntityOperationParams operationParams, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program = paramsValidator.validateTrackerProgram(operationParams.getProgramUid(), user);
+    Program program =
+        paramsValidator.validateTrackerProgram(
+            ObjectUtils.applyIfNotNull(operationParams.getProgram(), UID::getValue), user);
     ProgramStage programStage = validateProgramStage(operationParams, program);
 
     TrackedEntityType requestedTrackedEntityType =
-        paramsValidator.validateTrackedEntityType(operationParams.getTrackedEntityTypeUid(), user);
+        paramsValidator.validateTrackedEntityType(
+            ObjectUtils.applyIfNotNull(operationParams.getTrackedEntityType(), UID::getValue),
+            user);
 
     List<TrackedEntityType> trackedEntityTypes = getTrackedEntityTypes(program, user);
 
     List<Program> programs = getTrackerPrograms(program, user);
 
     Set<OrganisationUnit> orgUnits =
-        paramsValidator.validateOrgUnits(operationParams.getOrganisationUnits(), user);
+        paramsValidator.validateOrgUnits(
+            UID.toValueSet(operationParams.getOrganisationUnits()), user);
     validateOrgUnitMode(operationParams.getOrgUnitMode(), program, user);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
@@ -134,7 +140,7 @@ class TrackedEntityOperationParamsMapper {
         .setEventStartDate(operationParams.getEventStartDate())
         .setEventEndDate(operationParams.getEventEndDate())
         .setAssignedUserQueryParam(operationParams.getAssignedUserQueryParam())
-        .setTrackedEntityUids(operationParams.getTrackedEntityUids())
+        .setTrackedEntities(operationParams.getTrackedEntities())
         .setIncludeDeleted(operationParams.isIncludeDeleted())
         .setPotentialDuplicate(operationParams.getPotentialDuplicate());
 
@@ -179,11 +185,11 @@ class TrackedEntityOperationParamsMapper {
   }
 
   private void mapAttributeFilters(
-      TrackedEntityQueryParams params, Map<String, List<QueryFilter>> attributeFilters)
+      TrackedEntityQueryParams params, Map<UID, List<QueryFilter>> attributeFilters)
       throws BadRequestException {
-    for (Map.Entry<String, List<QueryFilter>> attributeFilter : attributeFilters.entrySet()) {
+    for (Map.Entry<UID, List<QueryFilter>> attributeFilter : attributeFilters.entrySet()) {
       TrackedEntityAttribute tea =
-          attributeService.getTrackedEntityAttribute(attributeFilter.getKey());
+          attributeService.getTrackedEntityAttribute(attributeFilter.getKey().getValue());
       if (tea == null) {
         throw new BadRequestException(
             String.format(
@@ -205,24 +211,24 @@ class TrackedEntityOperationParamsMapper {
       TrackedEntityOperationParams requestParams, Program program) throws BadRequestException {
 
     ProgramStage ps =
-        requestParams.getProgramStageUid() != null
-            ? getProgramStageFromProgram(program, requestParams.getProgramStageUid())
+        requestParams.getProgramStage() != null
+            ? getProgramStageFromProgram(program, requestParams.getProgramStage())
             : null;
-    if (requestParams.getProgramStageUid() != null && ps == null) {
+    if (requestParams.getProgramStage() != null && ps == null) {
       throw new BadRequestException(
           "Program does not contain the specified programStage: "
-              + requestParams.getProgramStageUid());
+              + requestParams.getProgramStage());
     }
     return ps;
   }
 
-  private ProgramStage getProgramStageFromProgram(Program program, String programStage) {
+  private ProgramStage getProgramStageFromProgram(Program program, UID programStage) {
     if (program == null) {
       return null;
     }
 
     return program.getProgramStages().stream()
-        .filter(ps -> ps.getUid().equals(programStage))
+        .filter(ps -> ps.getUid().equals(programStage.getValue()))
         .findFirst()
         .orElse(null);
   }
@@ -265,12 +271,13 @@ class TrackedEntityOperationParamsMapper {
         && trackedEntityType == null
         && operationParams.getFilters() != null
         && orgUnits.isEmpty()) {
-      List<String> uniqueAttributeIds =
+      List<UID> uniqueAttributeIds =
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
+              .map(UID::of)
               .toList();
 
-      for (String att : params.getFilterIds()) {
+      for (UID att : params.getFilterIds()) {
         if (!uniqueAttributeIds.contains(att)) {
           throw new IllegalQueryException(
               "Either a program or tracked entity type must be specified");
@@ -284,7 +291,7 @@ class TrackedEntityOperationParamsMapper {
     if (!isLocalSearch(params, user)) {
 
       if (params.hasFilters()) {
-        List<String> searchableAttributeIds = getSearchableAttributeIds(params);
+        List<UID> searchableAttributeIds = getSearchableAttributeIds(params);
         validateSearchableAttributes(params, searchableAttributeIds);
       }
 
@@ -294,21 +301,23 @@ class TrackedEntityOperationParamsMapper {
     }
   }
 
-  private List<String> getSearchableAttributeIds(TrackedEntityQueryParams params) {
-    List<String> searchableAttributeIds = new ArrayList<>();
+  private List<UID> getSearchableAttributeIds(TrackedEntityQueryParams params) {
+    List<UID> searchableAttributeIds = new ArrayList<>();
 
     if (params.hasProgram()) {
-      searchableAttributeIds.addAll(params.getProgram().getSearchableAttributeIds());
+      searchableAttributeIds.addAll(UID.of(params.getProgram().getSearchableAttributeIds()));
     }
 
     if (params.hasTrackedEntityType()) {
-      searchableAttributeIds.addAll(params.getTrackedEntityType().getSearchableAttributeIds());
+      searchableAttributeIds.addAll(
+          UID.of(params.getTrackedEntityType().getSearchableAttributeIds()));
     }
 
     if (!params.hasProgram() && !params.hasTrackedEntityType()) {
       searchableAttributeIds.addAll(
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
+              .map(UID::of)
               .toList());
     }
 
@@ -316,10 +325,10 @@ class TrackedEntityOperationParamsMapper {
   }
 
   private void validateSearchableAttributes(
-      TrackedEntityQueryParams params, List<String> searchableAttributeIds) {
-    List<String> violatingAttributes = new ArrayList<>();
+      TrackedEntityQueryParams params, List<UID> searchableAttributeIds) {
+    List<UID> violatingAttributes = new ArrayList<>();
 
-    for (String attributeId : params.getFilterIds()) {
+    for (UID attributeId : params.getFilterIds()) {
       if (!searchableAttributeIds.contains(attributeId)) {
         violatingAttributes.add(attributeId);
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -113,7 +114,7 @@ public class TrackedEntityQueryParams {
   private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
   /** Set of te uids to explicitly select. */
-  private Set<String> trackedEntityUids = new HashSet<>();
+  private Set<UID> trackedEntities = new HashSet<>();
 
   /** ProgramStage to be used in conjunction with eventstatus. */
   private ProgramStage programStage;
@@ -148,7 +149,7 @@ public class TrackedEntityQueryParams {
   public TrackedEntityQueryParams() {}
 
   public boolean hasTrackedEntities() {
-    return CollectionUtils.isNotEmpty(this.trackedEntityUids);
+    return CollectionUtils.isNotEmpty(this.trackedEntities);
   }
 
   public boolean hasFilterForEvents() {
@@ -157,9 +158,10 @@ public class TrackedEntityQueryParams {
   }
 
   /** Returns a list of attributes and filters combined. */
-  public Set<String> getFilterIds() {
+  public Set<UID> getFilterIds() {
     return filters.keySet().stream()
         .map(BaseIdentifiableObject::getUid)
+        .map(UID::of)
         .collect(Collectors.toSet());
   }
 
@@ -546,12 +548,12 @@ public class TrackedEntityQueryParams {
         .collect(Collectors.toSet());
   }
 
-  public Set<String> getTrackedEntityUids() {
-    return trackedEntityUids;
+  public Set<UID> getTrackedEntities() {
+    return trackedEntities;
   }
 
-  public TrackedEntityQueryParams setTrackedEntityUids(Set<String> trackedEntityUids) {
-    this.trackedEntityUids = trackedEntityUids;
+  public TrackedEntityQueryParams setTrackedEntities(Set<UID> trackedEntities) {
+    this.trackedEntities = trackedEntities;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -53,11 +53,10 @@ public interface TrackedEntityService {
   /**
    * Get the tracked entity matching given {@code UID} under the privileges of the currently
    * authenticated user. No program attributes are included, only TETAs. Enrollments and
-   * relationships are not included. Use {@link #getTrackedEntity(String, String,
-   * TrackedEntityParams)} instead to also get the relationships, enrollments and program
-   * attributes.
+   * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
+   * instead to also get the relationships, enrollments and program attributes.
    */
-  TrackedEntity getTrackedEntity(String uid)
+  TrackedEntity getTrackedEntity(UID uid)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
   /**
@@ -66,7 +65,7 @@ public interface TrackedEntityService {
    * are included, otherwise only TETAs are included. It will include enrollments, relationships,
    * attributes and ownerships as defined in @param params
    */
-  TrackedEntity getTrackedEntity(String uid, String programIdentifier, TrackedEntityParams params)
+  TrackedEntity getTrackedEntity(UID uid, UID programIdentifier, TrackedEntityParams params)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
   /** Get all tracked entities matching given params. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.tracker.imports.sms.SmsImportMapper.map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -97,8 +98,8 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
     try {
       trackedEntity =
           trackedEntityService.getTrackedEntity(
-              subm.getTrackedEntityInstance().getUid(),
-              subm.getTrackerProgram().getUid(),
+              UID.of(subm.getTrackedEntityInstance().getUid()),
+              UID.of(subm.getTrackerProgram().getUid()),
               TrackedEntityParams.FALSE.withIncludeAttributes(true));
     } catch (NotFoundException e) {
       // new TE will be created

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -153,7 +153,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
                   .build(),
               new PageParams(1, 2, false));
       enrollments = emptyIfNull(enrollmentPage.getItems());
-    } catch (BadRequestException | ForbiddenException | NotFoundException e) {
+    } catch (BadRequestException | ForbiddenException e) {
       // TODO(tracker) Find a better error message for these exceptions
       throw new SMSProcessingException(SmsResponse.UNKNOWN_ERROR);
     }
@@ -236,8 +236,8 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
     queryFilter.setFilter(sms.getOriginator());
 
     return TrackedEntityOperationParams.builder()
-        .filters(Map.of(attribute.getUid(), List.of(queryFilter)))
-        .trackedEntityTypeUid(program.getTrackedEntityType().getUid())
+        .filter(attribute, List.of(queryFilter))
+        .trackedEntityType(program.getTrackedEntityType())
         .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -63,11 +63,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RelationshipOperationParamsMapperTest extends TestBase {
 
-  private static final String TE_UID = "OBzmpRP6YUh";
+  private static final UID TE_UID = UID.of("OBzmpRP6YUh");
 
-  private static final String EN_UID = "KSd4PejqBf9";
+  private static final UID EN_UID = UID.of("KSd4PejqBf9");
 
-  private static final String EV_UID = "TvjwTPToKHO";
+  private static final UID EV_UID = UID.of("TvjwTPToKHO");
 
   @Mock private TrackedEntityService trackedEntityService;
 
@@ -92,11 +92,11 @@ class RelationshipOperationParamsMapperTest extends TestBase {
     ProgramStage programStage = createProgramStage('A', program);
 
     trackedEntity = createTrackedEntity(organisationUnit);
-    trackedEntity.setUid(TE_UID);
+    trackedEntity.setUid(TE_UID.getValue());
     enrollment = createEnrollment(program, trackedEntity, organisationUnit);
-    enrollment.setUid(EN_UID);
+    enrollment.setUid(EN_UID.getValue());
     event = createEvent(programStage, enrollment, organisationUnit);
-    event.setUid(EV_UID);
+    event.setUid(EV_UID.getValue());
   }
 
   @Test
@@ -104,41 +104,38 @@ class RelationshipOperationParamsMapperTest extends TestBase {
       throws NotFoundException, ForbiddenException, BadRequestException {
     when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
     RelationshipOperationParams params =
-        RelationshipOperationParams.builder()
-            .type(TRACKED_ENTITY)
-            .identifier(UID.of(TE_UID))
-            .build();
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
     RelationshipQueryParams queryParams = mapper.map(params);
 
     assertInstanceOf(TrackedEntity.class, queryParams.getEntity());
-    assertEquals(TE_UID, queryParams.getEntity().getUid());
+    assertEquals(TE_UID.getValue(), queryParams.getEntity().getUid());
   }
 
   @Test
   void shouldMapEnrollmentWhenAEnrollmentIsPassed()
       throws NotFoundException, ForbiddenException, BadRequestException {
-    when(enrollmentService.getEnrollment(UID.of(EN_UID))).thenReturn(enrollment);
+    when(enrollmentService.getEnrollment(EN_UID)).thenReturn(enrollment);
     RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(UID.of(EN_UID)).build();
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
 
     RelationshipQueryParams queryParams = mapper.map(params);
 
     assertInstanceOf(Enrollment.class, queryParams.getEntity());
-    assertEquals(EN_UID, queryParams.getEntity().getUid());
+    assertEquals(EN_UID.getValue(), queryParams.getEntity().getUid());
   }
 
   @Test
   void shouldMapEventWhenAEventIsPassed()
       throws NotFoundException, ForbiddenException, BadRequestException {
-    when(eventService.getEvent(UID.of(EV_UID))).thenReturn(event);
+    when(eventService.getEvent(EV_UID)).thenReturn(event);
     RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(EVENT).identifier(UID.of(EV_UID)).build();
+        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
     RelationshipQueryParams queryParams = mapper.map(params);
 
     assertInstanceOf(Event.class, queryParams.getEntity());
-    assertEquals(EV_UID, queryParams.getEntity().getUid());
+    assertEquals(EV_UID.getValue(), queryParams.getEntity().getUid());
   }
 
   @Test
@@ -149,7 +146,7 @@ class RelationshipOperationParamsMapperTest extends TestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
             .type(TRACKED_ENTITY)
-            .identifier(UID.of(TE_UID))
+            .identifier(TE_UID)
             .orderBy("created", SortDirection.DESC)
             .build();
 
@@ -164,10 +161,7 @@ class RelationshipOperationParamsMapperTest extends TestBase {
     when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
 
     RelationshipOperationParams operationParams =
-        RelationshipOperationParams.builder()
-            .type(TRACKED_ENTITY)
-            .identifier(UID.of(TE_UID))
-            .build();
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
     RelationshipQueryParams queryParams = mapper.map(operationParams);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -88,19 +88,19 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT) // common setup
 @ExtendWith(MockitoExtension.class)
 class TrackedEntityOperationParamsMapperTest {
-  public static final String TEA_1_UID = "TvjwTPToKHO";
+  public static final UID TEA_1_UID = UID.of("TvjwTPToKHO");
 
-  public static final String TEA_2_UID = "cy2oRh2sNr6";
+  public static final UID TEA_2_UID = UID.of("cy2oRh2sNr6");
 
-  private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
+  private static final UID ORG_UNIT_1_UID = UID.of("lW0T2U7gZUi");
 
-  private static final String ORG_UNIT_2_UID = "TK4KA0IIWqa";
+  private static final UID ORG_UNIT_2_UID = UID.of("TK4KA0IIWqa");
 
-  private static final String PROGRAM_UID = "XhBYIraw7sv";
+  private static final UID PROGRAM_UID = UID.of("XhBYIraw7sv");
 
-  private static final String PROGRAM_STAGE_UID = "RpCr2u2pFqw";
+  private static final UID PROGRAM_STAGE_UID = UID.of("RpCr2u2pFqw");
 
-  private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
+  private static final UID TRACKED_ENTITY_TYPE_UID = UID.of("Dp8baZYrLtr");
 
   @Mock private OrganisationUnitService organisationUnitService;
 
@@ -134,9 +134,9 @@ class TrackedEntityOperationParamsMapperTest {
   public void setUp() {
 
     orgUnit1 = new OrganisationUnit("orgUnit1");
-    orgUnit1.setUid(ORG_UNIT_1_UID);
+    orgUnit1.setUid(ORG_UNIT_1_UID.getValue());
     orgUnit2 = new OrganisationUnit("orgUnit2");
-    orgUnit2.setUid(ORG_UNIT_2_UID);
+    orgUnit2.setUid(ORG_UNIT_2_UID.getValue());
     User testUser = new User();
     testUser.setUid(CodeGenerator.generateUid());
     testUser.setOrganisationUnits(Set.of(orgUnit1, orgUnit2));
@@ -152,29 +152,29 @@ class TrackedEntityOperationParamsMapperTest {
         .thenReturn(true);
 
     trackedEntityType = new TrackedEntityType();
-    trackedEntityType.setUid(TRACKED_ENTITY_TYPE_UID);
-    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
+    trackedEntityType.setUid(TRACKED_ENTITY_TYPE_UID.getValue());
+    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID.getValue()))
         .thenReturn(trackedEntityType);
 
     program = new Program();
-    program.setUid(PROGRAM_UID);
+    program.setUid(PROGRAM_UID.getValue());
     program.setTrackedEntityType(trackedEntityType);
     programStage = new ProgramStage();
-    programStage.setUid(PROGRAM_STAGE_UID);
+    programStage.setUid(PROGRAM_STAGE_UID.getValue());
     programStage.setProgram(program);
     program.setProgramStages(Set.of(programStage));
 
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
 
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
-    tea1.setUid(TEA_1_UID);
+    tea1.setUid(TEA_1_UID.getValue());
 
     TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
-    tea2.setUid(TEA_2_UID);
+    tea2.setUid(TEA_2_UID.getValue());
 
-    when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
-    when(attributeService.getTrackedEntityAttribute(TEA_2_UID)).thenReturn(tea2);
+    when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(tea1);
+    when(attributeService.getTrackedEntityAttribute(TEA_2_UID.getValue())).thenReturn(tea2);
   }
 
   @Test
@@ -199,7 +199,7 @@ class TrackedEntityOperationParamsMapperTest {
             .lastUpdatedDuration("20")
             .programEnrollmentStartDate(getDate(2019, 5, 5))
             .programEnrollmentEndDate(getDate(2020, 5, 5))
-            .trackedEntityTypeUid(TRACKED_ENTITY_TYPE_UID)
+            .trackedEntityType(TRACKED_ENTITY_TYPE_UID)
             .eventStatus(EventStatus.COMPLETED)
             .eventStartDate(getDate(2019, 7, 7))
             .eventEndDate(getDate(2020, 7, 7))
@@ -236,7 +236,7 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
             .programEnrollmentStartDate(date)
-            .programUid(program.getUid())
+            .program(program)
             .build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
@@ -253,7 +253,7 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
             .programEnrollmentEndDate(date)
-            .programUid(program.getUid())
+            .program(program)
             .build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
@@ -269,7 +269,7 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(program.getUid())
+            .program(program)
             .filters(
                 Map.of(
                     TEA_1_UID,
@@ -285,7 +285,7 @@ class TrackedEntityOperationParamsMapperTest {
     // mapping to UIDs as the error message by just relying on QueryItem
     // equals() is not helpful
     assertContainsOnly(
-        List.of(TEA_1_UID, TEA_2_UID),
+        UID.toValueList(List.of(TEA_1_UID, TEA_2_UID)),
         items.keySet().stream().map(BaseIdentifiableObject::getUid).toList());
 
     // QueryItem equals() does not take the QueryFilter into account so
@@ -294,7 +294,7 @@ class TrackedEntityOperationParamsMapperTest {
     // the following block is needed because of that
     // assertion is order independent as the order of QueryItems is not
     // guaranteed
-    Map<String, QueryFilter> expectedFilters =
+    Map<UID, QueryFilter> expectedFilters =
         Map.of(
             TEA_1_UID,
             new QueryFilter(QueryOperator.EQ, "2"),
@@ -307,7 +307,7 @@ class TrackedEntityOperationParamsMapperTest {
                     (Executable)
                         () -> {
                           String uid = i.getKey().getUid();
-                          QueryFilter expected = expectedFilters.get(uid);
+                          QueryFilter expected = expectedFilters.get(UID.of(uid));
                           assertEquals(
                               expected,
                               i.getValue().get(0),
@@ -324,7 +324,7 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(program.getUid())
+            .program(program)
             .filters(
                 Map.of(
                     TEA_1_UID,
@@ -340,7 +340,8 @@ class TrackedEntityOperationParamsMapperTest {
     // mapping to UIDs as the error message by just relying on QueryItem
     // equals() is not helpful
     assertContainsOnly(
-        List.of(TEA_1_UID), items.keySet().stream().map(BaseIdentifiableObject::getUid).toList());
+        List.of(TEA_1_UID.getValue()),
+        items.keySet().stream().map(BaseIdentifiableObject::getUid).toList());
 
     // QueryItem equals() does not take the QueryFilter into account so
     // assertContainsOnly alone does not ensure operators and filter value
@@ -356,10 +357,7 @@ class TrackedEntityOperationParamsMapperTest {
     when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .programUid(PROGRAM_UID)
-            .build();
+        TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
 
@@ -374,8 +372,8 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(PROGRAM_UID)
-            .programStageUid(PROGRAM_STAGE_UID)
+            .program(PROGRAM_UID)
+            .programStage(PROGRAM_STAGE_UID)
             .build();
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
@@ -386,7 +384,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgramStageGivenWithoutProgram() {
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder().programStageUid(PROGRAM_STAGE_UID).build();
+        TrackedEntityOperationParams.builder().programStage(PROGRAM_STAGE_UID).build();
 
     BadRequestException e =
         assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
@@ -398,7 +396,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgramStageNotFound() {
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder().programStageUid("NeU85luyD4w").build();
+        TrackedEntityOperationParams.builder().programStage(UID.of("NeU85luyD4w")).build();
 
     BadRequestException e =
         assertThrows(BadRequestException.class, () -> mapper.map(operationParams, user));
@@ -414,7 +412,7 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(program.getUid())
+            .program(program)
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
                     AssignedUserSelectionMode.PROVIDED,
@@ -436,15 +434,15 @@ class TrackedEntityOperationParamsMapperTest {
     when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
 
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
-    tea1.setUid(TEA_1_UID);
-    when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
+    tea1.setUid(TEA_1_UID.getValue());
+    when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(tea1);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(program.getUid())
+            .program(program)
             .orderBy("created", SortDirection.ASC)
-            .orderBy(UID.of(TEA_1_UID), SortDirection.ASC)
+            .orderBy(TEA_1_UID, SortDirection.ASC)
             .orderBy("createdAtClient", SortDirection.DESC)
             .build();
 
@@ -461,16 +459,16 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void shouldFailToMapOrderIfUIDIsNotAnAttribute() throws ForbiddenException, BadRequestException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
-    tea1.setUid(TEA_1_UID);
-    when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(null);
+    tea1.setUid(TEA_1_UID.getValue());
+    when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(null);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
-            .programUid(program.getUid())
-            .orderBy(UID.of(TEA_1_UID), SortDirection.ASC)
+            .program(program)
+            .orderBy(TEA_1_UID, SortDirection.ASC)
             .build();
 
     Exception exception =
@@ -492,7 +490,7 @@ class TrackedEntityOperationParamsMapperTest {
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ACCESSIBLE)
             .orderBy(UID.of("lastUpdated"), SortDirection.ASC)
-            .programUid(program.getUid())
+            .program(program)
             .build();
 
     Exception exception =
@@ -516,10 +514,7 @@ class TrackedEntityOperationParamsMapperTest {
         .thenReturn(List.of(orgUnit1, orgUnit2));
 
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .programUid(PROGRAM_UID)
-            .build();
+        TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
 
     Exception illegalQueryException =
         assertThrows(
@@ -542,7 +537,7 @@ class TrackedEntityOperationParamsMapperTest {
     when(aclService.canDataRead(any(UserDetails.class), any(Program.class))).thenReturn(true);
     program.setMinAttributesRequiredToSearch(0);
     program.setMaxTeiCountToReturn(1);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(paramsValidator.validateTrackerProgram(program.getUid(), currentUserWithOrgUnits))
         .thenReturn(program);
 
@@ -552,10 +547,7 @@ class TrackedEntityOperationParamsMapperTest {
         .thenReturn(List.of(orgUnit1, orgUnit2));
 
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .programUid(PROGRAM_UID)
-            .build();
+        TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
 
     Exception illegalQueryException =
         assertThrows(
@@ -573,7 +565,7 @@ class TrackedEntityOperationParamsMapperTest {
     when(aclService.canDataRead(currentUserWithOrgUnits, program)).thenReturn(true);
     program.setMinAttributesRequiredToSearch(0);
     program.setMaxTeiCountToReturn(1);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
 
     when(trackedEntityStore.getTrackedEntityCountWithMaxTrackedEntityLimit(any())).thenReturn(100);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -244,7 +243,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedEnrollmentWithAProgramMessage()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
     programMessageRecipients.setEmailAddresses(Sets.newHashSet("testemail"));
     programMessageRecipients.setPhoneNumbers(Sets.newHashSet("testphone"));
@@ -315,11 +314,11 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .build();
     manager.save(trackedEntityB);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(trackedEntityService.getTrackedEntity(trackedEntityB.getUid()));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
     manager.delete(trackedEntityB);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(trackedEntityB.getUid()));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
 
     maintenanceService.deleteSoftDeletedTrackedEntities();
@@ -329,7 +328,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedEnrollmentLinkedToATrackedEntityDataValueAudit()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = createDataElement('A');
     dataElementService.addDataElement(dataElement);
     Event eventA = new Event(enrollment, program.getProgramStageByStage(1));
@@ -395,7 +394,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedEnrollmentLinkedToARelationshipItem()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     RelationshipType rType = createRelationshipType('A');
     rType.getFromConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_INSTANCE);
     rType.getFromConstraint().setProgram(program);
@@ -454,7 +453,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
         audits.stream()
             .filter(a -> a.getKlass().equals("org.hisp.dhis.trackedentity.TrackedEntity"))
             .count());
-    audits.forEach(a -> assertSame(a.getAuditType(), AuditType.DELETE));
+    audits.forEach(a -> assertEquals(AuditType.DELETE, a.getAuditType()));
   }
 
   @Test
@@ -503,7 +502,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
   }
 
   private boolean enrollmentExistsIncludingDeleted(Enrollment enrollment)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
             .enrollments(Set.of(UID.of(enrollment)))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
@@ -200,7 +201,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Can read te
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // can write te
@@ -218,7 +219,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Can Read
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // Can write
@@ -235,7 +236,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Cannot Read
     assertHasError(trackerAccessManager.canRead(userDetails, te), OWNERSHIP_ACCESS_DENIED);
     // Cannot write

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -197,7 +198,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+                    UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals("OWNERSHIP_ACCESS_DENIED", exception.getMessage());
   }
 
@@ -212,7 +213,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+            UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
   @Test
@@ -228,7 +229,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+            UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
   @Test
@@ -238,7 +239,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getTrackedEntity(trackedEntityA1.getUid(), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
   }
 
   @Test
@@ -252,7 +253,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), null, defaultParams));
+                    UID.of(trackedEntityA1), null, defaultParams));
 
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA1.getUid()),
@@ -299,7 +300,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+                    UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(TrackerOwnershipManager.NO_READ_ACCESS_TO_ORG_UNIT, exception.getMessage());
   }
 
@@ -322,7 +323,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+                    UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED, exception.getMessage());
   }
 
@@ -355,7 +356,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programB.getUid(), defaultParams));
+                    UID.of(trackedEntityA1), UID.of(programB), defaultParams));
     assertEquals(TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED, exception.getMessage());
   }
 
@@ -368,7 +369,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA1,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+            UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
   @Test
@@ -386,7 +387,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), programA.getUid(), defaultParams));
+                    UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(TrackerOwnershipManager.NO_READ_ACCESS_TO_ORG_UNIT, exception.getMessage());
   }
 
@@ -400,7 +401,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(userB);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getTrackedEntity(trackedEntityA1.getUid(), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
   }
 
   @Test
@@ -412,7 +413,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA1.getUid(), null, defaultParams));
+                    UID.of(trackedEntityA1), null, defaultParams));
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA1.getUid()),
         exception.getMessage());
@@ -425,7 +426,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityB1,
-        trackedEntityService.getTrackedEntity(trackedEntityB1.getUid(), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityB1), null, defaultParams));
   }
 
   @Test
@@ -437,7 +438,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityB1.getUid(), null, defaultParams));
+                    UID.of(trackedEntityB1), null, defaultParams));
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityB1.getUid()),
         exception.getMessage());
@@ -531,7 +532,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
   void shouldFindTrackedEntityWhenProgramSuppliedAndUserIsOwner()
       throws ForbiddenException, BadRequestException, NotFoundException {
     assignOwnership(trackedEntityA1, programA, organisationUnitA);
-    TrackedEntityOperationParams operationParams = createOperationParams(programA.getUid());
+    TrackedEntityOperationParams operationParams = createOperationParams(UID.of(programA));
     injectSecurityContext(userDetailsA);
 
     List<String> trackedEntities = getTrackedEntities(operationParams);
@@ -543,7 +544,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
   void shouldNotFindTrackedEntityWhenProgramSuppliedAndUserIsNotOwner()
       throws ForbiddenException, BadRequestException, NotFoundException {
     assignOwnership(trackedEntityA1, programA, organisationUnitA);
-    TrackedEntityOperationParams operationParams = createOperationParams(programA.getUid());
+    TrackedEntityOperationParams operationParams = createOperationParams(UID.of(programA));
     injectSecurityContext(userDetailsB);
 
     assertIsEmpty(getTrackedEntities(operationParams));
@@ -560,11 +561,11 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     trackerOwnershipAccessManager.assignOwnership(trackedEntity, program, orgUnit, false, true);
   }
 
-  private TrackedEntityOperationParams createOperationParams(String programUid) {
+  private TrackedEntityOperationParams createOperationParams(UID programUid) {
     return TrackedEntityOperationParams.builder()
-        .trackedEntityTypeUid(trackedEntityA1.getTrackedEntityType().getUid())
+        .trackedEntityType(trackedEntityA1.getTrackedEntityType())
         .orgUnitMode(ACCESSIBLE)
-        .programUid(programUid)
+        .program(programUid)
         .build();
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -143,9 +143,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(DESCENDANTS)
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("numericAttr"), SortDirection.ASC)
             .build();
 
@@ -178,9 +178,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(DESCENDANTS)
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("numericAttr"), SortDirection.ASC)
             .build();
 
@@ -221,10 +221,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -240,10 +240,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("created", SortDirection.ASC)
             .build();
 
@@ -272,10 +272,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("created", SortDirection.DESC)
             .build();
 
@@ -301,10 +301,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("createdAtClient", SortDirection.DESC)
             .build();
 
@@ -318,10 +318,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("createdAtClient", SortDirection.ASC)
             .build();
 
@@ -335,10 +335,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
@@ -352,10 +352,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
@@ -372,11 +372,11 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
-            .programUid("BFcipDERJnf")
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
+            .program(UID.of("BFcipDERJnf"))
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
@@ -390,10 +390,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toDelete000"), SortDirection.ASC)
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
@@ -408,10 +408,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
@@ -425,10 +425,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
@@ -442,11 +442,12 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
-            .filters(Map.of("numericAttr", List.of(new QueryFilter(QueryOperator.LT, "75"))))
+            .filters(
+                Map.of(UID.of("numericAttr"), List.of(new QueryFilter(QueryOperator.LT, "75"))))
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -459,10 +460,11 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityType.getUid())
-            .filters(Map.of("numericAttr", List.of(new QueryFilter(QueryOperator.LT, "75"))))
+            .trackedEntityType(trackedEntityType)
+            .filters(
+                Map.of(UID.of("numericAttr"), List.of(new QueryFilter(QueryOperator.LT, "75"))))
             .orderBy(UID.of("numericAttr"), SortDirection.DESC)
             .build();
 
@@ -476,11 +478,11 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityType.getUid())
-            .trackedEntityUids(
-                Set.of(
+            .trackedEntityType(trackedEntityType)
+            .trackedEntities(
+                UID.of(
                     "dUE514NMOlo", "QS6w44flWAf")) // TE QS6w44flWAf without attribute notUpdated0
             .orderBy(UID.of("notUpdated0"), SortDirection.DESC)
             .build();
@@ -498,10 +500,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("numericAttr"), SortDirection.ASC)
             .build();
@@ -516,10 +518,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("numericAttr"), SortDirection.DESC)
             .build();
@@ -535,10 +537,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("inactive", SortDirection.DESC)
             .build();
 
@@ -553,10 +555,10 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     TrackedEntityOperationParams params =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
+            .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntities(UID.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
             .orderBy("inactive", SortDirection.ASC)
             .build();
 
@@ -567,7 +569,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedEnrollmentsGivenNonDefaultPageSize()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
             .orgUnits(Set.of(UID.of(orgUnit)))
@@ -599,7 +601,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedEnrollmentsGivenNonDefaultPageSizeAndTotalPages()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
             .orgUnits(Set.of(UID.of(orgUnit)))
@@ -631,7 +633,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEnrollmentsByPrimaryKeyDescByDefault()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     Enrollment nxP7UnKhomJ = get(Enrollment.class, "nxP7UnKhomJ");
     Enrollment TvctPPhpD8z = get(Enrollment.class, "TvctPPhpD8z");
     List<String> expected =
@@ -652,8 +654,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEnrollmentsByEnrolledAtAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEnrollmentsByEnrolledAtAsc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
             .orgUnits(Set.of(UID.of(orgUnit)))
@@ -667,8 +668,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEnrollmentsByEnrolledAtDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEnrollmentsByEnrolledAtDesc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
             .orgUnits(Set.of(UID.of(orgUnit)))
@@ -683,7 +683,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedEventsWithNotesGivenNonDefaultPageSize()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams operationParams =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -709,8 +709,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnPaginatedEventsWithTotalPages()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldReturnPaginatedEventsWithTotalPages() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder.orgUnit(UID.of(orgUnit)).programStage(UID.of(programStage)).build();
 
@@ -724,7 +723,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
 
@@ -754,7 +753,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
 
@@ -774,8 +773,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByPrimaryKeyDescByDefault()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByPrimaryKeyDescByDefault() throws ForbiddenException, BadRequestException {
     Event d9PbzJY8bJM = get(Event.class, "D9PbzJY8bJM");
     Event pTzf9KYMk72 = get(Event.class, "pTzf9KYMk72");
     List<String> expected =
@@ -792,8 +790,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByEnrollmentProgramUIDAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByEnrollmentProgramUIDAsc() throws ForbiddenException, BadRequestException {
     Event pTzf9KYMk72 =
         get(Event.class, "pTzf9KYMk72"); // enrolled in program BFcipDERJnf with registration
     Event QRYjLTiJTrA =
@@ -818,7 +815,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByEnrollmentProgramUIDDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     Event pTzf9KYMk72 =
         get(Event.class, "pTzf9KYMk72"); // enrolled in program BFcipDERJnf with registration
     Event QRYjLTiJTrA =
@@ -844,8 +841,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByAttributeAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByAttributeAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -858,8 +854,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByAttributeDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByAttributeDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -873,7 +868,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByAttributeAndNotFilterOutEventsWithATrackedEntityWithoutThatAttribute()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -891,8 +886,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByMultipleAttributesDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByMultipleAttributesDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -924,7 +918,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedEventsOrderedByMultipleAttributesWhenGivenNonDefaultPageSize()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams operationParams =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -950,8 +944,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByProgramStageUidDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByProgramStageUidDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of("uoNW0E3xXUy"))
@@ -964,8 +957,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByProgramStageUidAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByProgramStageUidAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of("uoNW0E3xXUy"))
@@ -978,8 +970,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByTrackedEntityUidDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByTrackedEntityUidDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -992,8 +983,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByTrackedEntityUidAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByTrackedEntityUidAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1007,7 +997,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByAttributeOptionComboUidDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of("DiszpKrYNg8"))
@@ -1022,7 +1012,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByAttributeOptionComboUidAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of("DiszpKrYNg8"))
@@ -1036,8 +1026,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByOccurredAtDesc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByOccurredAtDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1050,8 +1039,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByOccurredAtAsc()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+  void shouldOrderEventsByOccurredAtAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1065,7 +1053,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByCreatedAtClientInAscOrder()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1080,7 +1068,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByCreatedAtClientInDescOrder()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1095,7 +1083,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByUpdatedAtClientInAscOrder()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1110,7 +1098,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByUpdatedAtClientInDescOrder()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1125,7 +1113,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsRespectingOrderWhenAttributeOrderSuppliedBeforeOrderParam()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1140,7 +1128,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsRespectingOrderWhenOrderParamSuppliedBeforeAttributeOrder()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1155,7 +1143,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsRespectingOrderWhenDataElementSuppliedBeforeOrderParam()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1171,7 +1159,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsRespectingOrderWhenOrderParamSuppliedBeforeDataElement()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1186,7 +1174,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByDataElementAndNotFilterOutEventsWithoutThatDataElement()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
             .orgUnit(UID.of(orgUnit))
@@ -1226,7 +1214,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @MethodSource("orderByFieldInDescendingOrderWhenModeSelected")
   void shouldOrderEventsByFieldInDescendingOrderWhenModeSelected(
       String field, String firstEvent, String secondEvent)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
     eventParamsBuilder.orgUnit(UID.of(orgUnit));
@@ -1240,7 +1228,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @MethodSource("orderByFieldInAscendingOrderWhenModeSelected")
   void shouldOrderEventsByFieldInAscendingOrderWhenModeSelected(
       String field, String firstEvent, String secondEvent)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
     eventParamsBuilder.orgUnit(UID.of(orgUnit));
@@ -1272,7 +1260,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @MethodSource("orderByFieldInDescendingOrderWhenModeDescendants")
   void shouldOrderByFieldInDescendingOrderWhenModeDescendants(
       String field, String firstEvent, String secondEvent)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(DESCENDANTS);
     eventParamsBuilder.orgUnit(UID.of("RojfDTBhoGC"));
@@ -1286,7 +1274,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @MethodSource("orderByFieldInAscendingOrderWhenModeDescendants")
   void shouldOrderByFieldInAscendingOrderWhenModeDescendants(
       String field, String firstEvent, String secondEvent)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(DESCENDANTS);
     eventParamsBuilder.orgUnit(UID.of("RojfDTBhoGC"));
@@ -1298,7 +1286,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderRelationshipsByPrimaryKeyDescByDefault()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
     Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
     List<String> expected =
@@ -1320,7 +1308,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderRelationshipsByUpdatedAtClientInDescOrder()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     RelationshipOperationParams params =
         RelationshipOperationParams.builder()
             .type(TrackerType.EVENT)
@@ -1335,7 +1323,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderRelationshipsByUpdatedAtClientInAscOrder()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     RelationshipOperationParams params =
         RelationshipOperationParams.builder()
             .type(TrackerType.EVENT)
@@ -1350,7 +1338,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedRelationshipsGivenNonDefaultPageSize()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     // relationships can only be ordered by created date which is not under our control during
     // testing
     // pagination is tested using default order by primary key desc. We thus need to get the
@@ -1395,7 +1383,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnPaginatedRelationshipsGivenNonDefaultPageSizeAndTotalPages()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     // relationships can only be ordered by created date which is not under our control during
     // testing
     // pagination is tested using default order by primary key desc. We thus need to get the
@@ -1440,7 +1428,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderRelationshipsByCreatedAsc()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
     Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
 
@@ -1470,7 +1458,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderRelationshipsByCreatedDesc()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
     Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
 
@@ -1531,22 +1519,22 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   private List<String> getEnrollments(EnrollmentOperationParams params)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     return uids(enrollmentService.getEnrollments(params));
   }
 
   private List<String> getEvents(EventOperationParams params)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     return uids(eventService.getEvents(params));
   }
 
   private List<String> getEvents(EventOperationParams params, PageParams pageParams)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     return uids(eventService.getEvents(params, pageParams).getItems());
   }
 
   private List<String> getRelationships(RelationshipOperationParams params)
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException, NotFoundException {
     return uids(relationshipService.getRelationships(params));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -58,7 +58,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -69,6 +68,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.AssignedUserQueryParam;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
@@ -188,9 +188,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
   private static List<String> uids(
       Collection<? extends BaseIdentifiableObject> identifiableObjects) {
-    return identifiableObjects.stream()
-        .map(BaseIdentifiableObject::getUid)
-        .collect(Collectors.toList());
+    return identifiableObjects.stream().map(BaseIdentifiableObject::getUid).toList();
   }
 
   @BeforeEach
@@ -561,8 +559,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   void shouldReturnEmptyCollectionGivenUserHasNoAccessToTrackedEntityType() {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .organisationUnits(orgUnitA)
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     trackedEntityTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
@@ -583,9 +581,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitB.getUid()))
+            .organisationUnits(orgUnitA, orgUnitB)
             .orgUnitMode(DESCENDANTS)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     final List<TrackedEntity> trackedEntities =
@@ -604,15 +602,15 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
 
     TrackedEntity te =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
+            UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
     assertEquals(1, te.getEnrollments().size());
     assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
 
@@ -649,9 +647,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .programUid(programB.getUid())
+            .program(programB)
             .build();
 
     final List<TrackedEntity> trackedEntities =
@@ -668,9 +666,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .programUid(programA.getUid())
+            .program(programA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -691,7 +689,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
+            UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertContainsOnly(Set.of(enrollmentA), trackedEntity.getEnrollments());
   }
@@ -706,7 +704,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE);
+            UID.of(trackedEntityA), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(enrollmentA, enrollmentB, enrollmentProgramB), trackedEntity.getEnrollments());
@@ -717,10 +715,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .filters(Map.of(teaA.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "M'M"))))
+            .trackedEntityType(trackedEntityTypeA)
+            .filter(teaA, List.of(new QueryFilter(QueryOperator.EQ, "M'M")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -733,10 +731,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .filters(Map.of(teaA.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "A"))))
+            .trackedEntityType(trackedEntityTypeA)
+            .filter(teaA, List.of(new QueryFilter(QueryOperator.EQ, "A")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -751,9 +749,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedStartDate(oneHourBeforeLastUpdated)
             .build();
 
@@ -769,9 +767,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedStartDate(oneHourAfterLastUpdated)
             .build();
 
@@ -787,9 +785,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedEndDate(oneHourAfterLastUpdated)
             .build();
 
@@ -805,9 +803,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedEndDate(oneHourBeforeLastUpdated)
             .build();
 
@@ -823,8 +821,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programEnrollmentStartDate(oneHourBeforeEnrollmentDate)
             .build();
@@ -841,8 +839,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programEnrollmentStartDate(oneHourAfterEnrollmentDate)
             .build();
@@ -859,8 +857,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programEnrollmentEndDate(oneHourAfterEnrollmentDate)
             .build();
@@ -877,8 +875,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programEnrollmentEndDate(oneHourBeforeEnrollmentDate)
             .build();
@@ -895,8 +893,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programIncidentStartDate(oneHourBeforeIncidentDate)
             .build();
@@ -913,8 +911,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programIncidentStartDate(oneHourAfterIncidentDate)
             .build();
@@ -931,8 +929,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programIncidentEndDate(oneHourAfterIncidentDate)
             .build();
@@ -949,8 +947,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .programIncidentEndDate(oneHourBeforeIncidentDate)
             .build();
@@ -968,8 +966,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .eventStatus(EventStatus.ACTIVE)
             .eventStartDate(oneHourBeforeOccurredDate)
@@ -989,8 +987,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .eventStatus(EventStatus.ACTIVE)
             .eventStartDate(oneHourAfterOccurredDate)
@@ -1010,8 +1008,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .programUid(programA.getUid())
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .program(programA)
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .eventStatus(EventStatus.ACTIVE)
             .eventStartDate(twoHoursBeforeOccurredDate)
@@ -1028,10 +1026,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .filters(Map.of(teaA.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "Z"))))
+            .trackedEntityType(trackedEntityTypeA)
+            .filter(teaA, List.of(new QueryFilter(QueryOperator.EQ, "Z")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1044,10 +1042,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitB.getUid()))
+            .organisationUnits(orgUnitA, orgUnitB)
             .orgUnitMode(DESCENDANTS)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .filters(Map.of(teaA.getUid(), List.of()))
+            .trackedEntityType(trackedEntityTypeA)
+            .filter(teaA, List.of())
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1061,9 +1059,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedStartDate(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)))
             .lastUpdatedEndDate(Date.from(Instant.now().plus(1, ChronoUnit.MINUTES)))
             .build();
@@ -1075,9 +1073,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     // Update last updated start date to today
     operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .lastUpdatedStartDate(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
             .lastUpdatedEndDate(Date.from(Instant.now().plus(1, ChronoUnit.MINUTES)))
             .build();
@@ -1093,8 +1091,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
             .assignedUserQueryParam(new AssignedUserQueryParam(null, null, UID.of(user)))
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .programUid(programA.getUid())
+            .organisationUnits(orgUnitA)
+            .program(programA)
             .eventStartDate(Date.from(Instant.now().minus(10, ChronoUnit.DAYS)))
             .eventEndDate(Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
 
@@ -1129,9 +1127,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .includeDeleted(true)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
@@ -1185,8 +1183,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .organisationUnits(orgUnitA)
+            .trackedEntityType(trackedEntityTypeA)
             .includeDeleted(false)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
@@ -1208,10 +1206,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(false, TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntityType(trackedEntityTypeA)
+            .trackedEntities(trackedEntityA)
             .trackedEntityParams(params)
             .build();
 
@@ -1238,10 +1236,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntityType(trackedEntityTypeA)
+            .trackedEntities(trackedEntityA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1256,10 +1254,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(false, TRUE, true, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntityType(trackedEntityTypeA)
+            .trackedEntities(trackedEntityA)
             .trackedEntityParams(params)
             .build();
 
@@ -1287,9 +1285,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         new TrackedEntityParams(false, TRUE.withIncludeEvents(false), false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .trackedEntityParams(params)
             .build();
 
@@ -1313,9 +1311,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     final Date currentTime = new Date();
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1344,9 +1342,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(false, TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .trackedEntityParams(params)
             .build();
 
@@ -1388,9 +1386,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(false, TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .trackedEntityType(trackedEntityTypeA)
             .trackedEntityParams(params)
             .build();
 
@@ -1440,9 +1438,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(true, FALSE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntities(trackedEntityA)
             .trackedEntityParams(params)
             .build();
 
@@ -1592,9 +1590,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(true, FALSE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntities(trackedEntityA)
             .trackedEntityParams(params)
             .build();
 
@@ -1618,9 +1616,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityParams params = new TrackedEntityParams(true, TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
+            .organisationUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
+            .trackedEntities(trackedEntityA)
             .trackedEntityParams(params)
             .build();
 
@@ -1646,8 +1644,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ALL)
-            .programUid(programA.getUid())
-            .filters(Map.of(teaC.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "C"))))
+            .program(programA)
+            .filter(teaC, List.of(new QueryFilter(QueryOperator.LIKE, "C")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1662,8 +1660,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ALL)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .filters(Map.of(teaA.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "A"))))
+            .trackedEntityType(trackedEntityTypeA)
+            .filter(teaA, List.of(new QueryFilter(QueryOperator.LIKE, "A")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1680,8 +1678,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(ALL)
-            .programUid(programB.getUid())
-            .filters(Map.of(teaA.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "A"))))
+            .program(programB)
+            .filter(teaA, List.of(new QueryFilter(QueryOperator.LIKE, "A")))
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1693,10 +1691,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   void shouldFailWhenModeAllUserCanSearchEverywhereButNotSuperuserAndNoAccessToProgram() {
     injectSecurityContextUser(userWithSearchInAllAuthority);
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ALL)
-            .programUid(programC.getUid())
-            .build();
+        TrackedEntityOperationParams.builder().orgUnitMode(ALL).program(programC).build();
 
     ForbiddenException ex =
         assertThrows(
@@ -1713,8 +1708,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(CHILDREN)
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .organisationUnits(orgUnitA)
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1728,8 +1723,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(CHILDREN)
-            .organisationUnits(Set.of(orgUnitChildA.getUid()))
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .organisationUnits(orgUnitChildA)
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1745,8 +1740,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .orgUnitMode(CHILDREN)
-            .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitChildA.getUid()))
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .organisationUnits(orgUnitA, orgUnitChildA)
+            .trackedEntityType(trackedEntityTypeA)
             .build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
@@ -1763,10 +1758,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, BadRequestException, NotFoundException {
     injectSecurityContextUser(superuser);
     TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ALL)
-            .programUid(programA.getUid())
-            .build();
+        TrackedEntityOperationParams.builder().orgUnitMode(ALL).program(programA).build();
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
     assertContainsOnly(Set.of(trackedEntityA.getUid()), uids(trackedEntities));
@@ -1780,7 +1772,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             NotFoundException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), programUid, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), UID.of(programUid), TrackedEntityParams.TRUE));
     assertEquals(
         String.format("Program with id %s could not be found.", programUid),
         exception.getMessage());
@@ -1788,15 +1780,15 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldFailWhenRequestingSingleTEAndProvidedTEDoesNotExist() {
-    String trackedEntityUid = "made up tracked entity";
+    String notExistentTE = CodeGenerator.generateUid();
     NotFoundException exception =
         assertThrows(
             NotFoundException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityUid, programA.getUid(), TrackedEntityParams.TRUE));
+                    UID.of(notExistentTE), UID.of(programA), TrackedEntityParams.TRUE));
     assertEquals(
-        String.format("TrackedEntity with id %s could not be found.", trackedEntityUid),
+        String.format("TrackedEntity with id %s could not be found.", notExistentTE),
         exception.getMessage());
   }
 
@@ -1814,9 +1806,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(),
-                    inaccessibleProgram.getUid(),
-                    TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), UID.of(inaccessibleProgram), TrackedEntityParams.TRUE));
     assertContains(
         String.format("User has no data read access to program: %s", inaccessibleProgram.getUid()),
         exception.getMessage());
@@ -1836,7 +1826,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntity.getUid(), programA.getUid(), TrackedEntityParams.TRUE));
+                    UID.of(trackedEntity), UID.of(programA), TrackedEntityParams.TRUE));
     assertContains(
         String.format(
             "User has no data read access to tracked entity type: %s",
@@ -1857,7 +1847,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
         exception.getMessage());
@@ -1878,7 +1868,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1903,7 +1893,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1923,7 +1913,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1942,7 +1932,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             ForbiddenException.class,
             () ->
                 trackedEntityService.getTrackedEntity(
-                    trackedEntityA.getUid(), null, TrackedEntityParams.TRUE));
+                    UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
@@ -1954,7 +1944,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE);
+            UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(
@@ -1969,7 +1959,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE);
+            UID.of(trackedEntityA), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
         Set.of(trackedEntityAttributeValueA, trackedEntityAttributeValueB),
@@ -1993,7 +1983,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     assertEquals(
         trackedEntityA,
         trackedEntityService.getTrackedEntity(
-            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE));
+            UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE));
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {
@@ -2037,9 +2027,9 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   private TrackedEntityOperationParams createOperationParams(
       OrganisationUnit orgUnit, TrackedEntity trackedEntity) {
     return TrackedEntityOperationParams.builder()
-        .organisationUnits(Set.of(orgUnit.getUid()))
+        .organisationUnits(orgUnit)
         .orgUnitMode(SELECTED)
-        .trackedEntityUids(Set.of(trackedEntity.getUid()))
+        .trackedEntities(trackedEntity)
         .trackedEntityParams(new TrackedEntityParams(true, TRUE, false, false))
         .build();
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -267,13 +267,13 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     assertDoesNotThrow(
         () ->
             trackedEntityService.getTrackedEntity(
-                submission.getTrackedEntityInstance().getUid(),
-                submission.getTrackerProgram().getUid(),
+                UID.of(submission.getTrackedEntityInstance().getUid()),
+                UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
         trackedEntityService.getTrackedEntity(
-            submission.getTrackedEntityInstance().getUid(),
-            submission.getTrackerProgram().getUid(),
+            UID.of(submission.getTrackedEntityInstance().getUid()),
+            UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
     assertAll(
         "created tracked entity with tracked entity attribute values",
@@ -367,13 +367,13 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     assertDoesNotThrow(
         () ->
             trackedEntityService.getTrackedEntity(
-                submission.getTrackedEntityInstance().getUid(),
-                submission.getTrackerProgram().getUid(),
+                UID.of(submission.getTrackedEntityInstance().getUid()),
+                UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
         trackedEntityService.getTrackedEntity(
-            submission.getTrackedEntityInstance().getUid(),
-            submission.getTrackerProgram().getUid(),
+            UID.of(submission.getTrackedEntityInstance().getUid()),
+            UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
     assertAll(
         "update tracked entity with tracked entity attribute values",
@@ -455,11 +455,11 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     assertDoesNotThrow(
         () ->
             trackedEntityService.getTrackedEntity(
-                trackedEntity.getUid(), trackerProgram.getUid(), TrackedEntityParams.FALSE));
+                UID.of(trackedEntity), UID.of(trackerProgram), TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
         trackedEntityService.getTrackedEntity(
-            trackedEntity.getUid(),
-            trackerProgram.getUid(),
+            UID.of(trackedEntity),
+            UID.of(trackerProgram),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
     assertAll(
         "created tracked entity with tracked entity attribute values",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -270,8 +270,7 @@ class TrackedEntitiesExportController {
     TrackedEntityParams trackedEntityParams = fieldsMapper.map(fields);
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.from(
-            trackedEntityService.getTrackedEntity(
-                uid.getValue(), program == null ? null : program.getValue(), trackedEntityParams));
+            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(trackedEntity, fields));
   }
@@ -280,10 +279,10 @@ class TrackedEntitiesExportController {
       value = "/{uid}",
       produces = {CONTENT_TYPE_CSV, CONTENT_TYPE_TEXT_CSV})
   void getTrackedEntityByUidAsCsv(
-      @PathVariable String uid,
+      @PathVariable UID uid,
       HttpServletResponse response,
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader,
-      @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) String program)
+      @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program)
       throws IOException, ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams trackedEntityParams = fieldsMapper.map(CSV_FIELDS);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -37,7 +37,6 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValida
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserQueryParam;
@@ -128,9 +127,8 @@ class TrackedEntityRequestParamsMapper {
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
-            .programUid(applyIfNotNull(trackedEntityRequestParams.getProgram(), UID::getValue))
-            .programStageUid(
-                applyIfNotNull(trackedEntityRequestParams.getProgramStage(), UID::getValue))
+            .program(trackedEntityRequestParams.getProgram())
+            .programStage(trackedEntityRequestParams.getProgramStage())
             .enrollmentStatus(enrollmentStatus)
             .followUp(trackedEntityRequestParams.getFollowUp())
             .lastUpdatedStartDate(
@@ -150,9 +148,8 @@ class TrackedEntityRequestParamsMapper {
             .programIncidentEndDate(
                 applyIfNotNull(
                     trackedEntityRequestParams.getEnrollmentOccurredBefore(), EndDateTime::toDate))
-            .trackedEntityTypeUid(
-                applyIfNotNull(trackedEntityRequestParams.getTrackedEntityType(), UID::getValue))
-            .organisationUnits(UID.toValueSet(orgUnitUids))
+            .trackedEntityType(trackedEntityRequestParams.getTrackedEntityType())
+            .organisationUnits(orgUnitUids)
             .orgUnitMode(orgUnitMode)
             .eventStatus(trackedEntityRequestParams.getEventStatus())
             .eventStartDate(
@@ -164,9 +161,8 @@ class TrackedEntityRequestParamsMapper {
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
                     trackedEntityRequestParams.getAssignedUserMode(), assignedUsers, UID.of(user)))
-            .trackedEntityUids(UID.toValueSet(trackedEntities))
-            .filters(
-                filters.keySet().stream().collect(Collectors.toMap(UID::getValue, filters::get)))
+            .trackedEntities(trackedEntities)
+            .filters(filters)
             .includeDeleted(trackedEntityRequestParams.isIncludeDeleted())
             .potentialDuplicate(trackedEntityRequestParams.getPotentialDuplicate())
             .trackedEntityParams(fieldsParamMapper.map(fields));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -95,7 +95,7 @@ public class TrackerOwnershipController {
             "trackedEntityInstance", trackedEntityInstance, "trackedEntity", trackedEntity);
 
     trackerOwnershipAccessManager.transferOwnership(
-        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue()),
+        trackedEntityService.getTrackedEntity(trackedEntityUid),
         programService.getProgram(program),
         organisationUnitService.getOrganisationUnit(ou));
     return ok("Ownership transferred");
@@ -115,7 +115,7 @@ public class TrackerOwnershipController {
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
-        trackedEntityService.getTrackedEntity(trackedEntityUid.getValue()),
+        trackedEntityService.getTrackedEntity(trackedEntityUid),
         programService.getProgram(program),
         currentUser,
         reason);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -150,7 +150,7 @@ class EventRequestParamsMapperTest {
     when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
 
     TrackedEntity trackedEntity = new TrackedEntity();
-    when(trackedEntityService.getTrackedEntity("qnR1RK4cTIZ", null, FALSE))
+    when(trackedEntityService.getTrackedEntity(UID.of("qnR1RK4cTIZ"), null, FALSE))
         .thenReturn(trackedEntity);
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID.getValue());

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -67,15 +67,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TrackedEntityRequestParamsMapperTest {
-  public static final String TEA_1_UID = "TvjwTPToKHO";
+  public static final UID TEA_1_UID = UID.of("TvjwTPToKHO");
 
-  public static final String TEA_2_UID = "cy2oRh2sNr6";
+  public static final UID TEA_2_UID = UID.of("cy2oRh2sNr6");
 
-  private static final String PROGRAM_UID = "XhBYIraw7sv";
+  private static final UID PROGRAM_UID = UID.of("XhBYIraw7sv");
 
-  private static final String PROGRAM_STAGE_UID = "RpCr2u2pFqw";
+  private static final UID PROGRAM_STAGE_UID = UID.of("RpCr2u2pFqw");
 
-  private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
+  private static final UID TRACKED_ENTITY_TYPE_UID = UID.of("Dp8baZYrLtr");
 
   @Mock private TrackedEntityFieldsParamMapper fieldsParamMapper;
 
@@ -95,8 +95,8 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldMapCorrectlyWhenProgramAndSpecificUpdateDatesSupplied() throws BadRequestException {
     trackedEntityRequestParams.setOuMode(CAPTURE);
     trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
-    trackedEntityRequestParams.setProgramStage(UID.of(PROGRAM_STAGE_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
+    trackedEntityRequestParams.setProgramStage(PROGRAM_STAGE_UID);
     trackedEntityRequestParams.setFollowUp(true);
     trackedEntityRequestParams.setUpdatedAfter(StartDateTime.of("2019-01-01"));
     trackedEntityRequestParams.setUpdatedBefore(EndDateTime.of("2020-01-01"));
@@ -109,8 +109,8 @@ class TrackedEntityRequestParamsMapperTest {
 
     final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertThat(params.getProgramUid(), is(PROGRAM_UID));
-    assertThat(params.getProgramStageUid(), is(PROGRAM_STAGE_UID));
+    assertThat(params.getProgram(), is(PROGRAM_UID));
+    assertThat(params.getProgramStage(), is(PROGRAM_STAGE_UID));
     assertThat(params.getFollowUp(), is(true));
     assertThat(
         params.getLastUpdatedStartDate(),
@@ -139,7 +139,7 @@ class TrackedEntityRequestParamsMapperTest {
       throws BadRequestException {
     trackedEntityRequestParams.setOuMode(CAPTURE);
     trackedEntityRequestParams.setUpdatedWithin("20h");
-    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setTrackedEntityType(TRACKED_ENTITY_TYPE_UID);
     trackedEntityRequestParams.setEventStatus(EventStatus.COMPLETED);
     trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2019-07-07"));
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
@@ -147,7 +147,7 @@ class TrackedEntityRequestParamsMapperTest {
 
     final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertThat(params.getTrackedEntityTypeUid(), is(TRACKED_ENTITY_TYPE_UID));
+    assertThat(params.getTrackedEntityType(), is(TRACKED_ENTITY_TYPE_UID));
     assertThat(params.getLastUpdatedStartDate(), is(trackedEntityRequestParams.getUpdatedAfter()));
     assertThat(params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore()));
     assertThat(
@@ -171,7 +171,7 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
     trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOrgUnitMode(CAPTURE);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
@@ -182,7 +182,7 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldMapOrgUnitModeGivenOuModeParam() throws BadRequestException {
     trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOuMode(CAPTURE);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
@@ -192,7 +192,7 @@ class TrackedEntityRequestParamsMapperTest {
   @Test
   void shouldMapOrgUnitModeToDefaultGivenNoOrgUnitModeParamIsSet() throws BadRequestException {
     trackedEntityRequestParams = new TrackedEntityRequestParams();
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
 
@@ -228,7 +228,7 @@ class TrackedEntityRequestParamsMapperTest {
   void testMappingProgramEnrollmentStartDate() throws BadRequestException {
     StartDateTime startDate = StartDateTime.of("2022-12-13");
     trackedEntityRequestParams.setEnrollmentEnrolledAfter(startDate);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
@@ -237,36 +237,36 @@ class TrackedEntityRequestParamsMapperTest {
 
   @Test
   void testMappingProgram() throws BadRequestException {
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertEquals(PROGRAM_UID, params.getProgramUid());
+    assertEquals(PROGRAM_UID, params.getProgram());
   }
 
   @Test
   void testMappingProgramStage() throws BadRequestException {
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
-    trackedEntityRequestParams.setProgramStage(UID.of(PROGRAM_STAGE_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
+    trackedEntityRequestParams.setProgramStage(PROGRAM_STAGE_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertEquals(PROGRAM_STAGE_UID, params.getProgramStageUid());
+    assertEquals(PROGRAM_STAGE_UID, params.getProgramStage());
   }
 
   @Test
   void testMappingTrackedEntityType() throws BadRequestException {
-    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setTrackedEntityType(TRACKED_ENTITY_TYPE_UID);
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertEquals(TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityTypeUid());
+    assertEquals(TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityType());
   }
 
   @Test
   void testMappingAssignedUser() throws BadRequestException {
     trackedEntityRequestParams.setAssignedUser("IsdLBTOBzMi;l5ab8q5skbB");
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
@@ -280,7 +280,7 @@ class TrackedEntityRequestParamsMapperTest {
   void testMappingAssignedUsers() throws BadRequestException {
     trackedEntityRequestParams.setAssignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"));
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
@@ -292,7 +292,7 @@ class TrackedEntityRequestParamsMapperTest {
 
   @Test
   void shouldFailIfProgramStatusIsSetWithoutProgram() {
-    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setTrackedEntityType(TRACKED_ENTITY_TYPE_UID);
     trackedEntityRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
 
     BadRequestException exception =
@@ -304,7 +304,7 @@ class TrackedEntityRequestParamsMapperTest {
 
   @Test
   void shouldFailIfEnrollmentStatusIsSetWithoutProgram() {
-    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setTrackedEntityType(TRACKED_ENTITY_TYPE_UID);
     trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
 
     BadRequestException exception =
@@ -378,7 +378,7 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
     trackedEntityRequestParams.setOrder(
         OrderCriteria.fromOrderString("createdAt:asc,zGlzbfreTOH,enrolledAt:desc"));
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
@@ -392,7 +392,7 @@ class TrackedEntityRequestParamsMapperTest {
 
   @Test
   void testMappingOrderParamsNoOrder() throws BadRequestException {
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
@@ -415,10 +415,9 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldMapFilterParameter() throws BadRequestException {
     trackedEntityRequestParams.setOrgUnitMode(ACCESSIBLE);
     trackedEntityRequestParams.setFilter(TEA_1_UID + ":like:value1," + TEA_2_UID + ":like:value2");
-    trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
+    trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    Map<String, List<QueryFilter>> filters =
-        mapper.map(trackedEntityRequestParams, user).getFilters();
+    Map<UID, List<QueryFilter>> filters = mapper.map(trackedEntityRequestParams, user).getFilters();
 
     assertEquals(
         Map.of(


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UID in TrackedEntityService and propagate the change until the generic stores.
Use UID in TrackedEntityOperationParams and propagate until the generic stores and until tracker stores when building the queries.
TrackedEntityarams are already using UIDs.
TrackedEntityOperationParams are now using UIDs. Enhance the API to make the builder accept UID and UidObject types.
TrackedEntityQueryParams is using hibernate object to build the query. A few fields are using UID and they are passed to the store and the value is used to build the query.

Next steps*

Harmonize UID in OperationsParamsValidator
Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages