### PR TITLE
chore: Use UID in OperationParamsValidator [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -73,6 +73,10 @@ public final class UID implements Serializable {
     return value;
   }
 
+  public static UID generate() {
+    return new UID(CodeGenerator.generateUid());
+  }
+
   @JsonCreator
   public static UID of(@Nonnull String value) {
     return new UID(value);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/message/ProgramMessageOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/message/ProgramMessageOperationParamsMapperTest.java
@@ -36,7 +36,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.UID;
@@ -65,8 +64,8 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
 class ProgramMessageOperationParamsMapperTest {
-  private static UID ENROLLMENT = UID.of(CodeGenerator.generateUid());
-  private static UID EVENT = UID.of(CodeGenerator.generateUid());
+  private static final UID ENROLLMENT = UID.generate();
+  private static final UID EVENT = UID.generate();
 
   @Mock private IdentifiableObjectManager manager;
   @Mock private ProgramService programService;
@@ -119,7 +118,7 @@ class ProgramMessageOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenEnrollmentNotFound() {
-    UID invalidEnrollment = UID.of(CodeGenerator.generateUid());
+    UID invalidEnrollment = UID.generate();
     when(manager.get(eq(Enrollment.class), anyString())).thenReturn(null);
 
     NotFoundException exception =
@@ -137,7 +136,7 @@ class ProgramMessageOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenEventNotFound() {
-    UID invalidEvent = UID.of(CodeGenerator.generateUid());
+    UID invalidEvent = UID.generate();
     when(manager.get(eq(Event.class), anyString())).thenReturn(null);
 
     NotFoundException exception =

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/notification/ProgramNotificationTemplateOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/notification/ProgramNotificationTemplateOperationParamsMapperTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.UID;
@@ -51,8 +50,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProgramNotificationTemplateOperationParamsMapperTest {
-  private static final UID PROGRAM = UID.of(CodeGenerator.generateUid());
-  private static final UID PROGRAM_STAGE = UID.of(CodeGenerator.generateUid());
+  private static final UID PROGRAM = UID.generate();
+  private static final UID PROGRAM_STAGE = UID.generate();
 
   @Mock private IdentifiableObjectManager manager;
 
@@ -118,7 +117,7 @@ class ProgramNotificationTemplateOperationParamsMapperTest {
 
   @Test
   void shouldThrowWhenProgramIdIsInvalid() {
-    UID invalidProgram = UID.of(CodeGenerator.generateUid());
+    UID invalidProgram = UID.generate();
     ProgramNotificationTemplateOperationParams operationParams =
         ProgramNotificationTemplateOperationParams.builder().program(invalidProgram).build();
     when(manager.get(Program.class, invalidProgram.getValue())).thenReturn(null);
@@ -135,7 +134,7 @@ class ProgramNotificationTemplateOperationParamsMapperTest {
 
   @Test
   void shouldThrowWhenProgramStageIdIsInvalid() {
-    UID invalidProgramStage = UID.of(CodeGenerator.generateUid());
+    UID invalidProgramStage = UID.generate();
     ProgramNotificationTemplateOperationParams operationParams =
         ProgramNotificationTemplateOperationParams.builder()
             .programStage(invalidProgramStage)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -121,16 +122,16 @@ public class OperationsParamsValidator {
    * @throws ForbiddenException if the user has no data read access to the program or its tracked
    *     entity type
    */
-  public Program validateTrackerProgram(String programUid, UserDetails user)
+  public Program validateTrackerProgram(UID uid, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program = validateProgramAccess(programUid, user);
+    Program program = validateProgramAccess(uid, user);
 
     if (program == null) {
       return null;
     }
 
     if (program.isWithoutRegistration()) {
-      throw new BadRequestException("Program specified is not a tracker program: " + programUid);
+      throw new BadRequestException("Program specified is not a tracker program: " + uid);
     }
 
     if (program.getTrackedEntityType() != null
@@ -151,15 +152,15 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the program uid does not exist
    * @throws ForbiddenException if the user has no data read access to the program
    */
-  public Program validateProgramAccess(String programUid, UserDetails user)
+  public Program validateProgramAccess(UID uid, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    if (programUid == null) {
+    if (uid == null) {
       return null;
     }
 
-    Program program = programService.getProgram(programUid);
+    Program program = programService.getProgram(uid.getValue());
     if (program == null) {
-      throw new BadRequestException("Program is specified but does not exist: " + programUid);
+      throw new BadRequestException("Program is specified but does not exist: " + uid);
     }
 
     if (!aclService.canDataRead(user, program)) {
@@ -176,17 +177,16 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the tracked entity uid does not exist
    * @throws ForbiddenException if the user has no data read access to type of the tracked entity
    */
-  public TrackedEntity validateTrackedEntity(String trackedEntityUid, UserDetails user)
+  public TrackedEntity validateTrackedEntity(UID uid, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    if (trackedEntityUid == null) {
+    if (uid == null) {
       return null;
     }
 
     // TODO(tracker) Are these validations enough? Should we check for ownership too?
-    TrackedEntity trackedEntity = manager.get(TrackedEntity.class, trackedEntityUid);
+    TrackedEntity trackedEntity = manager.get(TrackedEntity.class, uid.getValue());
     if (trackedEntity == null) {
-      throw new BadRequestException(
-          "Tracked entity is specified but does not exist: " + trackedEntityUid);
+      throw new BadRequestException("Tracked entity is specified but does not exist: " + uid);
     }
     trackedEntityAuditService.addTrackedEntityAudit(trackedEntity, user.getUsername(), READ);
 
@@ -207,13 +207,14 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the tracked entity type uid does not exist
    * @throws ForbiddenException if the user has no data read access to the tracked entity type
    */
-  public TrackedEntityType validateTrackedEntityType(String uid, UserDetails user)
+  public TrackedEntityType validateTrackedEntityType(UID uid, UserDetails user)
       throws BadRequestException, ForbiddenException {
     if (uid == null) {
       return null;
     }
 
-    TrackedEntityType trackedEntityType = trackedEntityTypeService.getTrackedEntityType(uid);
+    TrackedEntityType trackedEntityType =
+        trackedEntityTypeService.getTrackedEntityType(uid.getValue());
     if (trackedEntityType == null) {
       throw new BadRequestException("Tracked entity type is specified but does not exist: " + uid);
     }
@@ -234,11 +235,11 @@ public class OperationsParamsValidator {
    * @throws BadRequestException if the org unit uid does not exist
    * @throws ForbiddenException if the org unit is not part of the user scope
    */
-  public Set<OrganisationUnit> validateOrgUnits(Set<String> orgUnitIds, UserDetails user)
+  public Set<OrganisationUnit> validateOrgUnits(Set<UID> orgUnitIds, UserDetails user)
       throws BadRequestException, ForbiddenException {
     Set<OrganisationUnit> orgUnits = new HashSet<>();
-    for (String orgUnitUid : orgUnitIds) {
-      OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit(orgUnitUid);
+    for (UID orgUnitUid : orgUnitIds) {
+      OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit(orgUnitUid.getValue());
       if (orgUnit == null) {
         throw new BadRequestException("Organisation unit does not exist: " + orgUnitUid);
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -31,13 +31,11 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrgUnitMode;
-import static org.hisp.dhis.util.ObjectUtils.applyIfNotNull;
 
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -65,18 +63,14 @@ class EnrollmentOperationParamsMapper {
   public EnrollmentQueryParams map(
       @Nonnull EnrollmentOperationParams operationParams, @Nonnull UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program =
-        paramsValidator.validateTrackerProgram(
-            applyIfNotNull(operationParams.getProgram(), UID::getValue), user);
+    Program program = paramsValidator.validateTrackerProgram(operationParams.getProgram(), user);
     TrackedEntityType trackedEntityType =
-        paramsValidator.validateTrackedEntityType(
-            applyIfNotNull(operationParams.getTrackedEntityType(), UID::getValue), user);
+        paramsValidator.validateTrackedEntityType(operationParams.getTrackedEntityType(), user);
     TrackedEntity trackedEntity =
-        paramsValidator.validateTrackedEntity(
-            applyIfNotNull(operationParams.getTrackedEntity(), UID::getValue), user);
+        paramsValidator.validateTrackedEntity(operationParams.getTrackedEntity(), user);
 
     Set<OrganisationUnit> orgUnits =
-        paramsValidator.validateOrgUnits(UID.toValueSet(operationParams.getOrgUnits()), user);
+        paramsValidator.validateOrgUnits(operationParams.getOrgUnits(), user);
     validateOrgUnitMode(operationParams.getOrgUnitMode(), program, user);
 
     EnrollmentQueryParams params = new EnrollmentQueryParams();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -84,15 +84,12 @@ class EventOperationParamsMapper {
   public EventQueryParams map(
       @Nonnull EventOperationParams operationParams, @Nonnull UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program =
-        paramsValidator.validateProgramAccess(
-            applyIfNotNull(operationParams.getProgram(), UID::getValue), user);
+    Program program = paramsValidator.validateProgramAccess(operationParams.getProgram(), user);
     ProgramStage programStage =
         validateProgramStage(
             applyIfNotNull(operationParams.getProgramStage(), UID::getValue), user);
     TrackedEntity trackedEntity =
-        paramsValidator.validateTrackedEntity(
-            applyIfNotNull(operationParams.getTrackedEntity(), UID::getValue), user);
+        paramsValidator.validateTrackedEntity(operationParams.getTrackedEntity(), user);
     OrganisationUnit orgUnit =
         validateRequestedOrgUnit(applyIfNotNull(operationParams.getOrgUnit(), UID::getValue), user);
     validateOrgUnitMode(operationParams.getOrgUnitMode(), program, user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.export.OperationsParamsValidator;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,23 +91,18 @@ class TrackedEntityOperationParamsMapper {
   public TrackedEntityQueryParams map(
       TrackedEntityOperationParams operationParams, UserDetails user)
       throws BadRequestException, ForbiddenException {
-    Program program =
-        paramsValidator.validateTrackerProgram(
-            ObjectUtils.applyIfNotNull(operationParams.getProgram(), UID::getValue), user);
+    Program program = paramsValidator.validateTrackerProgram(operationParams.getProgram(), user);
     ProgramStage programStage = validateProgramStage(operationParams, program);
 
     TrackedEntityType requestedTrackedEntityType =
-        paramsValidator.validateTrackedEntityType(
-            ObjectUtils.applyIfNotNull(operationParams.getTrackedEntityType(), UID::getValue),
-            user);
+        paramsValidator.validateTrackedEntityType(operationParams.getTrackedEntityType(), user);
 
     List<TrackedEntityType> trackedEntityTypes = getTrackedEntityTypes(program, user);
 
     List<Program> programs = getTrackerPrograms(program, user);
 
     Set<OrganisationUnit> orgUnits =
-        paramsValidator.validateOrgUnits(
-            UID.toValueSet(operationParams.getOrganisationUnits()), user);
+        paramsValidator.validateOrgUnits(operationParams.getOrganisationUnits(), user);
     validateOrgUnitMode(operationParams.getOrgUnitMode(), program, user);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Sets;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -79,13 +80,13 @@ class OperationsParamsValidatorTest {
 
   private final OrganisationUnit orgUnit = new OrganisationUnit();
 
-  private static final String PROGRAM_UID = "PROGRAM_UID";
+  private static final UID PROGRAM_UID = UID.generate();
 
-  private static final String TRACKED_ENTITY_UID = "TRACKED_ENTITY_UID";
+  private static final UID TRACKED_ENTITY_UID = UID.generate();
 
-  private static final String TRACKED_ENTITY_TYPE_UID = "TRACKED_ENTITY_TYPE_UID";
+  private static final UID TRACKED_ENTITY_TYPE_UID = UID.generate();
 
-  private static final String ORG_UNIT_UID = "ORG_UNIT_UID";
+  private static final UID ORG_UNIT_UID = UID.generate();
 
   @Mock private ProgramService programService;
 
@@ -146,7 +147,7 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowBadRequestExceptionWhenProgramDoesNotExist() {
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(null);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -161,14 +162,14 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnProgramWhenUserHasAccessToProgram()
       throws ForbiddenException, BadRequestException {
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     assertEquals(program, paramsValidator.validateTrackerProgram(PROGRAM_UID, user));
   }
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToProgram() {
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(false);
 
     Exception exception =
@@ -186,7 +187,7 @@ class OperationsParamsValidatorTest {
       throws ForbiddenException, BadRequestException {
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     program.setTrackedEntityType(trackedEntityType);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
 
@@ -198,7 +199,7 @@ class OperationsParamsValidatorTest {
 
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     program.setTrackedEntityType(trackedEntityType);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(false);
 
@@ -217,7 +218,7 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldThrowBadRequestExceptionWhenRequestingTrackedEntitiesAndProgramIsNotATrackerProgram() {
     program.setProgramType(WITHOUT_REGISTRATION);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
 
     Exception exception =
@@ -233,14 +234,14 @@ class OperationsParamsValidatorTest {
   @Test
   void shouldReturnTrackedEntityWhenTrackedEntityUidExists()
       throws ForbiddenException, BadRequestException {
-    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
+    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID.getValue())).thenReturn(trackedEntity);
 
     assertEquals(trackedEntity, paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user));
   }
 
   @Test
   void shouldThrowBadRequestExceptionWhenTrackedEntityDoesNotExist() {
-    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(null);
+    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID.getValue())).thenReturn(null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -258,7 +259,7 @@ class OperationsParamsValidatorTest {
 
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     trackedEntity.setTrackedEntityType(trackedEntityType);
-    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
+    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID.getValue())).thenReturn(trackedEntity);
     when(aclService.canDataRead(user, trackedEntity.getTrackedEntityType())).thenReturn(true);
 
     assertEquals(trackedEntity, paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user));
@@ -269,7 +270,7 @@ class OperationsParamsValidatorTest {
 
     TrackedEntityType trackedEntityType = new TrackedEntityType("trackedEntityType", "");
     trackedEntity.setTrackedEntityType(trackedEntityType);
-    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID)).thenReturn(trackedEntity);
+    when(manager.get(TrackedEntity.class, TRACKED_ENTITY_UID.getValue())).thenReturn(trackedEntity);
     when(aclService.canDataRead(user, trackedEntity.getTrackedEntityType())).thenReturn(false);
 
     Exception exception =
@@ -286,7 +287,8 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowBadRequestExceptionWhenTrackedEntityTypeDoesNotExist() {
-    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID)).thenReturn(null);
+    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID.getValue()))
+        .thenReturn(null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -303,7 +305,7 @@ class OperationsParamsValidatorTest {
   void shouldReturnTrackedEntityTypeWhenUserHasAccessToTrackedEntityType()
       throws ForbiddenException, BadRequestException {
 
-    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
+    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID.getValue()))
         .thenReturn(trackedEntityType);
     when(aclService.canDataRead(user, trackedEntityType)).thenReturn(true);
 
@@ -314,7 +316,7 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToTrackedEntityType() {
-    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
+    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID.getValue()))
         .thenReturn(trackedEntityType);
     when(aclService.canDataRead(user, trackedEntityType)).thenReturn(false);
 
@@ -332,7 +334,7 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowBadRequestExceptionWhenOrgUnitDoesNotExist() {
-    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(null);
+    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID.getValue())).thenReturn(null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -349,7 +351,7 @@ class OperationsParamsValidatorTest {
       throws ForbiddenException, BadRequestException {
     User userWithOrgUnits = new User();
     userWithOrgUnits.setOrganisationUnits(Set.of(orgUnit));
-    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID.getValue())).thenReturn(orgUnit);
 
     assertEquals(
         Set.of(orgUnit),
@@ -359,7 +361,7 @@ class OperationsParamsValidatorTest {
 
   @Test
   void shouldThrowForbiddenExceptionWhenUserHasNoAccessToOrgUnit() {
-    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID.getValue())).thenReturn(orgUnit);
 
     Exception exception =
         Assertions.assertThrows(
@@ -379,7 +381,7 @@ class OperationsParamsValidatorTest {
     UserRole userRole = new UserRole();
     userRole.setAuthorities(Sets.newHashSet("ALL"));
     userWithRoles.setUserRoles(Set.of(userRole));
-    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID)).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnit(ORG_UNIT_UID.getValue())).thenReturn(orgUnit);
 
     Set<OrganisationUnit> orgUnits =
         paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_UID), UserDetails.fromUser(userWithRoles));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -70,15 +70,15 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 class EnrollmentOperationParamsMapperTest {
 
-  private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
+  private static final UID ORG_UNIT_1_UID = UID.generate();
 
-  private static final String ORG_UNIT_2_UID = "TK4KA0IIWqa";
+  private static final UID ORG_UNIT_2_UID = UID.generate();
 
-  private static final String PROGRAM_UID = "XhBYIraw7sv";
+  private static final UID PROGRAM_UID = UID.generate();
 
-  private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
+  private static final UID TRACKED_ENTITY_TYPE_UID = UID.generate();
 
-  private static final String TRACKED_ENTITY_UID = "DGbr8GHG4li";
+  private static final UID TRACKED_ENTITY_UID = UID.generate();
 
   @Mock private UserService userService;
 
@@ -106,10 +106,10 @@ class EnrollmentOperationParamsMapperTest {
     testUser.setUsername("admin");
 
     orgUnit1 = new OrganisationUnit("orgUnit1");
-    orgUnit1.setUid(ORG_UNIT_1_UID);
+    orgUnit1.setUid(ORG_UNIT_1_UID.getValue());
     when(organisationUnitService.getOrganisationUnit(orgUnit1.getUid())).thenReturn(orgUnit1);
     orgUnit2 = new OrganisationUnit("orgUnit2");
-    orgUnit2.setUid(ORG_UNIT_2_UID);
+    orgUnit2.setUid(ORG_UNIT_2_UID.getValue());
     orgUnit2.setParent(orgUnit1);
     orgUnit1.setChildren(Set.of(orgUnit2));
     when(organisationUnitService.getOrganisationUnit(orgUnit2.getUid())).thenReturn(orgUnit2);
@@ -127,17 +127,17 @@ class EnrollmentOperationParamsMapperTest {
     user = UserDetails.fromUser(testUser);
 
     TrackedEntityType trackedEntityType = new TrackedEntityType();
-    trackedEntityType.setUid(TRACKED_ENTITY_TYPE_UID);
-    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID))
+    trackedEntityType.setUid(TRACKED_ENTITY_TYPE_UID.getValue());
+    when(trackedEntityTypeService.getTrackedEntityType(TRACKED_ENTITY_TYPE_UID.getValue()))
         .thenReturn(trackedEntityType);
 
     Program program = new Program();
-    program.setUid(PROGRAM_UID);
+    program.setUid(PROGRAM_UID.getValue());
     program.setTrackedEntityType(trackedEntityType);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
+    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
 
     TrackedEntity trackedEntity = new TrackedEntity();
-    trackedEntity.setUid(TRACKED_ENTITY_UID);
+    trackedEntity.setUid(TRACKED_ENTITY_UID.getValue());
     trackedEntity.setTrackedEntityType(trackedEntityType);
 
     when(paramsValidator.validateTrackerProgram(PROGRAM_UID, user)).thenReturn(program);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -273,7 +273,7 @@ class EventOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenAttributeInGivenAttributeFilterDoesNotExist() {
-    UID filterName = UID.of(CodeGenerator.generateUid());
+    UID filterName = UID.generate();
     EventOperationParams operationParams =
         eventBuilder.attributeFilters(Map.of(filterName, List.of())).build();
 
@@ -386,7 +386,7 @@ class EventOperationParamsMapperTest {
 
   @Test
   void shouldFailWhenDataElementInGivenDataElementFilterDoesNotExist() {
-    UID filterName = UID.of(CodeGenerator.generateUid());
+    UID filterName = UID.generate();
     EventOperationParams operationParams =
         eventBuilder.dataElementFilters(Map.of(filterName, List.of())).build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -181,7 +181,7 @@ class TrackedEntityOperationParamsMapperTest {
   void testMapping() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(any(UserDetails.class), any(TrackedEntityType.class)))
         .thenReturn(true);
-    when(paramsValidator.validateTrackedEntityType(trackedEntityType.getUid(), user))
+    when(paramsValidator.validateTrackedEntityType(UID.of(trackedEntityType), user))
         .thenReturn(trackedEntityType);
     when(trackedEntityTypeService.getAllTrackedEntityType()).thenReturn(List.of(trackedEntityType));
 
@@ -229,7 +229,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgramEnrollmentStartDate() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     Date date = parseDate("2022-12-13");
     TrackedEntityOperationParams operationParams =
@@ -246,7 +246,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgramEnrollmentEndDate() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     Date date = parseDate("2022-12-13");
     TrackedEntityOperationParams operationParams =
@@ -264,7 +264,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testFilter() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -319,7 +319,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testFilterWhenTEAHasMultipleFilters() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -354,7 +354,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgram() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
@@ -367,7 +367,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingProgramStage() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -407,7 +407,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void testMappingAssignedUsers() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -431,7 +431,7 @@ class TrackedEntityOperationParamsMapperTest {
   @Test
   void shouldMapOrderInGivenOrder() throws BadRequestException, ForbiddenException {
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID.getValue());
@@ -462,7 +462,7 @@ class TrackedEntityOperationParamsMapperTest {
     tea1.setUid(TEA_1_UID.getValue());
     when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(null);
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -484,7 +484,7 @@ class TrackedEntityOperationParamsMapperTest {
     // invalid field names and UIDs. Such invalid order values will be caught in this mapper.
     assertTrue(CodeGenerator.isValidUid("lastUpdated"));
     when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), user)).thenReturn(program);
+    when(paramsValidator.validateTrackerProgram(UID.of(program), user)).thenReturn(program);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -507,7 +507,7 @@ class TrackedEntityOperationParamsMapperTest {
     UserDetails currentUserWithOrgUnits = UserDetails.fromUser(userWithOrgUnits);
 
     when(aclService.canDataRead(currentUserWithOrgUnits, program)).thenReturn(true);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUserWithOrgUnits))
+    when(paramsValidator.validateTrackerProgram(UID.of(program), currentUserWithOrgUnits))
         .thenReturn(program);
     when(organisationUnitService.getOrganisationUnitsByUid(
             Set.of(orgUnit1.getUid(), orgUnit2.getUid())))
@@ -538,7 +538,7 @@ class TrackedEntityOperationParamsMapperTest {
     program.setMinAttributesRequiredToSearch(0);
     program.setMaxTeiCountToReturn(1);
     when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
-    when(paramsValidator.validateTrackerProgram(program.getUid(), currentUserWithOrgUnits))
+    when(paramsValidator.validateTrackerProgram(UID.of(program), currentUserWithOrgUnits))
         .thenReturn(program);
 
     when(trackedEntityStore.getTrackedEntityCountWithMaxTrackedEntityLimit(any())).thenReturn(100);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.List;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -96,9 +95,7 @@ class EventChangeLogServiceTest extends TrackerTest {
   void shouldFailWhenEventDoesNotExist() {
     assertThrows(
         NotFoundException.class,
-        () ->
-            eventChangeLogService.getEventChangeLog(
-                UID.of(CodeGenerator.generateUid()), null, null));
+        () -> eventChangeLogService.getEventChangeLog(UID.generate(), null, null));
   }
 
   @Test
@@ -106,9 +103,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     trackerObjectDeletionService.deleteEvents(List.of("D9PbzJY8bJM"));
     assertThrows(
         NotFoundException.class,
-        () ->
-            eventChangeLogService.getEventChangeLog(
-                UID.of(CodeGenerator.generateUid()), null, null));
+        () -> eventChangeLogService.getEventChangeLog(UID.generate(), null, null));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -228,7 +228,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     submission.setTrackerProgram(trackerProgram.getUid());
     submission.setTrackedEntityInstance(CodeGenerator.generateUid());
     submission.setTrackedEntityType(trackedEntityType.getUid());
-    UID enrollmentUid = UID.of(CodeGenerator.generateUid());
+    UID enrollmentUid = UID.generate();
     submission.setEnrollment(enrollmentUid.getValue());
     submission.setEnrollmentDate(DateUtils.getDate(2024, 9, 2, 10, 15));
     submission.setIncidentDate(DateUtils.getDate(2024, 9, 3, 16, 23));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -364,7 +364,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldFailDeletingNonExistingEvent() throws SmsCompressionException {
-    UID uid = UID.of(CodeGenerator.generateUid());
+    UID uid = UID.generate();
     assertThrows(NotFoundException.class, () -> eventService.getEvent(uid));
 
     DeleteSmsSubmission submission = new DeleteSmsSubmission();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/message/ProgramMessageRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/message/ProgramMessageRequestParamsMapperTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
@@ -52,9 +51,9 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
 class ProgramMessageRequestParamsMapperTest {
-  private static UID ENROLLMENT = UID.of(CodeGenerator.generateUid());
-  private static UID PROGRAM_INSTANCE = UID.of(CodeGenerator.generateUid());
-  private static UID EVENT = UID.of(CodeGenerator.generateUid());
+  private static final UID ENROLLMENT = UID.generate();
+  private static final UID PROGRAM_INSTANCE = UID.generate();
+  private static final UID EVENT = UID.generate();
 
   @InjectMocks private ProgramMessageRequestParamMapper subject;
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/notification/ProgramNotificationTemplateRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/notification/ProgramNotificationTemplateRequestParamsMapperTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.tracker.notification;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
@@ -46,8 +45,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @ExtendWith(MockitoExtension.class)
 class ProgramNotificationTemplateRequestParamsMapperTest {
-  private static UID PROGRAM = UID.of(CodeGenerator.generateUid());
-  private static UID PROGRAM_STAGE = UID.of(CodeGenerator.generateUid());
+  private static final UID PROGRAM = UID.generate();
+  private static final UID PROGRAM_STAGE = UID.generate();
 
   @InjectMocks private ProgramNotificationTemplateRequestParamsMapper mapper;
 


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UID in OperationsParamsValidator.
Add a new static method in UID object to generate a UID.

Next steps*

Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages