### PR TITLE
chore: Clean up operation params APIs [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -39,7 +39,12 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.export.Order;
 
 @Getter
@@ -108,6 +113,60 @@ public class EnrollmentOperationParams {
 
     public EnrollmentOperationParamsBuilder orderBy(String field, SortDirection direction) {
       this.order.add(new Order(field, direction));
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder trackedEntityType(UID uid) {
+      this.trackedEntityType = uid;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder trackedEntityType(TrackedEntityType trackedEntityType) {
+      this.trackedEntityType = UID.of(trackedEntityType);
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder trackedEntity(UID uid) {
+      this.trackedEntity = uid;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder trackedEntity(TrackedEntity trackedEntity) {
+      this.trackedEntity = UID.of(trackedEntity);
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder program(UID uid) {
+      this.program = uid;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder program(Program program) {
+      this.program = UID.of(program);
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder orgUnits(Set<UID> uids) {
+      this.orgUnits$value = uids;
+      this.orgUnits$set = true;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder orgUnits(OrganisationUnit... organisationUnits) {
+      this.orgUnits$value = UID.of(organisationUnits);
+      this.orgUnits$set = true;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder enrollments(Set<UID> uids) {
+      this.enrollments$value = uids;
+      this.enrollments$set = true;
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder enrollments(Enrollment... enrollments) {
+      this.enrollments$value = UID.of(enrollments);
+      this.enrollments$set = true;
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -47,8 +47,12 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.export.Order;
 
 @Getter
@@ -164,6 +168,46 @@ public class EventOperationParams {
 
     public EventOperationParamsBuilder orderBy(UID uid, SortDirection direction) {
       this.order.add(new Order(uid, direction));
+      return this;
+    }
+
+    public EventOperationParamsBuilder program(UID uid) {
+      this.program = uid;
+      return this;
+    }
+
+    public EventOperationParamsBuilder program(Program program) {
+      this.program = UID.of(program);
+      return this;
+    }
+
+    public EventOperationParamsBuilder programStage(UID uid) {
+      this.programStage = uid;
+      return this;
+    }
+
+    public EventOperationParamsBuilder programStage(ProgramStage programStage) {
+      this.programStage = UID.of(programStage);
+      return this;
+    }
+
+    public EventOperationParamsBuilder orgUnit(UID uid) {
+      this.orgUnit = uid;
+      return this;
+    }
+
+    public EventOperationParamsBuilder orgUnit(OrganisationUnit orgUnit) {
+      this.orgUnit = UID.of(orgUnit);
+      return this;
+    }
+
+    public EventOperationParamsBuilder trackedEntity(UID uid) {
+      this.trackedEntity = uid;
+      return this;
+    }
+
+    public EventOperationParamsBuilder trackedEntity(TrackedEntity trackedEntity) {
+      this.trackedEntity = UID.of(trackedEntity);
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
@@ -35,6 +35,9 @@ import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.Order;
 
@@ -62,6 +65,26 @@ public class RelationshipOperationParams {
 
     public RelationshipOperationParamsBuilder orderBy(String field, SortDirection direction) {
       this.order.add(new Order(field, direction));
+      return this;
+    }
+
+    public RelationshipOperationParamsBuilder identifier(UID uid) {
+      this.identifier = uid;
+      return this;
+    }
+
+    public RelationshipOperationParamsBuilder identifier(TrackedEntity trackedEntity) {
+      this.identifier = UID.of(trackedEntity);
+      return this;
+    }
+
+    public RelationshipOperationParamsBuilder identifier(Enrollment enrollment) {
+      this.identifier = UID.of(enrollment);
+      return this;
+    }
+
+    public RelationshipOperationParamsBuilder identifier(Event event) {
+      this.identifier = UID.of(event);
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -146,8 +145,8 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
       Page<Enrollment> enrollmentPage =
           enrollmentService.getEnrollments(
               EnrollmentOperationParams.builder()
-                  .trackedEntity(UID.of(trackedEntity))
-                  .program(UID.of(smsCommand.getProgram()))
+                  .trackedEntity(trackedEntity)
+                  .program(smsCommand.getProgram())
                   .enrollmentStatus(EnrollmentStatus.ACTIVE)
                   .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                   .build(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -227,10 +227,7 @@ class EnrollmentOperationParamsMapperTest {
       throws ForbiddenException, BadRequestException {
 
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit1)))
-            .orgUnitMode(CHILDREN)
-            .build();
+        EnrollmentOperationParams.builder().orgUnits(orgUnit1).orgUnitMode(CHILDREN).build();
 
     EnrollmentQueryParams params = mapper.map(operationParams, user);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -154,8 +154,7 @@ class EventOperationParamsMapperTest {
   void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToProgramStage() {
     ProgramStage programStage = new ProgramStage();
     programStage.setUid("PlZSBEN7iZd");
-    EventOperationParams eventOperationParams =
-        eventBuilder.programStage(UID.of(programStage)).build();
+    EventOperationParams eventOperationParams = eventBuilder.programStage(programStage).build();
 
     when(aclService.canDataRead(user, programStage)).thenReturn(false);
     when(programStageService.getProgramStage("PlZSBEN7iZd")).thenReturn(programStage);
@@ -438,8 +437,8 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams =
         eventBuilder
-            .program(UID.of(program))
-            .orgUnit(UID.of(searchScopeChildOrgUnit))
+            .program(program)
+            .orgUnit(searchScopeChildOrgUnit)
             .orgUnitMode(orgUnitMode)
             .build();
 
@@ -472,11 +471,7 @@ class EventOperationParamsMapperTest {
         .thenReturn(searchScopeChildOrgUnit);
 
     EventOperationParams operationParams =
-        eventBuilder
-            .program(UID.of(program))
-            .orgUnit(UID.of(searchScopeChildOrgUnit))
-            .orgUnitMode(ALL)
-            .build();
+        eventBuilder.program(program).orgUnit(searchScopeChildOrgUnit).orgUnitMode(ALL).build();
 
     EventQueryParams queryParams = mapper.map(operationParams, UserDetails.fromUser(user));
     assertEquals(searchScopeChildOrgUnit, queryParams.getOrgUnit());
@@ -489,7 +484,7 @@ class EventOperationParamsMapperTest {
     OrganisationUnit orgUnit = createOrgUnit("name");
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
     EventOperationParams operationParams =
-        EventOperationParams.builder().orgUnit(UID.of(orgUnit)).orgUnitMode(orgUnitMode).build();
+        EventOperationParams.builder().orgUnit(orgUnit).orgUnitMode(orgUnitMode).build();
 
     ForbiddenException exception =
         assertThrows(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -505,7 +505,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
       throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .enrollments(Set.of(UID.of(enrollment)))
+            .enrollments(enrollment)
             .orgUnitMode(ALL)
             .includeDeleted(true)
             .build();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -572,7 +571,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit)))
+            .orgUnits(orgUnit)
             .orgUnitMode(SELECTED)
             .orderBy("enrollmentDate", SortDirection.ASC)
             .build();
@@ -604,7 +603,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit)))
+            .orgUnits(orgUnit)
             .orgUnitMode(SELECTED)
             .orderBy("enrollmentDate", SortDirection.ASC)
             .build();
@@ -643,10 +642,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .toList();
 
     EnrollmentOperationParams params =
-        EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit)))
-            .orgUnitMode(SELECTED)
-            .build();
+        EnrollmentOperationParams.builder().orgUnits(orgUnit).orgUnitMode(SELECTED).build();
 
     List<String> enrollments = getEnrollments(params);
 
@@ -657,7 +653,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEnrollmentsByEnrolledAtAsc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit)))
+            .orgUnits(orgUnit)
             .orgUnitMode(SELECTED)
             .orderBy("enrollmentDate", SortDirection.ASC)
             .build();
@@ -671,7 +667,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEnrollmentsByEnrolledAtDesc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnit)))
+            .orgUnits(orgUnit)
             .orgUnitMode(SELECTED)
             .orderBy("enrollmentDate", SortDirection.DESC)
             .build();
@@ -686,7 +682,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .events(UID.of("pTzf9KYMk72", "D9PbzJY8bJM"))
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
@@ -711,7 +707,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @Test
   void shouldReturnPaginatedEventsWithTotalPages() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        eventParamsBuilder.orgUnit(UID.of(orgUnit)).programStage(UID.of(programStage)).build();
+        eventParamsBuilder.orgUnit(orgUnit).programStage(programStage).build();
 
     Page<Event> page = eventService.getEvents(params, new PageParams(1, 2, true));
 
@@ -729,8 +725,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .program(UID.of(program))
+            .orgUnit(orgUnit)
+            .program(program)
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -759,8 +755,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .program(UID.of(program))
+            .orgUnit(orgUnit)
+            .program(program)
             .orderBy("occurredDate", SortDirection.DESC)
             .build();
 
@@ -782,7 +778,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .map(Event::getUid)
             .toList();
 
-    EventOperationParams params = eventParamsBuilder.orgUnit(UID.of(orgUnit)).build();
+    EventOperationParams params = eventParamsBuilder.orgUnit(orgUnit).build();
 
     List<String> events = getEvents(params);
 
@@ -844,7 +840,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByAttributeAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
@@ -857,7 +853,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByAttributeDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
@@ -871,7 +867,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .events(
                 UID.of(
                     "pTzf9KYMk72",
@@ -889,7 +885,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByMultipleAttributesDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
@@ -903,7 +899,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByMultipleAttributesAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
@@ -921,7 +917,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams operationParams =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toDelete000"), SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
@@ -973,7 +969,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByTrackedEntityUidDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy("enrollment.trackedEntity.uid", SortDirection.DESC)
             .build();
 
@@ -986,7 +982,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   void shouldOrderEventsByTrackedEntityUidAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy("enrollment.trackedEntity.uid", SortDirection.ASC)
             .build();
 
@@ -1028,10 +1024,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @Test
   void shouldOrderEventsByOccurredAtDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .orderBy("occurredDate", SortDirection.DESC)
-            .build();
+        eventParamsBuilder.orgUnit(orgUnit).orderBy("occurredDate", SortDirection.DESC).build();
 
     List<String> events = getEvents(params);
 
@@ -1041,10 +1034,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @Test
   void shouldOrderEventsByOccurredAtAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .orderBy("occurredDate", SortDirection.ASC)
-            .build();
+        eventParamsBuilder.orgUnit(orgUnit).orderBy("occurredDate", SortDirection.ASC).build();
 
     List<String> events = getEvents(params);
 
@@ -1056,8 +1046,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .programStage(UID.of(programStage))
+            .orgUnit(orgUnit)
+            .programStage(programStage)
             .orderBy("createdAtClient", SortDirection.ASC)
             .build();
 
@@ -1071,8 +1061,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .programStage(UID.of(programStage))
+            .orgUnit(orgUnit)
+            .programStage(programStage)
             .orderBy("createdAtClient", SortDirection.DESC)
             .build();
 
@@ -1086,8 +1076,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .programStage(UID.of(programStage))
+            .orgUnit(orgUnit)
+            .programStage(programStage)
             .orderBy("lastUpdatedAtClient", SortDirection.ASC)
             .build();
 
@@ -1101,8 +1091,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
-            .programStage(UID.of(programStage))
+            .orgUnit(orgUnit)
+            .programStage(programStage)
             .orderBy("lastUpdatedAtClient", SortDirection.DESC)
             .build();
 
@@ -1116,7 +1106,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
@@ -1131,7 +1121,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
@@ -1146,7 +1136,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy("scheduledDate", SortDirection.DESC)
             .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
@@ -1162,7 +1152,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .build();
@@ -1177,7 +1167,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .events(
                 UID.of(
                     "pTzf9KYMk72", // EV pTzf9KYMk72 without data element DATAEL00002
@@ -1217,7 +1207,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
-    eventParamsBuilder.orgUnit(UID.of(orgUnit));
+    eventParamsBuilder.orgUnit(orgUnit);
     eventParamsBuilder.orderBy(field, SortDirection.DESC);
 
     List<String> events = getEvents(eventParamsBuilder.build());
@@ -1231,7 +1221,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
 
     eventParamsBuilder.orgUnitMode(SELECTED);
-    eventParamsBuilder.orgUnit(UID.of(orgUnit));
+    eventParamsBuilder.orgUnit(orgUnit);
     eventParamsBuilder.orderBy(field, SortDirection.ASC);
 
     List<String> events = getEvents(eventParamsBuilder.build());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -309,8 +309,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     assertNotNull(enrollment);
     assertContainsOnly(
-        List.of(eventA.getUid()),
-        enrollment.getEvents().stream().map(Event::getUid).collect(Collectors.toList()));
+        List.of(eventA.getUid()), enrollment.getEvents().stream().map(Event::getUid).toList());
   }
 
   @Test
@@ -449,14 +448,14 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentsWhenUserHasReadAccessToProgramAndSearchScopeAccessToOrgUnit()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
 
     manager.updateNoAcl(programA);
 
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .program(UID.of(programA))
+            .program(programA)
             .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
             .build();
 
@@ -470,16 +469,13 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentsWhenUserHasReadAccessToProgramAndNoOrgUnitNorOrgUnitModeSpecified()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
 
     manager.updateNoAcl(programA);
 
     EnrollmentOperationParams params =
-        EnrollmentOperationParams.builder()
-            .program(UID.of(programA))
-            .orgUnitMode(ACCESSIBLE)
-            .build();
+        EnrollmentOperationParams.builder().program(programA).orgUnitMode(ACCESSIBLE).build();
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
 
@@ -491,7 +487,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentsInCaptureScopeIfOrgUnitModeCapture()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
 
     manager.updateNoAcl(programA);
@@ -509,15 +505,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentWhenEnrollmentsAndOtherParamsAreSpecified()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
 
     manager.updateNoAcl(programA);
 
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .program(UID.of(programA))
-            .enrollments(Set.of(UID.of(enrollmentA)))
+            .program(programA)
+            .enrollments(enrollmentA)
             .orgUnitMode(ACCESSIBLE)
             .build();
 
@@ -529,15 +525,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentsByTrackedEntityWhenUserHasAccessToTrackedEntityType()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.DATA_READ);
     manager.updateNoAcl(programA);
 
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(trackedEntityA.getOrganisationUnit())))
+            .orgUnits(trackedEntityA.getOrganisationUnit())
             .orgUnitMode(SELECTED)
-            .trackedEntity(UID.of(trackedEntityA))
+            .trackedEntity(trackedEntityA)
             .build();
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
@@ -548,12 +544,12 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEnrollmentIfEnrollmentWasUpdatedBeforePassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     Date oneHourBeforeLastUpdated = oneHourBefore(enrollmentA.getLastUpdated());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .lastUpdated(oneHourBeforeLastUpdated)
             .build();
@@ -565,12 +561,12 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEmptyIfEnrollmentWasUpdatedAfterPassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     Date oneHourAfterLastUpdated = oneHourAfter(enrollmentA.getLastUpdated());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
             .lastUpdated(oneHourAfterLastUpdated)
             .build();
@@ -582,15 +578,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEnrollmentIfEnrollmentStartedBeforePassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
     Date oneHourBeforeEnrollmentDate = oneHourBefore(enrollmentA.getEnrollmentDate());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .program(UID.of(programA))
+            .program(programA)
             .programStartDate(oneHourBeforeEnrollmentDate)
             .build();
 
@@ -601,15 +597,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEmptyIfEnrollmentStartedAfterPassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
     Date oneHourAfterEnrollmentDate = oneHourAfter(enrollmentA.getEnrollmentDate());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .program(UID.of(programA))
+            .program(programA)
             .programStartDate(oneHourAfterEnrollmentDate)
             .build();
 
@@ -620,15 +616,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEnrollmentIfEnrollmentEndedAfterPassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
     Date oneHourAfterEnrollmentDate = oneHourAfter(enrollmentA.getEnrollmentDate());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .program(UID.of(programA))
+            .program(programA)
             .programEndDate(oneHourAfterEnrollmentDate)
             .build();
 
@@ -639,15 +635,15 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEmptyIfEnrollmentEndedBeforePassedDateAndTime()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
     Date oneHourBeforeEnrollmentDate = oneHourBefore(enrollmentA.getEnrollmentDate());
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
+            .orgUnits(orgUnitA)
             .orgUnitMode(SELECTED)
-            .program(UID.of(programA))
+            .program(programA)
             .programEndDate(oneHourBeforeEnrollmentDate)
             .build();
 
@@ -658,7 +654,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnAllAccessibleEnrollmentsInTheSystemWhenModeAllAndUserAuthorized()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(authorizedUser);
 
     EnrollmentOperationParams operationParams =
@@ -687,10 +683,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(authorizedUser);
 
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder()
-            .orgUnitMode(DESCENDANTS)
-            .orgUnits(Set.of(UID.of(orgUnitA)))
-            .build();
+        EnrollmentOperationParams.builder().orgUnitMode(DESCENDANTS).orgUnits(orgUnitA).build();
 
     ForbiddenException exception =
         assertThrows(
@@ -702,7 +695,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnAllEnrollmentsWhenOrgUnitModeAllAndUserAuthorized()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(admin);
 
     EnrollmentOperationParams operationParams =
@@ -715,13 +708,10 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnAllDescendantsOfSelectedOrgUnitWhenOrgUnitModeDescendants()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
-            .orgUnitMode(DESCENDANTS)
-            .build();
+        EnrollmentOperationParams.builder().orgUnits(orgUnitA).orgUnitMode(DESCENDANTS).build();
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
     assertContainsOnly(
@@ -731,13 +721,10 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnChildrenOfRootOrgUnitWhenOrgUnitModeChildren()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitA)))
-            .orgUnitMode(CHILDREN)
-            .build();
+        EnrollmentOperationParams.builder().orgUnits(orgUnitA).orgUnitMode(CHILDREN).build();
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
     assertContainsOnly(List.of(enrollmentA.getUid(), enrollmentChildA.getUid()), uids(enrollments));
@@ -745,13 +732,10 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnChildrenOfRequestedOrgUnitWhenOrgUnitModeChildren()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder()
-            .orgUnits(Set.of(UID.of(orgUnitChildA)))
-            .orgUnitMode(CHILDREN)
-            .build();
+        EnrollmentOperationParams.builder().orgUnits(orgUnitChildA).orgUnitMode(CHILDREN).build();
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
     assertContainsOnly(
@@ -761,11 +745,11 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   @Test
   void
       shouldReturnAllChildrenOfRequestedOrgUnitsWhenOrgUnitModeChildrenAndMultipleOrgUnitsRequested()
-          throws ForbiddenException, BadRequestException, NotFoundException {
+          throws ForbiddenException, BadRequestException {
 
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnits(UID.of(orgUnitA, orgUnitChildA))
+            .orgUnits(orgUnitA, orgUnitChildA)
             .orgUnitMode(CHILDREN)
             .build();
 
@@ -813,7 +797,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   private static List<String> attributeUids(Enrollment enrollment) {
     return enrollment.getTrackedEntity().getTrackedEntityAttributeValues().stream()
         .map(v -> v.getAttribute().getUid())
-        .collect(Collectors.toList());
+        .toList();
   }
 
   private static Set<String> relationshipUids(Enrollment enrollment) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -119,7 +119,7 @@ class AclEventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .program(UID.of("pcxIanBWlSY"))
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orgUnitMode(DESCENDANTS)
             .build();
 
@@ -143,7 +143,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(DESCENDANTS).build();
+        operationParamsBuilder.orgUnit(orgUnit).orgUnitMode(DESCENDANTS).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -169,7 +169,7 @@ class AclEventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .program(UID.of("pcxIanBWlSY"))
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orgUnitMode(CHILDREN)
             .build();
 
@@ -193,7 +193,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(CHILDREN).build();
+        operationParamsBuilder.orgUnit(orgUnit).orgUnitMode(CHILDREN).build();
 
     List<Event> events = eventService.getEvents(params);
 
@@ -210,7 +210,7 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
         operationParamsBuilder
-            .program(UID.of(program))
+            .program(program)
             .orgUnit(UID.of("DiszpKrYNg8"))
             .orgUnitMode(DESCENDANTS)
             .build();
@@ -306,7 +306,7 @@ class AclEventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .program(UID.of("shPjYNifvMK"))
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .orgUnitMode(SELECTED)
             .build();
 
@@ -341,7 +341,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContextUser(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        operationParamsBuilder.program(UID.of(program)).orgUnitMode(ACCESSIBLE).build();
+        operationParamsBuilder.program(program).orgUnitMode(ACCESSIBLE).build();
 
     List<Event> events = eventService.getEvents(params);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -136,7 +136,7 @@ class EventExporterTest extends TrackerTest {
     injectSecurityContextUser(importUser);
 
     operationParamsBuilder = EventOperationParams.builder().eventParams(EventParams.FALSE);
-    operationParamsBuilder.orgUnit(UID.of(orgUnit)).orgUnitMode(SELECTED);
+    operationParamsBuilder.orgUnit(orgUnit).orgUnitMode(SELECTED);
   }
 
   @Test
@@ -144,7 +144,7 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .trackedEntity(UID.of(trackedEntity))
+            .trackedEntity(trackedEntity)
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
             .build();
 
@@ -189,7 +189,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void testExportEvents() throws ForbiddenException, BadRequestException {
-    EventOperationParams params = operationParamsBuilder.programStage(UID.of(programStage)).build();
+    EventOperationParams params = operationParamsBuilder.programStage(programStage).build();
 
     List<String> events = getEvents(params);
 
@@ -200,7 +200,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWhenFilteringByEnrollment() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .trackedEntity(UID.of(trackedEntity))
+            .trackedEntity(trackedEntity)
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
             .build();
 
@@ -215,7 +215,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .occurredAfter(getDate(2018, 1, 1))
             .occurredBefore(getDate(2020, 1, 29))
             .skipChangedBefore(getDate(2018, 1, 1))
@@ -231,7 +231,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .updatedWithin("1d")
             .build();
 
@@ -246,7 +246,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .occurredBefore(Date.from(getDate(2020, 1, 28).toInstant().plus(1, ChronoUnit.HOURS)))
             .occurredAfter(Date.from(getDate(2020, 1, 28).toInstant().minus(1, ChronoUnit.HOURS)))
             .build();
@@ -262,7 +262,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .occurredBefore(getDate(2020, 1, 28))
             .build();
 
@@ -277,7 +277,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .occurredAfter(getDate(2020, 1, 28))
             .build();
 
@@ -292,7 +292,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .updatedAfter(
                 Date.from(
                     date.toInstant()
@@ -353,7 +353,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
@@ -373,7 +373,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
             .dataElementFilters(
                 Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
@@ -392,7 +392,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .programType(ProgramType.WITH_REGISTRATION)
             .dataElementFilters(
                 Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
@@ -411,7 +411,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(
                     UID.of(dataElement),
@@ -431,7 +431,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(
                     UID.of(dataElement),
@@ -451,8 +451,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
-            .program(UID.of(program))
+            .programStage(programStage)
+            .program(program)
             .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
@@ -635,8 +635,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
-            .programStage(UID.of(programStage))
-            .program(UID.of(program))
+            .programStage(programStage)
+            .program(program)
             .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
             .dataElementFilters(
@@ -656,7 +656,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
             .build();
@@ -673,7 +673,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(
                     UID.of(dataElement),
@@ -692,7 +692,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
             .build();
@@ -709,7 +709,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
-            .programStage(UID.of(programStage))
+            .programStage(programStage)
             .dataElementFilters(
                 Map.of(
                     UID.of(dataElement),
@@ -905,7 +905,7 @@ class EventExporterTest extends TrackerTest {
           throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .attributeFilters(Map.of(UID.of("notUpdated0"), List.of()))
             .build();
 
@@ -921,7 +921,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterNumericAttributes() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .attributeFilters(
                 Map.of(
                     UID.of("numericAttr"),
@@ -942,7 +942,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterAttributes() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .attributeFilters(
                 Map.of(
                     UID.of("toUpdate000"),
@@ -962,7 +962,7 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .attributeFilters(
                 Map.of(
                     UID.of("toUpdate000"),
@@ -984,7 +984,7 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
-            .orgUnit(UID.of(orgUnit))
+            .orgUnit(orgUnit)
             .attributeFilters(
                 Map.of(
                     UID.of("toUpdate000"),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -37,11 +37,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -245,13 +243,12 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     relationship(teA, inaccessibleTe, teToInaccessibleTeType);
 
     RelationshipOperationParams operationParams =
-        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(UID.of(teA)).build();
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(teA).build();
 
     List<Relationship> relationships = relationshipService.getRelationships(operationParams);
 
     assertContainsOnly(
-        List.of(accessible.getUid()),
-        relationships.stream().map(Relationship::getUid).collect(Collectors.toList()));
+        List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
   }
 
   @Test
@@ -261,16 +258,12 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     relationship(teB, enrollmentA, teToInaccessibleEnType);
 
     RelationshipOperationParams operationParams =
-        RelationshipOperationParams.builder()
-            .type(ENROLLMENT)
-            .identifier(UID.of(enrollmentA))
-            .build();
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(enrollmentA).build();
 
     List<Relationship> relationships = relationshipService.getRelationships(operationParams);
 
     assertContainsOnly(
-        List.of(accessible.getUid()),
-        relationships.stream().map(Relationship::getUid).collect(Collectors.toList()));
+        List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
   }
 
   @Test
@@ -280,13 +273,12 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     relationship(eventA, inaccessibleEvent);
 
     RelationshipOperationParams operationParams =
-        RelationshipOperationParams.builder().type(EVENT).identifier(UID.of(eventA)).build();
+        RelationshipOperationParams.builder().type(EVENT).identifier(eventA).build();
 
     List<Relationship> relationships = relationshipService.getRelationships(operationParams);
 
     assertContainsOnly(
-        List.of(accessible.getUid()),
-        relationships.stream().map(Relationship::getUid).collect(Collectors.toList()));
+        List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
   }
 
   @Test
@@ -325,7 +317,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
             .type(TRACKED_ENTITY)
-            .identifier(UID.of(trackedEntityFrom))
+            .identifier(trackedEntityFrom)
             .build();
 
     assertThrows(
@@ -362,14 +354,13 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
             .type(TRACKED_ENTITY)
-            .identifier(UID.of(trackedEntityFrom))
+            .identifier(trackedEntityFrom)
             .build();
 
     List<Relationship> relationships = relationshipService.getRelationships(operationParams);
 
     assertContainsOnly(
-        List.of(accessible.getUid()),
-        relationships.stream().map(Relationship::getUid).collect(Collectors.toList()));
+        List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
   }
 
   @Test
@@ -403,7 +394,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
             .type(TRACKED_ENTITY)
-            .identifier(UID.of(trackedEntityFrom))
+            .identifier(trackedEntityFrom)
             .build();
 
     assertThrows(
@@ -442,7 +433,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder()
             .type(TRACKED_ENTITY)
-            .identifier(UID.of(trackedEntityFrom))
+            .identifier(trackedEntityFrom)
             .build();
 
     assertThrows(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -172,7 +171,7 @@ class EventsExportControllerTest extends H2ControllerIntegrationTestBase {
   @MethodSource
   void shouldMatchContentTypeAndAttachment_whenEndpointForCompressedEventJsonIsInvoked(
       String url, String expectedContentType, String expectedAttachment, String encoding)
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
 
     when(eventService.getEvents(any())).thenReturn(List.of());
     injectSecurityContextUser(user);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerPostgresTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerPostgresTest.java
@@ -387,14 +387,6 @@ class TrackedEntitiesExportControllerPostgresTest extends PostgresControllerInte
         () -> assertChange(attribute, previousValue, currentValue, actual));
   }
 
-  private static void assertDelete(
-      TrackedEntityAttribute attribute, String previousValue, JsonTrackedEntityChangeLog actual) {
-    assertAll(
-        () -> assertUser(actual),
-        () -> assertEquals("DELETE", actual.getType()),
-        () -> assertChange(attribute, previousValue, null, actual));
-  }
-
   private static void assertChange(
       TrackedEntityAttribute attribute,
       String previousValue,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -439,7 +439,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     List<Enrollment> enrollments =
         enrollmentService.getEnrollments(
             EnrollmentOperationParams.builder()
-                .program(UID.of(trackerProgram))
+                .program(trackerProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .build());
     assertHasSize(1, enrollments);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -608,7 +608,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldCreateEventInEventProgramViaEventRegistrationParserCommand()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException {
     SMSCommand command = new SMSCommand();
     command.setName("visit");
     command.setParserType(ParserType.EVENT_REGISTRATION_PARSER);
@@ -649,7 +649,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .program(UID.of(eventProgram))
+                .program(eventProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());
@@ -672,7 +672,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldCreateEventAndEnrollmentInTrackerProgramViaProgramStageDataEntryCommand()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException {
     SMSCommand command = new SMSCommand();
     command.setName("birth");
     command.setParserType(ParserType.PROGRAM_STAGE_DATAENTRY_PARSER);
@@ -714,8 +714,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Enrollment> enrollments =
         enrollmentService.getEnrollments(
             EnrollmentOperationParams.builder()
-                .trackedEntity(UID.of(trackedEntity))
-                .program(UID.of(trackerProgram))
+                .trackedEntity(trackedEntity)
+                .program(trackerProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .build());
     assertHasSize(1, enrollments);
@@ -730,8 +730,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .trackedEntity(UID.of(trackedEntity))
-                .program(UID.of(trackerProgram))
+                .trackedEntity(trackedEntity)
+                .program(trackerProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());
@@ -755,7 +755,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldCreateEventInExistingEnrollmentInTrackerProgramViaProgramStageDataEntryCommand()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException {
     SMSCommand command = new SMSCommand();
     command.setName("birth");
     command.setParserType(ParserType.PROGRAM_STAGE_DATAENTRY_PARSER);
@@ -798,8 +798,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     List<Event> events =
         eventService.getEvents(
             EventOperationParams.builder()
-                .trackedEntity(UID.of(trackedEntity))
-                .program(UID.of(trackerProgram))
+                .trackedEntity(trackedEntity)
+                .program(trackerProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
                 .eventParams(EventParams.FALSE)
                 .build());


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Syntatic sugar to make operationParams APIs easier to use.

Next steps*

Harmonize UID in deduplication package
Harmonize UID in remaining tracker packages