### PR TITLE
fix: don't expose password in logs on invalid input (#18156)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -535,7 +535,8 @@ public class DefaultUserService implements UserService {
     // Encode and set password
     Matcher matcher = this.BCRYPT_PATTERN.matcher(rawPassword);
     if (matcher.matches()) {
-      throw new IllegalArgumentException("Raw password look like BCrypt: " + rawPassword);
+      throw new IllegalArgumentException(
+          "Raw password look like BCrypt encoded password, this is most certainly a bug");
     }
 
     String encode = passwordManager.encode(rawPassword);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -54,6 +55,7 @@ import java.util.Set;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.security.PasswordManager;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
@@ -73,6 +75,8 @@ class UserServiceTest extends SingleSetupIntegrationTestBase {
   @Autowired private OrganisationUnitService organisationUnitService;
 
   @Autowired private SystemSettingManager systemSettingManager;
+
+  @Autowired private PasswordManager passwordManager;
 
   private OrganisationUnit unitA;
 
@@ -623,5 +627,20 @@ class UserServiceTest extends SingleSetupIntegrationTestBase {
   @Test
   void testGetDisplayNameNull() {
     assertNull(userService.getDisplayName("notExist"));
+  }
+
+  @Test
+  void testBCryptedPasswordOnInputError() {
+    User user = new User();
+    user.setUsername("test");
+    user.setPassword("password");
+    userService.addUser(user);
+
+    String encodedPassword = passwordManager.encode("password");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> userService.encodeAndSetPassword(user, encodedPassword),
+        "Raw password look like BCrypt encoded password, this is most certainly a bug");
   }
 }


### PR DESCRIPTION
* fix: don't expose password in logs on invalid input

(cherry picked from commit 3f53d8a4c3f951158c75d955ed0a76a5b03f8316)