### PR TITLE
ci(deps): update google-java-format

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobRunErrors.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobRunErrors.java
@@ -74,7 +74,8 @@ public interface JobRunErrors extends JsonObject {
     return get("finished", JsonDate.class);
   }
 
-  @OpenApi.Description("""
+  @OpenApi.Description(
+      """
     The file resource used to store the job's input
     """)
   @OpenApi.Property({UID.class, FileResource.class})

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdSchemesTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdSchemesTest.java
@@ -58,7 +58,8 @@ class IdSchemesTest {
     IdSchemes original = new IdSchemes();
     original.setProgramIdScheme("CODE");
     // language=JSON
-    String expected = """
+    String expected =
+        """
         {"programIdScheme":{"type":"CODE"}}""";
     assertEquals(expected, new ObjectMapper().writeValueAsString(original));
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
@@ -266,7 +266,8 @@ class DorisSqlBuilderTest {
   void testRenameTable() {
     Table table = getTableA();
 
-    String expected = """
+    String expected =
+        """
         alter table `immunization` rename `immunization_main`;""";
 
     assertEquals(expected, sqlBuilder.renameTable(table, "immunization_main"));
@@ -326,7 +327,8 @@ class DorisSqlBuilderTest {
 
   @Test
   void testCountRows() {
-    String expected = """
+    String expected =
+        """
         select count(*) as row_count from `immunization`;""";
 
     assertEquals(expected, sqlBuilder.countRows(getTableA()));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
@@ -351,7 +351,8 @@ class PostgreSqlBuilderTest {
 
   @Test
   void testCountRows() {
-    String expected = """
+    String expected =
+        """
         select count(*) as row_count from "immunization";""";
 
     assertEquals(expected, sqlBuilder.countRows(getTableA()));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -86,9 +86,7 @@ public final class GistParams {
       See [Gist inverse parameter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata-gist.html#the-inverse-parameter).""")
   boolean inverse = false;
 
-  @OpenApi.Description(
-      """
-      Old name for `totalPages`.""")
+  @OpenApi.Description("Old name for `totalPages`.")
   @Deprecated(since = "2.41", forRemoval = true)
   Boolean total;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -86,7 +86,8 @@ public final class GistParams {
       See [Gist inverse parameter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata-gist.html#the-inverse-parameter).""")
   boolean inverse = false;
 
-  @OpenApi.Description("""
+  @OpenApi.Description(
+      """
       Old name for `totalPages`.""")
   @Deprecated(since = "2.41", forRemoval = true)
   Boolean total;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
@@ -88,7 +88,8 @@ public class JdbcIconStore implements IconStore {
 
   @Override
   public long count(IconQueryParams params) {
-    String sql = """
+    String sql =
+        """
      select count(*) from icon c
                       """;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/JdbcTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/JdbcTrackedEntityChangeLogStore.java
@@ -138,7 +138,8 @@ public class JdbcTrackedEntityChangeLogStore {
 
     List<TrackedEntityChangeLog> changeLogs;
     if (!attributes.isEmpty()) {
-      sql += """
+      sql +=
+          """
               and tea.uid in (:attributes)
           """;
       parameters.addValue("attributes", attributes);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidator.java
@@ -49,11 +49,11 @@ class StatusUpdateValidator implements Validator<Event> {
 
   private boolean checkInvalidStatusTransition(EventStatus fromStatus, EventStatus toStatus) {
     return switch (fromStatus) {
-        // An event cannot transition from a STATUSES_WITH_DATA_VALUES to a
-        // STATUSES_WITHOUT_DATA_VALUES
+      // An event cannot transition from a STATUSES_WITH_DATA_VALUES to a
+      // STATUSES_WITHOUT_DATA_VALUES
       case VISITED, ACTIVE, COMPLETED ->
           EventStatus.STATUSES_WITHOUT_DATA_VALUES.contains(toStatus);
-        // An event can transition from a STATUSES_WITHOUT_DATA_VALUES to any status
+      // An event can transition from a STATUSES_WITHOUT_DATA_VALUES to any status
       case OVERDUE, SKIPPED, SCHEDULE -> false;
     };
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -158,7 +158,8 @@ class CategoryComboModificationControllerTest extends H2ControllerIntegrationTes
             "/categoryOptions",
             // language=JSON
             """
-                { "name": "%s", "shortName": "%s" }""".formatted(name, name)));
+                { "name": "%s", "shortName": "%s" }"""
+                .formatted(name, name)));
   }
 
   private String createSimpleCategory(String name, String categoryOptionId) {
@@ -207,7 +208,8 @@ class CategoryComboModificationControllerTest extends H2ControllerIntegrationTes
             getCurrentUser().getUid(),
             Body( // language=JSON
                 """
-                    {"additions":[{"id":"%s"}]}""".formatted(orgUnitId))));
+                    {"additions":[{"id":"%s"}]}"""
+                    .formatted(orgUnitId))));
 
     dataElementId = addDataElement("My data element", "DE1", ValueType.INTEGER, null, testCatCombo);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -661,7 +661,9 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
     assertThat(response.get("legacy").node().value(), is(equalTo(false)));
     assertThat(
         response.get("trackedEntityType").node().value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 {"id":"nEenWmSyUEp"}""")));
 
     JsonNode simpleDimensionNode0 = response.get("simpleDimensions").node().element(0);
@@ -670,7 +672,9 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
     assertThat(simpleDimensionNode0.get("program").value().toString(), is(equalTo("deabcdefghP")));
     assertThat(
         simpleDimensionNode0.get("values").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 ["2023-07-21_2023-08-01","2023-01-21_2023-02-01"]""")));
     assertThat(simpleDimensionNode0.get("parent").value().toString(), is(equalTo("COLUMN")));
 
@@ -697,13 +701,17 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
 
     assertThat(
         response.get("filterDimensions").node().value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 ["deabcdefghP.deabcdefghS.ou","deabcdefghE"]""")));
 
     JsonNode dataElementDimensionsNode0 = response.get("dataElementDimensions").node().element(0);
     assertThat(
         dataElementDimensionsNode0.get("dataElement").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 {"id":"deabcdefghC"}""")));
     assertThat(
         dataElementDimensionsNode0.get("filter").value().toString(), is(equalTo("IN:Female")));
@@ -711,18 +719,24 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
     JsonNode dataElementDimensionsNode1 = response.get("dataElementDimensions").node().element(1);
     assertThat(
         dataElementDimensionsNode1.get("dataElement").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 {"id":"deabcdefghE"}""")));
     assertFalse(dataElementDimensionsNode1.isMember("filter"));
 
     assertThat(
         response.get("programIndicatorDimensions").node().value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 [{"programIndicator":{"id":"deabcdefghB"}}]""")));
 
     assertThat(
         response.get("organisationUnits").node().value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 [{"id":"ImspTQPwCqd"}]""")));
 
     JsonNode repetitionsNode0 = response.get("repetitions").node().element(0);
@@ -742,7 +756,10 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
     JsonNode columnsNode0 = response.get("columns").node().element(0);
     assertThat(columnsNode0.get("items").value().toString(), is(equalTo("[]")));
     assertThat(
-        columnsNode0.get("program").value().toString(), is(equalTo("""
+        columnsNode0.get("program").value().toString(),
+        is(
+            equalTo(
+                """
 {"id":"deabcdefghP"}""")));
     assertThat(columnsNode0.get("dimension").value().toString(), is(equalTo("deabcdefghB")));
 
@@ -754,17 +771,24 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
     JsonNode columnsNode2 = response.get("columns").node().element(2);
     assertThat(
         columnsNode2.get("items").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 [{"id":"2023-07-21_2023-08-01"},{"id":"2023-01-21_2023-02-01"}]""")));
     assertThat(
-        columnsNode2.get("program").value().toString(), is(equalTo("""
+        columnsNode2.get("program").value().toString(),
+        is(
+            equalTo(
+                """
 {"id":"deabcdefghP"}""")));
     assertThat(columnsNode2.get("dimension").value().toString(), is(equalTo("eventDate")));
 
     JsonNode columnsNode3 = response.get("columns").node().element(3);
     assertThat(
         columnsNode3.get("items").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 [{"id":"2021-01-21_2021-02-01"}]""")));
     assertThat(columnsNode3.get("dimension").value().toString(), is(equalTo("created")));
 
@@ -777,7 +801,9 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         is(equalTo("ImspTQPwCqd")));
     assertThat(
         filtersNode0.get("programStage").value().toString(),
-        is(equalTo("""
+        is(
+            equalTo(
+                """
 {"id":"deabcdefghS"}""")));
     assertThat(filtersNode0.get("dimension").value().toString(), is(equalTo("ou")));
     assertThat(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -148,7 +148,8 @@ class SchemaBasedControllerTest extends PostgresControllerIntegrationTestBase {
     String endpoint = schema.getRelativeApiEndpoint();
     String uid = createdObjectIds.get(endpoint);
     @Language("json")
-    String json = """
+    String json =
+        """
     [{ "op": "add", "path": "/name", "value": "new_name_patch" }]""";
     assertStatus(HttpStatus.OK, PATCH(endpoint + "/" + uid, json));
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsGatewayControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsGatewayControllerTest.java
@@ -96,7 +96,8 @@ class SmsGatewayControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testUpdateGateway() {
     // language=JSON
-    String json = """
+    String json =
+        """
       {"name":"test", "username":"user", "password":"pwd", "type":"http"}""";
     uid = assertStatus(HttpStatus.OK, POST("/gateways", json));
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -244,12 +244,16 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonWebMessage response =
-        POST("/sms/inbound", format("""
+        POST(
+                "/sms/inbound",
+                format(
+                    """
 {
 "text": "%s",
 "originator": "%s"
 }
-""", text, originator))
+""",
+                    text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -497,12 +497,16 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user1);
 
     JsonWebMessage response =
-        POST("/sms/inbound", format("""
+        POST(
+                "/sms/inbound",
+                format(
+                    """
 {
 "text": "%s",
 "originator": "%s"
 }
-""", text, originator))
+""",
+                    text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
@@ -564,12 +568,16 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user1);
 
     JsonWebMessage response =
-        POST("/sms/inbound", format("""
+        POST(
+                "/sms/inbound",
+                format(
+                    """
 {
 "text": "%s",
 "originator": "%s"
 }
-""", text, originator))
+""",
+                    text, originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
@@ -626,12 +634,14 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     JsonWebMessage response =
         POST(
                 "/sms/inbound",
-                format("""
+                format(
+                    """
 {
 "text": "visit a=hello",
 "originator": "%s"
 }
-""", originator))
+""",
+                    originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
@@ -691,12 +701,14 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     JsonWebMessage response =
         POST(
                 "/sms/inbound",
-                format("""
+                format(
+                    """
 {
 "text": "birth a=hello",
 "originator": "%s"
 }
-""", originator))
+""",
+                    originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
@@ -775,12 +787,14 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     JsonWebMessage response =
         POST(
                 "/sms/inbound",
-                format("""
+                format(
+                    """
 {
 "text": "birth a=hello",
 "originator": "%s"
 }
-""", originator))
+""",
+                    originator))
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2028,7 +2028,10 @@ jasperreports.version=${jasperreports.version}
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
-              <googleJavaFormat/>
+              <googleJavaFormat>
+                <version>1.24.0</version>
+                <style>GOOGLE</style>
+              </googleJavaFormat>
               <trimTrailingWhitespace/>
               <licenseHeader>
                 <file>${rootDir}/license-header</file>


### PR DESCRIPTION
https://github.com/google/google-java-format/releases

`google-java-format` was set to the default version of https://github.com/google/google-java-format/releases/tag/google-java-format-1.8 from May 2020.

https://github.com/diffplug/spotless/tree/main/plugin-maven#google-java-format

They do fix bugs and add support for new language features. They also stop supporting running on old JDKs at some point

https://github.com/google/google-java-format/releases
> This is the last planned release of google-java-format that will support running on JDK 11

So I don't think we can never update it and have to accept some formatting changes once in a while.

It looks like text block formatting is still under debate

https://github.com/google/google-java-format/issues/1087#issuecomment-2016582504