### PR TITLE
chore: Use UID in Deduplication [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.common;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -67,6 +68,7 @@ public final class UID implements Serializable {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return value;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/deduplication/hibernate/PotentialDuplicate.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/deduplication/hibernate/PotentialDuplicate.hbm.xml
@@ -29,9 +29,9 @@
         <property name="lastUpdatedByUserName" column="lastupdatebyusername" not-null="true" />
 
         <property name="createdByUserName" column="createdbyusername" not-null="true" />
-        <property name="original" column="original" length="11" not-null="true" />
+        <property name="original" type="org.hisp.dhis.hibernate.UIDUserType" column="original" length="11" not-null="true" />
 
-        <property name="duplicate" column="duplicate" length="11" not-null="true" />
+        <property name="duplicate" type="org.hisp.dhis.hibernate.UIDUserType" column="duplicate" length="11" not-null="true" />
 
         <property name="status" column="status">
             <type name="org.hibernate.type.EnumType">

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
@@ -76,7 +76,7 @@ public class DeduplicationHelper {
     MergeObject mergeObject = params.getMergeObject();
 
     /*
-     * Step 1: Make sure all references objects exists in duplicate
+     * Step 1: Make sure all reference objects exists in duplicate
      */
     Set<UID> validTrackedEntityAttributes =
         duplicate.getTrackedEntityAttributeValues().stream()
@@ -114,7 +114,7 @@ public class DeduplicationHelper {
     }
 
     /*
-     * Step 3: Duplicate Relationships and Enrollments
+     * Step 2: Duplicate Relationships and Enrollments
      */
     Set<Relationship> relationshipsToMerge =
         params.getDuplicate().getRelationshipItems().stream()
@@ -152,7 +152,7 @@ public class DeduplicationHelper {
     }
 
     /*
-     * Step 4: Make sure no relationships will become self-referencing.
+     * Step 3: Make sure no relationships will become self-referencing.
      */
     Set<String> relationshipsToMergeUids =
         relationshipsToMerge.stream().map(IdentifiableObject::getUid).collect(Collectors.toSet());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.deduplication;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -35,7 +36,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 public interface DeduplicationService {
   PotentialDuplicate getPotentialDuplicateById(long id);
 
-  PotentialDuplicate getPotentialDuplicateByUid(UID uid);
+  PotentialDuplicate getPotentialDuplicateByUid(@Nonnull UID uid);
 
   int countPotentialDuplicates(PotentialDuplicateCriteria criteria);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
@@ -28,13 +28,14 @@
 package org.hisp.dhis.tracker.deduplication;
 
 import java.util.List;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 
 public interface DeduplicationService {
   PotentialDuplicate getPotentialDuplicateById(long id);
 
-  PotentialDuplicate getPotentialDuplicateByUid(String uid);
+  PotentialDuplicate getPotentialDuplicateByUid(UID uid);
 
   int countPotentialDuplicates(PotentialDuplicateCriteria criteria);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
@@ -64,8 +65,8 @@ public class DefaultDeduplicationService implements DeduplicationService {
 
   @Override
   @Transactional(readOnly = true)
-  public PotentialDuplicate getPotentialDuplicateByUid(String uid) {
-    return potentialDuplicateStore.getByUid(uid);
+  public PotentialDuplicate getPotentialDuplicateByUid(UID uid) {
+    return potentialDuplicateStore.getByUid(uid.getValue());
   }
 
   @Override
@@ -118,10 +119,10 @@ public class DefaultDeduplicationService implements DeduplicationService {
   @Override
   @Transactional
   public void manualMerge(DeduplicationMergeParams deduplicationMergeParams)
-      throws PotentialDuplicateConflictException,
-          PotentialDuplicateForbiddenException,
+      throws PotentialDuplicateForbiddenException,
           ForbiddenException,
-          NotFoundException {
+          NotFoundException,
+          PotentialDuplicateConflictException {
     String invalidReference =
         deduplicationHelper.getInvalidReferenceErrors(deduplicationMergeParams);
     if (invalidReference != null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -65,7 +66,7 @@ public class DefaultDeduplicationService implements DeduplicationService {
 
   @Override
   @Transactional(readOnly = true)
-  public PotentialDuplicate getPotentialDuplicateByUid(UID uid) {
+  public PotentialDuplicate getPotentialDuplicateByUid(@Nonnull UID uid) {
     return potentialDuplicateStore.getByUid(uid.getValue());
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/MergeObject.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/MergeObject.java
@@ -29,12 +29,13 @@ package org.hisp.dhis.tracker.deduplication;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.UID;
 
 @Data
 @Builder
@@ -42,9 +43,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MergeObject {
-  @Builder.Default @JsonProperty private List<String> trackedEntityAttributes = new ArrayList<>();
+  @Builder.Default @JsonProperty private Set<UID> trackedEntityAttributes = new HashSet<>();
 
-  @Builder.Default @JsonProperty private List<String> relationships = new ArrayList<>();
+  @Builder.Default @JsonProperty private Set<UID> relationships = new HashSet<>();
 
-  @Builder.Default @JsonProperty private List<String> enrollments = new ArrayList<>();
+  @Builder.Default @JsonProperty private Set<UID> enrollments = new HashSet<>();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicate.java
@@ -31,22 +31,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.annotation.Property;
-import org.hisp.dhis.schema.annotation.PropertyRange;
+import org.hisp.dhis.common.UID;
 
 public class PotentialDuplicate extends BaseIdentifiableObject {
   /**
    * original represents the UID of a TrackedEntity. original is required. original is a potential
    * duplicate of duplicate.
    */
-  private String original;
+  private UID original;
 
   /**
    * duplicate represents the UID of a TrackedEntity. duplicate is required. duplicate is a
    * potential duplicate of original.
    */
-  private String duplicate;
+  private UID duplicate;
 
   protected String lastUpdatedByUserName;
 
@@ -60,32 +58,28 @@ public class PotentialDuplicate extends BaseIdentifiableObject {
 
   public PotentialDuplicate() {}
 
-  public PotentialDuplicate(String original, String duplicate) {
+  public PotentialDuplicate(UID original, UID duplicate) {
     this.original = original;
     this.duplicate = duplicate;
   }
 
   @JsonProperty
   @JacksonXmlProperty
-  @Property(value = PropertyType.IDENTIFIER, required = Property.Value.TRUE)
-  @PropertyRange(min = 11, max = 11)
-  public String getOriginal() {
+  public UID getOriginal() {
     return original;
   }
 
-  public void setOriginal(String original) {
+  public void setOriginal(UID original) {
     this.original = original;
   }
 
   @JsonProperty
   @JacksonXmlProperty
-  @Property(value = PropertyType.IDENTIFIER, required = Property.Value.FALSE)
-  @PropertyRange(min = 11, max = 11)
-  public String getDuplicate() {
+  public UID getDuplicate() {
     return duplicate;
   }
 
-  public void setDuplicate(String duplicate) {
+  public void setDuplicate(UID duplicate) {
     this.duplicate = duplicate;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateCriteria.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateCriteria.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 @Data
@@ -42,7 +43,7 @@ public class PotentialDuplicateCriteria extends PagingAndSortingCriteriaAdapter 
   @OpenApi.Property(defaultValue = "true")
   private Boolean paging;
 
-  private List<String> trackedEntities = new ArrayList<>();
+  private List<UID> trackedEntities = new ArrayList<>();
 
   private DeduplicationStatus status = DeduplicationStatus.OPEN;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
@@ -208,7 +208,7 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
     }
 
     // If an attribute and value appear in 2 or more tracked entities
-    // it means that is not unique
+    // it means that is not uniqueF
     return teByAttributeValue.entrySet().stream()
         .filter(e -> e.getValue().size() > 1)
         .flatMap(av -> buildUniqueAttributeValues(av.getKey(), av.getValue()).stream())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
@@ -208,7 +208,7 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
     }
 
     // If an attribute and value appear in 2 or more tracked entities
-    // it means that is not uniqueF
+    // it means that is not unique
     return teByAttributeValue.entrySet().stream()
         .filter(e -> e.getValue().size() > 1)
         .flatMap(av -> buildUniqueAttributeValues(av.getKey(), av.getValue()).stream())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -110,7 +110,7 @@ class DeduplicationHelperTest extends TestBase {
   @BeforeEach
   public void setUp() throws ForbiddenException, NotFoundException {
     Set<UID> relationshipUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
-    List<String> attributeUids = List.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
+    Set<UID> attributeUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
     Set<UID> enrollmentUids = UID.of(CodeGenerator.generateUid(), CodeGenerator.generateUid());
 
     organisationUnitA = createOrganisationUnit('A');
@@ -123,9 +123,9 @@ class DeduplicationHelperTest extends TestBase {
     enrollment = createEnrollment(createProgram('A'), getTrackedEntityA(), organisationUnitA);
     mergeObject =
         MergeObject.builder()
-            .relationships(UID.toValueList(relationshipUids))
+            .relationships(relationshipUids)
             .trackedEntityAttributes(attributeUids)
-            .enrollments(UID.toValueList(enrollmentUids))
+            .enrollments(enrollmentUids)
             .build();
     user = makeUser("A", Lists.newArrayList("F_TRACKED_ENTITY_MERGE"));
 
@@ -327,7 +327,7 @@ class DeduplicationHelperTest extends TestBase {
 
     actualMergeObject
         .getTrackedEntityAttributes()
-        .forEach(a -> assertEquals(duplicateAttribute.getUid(), a));
+        .forEach(a -> assertEquals(UID.of(duplicateAttribute), a));
   }
 
   @Test
@@ -358,9 +358,7 @@ class DeduplicationHelperTest extends TestBase {
 
     assertFalse(actualMergeObject.getRelationships().isEmpty());
 
-    actualMergeObject
-        .getRelationships()
-        .forEach(r -> assertEquals(anotherRelationship.getUid(), r));
+    actualMergeObject.getRelationships().forEach(r -> assertEquals(UID.of(anotherRelationship), r));
 
     Relationship baseRelationship = getRelationship();
 
@@ -394,7 +392,7 @@ class DeduplicationHelperTest extends TestBase {
 
     MergeObject generatedMergeObject = deduplicationHelper.generateMergeObject(original, duplicate);
 
-    assertEquals("enrollmentB", generatedMergeObject.getEnrollments().get(0));
+    assertEquals(UID.of("enrollmentB"), generatedMergeObject.getEnrollments().iterator().next());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
@@ -103,7 +104,7 @@ class DeduplicationServiceTest {
 
   @BeforeEach
   void setUp() throws ForbiddenException, NotFoundException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate("original", "duplicate");
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(UID.generate(), UID.generate());
     deduplicationMergeParams =
         DeduplicationMergeParams.builder()
             .potentialDuplicate(potentialDuplicate)
@@ -326,7 +327,6 @@ class DeduplicationServiceTest {
     injectSecurityContextNoSettings(actingUser);
 
     deduplicationService.manualMerge(deduplicationMergeParams);
-    verify(deduplicationHelper, times(1)).getInvalidReferenceErrors(deduplicationMergeParams);
     verify(deduplicationHelper, times(0)).generateMergeObject(trackedEntityA, trackedEntityB);
     verify(deduplicationHelper)
         .getUserAccessErrors(

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/UIDUserType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/UIDUserType.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.hibernate;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.UserType;
+import org.hisp.dhis.common.UID;
+
+public class UIDUserType implements UserType, Serializable {
+
+  private static final int[] SQL_TYPES = {Types.VARCHAR};
+
+  @Override
+  public int[] sqlTypes() {
+    return SQL_TYPES;
+  }
+
+  @Override
+  public Class<?> returnedClass() {
+    return UID.class;
+  }
+
+  @Override
+  public Object nullSafeGet(
+      ResultSet resultSet, String[] names, SharedSessionContractImplementor impl, Object owner)
+      throws HibernateException, SQLException {
+    String value = resultSet.getString(names[0]);
+    if (!resultSet.wasNull()) {
+      return value == null ? null : UID.of(value);
+    }
+    return null;
+  }
+
+  @Override
+  public void nullSafeSet(
+      PreparedStatement preparedStatement,
+      Object value,
+      int index,
+      SharedSessionContractImplementor impl)
+      throws HibernateException, SQLException {
+    if (null == value) {
+      preparedStatement.setNull(index, Types.VARCHAR);
+    } else {
+      preparedStatement.setString(index, value.toString());
+    }
+  }
+
+  @Override
+  public Object deepCopy(Object value) throws HibernateException {
+    return value;
+  }
+
+  @Override
+  public boolean isMutable() {
+    return false;
+  }
+
+  @Override
+  public Object assemble(Serializable cached, Object owner) throws HibernateException {
+    return cached;
+  }
+
+  @Override
+  public Serializable disassemble(Object value) throws HibernateException {
+    return (Serializable) value;
+  }
+
+  @Override
+  public Object replace(Object original, Object target, Object owner) throws HibernateException {
+    return original;
+  }
+
+  @Override
+  public int hashCode(Object x) throws HibernateException {
+    return x.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object x, Object y) throws HibernateException {
+    if (x == y) return true;
+    if (null == x || null == y) return false;
+    return x.equals(y);
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
@@ -48,13 +49,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
   @Autowired private DeduplicationService deduplicationService;
 
-  private static final String trackedEntityA = "trackedentA";
+  private static final UID TRACKED_ENTITY_A = UID.generate();
 
-  private static final String trackedEntityB = "trackedentB";
+  private static final UID TRACKED_ENTITY_B = UID.generate();
 
-  private static final String trackedEntityC = "trackedentC";
+  private static final UID TRACKED_ENTITY_C = UID.generate();
 
-  private static final String trackedEntityD = "trackedentD";
+  private static final UID TRACKED_ENTITY_D = UID.generate();
 
   @BeforeEach
   public void setupTestUser() {
@@ -64,12 +65,14 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetAllPotentialDuplicateByDifferentStatus() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
-    PotentialDuplicate potentialDuplicate1 = new PotentialDuplicate(trackedEntityC, trackedEntityD);
+    PotentialDuplicate potentialDuplicate1 =
+        new PotentialDuplicate(TRACKED_ENTITY_C, TRACKED_ENTITY_D);
     deduplicationService.addPotentialDuplicate(potentialDuplicate1);
 
-    List<String> potentialDuplicates = List.of(trackedEntityA, trackedEntityC);
+    List<UID> potentialDuplicates = List.of(TRACKED_ENTITY_A, TRACKED_ENTITY_C);
 
     PotentialDuplicateCriteria criteria = new PotentialDuplicateCriteria();
 
@@ -98,7 +101,8 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testAddPotentialDuplicate() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertNotEquals(0, potentialDuplicate.getId());
     assertEquals(
@@ -108,19 +112,22 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetPotentialDuplicateByUid() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertNotEquals(0, potentialDuplicate.getId());
     assertEquals(
         potentialDuplicate,
-        deduplicationService.getPotentialDuplicateByUid(potentialDuplicate.getUid()));
+        deduplicationService.getPotentialDuplicateByUid(UID.of(potentialDuplicate)));
   }
 
   @Test
   void testGetPotentialDuplicateDifferentStatus() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
-    PotentialDuplicate potentialDuplicate1 = new PotentialDuplicate(trackedEntityC, trackedEntityB);
+    PotentialDuplicate potentialDuplicate1 =
+        new PotentialDuplicate(TRACKED_ENTITY_C, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate1);
 
     potentialDuplicate.setStatus(DeduplicationStatus.INVALID);
@@ -130,7 +137,7 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
     deduplicationService.updatePotentialDuplicate(potentialDuplicate1);
 
     PotentialDuplicateCriteria criteria = new PotentialDuplicateCriteria();
-    criteria.setTrackedEntities(Collections.singletonList(trackedEntityB));
+    criteria.setTrackedEntities(Collections.singletonList(TRACKED_ENTITY_B));
     criteria.setStatus(DeduplicationStatus.INVALID);
     assertEquals(
         Collections.singletonList(potentialDuplicate),
@@ -139,7 +146,8 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testCreatePotentialDuplicateNotCreationStatus() {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     potentialDuplicate.setStatus(DeduplicationStatus.ALL);
 
     assertThrows(
@@ -149,7 +157,8 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testExistsDuplicate() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertTrue(deduplicationService.exists(potentialDuplicate));
   }
@@ -157,42 +166,48 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
   @Test
   void testShouldThrowWhenMissingTrackedEntityBProperty()
       throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertThrows(
         PotentialDuplicateConflictException.class,
-        () -> deduplicationService.exists(new PotentialDuplicate(trackedEntityA, null)));
+        () -> deduplicationService.exists(new PotentialDuplicate(TRACKED_ENTITY_A, null)));
   }
 
   @Test
   void testShouldThrowWhenMissingTrackedEntityAProperty()
       throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertThrows(
         PotentialDuplicateConflictException.class,
-        () -> deduplicationService.exists(new PotentialDuplicate(null, trackedEntityB)));
+        () -> deduplicationService.exists(new PotentialDuplicate(null, TRACKED_ENTITY_B)));
   }
 
   @Test
   void testExistsTwoTrackedEntitiesReverse() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     PotentialDuplicate potentialDuplicateReverse =
-        new PotentialDuplicate(trackedEntityB, trackedEntityA);
+        new PotentialDuplicate(TRACKED_ENTITY_B, TRACKED_ENTITY_A);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertTrue(deduplicationService.exists(potentialDuplicateReverse));
   }
 
   @Test
   void testGetAllPotentialDuplicatedByQuery() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
-    PotentialDuplicate potentialDuplicate1 = new PotentialDuplicate(trackedEntityC, trackedEntityD);
-    PotentialDuplicate potentialDuplicate2 = new PotentialDuplicate(trackedEntityA, trackedEntityD);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
+    PotentialDuplicate potentialDuplicate1 =
+        new PotentialDuplicate(TRACKED_ENTITY_C, TRACKED_ENTITY_D);
+    PotentialDuplicate potentialDuplicate2 =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_D);
     PotentialDuplicateCriteria criteria = new PotentialDuplicateCriteria();
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     deduplicationService.addPotentialDuplicate(potentialDuplicate1);
     deduplicationService.addPotentialDuplicate(potentialDuplicate2);
-    criteria.setTrackedEntities(Collections.singletonList(trackedEntityA));
+    criteria.setTrackedEntities(Collections.singletonList(TRACKED_ENTITY_A));
     List<PotentialDuplicate> list = deduplicationService.getPotentialDuplicates(criteria);
     assertEquals(2, list.size());
     assertTrue(list.contains(potentialDuplicate));
@@ -201,17 +216,19 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testCountPotentialDuplicates() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
-    PotentialDuplicate potentialDuplicate1 = new PotentialDuplicate(trackedEntityC, trackedEntityD);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
+    PotentialDuplicate potentialDuplicate1 =
+        new PotentialDuplicate(TRACKED_ENTITY_C, TRACKED_ENTITY_D);
     PotentialDuplicateCriteria criteria = new PotentialDuplicateCriteria();
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     deduplicationService.addPotentialDuplicate(potentialDuplicate1);
     criteria.setStatus(DeduplicationStatus.ALL);
     assertEquals(2, deduplicationService.countPotentialDuplicates(criteria));
     criteria.setStatus(DeduplicationStatus.OPEN);
-    criteria.setTrackedEntities(Arrays.asList(trackedEntityA, trackedEntityC));
+    criteria.setTrackedEntities(Arrays.asList(TRACKED_ENTITY_A, TRACKED_ENTITY_C));
     assertEquals(2, deduplicationService.countPotentialDuplicates(criteria));
-    criteria.setTrackedEntities(Collections.singletonList(trackedEntityC));
+    criteria.setTrackedEntities(Collections.singletonList(TRACKED_ENTITY_C));
     assertEquals(1, deduplicationService.countPotentialDuplicates(criteria));
     criteria.setStatus(DeduplicationStatus.INVALID);
     assertEquals(0, deduplicationService.countPotentialDuplicates(criteria));
@@ -219,7 +236,8 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testUpdatePotentialDuplicate() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     assertEquals(
         DeduplicationStatus.OPEN,
@@ -233,7 +251,8 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldThrowWhenOrderFieldNotExists() throws PotentialDuplicateConflictException {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(trackedEntityA, trackedEntityB);
+    PotentialDuplicate potentialDuplicate =
+        new PotentialDuplicate(TRACKED_ENTITY_A, TRACKED_ENTITY_B);
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
 
     PotentialDuplicateCriteria criteria = new PotentialDuplicateCriteria();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -102,7 +103,7 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     manager.update(original);
     manager.update(duplicate);
     PotentialDuplicate potentialDuplicate =
-        new PotentialDuplicate(original.getUid(), duplicate.getUid());
+        new PotentialDuplicate(UID.of(original), UID.of(duplicate));
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     DeduplicationMergeParams deduplicationMergeParams =
         DeduplicationMergeParams.builder()
@@ -114,8 +115,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
         requireNonNull(manager.get(TrackedEntity.class, original.getUid())).getLastUpdated();
     deduplicationService.autoMerge(deduplicationMergeParams);
     assertEquals(
-        deduplicationService.getPotentialDuplicateByUid(potentialDuplicate.getUid()).getStatus(),
-        DeduplicationStatus.MERGED);
+        DeduplicationStatus.MERGED,
+        deduplicationService.getPotentialDuplicateByUid(UID.of(potentialDuplicate)).getStatus());
     assertTrue(
         requireNonNull(manager.get(TrackedEntity.class, original.getUid()))
                 .getLastUpdated()
@@ -161,7 +162,7 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     manager.update(original);
     manager.update(duplicate);
     PotentialDuplicate potentialDuplicate =
-        new PotentialDuplicate(original.getUid(), duplicate.getUid());
+        new PotentialDuplicate(UID.of(original), UID.of(duplicate));
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
     DeduplicationMergeParams deduplicationMergeParams =
         DeduplicationMergeParams.builder()
@@ -173,8 +174,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
         requireNonNull(manager.get(TrackedEntity.class, original.getUid())).getLastUpdated();
     deduplicationService.autoMerge(deduplicationMergeParams);
     assertEquals(
-        deduplicationService.getPotentialDuplicateByUid(potentialDuplicate.getUid()).getStatus(),
-        DeduplicationStatus.MERGED);
+        DeduplicationStatus.MERGED,
+        deduplicationService.getPotentialDuplicateByUid(UID.of(potentialDuplicate)).getStatus());
     assertTrue(
         requireNonNull(manager.get(TrackedEntity.class, original.getUid()))
                 .getLastUpdated()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
@@ -30,9 +30,9 @@ package org.hisp.dhis.tracker.deduplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.google.common.collect.Lists;
-import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -107,29 +107,29 @@ class PotentialDuplicateStoreRelationshipTest extends PostgresIntegrationTestBas
     manager.save(bi4);
     transactionTemplate.execute(
         status -> {
-          List<String> relationships = Lists.newArrayList(bi2.getUid());
+          Set<UID> relationships = Set.of(UID.of(bi2));
           potentialDuplicateStore.moveRelationships(original, duplicate, relationships);
           return null;
         });
     transactionTemplate.execute(
         status -> {
           dbmsManager.clearSession();
-          Relationship _bi1 = getRelationship(bi1.getUid());
-          Relationship _bi2 = getRelationship(bi2.getUid());
-          Relationship _bi3 = getRelationship(bi3.getUid());
-          Relationship _bi4 = getRelationship(bi4.getUid());
-          assertNotNull(_bi1);
-          assertEquals(original.getUid(), _bi1.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra2.getUid(), _bi1.getTo().getTrackedEntity().getUid());
-          assertNotNull(_bi2);
-          assertEquals(original.getUid(), _bi2.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra1.getUid(), _bi2.getTo().getTrackedEntity().getUid());
-          assertNotNull(_bi3);
-          assertEquals(duplicate.getUid(), _bi3.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra2.getUid(), _bi3.getTo().getTrackedEntity().getUid());
-          assertNotNull(_bi4);
-          assertEquals(extra1.getUid(), _bi4.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra2.getUid(), _bi4.getTo().getTrackedEntity().getUid());
+          Relationship bi1FromDB = getRelationship(bi1.getUid());
+          Relationship bi2FromDB = getRelationship(bi2.getUid());
+          Relationship bi3FromDB = getRelationship(bi3.getUid());
+          Relationship bi4FromDB = getRelationship(bi4.getUid());
+          assertNotNull(bi1FromDB);
+          assertEquals(original.getUid(), bi1FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra2.getUid(), bi1FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(bi2FromDB);
+          assertEquals(original.getUid(), bi2FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra1.getUid(), bi2FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(bi3FromDB);
+          assertEquals(duplicate.getUid(), bi3FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra2.getUid(), bi3FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(bi4FromDB);
+          assertEquals(extra1.getUid(), bi4FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra2.getUid(), bi4FromDB.getTo().getTrackedEntity().getUid());
           return null;
         });
   }
@@ -146,26 +146,26 @@ class PotentialDuplicateStoreRelationshipTest extends PostgresIntegrationTestBas
     manager.save(uni4);
     original = manager.get(TrackedEntity.class, original.getUid());
     duplicate = manager.get(TrackedEntity.class, duplicate.getUid());
-    List<String> relationships = Lists.newArrayList(uni3.getUid());
+    Set<UID> relationships = Set.of(UID.of(uni3));
     potentialDuplicateStore.moveRelationships(original, duplicate, relationships);
     manager.update(original);
     manager.update(duplicate);
-    Relationship _uni1 = getRelationship(uni1.getUid());
-    Relationship _uni2 = getRelationship(uni2.getUid());
-    Relationship _uni3 = getRelationship(uni3.getUid());
-    Relationship _uni4 = getRelationship(uni4.getUid());
-    assertNotNull(_uni1);
-    assertEquals(original.getUid(), _uni1.getFrom().getTrackedEntity().getUid());
-    assertEquals(extra2.getUid(), _uni1.getTo().getTrackedEntity().getUid());
-    assertNotNull(_uni2);
-    assertEquals(duplicate.getUid(), _uni2.getFrom().getTrackedEntity().getUid());
-    assertEquals(extra1.getUid(), _uni2.getTo().getTrackedEntity().getUid());
-    assertNotNull(_uni3);
-    assertEquals(extra2.getUid(), _uni3.getFrom().getTrackedEntity().getUid());
-    assertEquals(original.getUid(), _uni3.getTo().getTrackedEntity().getUid());
-    assertNotNull(_uni4);
-    assertEquals(extra1.getUid(), _uni4.getFrom().getTrackedEntity().getUid());
-    assertEquals(extra2.getUid(), _uni4.getTo().getTrackedEntity().getUid());
+    Relationship uni1FromDB = getRelationship(uni1.getUid());
+    Relationship uni2FromDB = getRelationship(uni2.getUid());
+    Relationship uni3FromDB = getRelationship(uni3.getUid());
+    Relationship uni4FromDB = getRelationship(uni4.getUid());
+    assertNotNull(uni1FromDB);
+    assertEquals(original.getUid(), uni1FromDB.getFrom().getTrackedEntity().getUid());
+    assertEquals(extra2.getUid(), uni1FromDB.getTo().getTrackedEntity().getUid());
+    assertNotNull(uni2FromDB);
+    assertEquals(duplicate.getUid(), uni2FromDB.getFrom().getTrackedEntity().getUid());
+    assertEquals(extra1.getUid(), uni2FromDB.getTo().getTrackedEntity().getUid());
+    assertNotNull(uni3FromDB);
+    assertEquals(extra2.getUid(), uni3FromDB.getFrom().getTrackedEntity().getUid());
+    assertEquals(original.getUid(), uni3FromDB.getTo().getTrackedEntity().getUid());
+    assertNotNull(uni4FromDB);
+    assertEquals(extra1.getUid(), uni4FromDB.getFrom().getTrackedEntity().getUid());
+    assertEquals(extra2.getUid(), uni4FromDB.getTo().getTrackedEntity().getUid());
   }
 
   @Test
@@ -180,29 +180,29 @@ class PotentialDuplicateStoreRelationshipTest extends PostgresIntegrationTestBas
     manager.save(bi2);
     transactionTemplate.execute(
         status -> {
-          List<String> relationships = Lists.newArrayList(uni2.getUid(), bi1.getUid());
+          Set<UID> relationships = UID.of(uni2, bi1);
           potentialDuplicateStore.moveRelationships(original, duplicate, relationships);
           return null;
         });
     transactionTemplate.execute(
         status -> {
           dbmsManager.clearSession();
-          Relationship _uni1 = getRelationship(uni1.getUid());
-          Relationship _uni2 = getRelationship(uni2.getUid());
-          Relationship _bi1 = getRelationship(bi1.getUid());
-          Relationship _bi2 = getRelationship(bi2.getUid());
-          assertNotNull(_uni1);
-          assertEquals(original.getUid(), _uni1.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra2.getUid(), _uni1.getTo().getTrackedEntity().getUid());
-          assertNotNull(_uni2);
-          assertEquals(original.getUid(), _uni2.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra1.getUid(), _uni2.getTo().getTrackedEntity().getUid());
-          assertNotNull(_bi1);
-          assertEquals(extra2.getUid(), _bi1.getFrom().getTrackedEntity().getUid());
-          assertEquals(original.getUid(), _bi1.getTo().getTrackedEntity().getUid());
-          assertNotNull(_bi2);
-          assertEquals(extra1.getUid(), _bi2.getFrom().getTrackedEntity().getUid());
-          assertEquals(extra2.getUid(), _bi2.getTo().getTrackedEntity().getUid());
+          Relationship uni1FromDB = getRelationship(uni1.getUid());
+          Relationship uni2FromDB = getRelationship(uni2.getUid());
+          Relationship bi1FromDB = getRelationship(bi1.getUid());
+          Relationship bi2FromDB = getRelationship(bi2.getUid());
+          assertNotNull(uni1FromDB);
+          assertEquals(original.getUid(), uni1FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra2.getUid(), uni1FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(uni2FromDB);
+          assertEquals(original.getUid(), uni2FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra1.getUid(), uni2FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(bi1FromDB);
+          assertEquals(extra2.getUid(), bi1FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(original.getUid(), bi1FromDB.getTo().getTrackedEntity().getUid());
+          assertNotNull(bi2FromDB);
+          assertEquals(extra1.getUid(), bi2FromDB.getFrom().getTrackedEntity().getUid());
+          assertEquals(extra2.getUid(), bi2FromDB.getTo().getTrackedEntity().getUid());
           return null;
         });
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreTEAVTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreTEAVTest.java
@@ -30,9 +30,9 @@ package org.hisp.dhis.tracker.deduplication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.google.common.collect.Lists;
-import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -136,7 +136,7 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
 
   @Test
   void moveTrackedEntityAttributeValuesSingleTea() {
-    List<String> teas = Lists.newArrayList(trackedEntityAttributeA.getUid());
+    Set<UID> teas = Set.of(UID.of(trackedEntityAttributeA));
     transactionTemplate.execute(
         status -> {
           potentialDuplicateStore.moveTrackedEntityAttributeValues(original, duplicate, teas);
@@ -147,13 +147,13 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
           // Clear the session so we get new data from the DB for the next
           // queries.
           dbmsManager.clearSession();
-          TrackedEntity _original = manager.get(TrackedEntity.class, original.getUid());
-          TrackedEntity _duplicate = manager.get(TrackedEntity.class, duplicate.getUid());
-          assertNotNull(_original);
-          assertNotNull(_duplicate);
-          assertEquals(3, _original.getTrackedEntityAttributeValues().size());
-          assertEquals(4, _duplicate.getTrackedEntityAttributeValues().size());
-          _original
+          TrackedEntity originalFromDB = manager.get(TrackedEntity.class, original.getUid());
+          TrackedEntity duplicateFromDB = manager.get(TrackedEntity.class, duplicate.getUid());
+          assertNotNull(originalFromDB);
+          assertNotNull(duplicateFromDB);
+          assertEquals(3, originalFromDB.getTrackedEntityAttributeValues().size());
+          assertEquals(4, duplicateFromDB.getTrackedEntityAttributeValues().size());
+          originalFromDB
               .getTrackedEntityAttributeValues()
               .forEach(
                   teav -> {
@@ -163,17 +163,16 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
                       assertEquals("AttributeA", teav.getValue());
                     }
                   });
-          TrackedEntity _control = manager.get(TrackedEntity.class, control.getUid());
-          assertNotNull(_control);
-          assertEquals(3, _control.getTrackedEntityAttributeValues().size());
+          TrackedEntity controlFromDB = manager.get(TrackedEntity.class, control.getUid());
+          assertNotNull(controlFromDB);
+          assertEquals(3, controlFromDB.getTrackedEntityAttributeValues().size());
           return null;
         });
   }
 
   @Test
   void moveTrackedEntityAttributeValuesMultipleTeas() {
-    List<String> teas =
-        Lists.newArrayList(trackedEntityAttributeA.getUid(), trackedEntityAttributeB.getUid());
+    Set<UID> teas = UID.of(trackedEntityAttributeA, trackedEntityAttributeB);
     transactionTemplate.execute(
         status -> {
           potentialDuplicateStore.moveTrackedEntityAttributeValues(original, duplicate, teas);
@@ -184,13 +183,14 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
           // Clear the session so we get new data from the DB for the next
           // queries.
           dbmsManager.clearSession();
-          TrackedEntity _original = manager.get(TrackedEntity.class, original.getUid());
-          TrackedEntity _duplicate = manager.get(TrackedEntity.class, duplicate.getUid());
-          assertNotNull(_original);
-          assertNotNull(_duplicate);
-          assertEquals(3, _original.getTrackedEntityAttributeValues().size());
-          assertEquals(3, _duplicate.getTrackedEntityAttributeValues().size());
-          _original
+          TrackedEntity originalFromDB = manager.get(TrackedEntity.class, original.getUid());
+          TrackedEntity duplicateoriginalFromDB =
+              manager.get(TrackedEntity.class, duplicate.getUid());
+          assertNotNull(originalFromDB);
+          assertNotNull(duplicateoriginalFromDB);
+          assertEquals(3, originalFromDB.getTrackedEntityAttributeValues().size());
+          assertEquals(3, duplicateoriginalFromDB.getTrackedEntityAttributeValues().size());
+          originalFromDB
               .getTrackedEntityAttributeValues()
               .forEach(
                   teav -> {
@@ -200,17 +200,16 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
                       assertEquals("AttributeA", teav.getValue());
                     }
                   });
-          TrackedEntity _control = manager.get(TrackedEntity.class, control.getUid());
-          assertNotNull(_control);
-          assertEquals(3, _control.getTrackedEntityAttributeValues().size());
+          TrackedEntity controlFromDB = manager.get(TrackedEntity.class, control.getUid());
+          assertNotNull(controlFromDB);
+          assertEquals(3, controlFromDB.getTrackedEntityAttributeValues().size());
           return null;
         });
   }
 
   @Test
   void moveTrackedEntityAttributeValuesByOverwritingAndCreatingNew() {
-    List<String> teas =
-        Lists.newArrayList(trackedEntityAttributeD.getUid(), trackedEntityAttributeB.getUid());
+    Set<UID> teas = UID.of(trackedEntityAttributeD, trackedEntityAttributeB);
     transactionTemplate.execute(
         status -> {
           potentialDuplicateStore.moveTrackedEntityAttributeValues(original, duplicate, teas);
@@ -221,13 +220,14 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
           // Clear the session so we get new data from the DB for the next
           // queries.
           dbmsManager.clearSession();
-          TrackedEntity _original = manager.get(TrackedEntity.class, original.getUid());
-          TrackedEntity _duplicate = manager.get(TrackedEntity.class, duplicate.getUid());
-          assertNotNull(_original);
-          assertNotNull(_duplicate);
-          assertEquals(4, _original.getTrackedEntityAttributeValues().size());
-          assertEquals(3, _duplicate.getTrackedEntityAttributeValues().size());
-          _original
+          TrackedEntity originalFromDB = manager.get(TrackedEntity.class, original.getUid());
+          TrackedEntity duplicateoriginalFromDB =
+              manager.get(TrackedEntity.class, duplicate.getUid());
+          assertNotNull(originalFromDB);
+          assertNotNull(duplicateoriginalFromDB);
+          assertEquals(4, originalFromDB.getTrackedEntityAttributeValues().size());
+          assertEquals(3, duplicateoriginalFromDB.getTrackedEntityAttributeValues().size());
+          originalFromDB
               .getTrackedEntityAttributeValues()
               .forEach(
                   teav -> {
@@ -237,9 +237,9 @@ class PotentialDuplicateStoreTEAVTest extends PostgresIntegrationTestBase {
                       assertEquals("AttributeA", teav.getValue());
                     }
                   });
-          TrackedEntity _control = manager.get(TrackedEntity.class, control.getUid());
-          assertNotNull(_control);
-          assertEquals(3, _control.getTrackedEntityAttributeValues().size());
+          TrackedEntity controlFromDB = manager.get(TrackedEntity.class, control.getUid());
+          assertNotNull(controlFromDB);
+          assertEquals(3, controlFromDB.getTrackedEntityAttributeValues().size());
           return null;
         });
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -88,9 +89,9 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
     dbmsManager.save(duplicate1);
     dbmsManager.save(duplicate2);
 
-    potentialDuplicate1 = new PotentialDuplicate(origin.getUid(), duplicate1.getUid());
+    potentialDuplicate1 = new PotentialDuplicate(UID.of(origin), UID.of(duplicate1));
     save(potentialDuplicate1);
-    potentialDuplicate2 = new PotentialDuplicate(origin.getUid(), duplicate2.getUid());
+    potentialDuplicate2 = new PotentialDuplicate(UID.of(origin), UID.of(duplicate2));
     save(potentialDuplicate2);
   }
 
@@ -100,7 +101,7 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
     trackedEntity.setTrackedEntityType(trackedEntityType);
     dbmsManager.save(trackedEntity);
     PotentialDuplicate potentialDuplicate =
-        new PotentialDuplicate(trackedEntity.getUid(), duplicate1.getUid());
+        new PotentialDuplicate(UID.of(trackedEntity), UID.of(duplicate1));
 
     assertStatus(
         HttpStatus.OK, POST(ENDPOINT, objectMapper.writeValueAsString(potentialDuplicate)));
@@ -246,7 +247,7 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void shouldThrowPostPotentialDuplicateWhenMissingDuplicateTeiInPayload() throws Exception {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(origin.getUid(), null);
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(UID.of(origin), null);
     assertStatus(
         HttpStatus.BAD_REQUEST,
         POST(ENDPOINT, objectMapper.writeValueAsString(potentialDuplicate)));
@@ -254,7 +255,7 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void shouldThrowPostPotentialDuplicateWhenMissingOriginTeiInPayload() throws Exception {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(null, duplicate1.getUid());
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(null, UID.of(duplicate1));
     assertStatus(
         HttpStatus.BAD_REQUEST,
         POST(ENDPOINT, objectMapper.writeValueAsString(potentialDuplicate)));
@@ -263,7 +264,7 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void shouldThrowBadRequestWhenPutPotentialDuplicateAlreadyMerged() {
     PotentialDuplicate potentialDuplicate =
-        new PotentialDuplicate(origin.getUid(), duplicate1.getUid());
+        new PotentialDuplicate(UID.of(origin), UID.of(duplicate1));
     potentialDuplicate.setStatus(DeduplicationStatus.MERGED);
     save(potentialDuplicate);
 
@@ -311,11 +312,11 @@ class DeduplicationControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void shouldThrowNotFoundWhenPotentialDuplicateDoNotExists() {
-    assertStatus(HttpStatus.NOT_FOUND, GET(ENDPOINT + "uid"));
+    assertStatus(HttpStatus.NOT_FOUND, GET(ENDPOINT + UID.generate()));
   }
 
   private PotentialDuplicate potentialDuplicate(String original, String duplicate) {
-    return save(new PotentialDuplicate(original, duplicate));
+    return save(new PotentialDuplicate(UID.of(original), UID.of(duplicate)));
   }
 
   private PotentialDuplicate save(PotentialDuplicate potentialDuplicate) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/JsonPotentialDuplicate.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/JsonPotentialDuplicate.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.deduplication;
 
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.tracker.deduplication.PotentialDuplicate;
 
@@ -36,12 +37,12 @@ public interface JsonPotentialDuplicate extends JsonObject {
     return getString("id").string();
   }
 
-  default String getOriginal() {
-    return getString("original").string();
+  default UID getOriginal() {
+    return UID.of(getString("original").string());
   }
 
-  default String getDuplicate() {
-    return getString("duplicate").string();
+  default UID getDuplicate() {
+    return UID.of(getString("duplicate").string());
   }
 
   default String getLastUpdated() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -209,11 +209,12 @@ public class DeduplicationController {
               + DeduplicationStatus.MERGED.name());
   }
 
-  private PotentialDuplicate getPotentialDuplicateBy(UID id) throws NotFoundException {
-    return Optional.ofNullable(deduplicationService.getPotentialDuplicateByUid(id))
+  private PotentialDuplicate getPotentialDuplicateBy(UID uid) throws NotFoundException {
+    return Optional.ofNullable(deduplicationService.getPotentialDuplicateByUid(uid))
         .orElseThrow(
             () ->
-                new NotFoundException("No potentialDuplicate records found with id '" + id + "'."));
+                new NotFoundException(
+                    "No potentialDuplicate records found with id '" + uid + "'."));
   }
 
   private void validatePotentialDuplicate(PotentialDuplicate potentialDuplicate)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -211,10 +211,7 @@ public class DeduplicationController {
 
   private PotentialDuplicate getPotentialDuplicateBy(UID uid) throws NotFoundException {
     return Optional.ofNullable(deduplicationService.getPotentialDuplicateByUid(uid))
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    "No potentialDuplicate records found with id '" + uid + "'."));
+        .orElseThrow(() -> new NotFoundException(PotentialDuplicate.class, uid));
   }
 
   private void validatePotentialDuplicate(PotentialDuplicate potentialDuplicate)
@@ -259,9 +256,7 @@ public class DeduplicationController {
     TrackedEntity trackedEntity = manager.get(TrackedEntity.class, uid.getValue());
     // TODO(tracker) Do we need to apply ACL here?
     return Optional.ofNullable(trackedEntity)
-        .orElseThrow(
-            () ->
-                new NotFoundException("No tracked entity found with id '" + trackedEntity + "'."));
+        .orElseThrow(() -> new NotFoundException(TrackedEntity.class, uid));
   }
 
   private void canReadTrackedEntity(TrackedEntity trackedEntity) throws ForbiddenException {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationMvcTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.deduplication;
 
 import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -44,8 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -97,16 +97,16 @@ class DeduplicationMvcTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  private static final String original = CodeGenerator.generateUid();
+  private static final UID ORIGINAL = UID.generate();
 
-  private static final String duplicate = CodeGenerator.generateUid();
+  private static final UID DUPLICATE = UID.generate();
 
   @BeforeEach
   void setUp() {
     injectSecurityContextNoSettings(new SystemUser());
     deduplicationMergeParams =
         DeduplicationMergeParams.builder()
-            .potentialDuplicate(new PotentialDuplicate(original, duplicate))
+            .potentialDuplicate(new PotentialDuplicate(ORIGINAL, DUPLICATE))
             .original(trackedEntityA)
             .duplicate(trackedEntityB)
             .mergeObject(MergeObject.builder().build())
@@ -122,10 +122,10 @@ class DeduplicationMvcTest {
     when(trackerAccessManager.canRead(any(), any(TrackedEntity.class)))
         .thenReturn(Collections.emptyList());
 
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
-    when(manager.get(TrackedEntity.class, duplicate)).thenReturn(trackedEntityB);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, DUPLICATE.getValue())).thenReturn(trackedEntityB);
 
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     mockMvc
         .perform(
             post(ENDPOINT)
@@ -142,9 +142,9 @@ class DeduplicationMvcTest {
     when(trackerAccessManager.canRead(any(), any(TrackedEntity.class)))
         .thenReturn(List.of("error"));
 
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
 
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     mockMvc
         .perform(
             post(ENDPOINT)
@@ -152,13 +152,13 @@ class DeduplicationMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
-            result -> assertTrue(result.getResolvedException() instanceof ForbiddenException));
+            result -> assertInstanceOf(ForbiddenException.class, result.getResolvedException()));
     verify(deduplicationService, times(0)).addPotentialDuplicate(any());
   }
 
   @Test
   void shouldThrowBadRequestExceptionWhenPostAndTeiDoNotExists() throws Exception {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, null);
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, null);
     mockMvc
         .perform(
             post(ENDPOINT)
@@ -166,15 +166,15 @@ class DeduplicationMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
-            result -> assertTrue(result.getResolvedException() instanceof BadRequestException));
+            result -> assertInstanceOf(BadRequestException.class, result.getResolvedException()));
     verify(deduplicationService, times(0)).addPotentialDuplicate(any());
   }
 
   @Test
   void shouldThrowBadRequestExceptionWhenPutAndPotentialDuplicateIsAlreadyMerged()
       throws Exception {
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     potentialDuplicate.setStatus(DeduplicationStatus.MERGED);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     mockMvc
@@ -185,14 +185,14 @@ class DeduplicationMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
-            result -> assertTrue(result.getResolvedException() instanceof BadRequestException));
+            result -> assertInstanceOf(BadRequestException.class, result.getResolvedException()));
     verify(deduplicationService).getPotentialDuplicateByUid(uid);
   }
 
   @Test
   void shouldThrowBadRequestExceptionWhenPutPotentialDuplicateToMergedStatus() throws Exception {
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     mockMvc
         .perform(
@@ -202,14 +202,14 @@ class DeduplicationMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
-            result -> assertTrue(result.getResolvedException() instanceof BadRequestException));
+            result -> assertInstanceOf(BadRequestException.class, result.getResolvedException()));
     verify(deduplicationService).getPotentialDuplicateByUid(uid);
   }
 
   @Test
   void shouldUpdatePotentialDuplicateWhenPotentialDuplicateExists() throws Exception {
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     mockMvc
         .perform(
@@ -230,8 +230,8 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldGetPotentialDuplicateByIdWhenPotentialDuplicateExists() throws Exception {
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
-    String uid = "uid";
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
+    UID uid = UID.generate();
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     mockMvc
         .perform(
@@ -246,7 +246,7 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldThrowNotFoundExceptionWhenPotentialDuplicateNotExists() throws Exception {
-    String uid = "uid";
+    UID uid = UID.generate();
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(null);
     mockMvc
         .perform(
@@ -255,17 +255,17 @@ class DeduplicationMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
-            result -> assertTrue(result.getResolvedException() instanceof NotFoundException));
+            result -> assertInstanceOf(NotFoundException.class, result.getResolvedException()));
     verify(deduplicationService).getPotentialDuplicateByUid(uid);
   }
 
   @Test
   void shouldAutoMergePotentialDuplicateWhenUserHasAccessAndMergeIsOk() throws Exception {
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
-    when(manager.get(TrackedEntity.class, duplicate)).thenReturn(trackedEntityB);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, DUPLICATE.getValue())).thenReturn(trackedEntityB);
 
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     MergeObject mergeObject = MergeObject.builder().build();
     mockMvc
@@ -282,11 +282,11 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldManualMergePotentialDuplicateWhenUserHasAccessAndMergeIsOk() throws Exception {
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
-    when(manager.get(TrackedEntity.class, duplicate)).thenReturn(trackedEntityB);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, DUPLICATE.getValue())).thenReturn(trackedEntityB);
 
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     MergeObject mergeObject = MergeObject.builder().build();
     mockMvc
@@ -303,11 +303,11 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldThrowForbiddenExceptionWhenAutoMergingIsForbidden() throws Exception {
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
-    when(manager.get(TrackedEntity.class, duplicate)).thenReturn(trackedEntityB);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, DUPLICATE.getValue())).thenReturn(trackedEntityB);
 
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     doThrow(new PotentialDuplicateForbiddenException("Forbidden"))
         .when(deduplicationService)
@@ -322,19 +322,19 @@ class DeduplicationMvcTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
             result ->
-                assertTrue(
-                    result.getResolvedException() instanceof PotentialDuplicateForbiddenException));
+                assertInstanceOf(
+                    PotentialDuplicateForbiddenException.class, result.getResolvedException()));
     verify(deduplicationService).autoMerge(deduplicationMergeParams);
     verify(deduplicationService, times(0)).manualMerge(deduplicationMergeParams);
   }
 
   @Test
   void shouldThrowConflictExceptionWhenAutoMergeHasConflicts() throws Exception {
-    when(manager.get(TrackedEntity.class, original)).thenReturn(trackedEntityA);
-    when(manager.get(TrackedEntity.class, duplicate)).thenReturn(trackedEntityB);
+    when(manager.get(TrackedEntity.class, ORIGINAL.getValue())).thenReturn(trackedEntityA);
+    when(manager.get(TrackedEntity.class, DUPLICATE.getValue())).thenReturn(trackedEntityB);
 
-    String uid = "uid";
-    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);
+    UID uid = UID.generate();
+    PotentialDuplicate potentialDuplicate = new PotentialDuplicate(ORIGINAL, DUPLICATE);
     when(deduplicationService.getPotentialDuplicateByUid(uid)).thenReturn(potentialDuplicate);
     doThrow(new PotentialDuplicateConflictException("Conflict"))
         .when(deduplicationService)
@@ -349,8 +349,8 @@ class DeduplicationMvcTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(
             result ->
-                assertTrue(
-                    result.getResolvedException() instanceof PotentialDuplicateConflictException));
+                assertInstanceOf(
+                    PotentialDuplicateConflictException.class, result.getResolvedException()));
     verify(deduplicationService).autoMerge(deduplicationMergeParams);
     verify(deduplicationService, times(0)).manualMerge(deduplicationMergeParams);
   }


### PR DESCRIPTION
Harmonize the usage of UID instead of plain String in tracker.

Use UID in DeduplicationService and propagate the change.
Use UID in PotentialDuplicateCriteria.
Use UID in PotentialDuplicate. This is a Hibernate object so in order to be persisted a new `UIDUserType` was created.
Add @JsonValue annotation on `UID` `toString` method in order to be serialized as a String.

Next steps*

Harmonize UID in remaining tracker packages