### PR TITLE
fix: /tracker/events exports notes with timestamps instead of dates [2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -515,7 +515,8 @@ public class JdbcEventStore implements EventStore {
               Note note = new Note();
               note.setNote(resultSet.getString("psinote_uid"));
               note.setValue(resultSet.getString("psinote_value"));
-              note.setStoredDate(DateUtils.getIso8601NoTz(resultSet.getDate("psinote_storeddate")));
+              note.setStoredDate(
+                  DateUtils.getIso8601NoTz(resultSet.getTimestamp("psinote_storeddate")));
               note.setStoredBy(resultSet.getString("psinote_storedby"));
 
               if (resultSet.getObject("usernote_id") != null) {
@@ -530,7 +531,7 @@ public class JdbcEventStore implements EventStore {
                         resultSet.getString("userinfo_surname")));
               }
 
-              note.setLastUpdated(resultSet.getDate("psinote_lastupdated"));
+              note.setLastUpdated(resultSet.getTimestamp("psinote_lastupdated"));
 
               event.getNotes().add(note);
               notes.add(resultSet.getString("psinote_id"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -74,12 +75,14 @@ import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,14 +113,14 @@ class EventExporterTest extends TrackerTest {
   private Program program;
 
   final Function<EventQueryParams, List<String>> eventsFunction =
-      (params) ->
+      params ->
           eventService.getEvents(params).getEvents().stream()
               .map(Event::getEvent)
               .collect(Collectors.toList());
 
   /** EVENT_ID is at position 0 in column headers in events grid */
   final Function<EventQueryParams, List<String>> eventsGridFunction =
-      (params) ->
+      params ->
           eventService.getEventsGrid(params).getRows().stream()
               .map(r -> r.get(0).toString())
               .collect(Collectors.toList());
@@ -177,6 +180,7 @@ class EventExporterTest extends TrackerTest {
 
   @Test
   void shouldReturnEventsWithNotes() {
+    ProgramStageInstance pTzf9KYMk72 = get(ProgramStageInstance.class, "pTzf9KYMk72");
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnit(orgUnit);
     params.setEvents(Set.of("pTzf9KYMk72"));
@@ -185,13 +189,7 @@ class EventExporterTest extends TrackerTest {
     Events events = eventService.getEvents(params);
 
     assertContainsOnly(List.of("pTzf9KYMk72"), eventUids(events));
-    List<Note> notes = events.getEvents().get(0).getNotes();
-    assertContainsOnly(
-        List.of("SGuCABkhpgn", "DRKO4xUVrpr"),
-        notes.stream().map(Note::getNote).collect(Collectors.toList()));
-    assertAll(
-        () -> assertNote(importUser, "comment value", notes.get(0)),
-        () -> assertNote(importUser, "comment value", notes.get(1)));
+    assertNotes(pTzf9KYMk72.getComments(), events.getEvents().get(0).getNotes());
   }
 
   @ParameterizedTest
@@ -1149,11 +1147,47 @@ class EventExporterTest extends TrackerTest {
         new HashSet<>(trackedEntities));
   }
 
-  private void assertNote(User expectedLastUpdatedBy, String expectedNote, Note actual) {
-    assertEquals(expectedNote, actual.getValue());
-    UserInfoSnapshot lastUpdatedBy = actual.getLastUpdatedBy();
-    assertEquals(expectedLastUpdatedBy.getUid(), lastUpdatedBy.getUid());
-    assertEquals(expectedLastUpdatedBy.getUsername(), lastUpdatedBy.getUsername());
+  private static void assertNotes(List<TrackedEntityComment> expected, List<Note> actual) {
+    Map<String, TrackedEntityComment> expectedNotes =
+        expected.stream()
+            .collect(Collectors.toMap(IdentifiableObject::getUid, Function.identity()));
+    Map<String, Note> actualNotes =
+        actual.stream().collect(Collectors.toMap(Note::getNote, Function.identity()));
+    List<Executable> assertions =
+        expectedNotes.entrySet().stream()
+            .map(
+                entry ->
+                    (Executable)
+                        () -> {
+                          TrackedEntityComment expectedNote = entry.getValue();
+                          Note actualNote = actualNotes.get(entry.getKey());
+                          assertNotNull(
+                              actualNote, "note " + expectedNote.getUid() + " does not exist");
+                          assertAll(
+                              "note assertions " + expectedNote.getUid(),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getCommentText(),
+                                      actualNote.getValue(),
+                                      "commentText"),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getCreator(),
+                                      actualNote.getStoredBy(),
+                                      "creator"),
+                              () ->
+                                  assertEquals(
+                                      DateUtils.getIso8601NoTz(expectedNote.getCreated()),
+                                      actualNote.getStoredDate(),
+                                      "created"),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getLastUpdated(),
+                                      actualNote.getLastUpdated(),
+                                      "lastUpdated"));
+                        })
+            .collect(Collectors.toList());
+    assertAll("note assertions", assertions);
   }
 
   private DataElement dataElement(String uid) {


### PR DESCRIPTION
Found the issue while working on https://github.com/dhis2/dhis2-core/pull/18943. It's already fixed on master.

Added assertion to existing test test. Example failure before the fix

```sh
[ERROR] Failures:
[ERROR]   EventExporterTest.shouldReturnEventsWithNotes:192->assertNotes:1190 note assertions (2 failures)
        org.opentest4j.MultipleFailuresError: note assertions DRKO4xUVrpr (2 failures)
        org.opentest4j.AssertionFailedError: created ==> expected: <2024-10-30T14:54:18.037> but was: <2024-10-30T00:00:00.000>
        org.opentest4j.AssertionFailedError: lastUpdated ==> expected: <Wed Oct 30 14:54:18 CET 2024> but was: <2024-10-30>
        org.opentest4j.MultipleFailuresError: note assertions SGuCABkhpgn (2 failures)
        org.opentest4j.AssertionFailedError: created ==> expected: <2024-10-30T14:54:18.037> but was: <2024-10-30T00:00:00.000>
        org.opentest4j.AssertionFailedError: lastUpdated ==> expected: <Wed Oct 30 14:54:18 CET 2024> but was: <2024-10-30>
```