### PR TITLE
fix: /tracker/events exports notes with timestamps instead of dates [2.39]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -514,7 +514,8 @@ public class JdbcEventStore implements EventStore {
               Note note = new Note();
               note.setNote(resultSet.getString("psinote_uid"));
               note.setValue(resultSet.getString("psinote_value"));
-              note.setStoredDate(DateUtils.getIso8601NoTz(resultSet.getDate("psinote_storeddate")));
+              note.setStoredDate(
+                  DateUtils.getIso8601NoTz(resultSet.getTimestamp("psinote_storeddate")));
               note.setStoredBy(resultSet.getString("psinote_storedby"));
 
               if (resultSet.getObject("usernote_id") != null) {
@@ -529,7 +530,7 @@ public class JdbcEventStore implements EventStore {
                         resultSet.getString("userinfo_surname")));
               }
 
-              note.setLastUpdated(resultSet.getDate("psinote_lastupdated"));
+              note.setLastUpdated(resultSet.getTimestamp("psinote_lastupdated"));
 
               event.getNotes().add(note);
               notes.add(resultSet.getString("psinote_id"));


### PR DESCRIPTION
Found the issue while working on https://github.com/dhis2/dhis2-core/pull/18943. It's already fixed on master.

Added assertion to existing test test. Example failure before the fix

```sh
[ERROR] Failures:
[ERROR]   EventExporterTest.shouldReturnEventsWithNotes:195->assertNotes:1267 note assertions (2 failures)
        org.opentest4j.MultipleFailuresError: note assertions DRKO4xUVrpr (2 failures)
        org.opentest4j.AssertionFailedError: created ==> expected: <2024-10-30T15:13:56.318> but was: <2024-10-30T00:00:00.000>
        org.opentest4j.AssertionFailedError: lastUpdated ==> expected: <Wed Oct 30 15:13:56 CET 2024> but was: <2024-10-30>
        org.opentest4j.MultipleFailuresError: note assertions SGuCABkhpgn (2 failures)
        org.opentest4j.AssertionFailedError: created ==> expected: <2024-10-30T15:13:56.318> but was: <2024-10-30T00:00:00.000>
        org.opentest4j.AssertionFailedError: lastUpdated ==> expected: <Wed Oct 30 15:13:56 CET 2024> but was: <2024-10-30>
```