### PR TITLE
refactor: Replace without specifying variables to qualify [DHIS2-16705]

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/RegexUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/RegexUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,40 +27,34 @@
  */
 package org.hisp.dhis.common;
 
-import java.util.HashSet;
-import java.util.Objects;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.ObjectUtils;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Lars Helge Overland
  */
-public class RegexUtils {
-  /**
-   * Return the matches in the given input based on the given pattern and group number.
-   *
-   * @param pattern the pattern.
-   * @param input the input. If the input is null, an empty set is returned.
-   * @param group the group, can be null.
-   * @return a set of matches.
-   */
-  public static Set<String> getMatches(Pattern pattern, String input, Integer group) {
-    Objects.requireNonNull(pattern);
+class RegexUtilsTest {
+  @Test
+  void testGetMatchesWithGroup() {
+    assertEquals(
+        Set.of("animal", "target"),
+        RegexUtils.getMatches(
+            Pattern.compile("\\$\\{([^}]+)\\}"), "The ${animal} jumped over the ${target}.", 1));
+  }
 
-    int gr = ObjectUtils.firstNonNull(group, 0);
+  @Test
+  void testGetMatchesWithNullInput() {
+    assertEquals(Set.of(), RegexUtils.getMatches(Pattern.compile("\\$\\{([^}]+)\\}"), null, 1));
+  }
 
-    Set<String> set = new HashSet<>();
-
-    if (input != null) {
-      Matcher matcher = pattern.matcher(input);
-
-      while (matcher.find()) {
-        set.add(matcher.group(gr));
-      }
-    }
-
-    return set;
+  @Test
+  void testGetMatchesWithNullGroup() {
+    assertEquals(
+        Set.of("${animal}", "${target}"),
+        RegexUtils.getMatches(
+            Pattern.compile("\\$\\{([^}]+)\\}"), "The ${animal} jumped over the ${target}.", null));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -716,6 +716,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
    */
   protected String replaceQualify(String template, Map<String, String> variables) {
     Map<String, String> map = new HashMap<>(variables);
+
     Set<String> variableNames = TextUtils.getVariableNames(template);
 
     variableNames.forEach(name -> map.putIfAbsent(name, qualify(name)));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -716,7 +716,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
    */
   protected String replaceQualify(String template, Map<String, String> variables) {
     Map<String, String> map = new HashMap<>(variables);
-
     Set<String> variableNames = TextUtils.getVariableNames(template);
 
     variableNames.forEach(name -> map.putIfAbsent(name, qualify(name)));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -716,9 +716,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
    */
   protected String replaceQualify(String template, Map<String, String> variables) {
     Map<String, String> map = new HashMap<>(variables);
-
     Set<String> variableNames = TextUtils.getVariableNames(template);
-
     variableNames.forEach(name -> map.putIfAbsent(name, qualify(name)));
 
     return TextUtils.replace(template, map);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -702,18 +702,25 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
   }
 
   /**
-   * Replaces variables in the given template string with the given variables to qualify and the
-   * given map of variable keys and values.
+   * Replaces variables in the given template string.
+   *
+   * <p>Variables which are present in the given template and in the given map of variables are
+   * replaced with the corresponding map value.
+   *
+   * <p>Variables which are present in the given template but not present in the given map of
+   * variables will be qualified using <code>qualify(String)</code>.
    *
    * @param template the template string.
-   * @param qualifyVariables the list of variables to qualify.
-   * @param variables the map of variables and values.
-   * @return a resolved string.
+   * @param variables the map of variable names and values.
+   * @return a string with replaced variables.
    */
-  protected String replaceQualify(
-      String template, List<String> qualifyVariables, Map<String, String> variables) {
+  protected String replaceQualify(String template, Map<String, String> variables) {
     Map<String, String> map = new HashMap<>(variables);
-    qualifyVariables.forEach(v -> map.put(v, qualify(v)));
+
+    Set<String> variableNames = TextUtils.getVariableNames(template);
+
+    variableNames.forEach(name -> map.putIfAbsent(name, qualify(name)));
+
     return TextUtils.replace(template, map);
   }
 

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
@@ -660,8 +660,8 @@ public class TextUtils {
   }
 
   /**
-   * Returns the names of the variables in the given input. The definition of a variable is
-   * ${variableName}.
+   * Returns the names of the variables in the given input. The definition of a variable is <code>
+   * ${variableName}</code>.
    *
    * @param input the input potentially containing variables.
    * @return a set of variable names.

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
@@ -37,9 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
+import org.hisp.dhis.common.RegexUtils;
 import org.slf4j.helpers.MessageFormatter;
 
 /**
@@ -67,6 +69,8 @@ public class TextUtils {
   private static final String OPTION_SEP = ";";
 
   private static final Character DOUBLE_QUOTE = '\"';
+
+  private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
 
   /**
    * Remove all non-alphanumeric characters within string
@@ -653,5 +657,16 @@ public class TextUtils {
    */
   public static String format(String pattern, Object... arguments) {
     return MessageFormatter.arrayFormat(pattern, arguments).getMessage();
+  }
+
+  /**
+   * Returns the names of the variables in the given input. The definition of a variable is
+   * ${variableName}.
+   *
+   * @param input the input potentially containing variables.
+   * @return a set of variable names.
+   */
+  public static Set<String> getVariableNames(String input) {
+    return RegexUtils.getMatches(VARIABLE_PATTERN, input, 1);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/TextUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/TextUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -266,5 +267,17 @@ class TextUtilsTest {
   void testEmptyIfTrue() {
     assertEquals("", TextUtils.emptyIfTrue("foo", true));
     assertEquals("foo", TextUtils.emptyIfTrue("foo", false));
+  }
+
+  @Test
+  void testGetVariableNames() {
+    assertEquals(
+        Set.of("animal", "target"),
+        TextUtils.getVariableNames("The ${animal} jumped over the ${target}."));
+  }
+
+  @Test
+  void testGetVariableNamesWithNullInput() {
+    assertEquals(Set.of(), TextUtils.getVariableNames(null));
   }
 }


### PR DESCRIPTION
This PR makes the `replaceAndQualify` method better, but removing the unnecessary requirement of specifying the names of variables to be qualified. Instead, the method looks at the specified variable name/value mapping, and then qualifies remaining variables. This will simplify the handling of SQL statements for populating the analytics database tables. See DHIS2-16705.

Removes unused method.

Adds unit tests.