### PR TITLE
ci: don't run analysis workflows for dependabot

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   sonarqube:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,13 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 concurrency:
-    group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   analyze:
+    if: github.actor != 'dependabot[bot]'
     name: Analyze
     runs-on: ubuntu-latest
 
@@ -27,7 +28,7 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: [ 'java' ]
+        language: ["java"]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 


### PR DESCRIPTION
Save GH compute/quota. We don't expect any different results when running these workflows on dependabot PR.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions

Dependabot does [not have access to org/repo secrets by default](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#adding-an-organization-secret-for-dependabot). This caused the sonar workflow to fail.

Our options were
1. add the secrets
2. don't run workflows that are not necessary for dependabot PRs

https://github.com/dhis2/dhis2-core/blob/master/.github/workflows/analyse-pr.yml is a required workflow. Not sure if we can make an exception to not require the sonar workflow on dependabot PRs.
