### PR TITLE
ci: ignore java:S1117 for tests

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -71,6 +71,9 @@
     <sonar.organization>dhis2</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.projectKey>dhis2_dhis2-core</sonar.projectKey>
+    <sonar.issue.ignore.multicriteria>S1117</sonar.issue.ignore.multicriteria>
+    <sonar.issue.ignore.multicriteria.S1117.ruleKey>java:S1117</sonar.issue.ignore.multicriteria.S1117.ruleKey>
+    <sonar.issue.ignore.multicriteria.S1117.resourceKey>**/src/test/**/*.java</sonar.issue.ignore.multicriteria.S1117.resourceKey>
 
     <surefireArgLine>-Xmx2024m</surefireArgLine>
 


### PR DESCRIPTION
As discussed in the backend meeting: do not apply

https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS1117&rule_key=java%3AS1117

in tests.