### PR TITLE
feat: Fallback for User analysis org is referred to user capturing org [2.42-DHIS2-13498_2]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -318,7 +318,7 @@ public class DefaultDataQueryService implements DataQueryService {
   private List<OrganisationUnit> getOrganisationUnitsGrantedForAnalyticsData(User currentUser) {
     Set<OrganisationUnit> organisationUnits = currentUser.getDataViewOrganisationUnits();
     if (organisationUnits != null && !organisationUnits.isEmpty()) {
-      return currentUser.getDataViewOrganisationUnits().stream().sorted().toList();
+      return organisationUnits.stream().sorted().toList();
     } else {
       // If the user has no analytics permissions for any organizational unit,
       // apply their data capture permissions instead.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -63,6 +63,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.DataQueryParams;
@@ -296,7 +298,7 @@ public class DefaultDataQueryService implements DataQueryService {
           units.addAll(currentUser.getOrganisationUnits().stream().sorted().toList());
           break;
         case DATA_OUTPUT:
-          units.addAll(currentUser.getDataViewOrganisationUnits().stream().sorted().toList());
+          units.addAll(getOrganisationUnitsGrantedForAnalyticsData(currentUser));
           break;
         case TEI_SEARCH:
           units.addAll(currentUser.getTeiSearchOrganisationUnits().stream().sorted().toList());
@@ -309,6 +311,21 @@ public class DefaultDataQueryService implements DataQueryService {
     return units;
   }
 
+  /**
+   * Retrieve the list of organizational units to which the current user has access rights.
+   *
+   * @param currentUser {@link User}
+   */
+  private List<OrganisationUnit> getOrganisationUnitsGrantedForAnalyticsData(User currentUser) {
+    Set<OrganisationUnit> organisationUnits = currentUser.getDataViewOrganisationUnits();
+    if (organisationUnits != null && !organisationUnits.isEmpty()) {
+      return currentUser.getDataViewOrganisationUnits().stream().sorted().toList();
+    } else {
+      // If the user has no analytics permissions for any organizational unit,
+      // apply their data capture permissions instead.
+      return currentUser.getOrganisationUnits().stream().sorted().toList();
+    }
+  }
   private List<DimensionalObject> getDimensionalObjects(DataQueryRequest request) {
     List<DimensionalObject> list = new ArrayList<>();
     DataQueryParams params =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -64,7 +64,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.DataQueryParams;
@@ -312,8 +311,7 @@ public class DefaultDataQueryService implements DataQueryService {
   }
 
   /**
-   * Retrieve the list of organizational units
-   * to which the current user has access rights.
+   * Retrieve the list of organizational units to which the current user has access rights.
    *
    * @param currentUser {@link User}
    */
@@ -327,6 +325,7 @@ public class DefaultDataQueryService implements DataQueryService {
       return currentUser.getOrganisationUnits().stream().sorted().toList();
     }
   }
+
   private List<DimensionalObject> getDimensionalObjects(DataQueryRequest request) {
     List<DimensionalObject> list = new ArrayList<>();
     DataQueryParams params =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -297,7 +297,7 @@ public class DefaultDataQueryService implements DataQueryService {
           units.addAll(currentUser.getOrganisationUnits().stream().sorted().toList());
           break;
         case DATA_OUTPUT:
-          units.addAll(getOrganisationUnitsGrantedForAnalyticsData(currentUser));
+          units.addAll(getAnalyticsOrganisationUnitsOrDefault(currentUser));
           break;
         case TEI_SEARCH:
           units.addAll(currentUser.getTeiSearchOrganisationUnits().stream().sorted().toList());
@@ -311,19 +311,27 @@ public class DefaultDataQueryService implements DataQueryService {
   }
 
   /**
-   * Retrieve the list of organizational units to which the current user has access rights.
+   * Retrieve the list of organisation units to which the current user has access rights. If the
+   * user has analytics organisation units assigned, those will be returned. Otherwise, it returns
+   * the default ones (data capture organisation units).
    *
    * @param currentUser {@link User}
+   * @return a list of {@link OrganisationUnit}.
    */
-  private List<OrganisationUnit> getOrganisationUnitsGrantedForAnalyticsData(User currentUser) {
+  private List<OrganisationUnit> getAnalyticsOrganisationUnitsOrDefault(User currentUser) {
     Set<OrganisationUnit> organisationUnits = currentUser.getDataViewOrganisationUnits();
     if (organisationUnits != null && !organisationUnits.isEmpty()) {
       return organisationUnits.stream().sorted().toList();
     } else {
-      // If the user has no analytics permissions for any organizational unit,
-      // apply their data capture permissions instead.
-      return currentUser.getOrganisationUnits().stream().sorted().toList();
+      // If the user has no analytics permissions for any organization unit,
+      // returns data capture organization units, instead.
+      Set<OrganisationUnit> defaultOrganisationUnits = currentUser.getOrganisationUnits();
+      if (defaultOrganisationUnits != null && !defaultOrganisationUnits.isEmpty()) {
+        return defaultOrganisationUnits.stream().sorted().toList();
+      }
     }
+
+    return new ArrayList<>();
   }
 
   private List<DimensionalObject> getDimensionalObjects(DataQueryRequest request) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -312,7 +312,8 @@ public class DefaultDataQueryService implements DataQueryService {
   }
 
   /**
-   * Retrieve the list of organizational units to which the current user has access rights.
+   * Retrieve the list of organizational units
+   * to which the current user has access rights.
    *
    * @param currentUser {@link User}
    */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.data;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hisp.dhis.common.UserOrgUnitType.DATA_OUTPUT;
 import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -41,39 +42,24 @@ import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.DataQueryService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.user.User;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/** Unit tests for {@link DataQueryService}. */
 @ExtendWith(MockitoExtension.class)
 class DataQueryServiceTest {
-  private static OrganisationUnit ouA;
-
-  private static OrganisationUnit ouB;
-
-  private static OrganisationUnit ouC;
-
-  private static OrganisationUnit ouD;
-
-  private static DataQueryParams dataQueryParams;
-
-  @BeforeAll
-  static void setUp() {
-    ouA = createOrganisationUnit('A');
-    ouB = createOrganisationUnit('B');
-    ouC = createOrganisationUnit('C');
-    ouD = createOrganisationUnit('D');
-    dataQueryParams =
-        DataQueryParams.newBuilder().withUserOrgUnitType(UserOrgUnitType.DATA_OUTPUT).build();
-  }
 
   @Test
-  void testGetUserOrgUnitsWithExplicitGrantedForAnalyticsOrganisationUnits() {
+  void testGetUserOrgUnitsWithExplicitlyDefinedAnalyticsOrganisationUnits() {
     // given
+    OrganisationUnit ouB = createOrganisationUnit('B');
+    OrganisationUnit ouC = createOrganisationUnit('C');
+    OrganisationUnit ouD = createOrganisationUnit('D');
+    DataQueryParams dataQueryParams =
+        DataQueryParams.newBuilder().withUserOrgUnitType(DATA_OUTPUT).build();
     User currentUser = mock(User.class);
     AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
     when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouB, ouC, ouD));
@@ -95,11 +81,13 @@ class DataQueryServiceTest {
   }
 
   @Test
-  void testGetUserOrgUnitsWithDeniedForAnalyticsOrganisationUnits() {
+  void testGetUserOrgUnitsWithNoAnalyticsOrganisationUnitsDefined() {
     // given
+    OrganisationUnit ouA = createOrganisationUnit('A');
+    DataQueryParams dataQueryParams =
+        DataQueryParams.newBuilder().withUserOrgUnitType(DATA_OUTPUT).build();
     User currentUser = mock(User.class);
     AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
-    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
     when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouA));
     when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
     DataQueryService dataQueryService =
@@ -119,11 +107,12 @@ class DataQueryServiceTest {
   }
 
   @Test
-  void testGetUserOrgUnitsWithDeniedForAllOrganisationUnits() {
+  void testGetUserOrgUnitsWithNoneOrganisationUnitDefined() {
     // given
+    DataQueryParams dataQueryParams =
+        DataQueryParams.newBuilder().withUserOrgUnitType(DATA_OUTPUT).build();
     User currentUser = mock(User.class);
     AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
-    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
     when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
     when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
     DataQueryService dataQueryService =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -88,7 +88,8 @@ class DataQueryServiceTest {
         DataQueryParams.newBuilder().withUserOrgUnitType(DATA_OUTPUT).build();
     User currentUser = mock(User.class);
     AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
-    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouA));
+    when(currentUser.getOrganisationUnits()).thenReturn(Set.of(ouA));
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
     when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
     DataQueryService dataQueryService =
         new DefaultDataQueryService(
@@ -113,6 +114,7 @@ class DataQueryServiceTest {
         DataQueryParams.newBuilder().withUserOrgUnitType(DATA_OUTPUT).build();
     User currentUser = mock(User.class);
     AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
+    when(currentUser.getOrganisationUnits()).thenReturn(Set.of());
     when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
     when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
     DataQueryService dataQueryService =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.analytics.AnalyticsSecurityManager;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.DataQueryService;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UserOrgUnitType;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataQueryServiceTest {
+  private static OrganisationUnit ouA;
+
+  private static OrganisationUnit ouB;
+
+  private static OrganisationUnit ouC;
+
+  private static OrganisationUnit ouD;
+
+  private static DataQueryParams dataQueryParams;
+
+  @BeforeAll
+  static void setUp() {
+    ouA = createOrganisationUnit('A');
+    ouB = createOrganisationUnit('B');
+    ouC = createOrganisationUnit('C');
+    ouD = createOrganisationUnit('D');
+    dataQueryParams =
+        DataQueryParams.newBuilder().withUserOrgUnitType(UserOrgUnitType.DATA_OUTPUT).build();
+  }
+
+  @Test
+  void testGetUserOrgUnitsWithExplicitGrantedForAnalyticsOrganisationUnits() {
+    // given
+    User currentUser = mock(User.class);
+    AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouB, ouC, ouD));
+    when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
+    DataQueryService dataQueryService =
+        new DefaultDataQueryService(
+            mock(DimensionalObjectProducer.class),
+            mock(IdentifiableObjectManager.class),
+            analyticsSecurityManager);
+
+    // when
+    List<OrganisationUnit> userOrgUnits = dataQueryService.getUserOrgUnits(dataQueryParams, null);
+
+    // then
+    assertEquals(3, userOrgUnits.size());
+    assertThat(
+        userOrgUnits.stream().map(BaseIdentifiableObject::getName).toList(),
+        containsInAnyOrder("OrganisationUnitB", "OrganisationUnitC", "OrganisationUnitD"));
+  }
+
+  @Test
+  void testGetUserOrgUnitsWithDeniedForAnalyticsOrganisationUnits() {
+    // given
+    User currentUser = mock(User.class);
+    AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouA));
+    when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
+    DataQueryService dataQueryService =
+        new DefaultDataQueryService(
+            mock(DimensionalObjectProducer.class),
+            mock(IdentifiableObjectManager.class),
+            analyticsSecurityManager);
+
+    // when
+    List<OrganisationUnit> userOrgUnits = dataQueryService.getUserOrgUnits(dataQueryParams, null);
+
+    // then
+    assertEquals(1, userOrgUnits.size());
+    assertThat(
+        userOrgUnits.stream().map(BaseIdentifiableObject::getName).toList(),
+        containsInAnyOrder("OrganisationUnitA"));
+  }
+
+  @Test
+  void testGetUserOrgUnitsWithDeniedForAllOrganisationUnits() {
+    // given
+    User currentUser = mock(User.class);
+    AnalyticsSecurityManager analyticsSecurityManager = mock(AnalyticsSecurityManager.class);
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
+    when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of());
+    when(analyticsSecurityManager.getCurrentUser(dataQueryParams)).thenReturn(currentUser);
+    DataQueryService dataQueryService =
+        new DefaultDataQueryService(
+            mock(DimensionalObjectProducer.class),
+            mock(IdentifiableObjectManager.class),
+            analyticsSecurityManager);
+
+    // when
+    List<OrganisationUnit> userOrgUnits = dataQueryService.getUserOrgUnits(dataQueryParams, null);
+
+    // then
+    assertEquals(0, userOrgUnits.size());
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -184,6 +184,7 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
   private PeriodType monthly = PeriodType.getPeriodType(PeriodTypeEnum.MONTHLY);
 
   private final String UserWithDataViewOrgUnitsTag = "UserWithDataViewOrgUnits";
+
   private final String UserWithoutDataViewOrgUnitsTag = "UserWithoutDataViewOrgUnits";
 
   @Autowired private DataQueryService dataQueryService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -183,8 +183,8 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   private PeriodType monthly = PeriodType.getPeriodType(PeriodTypeEnum.MONTHLY);
 
-  private final String UserWithDataViewOrgUnits_Tag = "UserWithDataViewOrgUnits";
-  private final String UserWithoutDataViewOrgUnits_Tag = "UserWithoutDataViewOrgUnits";
+  private final String UserWithDataViewOrgUnitsTag = "UserWithDataViewOrgUnits";
+  private final String UserWithoutDataViewOrgUnitsTag = "UserWithoutDataViewOrgUnits";
 
   @Autowired private DataQueryService dataQueryService;
 
@@ -331,14 +331,14 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeEach
   void setUp(TestInfo testInfo) {
-    if (testInfo.getTags().contains(UserWithDataViewOrgUnits_Tag)
-        || testInfo.getTags().contains(UserWithoutDataViewOrgUnits_Tag)) {
+    if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)
+        || testInfo.getTags().contains(UserWithoutDataViewOrgUnitsTag)) {
       UserRole role = createUserRole('X', "ALL");
       userService.addUserRole(role);
       User user = makeUser("X");
       user.addOrganisationUnit(ouA);
 
-      if (testInfo.getTags().contains(UserWithDataViewOrgUnits_Tag)) {
+      if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)) {
         user.setDataViewOrganisationUnits(Set.of(ouB, ouC, ouD));
       } else {
         user.setDataViewOrganisationUnits(Set.of());
@@ -352,8 +352,8 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   @AfterEach
   void tearDown(TestInfo testInfo) {
-    if (testInfo.getTags().contains(UserWithDataViewOrgUnits_Tag)
-        || testInfo.getTags().contains(UserWithoutDataViewOrgUnits_Tag)) {
+    if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)
+        || testInfo.getTags().contains(UserWithoutDataViewOrgUnitsTag)) {
       injectSecurityContextUser(userService.getUser(BASE_USER_UID + "A"));
       User user = userService.getUser(BASE_USER_UID + "X");
       UserRole role = userService.getUserRole(BASE_UID + "X");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -1065,7 +1065,7 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  @Tag(UserWithDataViewOrgUnits_Tag)
+  @Tag(UserWithDataViewOrgUnitsTag)
   void testGetUserOrgUnitsWithGrantedForAnalyticsOrganisationUnits() {
     // given
     DataQueryParams dataQueryParams =
@@ -1082,7 +1082,7 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  @Tag(UserWithoutDataViewOrgUnits_Tag)
+  @Tag(UserWithoutDataViewOrgUnitsTag)
   void testGetUserOrgUnitsWithDeniedForAnalyticsOrganisationUnits() {
     // given
     DataQueryParams dataQueryParams =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -183,9 +183,9 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   private PeriodType monthly = PeriodType.getPeriodType(PeriodTypeEnum.MONTHLY);
 
-  private final String UserWithDataViewOrgUnitsTag = "UserWithDataViewOrgUnits";
+  private final String userWithDataViewOrgUnitsTag = "UserWithDataViewOrgUnits";
 
-  private final String UserWithoutDataViewOrgUnitsTag = "UserWithoutDataViewOrgUnits";
+  private final String userWithoutDataViewOrgUnitsTag = "UserWithoutDataViewOrgUnits";
 
   @Autowired private DataQueryService dataQueryService;
 
@@ -332,14 +332,14 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeEach
   void setUp(TestInfo testInfo) {
-    if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)
-        || testInfo.getTags().contains(UserWithoutDataViewOrgUnitsTag)) {
+    if (testInfo.getTags().contains(userWithDataViewOrgUnitsTag)
+        || testInfo.getTags().contains(userWithoutDataViewOrgUnitsTag)) {
       UserRole role = createUserRole('X', "ALL");
       userService.addUserRole(role);
       User user = makeUser("X");
       user.addOrganisationUnit(ouA);
 
-      if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)) {
+      if (testInfo.getTags().contains(userWithDataViewOrgUnitsTag)) {
         user.setDataViewOrganisationUnits(Set.of(ouB, ouC, ouD));
       } else {
         user.setDataViewOrganisationUnits(Set.of());
@@ -353,8 +353,8 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
 
   @AfterEach
   void tearDown(TestInfo testInfo) {
-    if (testInfo.getTags().contains(UserWithDataViewOrgUnitsTag)
-        || testInfo.getTags().contains(UserWithoutDataViewOrgUnitsTag)) {
+    if (testInfo.getTags().contains(userWithDataViewOrgUnitsTag)
+        || testInfo.getTags().contains(userWithoutDataViewOrgUnitsTag)) {
       injectSecurityContextUser(userService.getUser(BASE_USER_UID + "A"));
       User user = userService.getUser(BASE_USER_UID + "X");
       UserRole role = userService.getUserRole(BASE_UID + "X");
@@ -1066,7 +1066,7 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  @Tag(UserWithDataViewOrgUnitsTag)
+  @Tag(userWithDataViewOrgUnitsTag)
   void testGetUserOrgUnitsWithGrantedForAnalyticsOrganisationUnits() {
     // given
     DataQueryParams dataQueryParams =
@@ -1083,7 +1083,7 @@ class DataQueryServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  @Tag(UserWithoutDataViewOrgUnitsTag)
+  @Tag(userWithoutDataViewOrgUnitsTag)
   void testGetUserOrgUnitsWithDeniedForAnalyticsOrganisationUnits() {
     // given
     DataQueryParams dataQueryParams =


### PR DESCRIPTION
For analytics operations the authenticated user must have permission to export and analyze data for the designated organization units. If no organization unit permissions  are explicitly granted, data capture and maintenance rights will be applied instead.