### PR TITLE
feat: Add embedded dashboard [DHIS2-18239]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
@@ -43,8 +43,12 @@ import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.dashboard.design.ItemConfig;
 import org.hisp.dhis.dashboard.design.Layout;
+import org.hisp.dhis.dashboard.embedded.EmbeddedDashboard;
 
 /**
+ * Encapsulates information about an embedded dashboard. An embedded dashboard is typically loaded
+ * from an external provider.
+ *
  * @author Lars Helge Overland
  */
 @NoArgsConstructor
@@ -66,6 +70,9 @@ public class Dashboard extends BaseNameableObject implements MetadataObject {
 
   /** Allowed filter dimensions (if any) which may be used for the dashboard. */
   private List<String> allowedFilters = new ArrayList<>();
+
+  /** Optional, only set if this dashboard is embedded and loaded from an external provider. */
+  private EmbeddedDashboard embedded;
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -145,5 +152,15 @@ public class Dashboard extends BaseNameableObject implements MetadataObject {
 
   public void setAllowedFilters(List<String> allowedFilters) {
     this.allowedFilters = allowedFilters;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  public EmbeddedDashboard getEmbedded() {
+    return embedded;
+  }
+
+  public void setEmbedded(EmbeddedDashboard embedded) {
+    this.embedded = embedded;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedDashboard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedDashboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dashboard;
+package org.hisp.dhis.dashboard.embedded;
 
-/**
- * Encapsulates type of dashboard item.
- *
- * @author Lars Helge Overland
- */
-public enum DashboardItemType {
-  VISUALIZATION,
-  EVENT_VISUALIZATION,
-  EVENT_CHART,
-  MAP,
-  EVENT_REPORT,
-  USERS,
-  REPORTS,
-  RESOURCES,
-  TEXT,
-  MESSAGES,
-  APP
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Encapsulates metadata for an embedded and externally provided dashboard. */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmbeddedDashboard implements Serializable {
+  /** Provider of embedded dashboards. */
+  @JsonProperty private EmbeddedProvider provider;
+
+  /** Identifier for embedded dashboard. */
+  @JsonProperty private String id;
+
+  /** Customization options for embedded dashboard. */
+  @JsonProperty private EmbeddedOptions options;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,34 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dashboard;
+package org.hisp.dhis.dashboard.embedded;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
- * Encapsulates type of dashboard item.
+ * Encapsulates customization options for embedded dashboards.
  *
  * @author Lars Helge Overland
  */
-public enum DashboardItemType {
-  VISUALIZATION,
-  EVENT_VISUALIZATION,
-  EVENT_CHART,
-  MAP,
-  EVENT_REPORT,
-  USERS,
-  REPORTS,
-  RESOURCES,
-  TEXT,
-  MESSAGES,
-  APP
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmbeddedOptions implements Serializable {
+  /** Hide tab. Applies to Superset. */
+  @JsonProperty private boolean hideTab;
+
+  /** Hide the chart controls. Applies to Superset. */
+  @JsonProperty private boolean hideChartControls;
+
+  /** Filter options. Applies to Superset. */
+  @JsonProperty private FilterOptions filters;
+
+  /** Show the filters panel. Applies to Superset. */
+  @JsonProperty private boolean showFilters;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/EmbeddedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dashboard;
+package org.hisp.dhis.dashboard.embedded;
 
 /**
- * Encapsulates type of dashboard item.
+ * Enumeration of providers for embedded dashboards.
  *
  * @author Lars Helge Overland
  */
-public enum DashboardItemType {
-  VISUALIZATION,
-  EVENT_VISUALIZATION,
-  EVENT_CHART,
-  MAP,
-  EVENT_REPORT,
-  USERS,
-  REPORTS,
-  RESOURCES,
-  TEXT,
-  MESSAGES,
-  APP
+public enum EmbeddedProvider {
+  SUPERSET;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/FilterOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/embedded/FilterOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dashboard;
+package org.hisp.dhis.dashboard.embedded;
 
-/**
- * Encapsulates type of dashboard item.
- *
- * @author Lars Helge Overland
- */
-public enum DashboardItemType {
-  VISUALIZATION,
-  EVENT_VISUALIZATION,
-  EVENT_CHART,
-  MAP,
-  EVENT_REPORT,
-  USERS,
-  REPORTS,
-  RESOURCES,
-  TEXT,
-  MESSAGES,
-  APP
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilterOptions implements Serializable {
+  /** Whether filter sidebar should be accessible when opening the dashboard. */
+  @JsonProperty private boolean visible;
+
+  /** Whether filter sidebar should be expanded when opening the dashboard. */
+  @JsonProperty private boolean expanded;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -115,10 +115,7 @@ public non-sealed interface SystemSettings extends Settings {
     return LazySettings.isTranslatable(key);
   }
 
-  /*
-  settings used in core
-   */
-
+  /** Settings used in core */
   default Locale getUiLocale() {
     return asLocale("keyUiLocale", LocaleManager.DEFAULT_LOCALE);
   }
@@ -306,6 +303,10 @@ public non-sealed interface SystemSettings extends Settings {
 
   default boolean getIncludeZeroValuesInAnalytics() {
     return asBoolean("keyIncludeZeroValuesInAnalytics", false);
+  }
+
+  default boolean getEmbeddedDashboardsEnabled() {
+    return asBoolean("keyEmbeddedDashboardsEnabled", false);
   }
 
   default int getSqlViewMaxLimit() {
@@ -720,12 +721,7 @@ public non-sealed interface SystemSettings extends Settings {
     return asString("globalShellAppName", "global-app-shell");
   }
 
-  /*
-
-  Combinators based on several settings
-
-  */
-
+  /** Combinators based on several settings. */
   default boolean isEmailConfigured() {
     return !getEmailHostName().isBlank() && !getEmailUsername().isBlank();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/Dashboard.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dashboard/hibernate/Dashboard.hbm.xml
@@ -39,6 +39,8 @@
     
     <property name="allowedFilters" column="allowedfilters" type="jbList" />
 
+    <property name="embedded" column="embedded" type="jbEmbeddedDashboard" />
+
     <!-- Sharing -->
     <property name="sharing" type="jsbObjectSharing"/>
     

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSetting.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSetting.java
@@ -32,10 +32,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /** A system setting, for use in store layer only. */
-@Slf4j
 @Setter
 @Getter
 @ToString

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -90,7 +90,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(135, keys.size());
+    assertEquals(136, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_23__Add_embedded_to_dashboard.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_23__Add_embedded_to_dashboard.sql
@@ -1,0 +1,2 @@
+
+alter table "dashboard" add column if not exists "embedded" jsonb null;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -77,6 +77,10 @@
     <param name="clazz">org.hisp.dhis.dashboard.design.ItemConfig</param>
   </typedef>
 
+  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbEmbeddedDashboard">
+    <param name="clazz">org.hisp.dhis.dashboard.embedded.EmbeddedDashboard</param>
+  </typedef>
+
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbTextPattern">
     <param name="clazz">org.hisp.dhis.textpattern.TextPattern</param>
   </typedef>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dashboard;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.IntStream.range;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.dashboard.DashboardItemType.EVENT_REPORT;
@@ -40,11 +39,16 @@ import static org.hisp.dhis.eventvisualization.EventVisualizationType.PIVOT_TABL
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dashboard.embedded.EmbeddedDashboard;
+import org.hisp.dhis.dashboard.embedded.EmbeddedOptions;
+import org.hisp.dhis.dashboard.embedded.EmbeddedProvider;
+import org.hisp.dhis.dashboard.embedded.FilterOptions;
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.document.DocumentService;
 import org.hisp.dhis.eventchart.EventChart;
@@ -78,9 +82,13 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager objectManager;
 
+  private static final String UUID_A = "41c52308-1db4-4971-ade4-50c4d12c201d";
+
   private Dashboard dbA;
 
   private Dashboard dbB;
+
+  private Dashboard dbC;
 
   private DashboardItem diA;
 
@@ -91,6 +99,8 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
   private DashboardItem diD;
 
   private DashboardItem diE;
+
+  private DashboardItem diF;
 
   private Visualization vzA;
 
@@ -136,28 +146,54 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
     diE = new DashboardItem();
     diE.setAutoFields();
     diE.setEventVisualization(evzB);
+    diF = new DashboardItem();
+    diF.setAutoFields();
+    diF.setVisualization(vzA);
+
     dbA = new Dashboard("A");
     dbA.setAutoFields();
     dbA.getItems().add(diA);
     dbA.getItems().add(diB);
     dbA.getItems().add(diC);
+
     dbB = new Dashboard("B");
     dbB.setAutoFields();
     dbB.setRestrictFilters(true);
     dbB.setAllowedFilters(allowedFilters);
     dbB.getItems().add(diD);
     dbB.getItems().add(diE);
+
+    dbC = new Dashboard("C");
+    dbC.setAutoFields();
+    dbC.getItems().add(diF);
+    dbC.setEmbedded(
+        new EmbeddedDashboard(
+            EmbeddedProvider.SUPERSET,
+            UUID_A,
+            new EmbeddedOptions(true, true, new FilterOptions(true, true), true)));
   }
 
   @Test
-  void testAddGet() {
+  void testSaveGet() {
     long dAId = dashboardService.saveDashboard(dbA);
     long dBId = dashboardService.saveDashboard(dbB);
+    long dCId = dashboardService.saveDashboard(dbC);
     assertEquals(dbA, dashboardService.getDashboard(dAId));
     assertEquals(dbB, dashboardService.getDashboard(dBId));
+    assertEquals(dbC, dashboardService.getDashboard(dCId));
     assertEquals(2, dbB.getAllowedFilters().size());
     assertEquals(3, dashboardService.getDashboard(dAId).getItems().size());
     assertEquals(2, dashboardService.getDashboard(dBId).getItems().size());
+    assertEquals(1, dashboardService.getDashboard(dCId).getItems().size());
+
+    Dashboard rdC = dashboardService.getDashboard(dCId);
+    assertNotNull(rdC.getEmbedded());
+    assertEquals(EmbeddedProvider.SUPERSET, rdC.getEmbedded().getProvider());
+    assertEquals(UUID_A, rdC.getEmbedded().getId());
+    assertNotNull(rdC.getEmbedded().getOptions());
+    assertTrue(rdC.getEmbedded().getOptions().isHideChartControls());
+    assertTrue(rdC.getEmbedded().getOptions().isHideChartControls());
+    assertTrue(rdC.getEmbedded().getOptions().isShowFilters());
   }
 
   @Test
@@ -234,7 +270,7 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
         .forEach(
             i -> {
               Visualization visualization = createVisualization('A');
-              visualization.setName(randomAlphabetic(5));
+              visualization.setName("Visualization" + i);
               visualizationService.save(visualization);
             });
 
@@ -242,18 +278,18 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
         .forEach(
             i -> {
               EventVisualization eventVisualization = createEventVisualization("A", prA);
-              eventVisualization.setName(randomAlphabetic(5));
+              eventVisualization.setName("EventVisualization" + i);
               eventVisualizationService.save(eventVisualization);
             });
 
     // Non Line List event visualization should be ignored when we search for EVENT_VISUALIZATION:
     EventVisualization eventVisualization = createEventVisualization("A", prA);
-    eventVisualization.setName(randomAlphabetic(5));
+    eventVisualization.setName("EventVisualizationA");
     eventVisualization.setType(COLUMN);
     eventVisualizationService.save(eventVisualization);
 
-    range(1, 30).forEach(i -> eventChartService.saveEventChart(createEventChart(prA)));
-    range(1, 20).forEach(i -> eventReportService.saveEventReport(createEventReport(prA)));
+    range(1, 30).forEach(i -> eventChartService.saveEventChart(createEventChart(prA, i)));
+    range(1, 20).forEach(i -> eventReportService.saveEventReport(createEventReport(prA, i)));
 
     DashboardSearchResult result = dashboardService.search(Set.of(VISUALIZATION));
     assertThat(result.getVisualizationCount(), is(25));
@@ -292,15 +328,15 @@ class DashboardServiceTest extends PostgresIntegrationTestBase {
     return eventVisualization;
   }
 
-  private EventChart createEventChart(Program program) {
-    EventChart eventChart = new EventChart(randomAlphabetic(5));
+  private EventChart createEventChart(Program program, int i) {
+    EventChart eventChart = new EventChart("EventChart" + i);
     eventChart.setProgram(program);
     eventChart.setType(COLUMN);
     return eventChart;
   }
 
-  private EventReport createEventReport(Program program) {
-    EventReport eventReport = new EventReport(randomAlphabetic(5));
+  private EventReport createEventReport(Program program, int i) {
+    EventReport eventReport = new EventReport("EventReport" + i);
     eventReport.setProgram(program);
     eventReport.setType(PIVOT_TABLE);
     return eventReport;


### PR DESCRIPTION
This PR adds a object EmbeddedDashboard properties to the Dashboard entity meant to represent an embedded dashboard.

* provider refers to the provider of embedded dashboards, and can be extended to Power BI, Tableau and the like later.
* id refers to the identifier of the embedded dashboard defined by the external provider.
* options refers to customization options from the embedded dashboard provider, and can be extended later.

Adds a system setting for enabling Superset embedded dashboards.