### PR TITLE
chore: OpenAPI - use : as scope divider

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -273,7 +273,7 @@ public class OpenApiController {
   private Api extractUncached(OpenApiScopingParams scoping, OpenApiGenerationParams generation) {
     Map<String, Set<String>> filters = new HashMap<>();
     for (String s : scoping.scope) {
-      int split = s.indexOf('.');
+      int split = s.indexOf(':');
       if (split > 0) {
         String key = s.substring(0, split);
         String value = s.substring(split + 1);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderer.java
@@ -451,13 +451,13 @@ public class OpenApiRenderer {
     } else {
       searchParams.set(name, value);
     }
-    window.location.search = searchParams.toString()
+    setLocationSearchParams(searchParams);
   }
 
   function removeLocationSearch(name, value) {
     const searchParams = new URLSearchParams(window.location.search)
     searchParams.delete(name, value);
-    window.location.search = searchParams.toString();
+    setLocationSearchParams(searchParams);
   }
 
   function modifyLocationSearch(button) {
@@ -466,14 +466,19 @@ public class OpenApiRenderer {
     if (value === '') return;
     const key = select.getAttribute("data-key");
     const params = new URLSearchParams(window.location.search);
-    const scope = key + '.' + value
+    const scope = key + ':' + value
     if (button.value === '+') {
       if (!params.has('scope', scope)) params.append('scope', scope);
     } else {
       params.set('scope', scope);
     }
     window.location.hash = '';
-    window.location.search = params.toString();
+    setLocationSearchParams(params);
+  }
+
+  function setLocationSearchParams(params) {
+    // undo : and / escaping for URL readability
+    window.location.search = params.toString().replaceAll('%3A', ':').replaceAll('%2F', '/');
   }
 
   function addHashHotkey() {
@@ -832,12 +837,12 @@ public class OpenApiRenderer {
 
   private void renderPageHeaderSelectionItems(String name, String value) {
     appendA(
-        "setLocationSearch('scope', '%s.%s')".formatted(name, value),
+        "setLocationSearch('scope', '%s:%s')".formatted(name, value),
         value,
         "View a document containing only this scope");
     appendRaw(" ");
     appendA(
-        "removeLocationSearch('scope', '%s.%s')".formatted(name, value),
+        "removeLocationSearch('scope', '%s:%s')".formatted(name, value),
         "[-]",
         "Remove this scope from this document");
   }
@@ -863,7 +868,7 @@ public class OpenApiRenderer {
         "h2",
         () -> {
           appendRaw(toWords(op.entity()));
-          appendA("/api/openapi/openapi.html?scope=entity." + op.entity, true, "&#x1F5D7;");
+          appendA("/api/openapi/openapi.html?scope=entity:" + op.entity, true, "&#x1F5D7;");
         });
   }
 


### PR DESCRIPTION
I forgot about this change in my last PR.

It changes the divider character between scope name and value from `.` to `:`. 

I initially wanted to use `:`, then found that it is escaped by JS when using the `URLSearchParams` class. 
Therefore I switched to `.` to avoid ugly URLs.
But then I thought I can just undo the escaping. I also found that `/` does not need escaping in the query part of an URL.
The `URLSearchParams` is just overly cautious when it comes to escaping. The specification does allow these characters plain in the query part but they can be escaped.  