### PR TITLE
fix: broken run-api.sh environment variable check

### DIFF
--- a/dhis-2/run-api.sh
+++ b/dhis-2/run-api.sh
@@ -21,7 +21,7 @@ DHIS2_PORT=9090
 SKIP_COMPILE=0
 
 # Set DHIS2 home directory to DHIS2_HOME_DIR env variable if set
-if [[ -v "$DHIS2_HOME" ]]; then
+if [[ -n "$DHIS2_HOME" ]]; then
   DHIS2_HOME_DIR=$DHIS2_HOME
 fi
 


### PR DESCRIPTION
### Summary
Fixes a check for the `DHIS2_HOME` environment variable in the bash script `run_api.sh`.
The script was using `-v` when it should have been using `-n`, `-v` means to check if a variable is set, but can not be used with the `[[` syntax, `-n` should be used instead, this checks if a variable is not empty.