### PR TITLE
fix: consider all attribute flag properties as persisted and writable [DHIS2-18297]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -235,8 +235,8 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return objectTypes.contains(type);
   }
 
-  private void setAttribute(ObjectType type, Boolean isAttribute) {
-    if (isAttribute != null && isAttribute) {
+  private void setAttribute(ObjectType type, boolean isAttribute) {
+    if (isAttribute) {
       objectTypes.add(type);
     } else {
       objectTypes.remove(type);
@@ -305,7 +305,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.DATA_ELEMENT_GROUP);
   }
 
-  public void setDataElementGroupAttribute(Boolean dataElementGroupAttribute) {
+  public void setDataElementGroupAttribute(boolean dataElementGroupAttribute) {
     setAttribute(ObjectType.DATA_ELEMENT_GROUP, dataElementGroupAttribute);
   }
 
@@ -327,7 +327,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.INDICATOR_GROUP);
   }
 
-  public void setIndicatorGroupAttribute(Boolean indicatorGroupAttribute) {
+  public void setIndicatorGroupAttribute(boolean indicatorGroupAttribute) {
     setAttribute(ObjectType.INDICATOR_GROUP, indicatorGroupAttribute);
   }
 
@@ -338,7 +338,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.DATA_SET);
   }
 
-  public void setDataSetAttribute(Boolean dataSetAttribute) {
+  public void setDataSetAttribute(boolean dataSetAttribute) {
     setAttribute(ObjectType.DATA_SET, dataSetAttribute);
   }
 
@@ -360,7 +360,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.ORGANISATION_UNIT_GROUP);
   }
 
-  public void setOrganisationUnitGroupAttribute(Boolean organisationUnitGroupAttribute) {
+  public void setOrganisationUnitGroupAttribute(boolean organisationUnitGroupAttribute) {
     setAttribute(ObjectType.ORGANISATION_UNIT_GROUP, organisationUnitGroupAttribute);
   }
 
@@ -371,7 +371,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.ORGANISATION_UNIT_GROUP_SET);
   }
 
-  public void setOrganisationUnitGroupSetAttribute(Boolean organisationUnitGroupSetAttribute) {
+  public void setOrganisationUnitGroupSetAttribute(boolean organisationUnitGroupSetAttribute) {
     setAttribute(ObjectType.ORGANISATION_UNIT_GROUP_SET, organisationUnitGroupSetAttribute);
   }
 
@@ -393,7 +393,7 @@ public class Attribute extends BaseNameableObject implements MetadataObject {
     return isAttribute(ObjectType.USER_GROUP);
   }
 
-  public void setUserGroupAttribute(Boolean userGroupAttribute) {
+  public void setUserGroupAttribute(boolean userGroupAttribute) {
     setAttribute(ObjectType.USER_GROUP, userGroupAttribute);
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonSchema;
 import org.junit.jupiter.api.Test;
@@ -113,5 +114,20 @@ class SchemaControllerTest extends H2ControllerIntegrationTestBase {
       assertNull(schema.getSingular());
       assertNull(schema.getPlural());
     }
+  }
+
+  @Test
+  void testAttributeWritable() {
+    JsonSchema schema = GET("/schemas/attribute").content().as(JsonSchema.class);
+    schema
+        .getProperties()
+        .forEach(
+            p -> {
+              if (p.getName().endsWith("Attribute")
+                  && p.getPropertyType() == PropertyType.BOOLEAN) {
+                assertTrue(p.isWritable());
+                assertTrue(p.isPersisted());
+              }
+            });
   }
 }


### PR DESCRIPTION
### Summary
Using `Boolean` instead of `boolean` in the setters somehow made the properties in question non-persisted and non-writable. 

Likely the issue was that getter and setter were using different types (boolean vs Boolean) resulting in not finding the setter and from that concluding that the property isn't writable or persisted.

### Automatic Testing
Adds a test that makes sure all boolean `*Attribute` properties are persisted and writable. 

### Manual Testing
* goto `/api/schemas/attribute` 
* check the JSON for `"properties"` and make sure all booleans with a suffix name of "Attribute" are considered both `"writable"` and `"persisted"`.
