### PR TITLE
chore: Use UID for notes in tracker importer [DHIS2-17790]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdentifierCollector.java
@@ -135,7 +135,7 @@ public class TrackerIdentifierCollector {
   private void collectNotes(Map<Class<?>, Set<String>> identifiers, List<Note> notes) {
     notes.forEach(
         note -> {
-          if (!StringUtils.isEmpty(note.getNote()) && !StringUtils.isEmpty(note.getValue())) {
+          if (note.getNote() != null && StringUtils.isNotEmpty(note.getValue())) {
             addIdentifier(identifiers, org.hisp.dhis.note.Note.class, note.getNote());
           }
         });

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
@@ -310,7 +310,7 @@ public class TrackerObjectsMapper {
     Date now = new Date();
 
     Note dbNote = new Note();
-    dbNote.setUid(note.getNote());
+    dbNote.setUid(note.getNote().getValue());
     dbNote.setCreated(now);
     dbNote.setLastUpdated(now);
     dbNote.setLastUpdatedBy(preheat.getUserByUid(user.getUid()).orElse(null));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.UID;
 
 /**
  * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have
@@ -45,7 +46,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Note implements Serializable {
-  @JsonProperty private String note;
+  @JsonProperty private UID note;
 
   @JsonProperty private String value;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -228,7 +228,7 @@ public class TrackerPreheat {
   private final Set<String> existingRelationships = new HashSet<>();
 
   /** Internal set of all preheated notes uids (events and enrollments) */
-  private final Set<String> notes = new HashSet<>();
+  private final Set<UID> notes = new HashSet<>();
 
   /**
    * Internal map of all existing TrackedEntityProgramOwner. Used for ownership validations and
@@ -471,11 +471,11 @@ public class TrackerPreheat {
     events.put(UID.of(event), event);
   }
 
-  public void addNotes(Set<String> notes) {
+  public void addNotes(Set<UID> notes) {
     this.notes.addAll(notes);
   }
 
-  public boolean hasNote(String uid) {
+  public boolean hasNote(UID uid) {
     return notes.contains(uid);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -95,7 +95,7 @@ public class ValidationUtils {
       {
         // If a note having the same UID already exist in the db, raise
         // warning, ignore the note and continue
-        if (isNotEmpty(note.getNote()) && preheat.hasNote(note.getNote())) {
+        if (note.getNote() != null && preheat.hasNote(note.getNote())) {
           reporter.addWarning(dto, ValidationCode.E1119, note.getNote());
         } else {
           notes.add(note);
@@ -236,12 +236,6 @@ public class ValidationUtils {
 
     if (!isValid) {
       reporter.addError(dto, ValidationCode.E1125, value, optionalObject.getOptionSet().getUid());
-    }
-  }
-
-  public static void validateNotesUid(List<Note> notes, Reporter reporter, TrackerDto dto) {
-    for (Note note : notes) {
-      checkUidFormat(note.getNote(), reporter, dto, note, note.getNote());
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -137,7 +137,7 @@ class TrackerIdentifierCollectorTest {
             .dataValues(dataValues("VohJnvWfvyo", "qv9xOw8fBzy"))
             .attributeOptionCombo(ofCode("rgb"))
             .attributeCategoryOptions(Set.of(ofCode("red"), ofCode("green"), ofCode("blue")))
-            .notes(List.of(Note.builder().note("i1vviSlidJE").value("nice day!").build()))
+            .notes(List.of(Note.builder().note(UID.of("i1vviSlidJE")).value("nice day!").build()))
             .build();
 
     TrackerObjects trackerObjects = TrackerObjects.builder().events(singletonList(event)).build();
@@ -177,7 +177,7 @@ class TrackerIdentifierCollectorTest {
     Event event =
         Event.builder()
             .event(UID.generate())
-            .notes(List.of(Note.builder().note("i1vviSlidJE").build()))
+            .notes(List.of(Note.builder().note(UID.of("i1vviSlidJE")).build()))
             .build();
 
     TrackerObjects trackerObjects = TrackerObjects.builder().events(singletonList(event)).build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
@@ -78,7 +78,7 @@ class TrackerObjectsMapperTest extends TestBase {
 
   private static final UID RELATIONSHIP_UID = UID.generate();
 
-  private static final String NOTE_UID = CodeGenerator.generateUid();
+  private static final UID NOTE_UID = UID.generate();
 
   private static final String PROGRAM_STAGE_UID = CodeGenerator.generateUid();
 
@@ -625,7 +625,10 @@ class TrackerObjectsMapperTest extends TestBase {
       UserDetails updatedBy) {
     for (org.hisp.dhis.tracker.imports.domain.Note note : notes) {
       Note dbNote =
-          dbNotes.stream().filter(n -> n.getUid().equals(note.getNote())).findFirst().orElse(null);
+          dbNotes.stream()
+              .filter(n -> n.getUid().equals(note.getNote().getValue()))
+              .findFirst()
+              .orElse(null);
       assertNotNull(dbNote);
       assertEquals(note.getValue(), dbNote.getNoteText());
       assertEquals(note.getStoredBy(), dbNote.getCreator());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/EachTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/EachTest.java
@@ -71,12 +71,15 @@ class EachTest {
   @Test
   void testCallsValidatorForEachItemInCollection() {
     Validator<Enrollment> validator =
-        each(Enrollment::getNotes, (r, b, n) -> addError(r, n.getNote()));
+        each(Enrollment::getNotes, (r, b, n) -> addError(r, n.getNote().getValue()));
 
-    validator.validate(reporter, bundle, enrollment(UID.of("Kj6vYde4LHh"), "V1", "V2", "V3"));
+    UID note1 = UID.generate();
+    UID note2 = UID.generate();
+    UID note3 = UID.generate();
+    validator.validate(reporter, bundle, enrollment(UID.of("Kj6vYde4LHh"), note1, note2, note3));
 
     // order of input collection is preserved
-    assertEquals(List.of("V1", "V2", "V3"), actualErrorMessages());
+    assertEquals(UID.toValueList(List.of(note1, note2, note3)), actualErrorMessages());
   }
 
   @Test
@@ -99,7 +102,9 @@ class EachTest {
             });
 
     validator.validate(
-        reporter, bundle, enrollment(UID.of("Kj6vYde4LHh"), "input1", "input2", "input2"));
+        reporter,
+        bundle,
+        enrollment(UID.of("Kj6vYde4LHh"), UID.generate(), UID.generate(), UID.generate()));
 
     assertIsEmpty(actualErrorMessages());
   }
@@ -140,7 +145,7 @@ class EachTest {
     assertContainsOnly(List.of("Nav6inZRw1u"), actualErrorMessages());
   }
 
-  private static Enrollment enrollment(UID uid, String... notes) {
+  private static Enrollment enrollment(UID uid, UID... notes) {
     List<Note> n = Arrays.stream(notes).map(s -> Note.builder().note(s).build()).toList();
 
     return Enrollment.builder().enrollment(uid).notes(n).build();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/NoteMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/NoteMapper.java
@@ -30,10 +30,11 @@ package org.hisp.dhis.webapi.controller.tracker.imports;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Note;
+import org.hisp.dhis.webapi.controller.tracker.view.UIDMapper;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 
-@Mapper(uses = {InstantMapper.class, UserMapper.class})
+@Mapper(uses = {InstantMapper.class, UIDMapper.class, UserMapper.class})
 public interface NoteMapper extends DomainMapper<Note, org.hisp.dhis.tracker.imports.domain.Note> {
   org.hisp.dhis.tracker.imports.domain.Note from(
       org.hisp.dhis.tracker.imports.domain.Note note,


### PR DESCRIPTION
***Big Picture***
At the moment, tracker objects uids are represented as strings because the are validated in the importer and they can represent an invalid UID.
We are now changing this and tracker objects are going to use UID object instead so the validation of UIDs is happening when binding the body object in the API.
This allows the importer to not worry anymore on the UIDs for tracker objects as they now are valid and not null (this is guaranteed by the `BodyConverter` that is initializing all the UIDs).

***What is in this PR***
This PR is changing the importer domain for `Note`.

***What is next***
- Change API view model
- Handle TODO left in `Event` PR