### PR TITLE
perf: improves CSV exports when too many dimensions combinations exists [DHIS2-18377]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -468,7 +468,6 @@ public enum ErrorCode {
   E7146("A {0} date was not specified in periods, dimensions, filters"),
   E7147("Query failed because of a missing column: `{0}`"),
 
-
   /* Analytics outliers */
 
   E7180(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -466,6 +466,8 @@ public enum ErrorCode {
       "Query failed because a referenced table does not exist. Please ensure analytics job was run"),
   E7145("Query failed because of a syntax error"),
   E7146("A {0} date was not specified in periods, dimensions, filters"),
+  E7147("Query failed because of a missing column: `{0}`"),
+
 
   /* Analytics outliers */
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -33,12 +33,20 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDataValueSet;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDataValueSetAsGrid;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.isTableLayout;
 import static org.hisp.dhis.commons.collection.ListUtils.removeEmptys;
+import static org.hisp.dhis.feedback.ErrorCode.E7146;
 import static org.hisp.dhis.visualization.Visualization.addListIfEmpty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.DataQueryParams;
@@ -52,6 +60,7 @@ import org.hisp.dhis.common.CombinationGenerator;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.visualization.Visualization;
@@ -64,6 +73,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service("org.hisp.dhis.analytics.AnalyticsService")
 @RequiredArgsConstructor
 public class DefaultAnalyticsService implements AnalyticsService {
+
   private final AnalyticsSecurityManager securityManager;
 
   private final QueryValidator queryValidator;
@@ -220,6 +230,8 @@ public class DefaultAnalyticsService implements AnalyticsService {
 
     List<List<DimensionalItemObject>> tableColumns = new ArrayList<>();
     List<List<DimensionalItemObject>> tableRows = new ArrayList<>();
+    Map<String, List<DimensionalItemObject>> columnsDimensionItemsByDimension = new HashMap<>();
+    Map<String, List<DimensionalItemObject>> rowsDimensionItemsByDimension = new HashMap<>();
 
     if (columns != null) {
       for (String dimension : columns) {
@@ -227,7 +239,10 @@ public class DefaultAnalyticsService implements AnalyticsService {
             dimension, params.getDimension(dimension).getDimensionType());
 
         visualization.getColumnDimensions().add(dimension);
-        tableColumns.add(params.getDimensionItemsExplodeCoc(dimension));
+        List<DimensionalItemObject> dimensionItemsExplodeCoc =
+            params.getDimensionItemsExplodeCoc(dimension);
+        columnsDimensionItemsByDimension.put(dimension, dimensionItemsExplodeCoc);
+        tableColumns.add(dimensionItemsExplodeCoc);
       }
     }
 
@@ -237,14 +252,32 @@ public class DefaultAnalyticsService implements AnalyticsService {
             dimension, params.getDimension(dimension).getDimensionType());
 
         visualization.getRowDimensions().add(dimension);
-        tableRows.add(params.getDimensionItemsExplodeCoc(dimension));
+
+        List<DimensionalItemObject> dimensionItemsExplodeCoc =
+            params.getDimensionItemsExplodeCoc(dimension);
+        rowsDimensionItemsByDimension.put(dimension, dimensionItemsExplodeCoc);
+        tableRows.add(dimensionItemsExplodeCoc);
       }
     }
 
+    List<List<DimensionalItemObject>> gridColumns =
+        Optional.ofNullable(columns)
+            .map(cols -> getGridItems(grid, columnsDimensionItemsByDimension, cols))
+            .filter(CollectionUtils::isNotEmpty)
+            .map(this::reorderItems)
+            .orElseGet(() -> CombinationGenerator.newInstance(tableColumns).getCombinations());
+
+    List<List<DimensionalItemObject>> gridRows =
+        Optional.ofNullable(rows)
+            .map(rws -> getGridItems(grid, rowsDimensionItemsByDimension, rws))
+            .filter(CollectionUtils::isNotEmpty)
+            .map(this::reorderItems)
+            .orElseGet(() -> CombinationGenerator.newInstance(tableRows).getCombinations());
+
     visualization
         .setGridTitle(IdentifiableObjectUtils.join(params.getFilterItems()))
-        .setGridColumns(CombinationGenerator.newInstance(tableColumns).getCombinations())
-        .setGridRows(CombinationGenerator.newInstance(tableRows).getCombinations());
+        .setGridColumns(gridColumns)
+        .setGridRows(gridRows);
 
     addListIfEmpty(visualization.getGridColumns());
     addListIfEmpty(visualization.getGridRows());
@@ -260,5 +293,66 @@ public class DefaultAnalyticsService implements AnalyticsService {
         valueMap,
         params.getDisplayProperty(),
         false);
+  }
+
+  private List<List<DimensionalItemObject>> reorderItems(
+      List<List<DimensionalItemObject>> alternateItems) {
+    return alternateItems.stream().sorted(this::compareItems).collect(Collectors.toList());
+  }
+
+  private int compareItems(List<DimensionalItemObject> dio, List<DimensionalItemObject> other) {
+    return dio.get(0).getDisplayName().compareTo(other.get(0).getDisplayName());
+  }
+
+  /**
+   * Returns alternative grid dimensional items based on the given grid and all dimension items.
+   * Alternative grid items are used improve the performance of the grid rendering when the
+   * combination of dimension items is large. The alternative grid items are a list of lists of
+   * dimension items where each list represents a possible combination of dimension items that are
+   * used to render the grid.
+   *
+   * @param grid the grid
+   * @param dimensionItemsByDimension a map of dimension items by dimension
+   * @param dimensionIds the dimension ids
+   * @return the alternative grid items
+   */
+  static List<List<DimensionalItemObject>> getGridItems(
+      Grid grid,
+      Map<String, List<DimensionalItemObject>> dimensionItemsByDimension,
+      List<String> dimensionIds) {
+    Set<List<DimensionalItemObject>> alternateItems = new HashSet<>();
+
+    // Last column is the value column.
+    int metaCount = grid.getWidth() - 1;
+
+    for (List<Object> row : grid.getRows()) {
+      DimensionalItemObject[] alternateItem = new DimensionalItemObject[dimensionIds.size()];
+
+      for (int i = 0; i < metaCount; i++) {
+        // Header name is the dimension id.
+        String headerName = grid.getHeaders().get(i).getName();
+        String value = row.get(i).toString();
+        if (isDimension(headerName, dimensionItemsByDimension)) {
+          int indexInColumn = dimensionIds.indexOf(headerName);
+          alternateItem[indexInColumn] = findValueInDimensionItem(dimensionItemsByDimension, value);
+        }
+      }
+      alternateItems.add(Arrays.stream(alternateItem).collect(Collectors.toList()));
+    }
+    return new ArrayList<>(alternateItems);
+  }
+
+  private static DimensionalItemObject findValueInDimensionItem(
+      Map<String, List<DimensionalItemObject>> dimensionItemsByDimension, String value) {
+    return dimensionItemsByDimension.values().stream()
+        .flatMap(List::stream)
+        .filter(dio -> dio.getDimensionItem().equals(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalQueryException(E7146, value));
+  }
+
+  private static boolean isDimension(
+      String dimensionUid, Map<String, List<DimensionalItemObject>> rowsDimensionItemsByDimension) {
+    return rowsDimensionItemsByDimension.containsKey(dimensionUid);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDataValueSetAsGrid;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.isTableLayout;
 import static org.hisp.dhis.commons.collection.ListUtils.removeEmptys;
 import static org.hisp.dhis.feedback.ErrorCode.E7146;
+import static org.hisp.dhis.feedback.ErrorCode.E7147;
 import static org.hisp.dhis.visualization.Visualization.addListIfEmpty;
 
 import java.util.ArrayList;
@@ -348,7 +349,7 @@ public class DefaultAnalyticsService implements AnalyticsService {
         .flatMap(List::stream)
         .filter(dio -> dio.getDimensionItem().equals(value))
         .findFirst()
-        .orElseThrow(() -> new IllegalQueryException(E7146, value));
+        .orElseThrow(() -> new IllegalQueryException(E7147, value));
   }
 
   private static boolean isDimension(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
@@ -297,7 +296,7 @@ public class DefaultAnalyticsService implements AnalyticsService {
 
   private List<List<DimensionalItemObject>> reorderItems(
       List<List<DimensionalItemObject>> alternateItems) {
-    return alternateItems.stream().sorted(this::compareItems).collect(Collectors.toList());
+    return alternateItems.stream().sorted(this::compareItems).toList();
   }
 
   private int compareItems(List<DimensionalItemObject> dio, List<DimensionalItemObject> other) {
@@ -337,7 +336,7 @@ public class DefaultAnalyticsService implements AnalyticsService {
           alternateItem[indexInColumn] = findValueInDimensionItem(dimensionItemsByDimension, value);
         }
       }
-      alternateItems.add(Arrays.stream(alternateItem).collect(Collectors.toList()));
+      alternateItems.add(Arrays.stream(alternateItem).toList());
     }
     return new ArrayList<>(alternateItems);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDataValueSet;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDataValueSetAsGrid;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.isTableLayout;
 import static org.hisp.dhis.commons.collection.ListUtils.removeEmptys;
-import static org.hisp.dhis.feedback.ErrorCode.E7146;
 import static org.hisp.dhis.feedback.ErrorCode.E7147;
 import static org.hisp.dhis.visualization.Visualization.addListIfEmpty;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultAnalyticsServiceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.system.grid.ListGrid;
+import org.junit.jupiter.api.Test;
+
+class DefaultAnalyticsServiceTest {
+
+  @Test
+  void testGetGridItems() {
+    Grid grid = new ListGrid();
+
+    List.of(
+            new GridHeader("R-A", false, false),
+            new GridHeader("R-B", false, false),
+            new GridHeader("R-C", false, false),
+            new GridHeader("C-A", false, false),
+            new GridHeader("C-B", false, false))
+        .forEach(grid::addHeader);
+
+    List.of(
+            List.of("R-A1", "R-B1", "R-C2", "C-A1", "C-B1", "v1"),
+            List.of("R-A1", "R-B2", "R-C1", "C-A1", "C-B3", "v2"),
+            List.of("R-A2", "R-B1", "R-C1", "C-A2", "C-B1", "v3"))
+        .forEach(
+            row -> {
+              grid.addRow();
+              row.forEach(grid::addValue);
+            });
+
+    Map<String, List<DimensionalItemObject>> dimensionItemsByDimension =
+        Map.of(
+            "R-A",
+                List.of(
+                    new BaseDimensionalItemObject("R-A1"),
+                    new BaseDimensionalItemObject("R-A2"),
+                    new BaseDimensionalItemObject("R-A3")),
+            "R-B",
+                List.of(
+                    new BaseDimensionalItemObject("R-B1"),
+                    new BaseDimensionalItemObject("R-B2"),
+                    new BaseDimensionalItemObject("R-B3")),
+            "R-C",
+                List.of(
+                    new BaseDimensionalItemObject("R-C1"),
+                    new BaseDimensionalItemObject("R-C2"),
+                    new BaseDimensionalItemObject("R-C3")),
+            "C-A",
+                List.of(
+                    new BaseDimensionalItemObject("C-A1"),
+                    new BaseDimensionalItemObject("C-A2"),
+                    new BaseDimensionalItemObject("C-A3")),
+            "C-B",
+                List.of(
+                    new BaseDimensionalItemObject("C-B1"),
+                    new BaseDimensionalItemObject("C-B2"),
+                    new BaseDimensionalItemObject("C-B3")));
+
+    List<String> dimensionIds = List.of("R-A", "R-B", "R-C", "C-A", "C-B");
+
+    List<List<DimensionalItemObject>> gridItems =
+        DefaultAnalyticsService.getGridItems(grid, dimensionItemsByDimension, dimensionIds);
+
+    assertEquals(grid.getRows().size(), gridItems.size());
+
+    for (int i = 0; i < grid.getRows().size(); i++) {
+      assertEquals(grid.getWidth() - 1, gridItems.get(i).size());
+    }
+
+    Set<List<String>> rowsFromGrid = getRowsFromGrid(grid);
+    Set<List<String>> rowsFromGridItems = getRowsFromGridItems(gridItems);
+
+    assertEquals(rowsFromGrid, rowsFromGridItems);
+  }
+
+  private Set<List<String>> getRowsFromGrid(Grid grid) {
+    Set<List<String>> rowsFromGrid = new HashSet<>();
+    for (List<Object> gridRow : grid.getRows()) {
+      List<String> gridRowAsString = new ArrayList<>();
+      for (int j = 0; j < gridRow.size() - 1; j++) {
+        gridRowAsString.add(gridRow.get(j).toString());
+      }
+      rowsFromGrid.add(gridRowAsString);
+    }
+    return rowsFromGrid;
+  }
+
+  private Set<List<String>> getRowsFromGridItems(List<List<DimensionalItemObject>> gridItems) {
+    Set<List<String>> rowsFromGridItems = new HashSet<>();
+    for (List<DimensionalItemObject> gridItem : gridItems) {
+      List<String> gridItemAsString = new ArrayList<>();
+      for (DimensionalItemObject dimensionalItemObject : gridItem) {
+        gridItemAsString.add(dimensionalItemObject.getDimensionItem());
+      }
+      rowsFromGridItems.add(gridItemAsString);
+    }
+    return rowsFromGridItems;
+  }
+}


### PR DESCRIPTION
This PR improves the CSV Export when the combinations of dimensions explode into huge numbers.

Before this change, when exporting a CSV, all possible rows would be generated, just to check if they had a value in the query result. While the result is correct, the approach seemed to not consider performance implications when the cartesian product of all dimensionalItems is big.

This PR improves it by generating only the rows that exist in the query result.