### PR TITLE
feat: support /tracker/event?categoryOptionIdScheme DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>dhis-support-system</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hisp.dhis.rules</groupId>
       <artifactId>rule-engine-jvm</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -138,6 +138,17 @@ public final class Assertions {
   }
 
   /**
+   * Asserts that the given collection is not null and not empty.
+   *
+   * @param actual the collection.
+   * @param message fails with this message
+   */
+  public static void assertNotEmpty(Collection<?> actual, String message) {
+    assertNotNull(actual, message);
+    assertFalse(actual.isEmpty(), message);
+  }
+
+  /**
    * Asserts that the given collection contains the expected number of elements.
    *
    * @param actual the collection.

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
@@ -269,6 +269,14 @@
     },
     {
       "id": "xwZ2u3WyQR0",
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "categoryOption xwZ2u3WyQR0"
+        }
+      ],
       "code": "Unicef",
       "name": "Unicef",
       "sharing": {
@@ -290,6 +298,14 @@
     },
     {
       "id": "i4Nbp8S2G6A",
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "categoryOption i4Nbp8S2G6A"
+        }
+      ],
       "code": "Project01",
       "description": "used to test sharing when owner is null",
       "name": "Improve access to clean water",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,13 +37,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -54,10 +56,7 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationR
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
@@ -96,11 +95,6 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
 
   @Autowired private IdentifiableObjectManager manager;
 
-  private OrganisationUnit orgUnit;
-  private ProgramStage programStage;
-  private Program program;
-  private CategoryOptionCombo categoryOptionCombo;
-
   private User importUser;
 
   protected ObjectBundle setUpMetadata(String path) throws IOException {
@@ -132,10 +126,6 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
     assertNoErrors(
         trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
     get(Attribute.class, METADATA_ATTRIBUTE); // ensure this is created in setup
-    orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
-    program = get(Program.class, "iS7eutanDry");
-    programStage = get(ProgramStage.class, "qLZC0lvvxQH");
-    categoryOptionCombo = get(CategoryOptionCombo.class, "SeWJkpLAyLt");
 
     manager.flush();
     manager.clear();
@@ -145,6 +135,7 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
   @MethodSource(value = "shouldExportMetadataUsingGivenIdSchemeProvider")
   void shouldExportMetadataUsingGivenIdScheme(TrackerIdSchemeParam idSchemeParam) {
     switchContextToUser(importUser);
+    Event event = get(Event.class, "QRYjLTiJTrA");
 
     // maps JSON fields to idScheme request parameters
     Map<String, String> idSchemeRequestParams =
@@ -156,35 +147,85 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
             "programStage",
             "programStage",
             "attributeOptionCombo",
-            "categoryOptionCombo");
-    // maps JSON fields to metadata
-    Map<String, IdentifiableObject> metadata =
+            "categoryOptionCombo",
+            "attributeCategoryOptions",
+            "categoryOption");
+    // maps JSON fields to expected metadata identifier in the requested idScheme and form. many
+    // category options are mapped to a single string value in the event.attributeCategoryOptions
+    Map<String, Function<JsonObject, Executable>> metadata =
         Map.of(
             "orgUnit",
-            orgUnit,
+            actual ->
+                ((Executable)
+                    () ->
+                        assertIdScheme(
+                            idSchemeParam.getIdentifier(event.getOrganisationUnit()),
+                            actual,
+                            idSchemeParam,
+                            "orgUnit")),
             "program",
-            program,
+            actual ->
+                ((Executable)
+                    () ->
+                        assertIdScheme(
+                            idSchemeParam.getIdentifier(event.getProgramStage().getProgram()),
+                            actual,
+                            idSchemeParam,
+                            "program")),
             "programStage",
-            programStage,
+            actual ->
+                ((Executable)
+                    () ->
+                        assertIdScheme(
+                            idSchemeParam.getIdentifier(event.getProgramStage()),
+                            actual,
+                            idSchemeParam,
+                            "programStage")),
             "attributeOptionCombo",
-            categoryOptionCombo);
+            actual ->
+                ((Executable)
+                    () ->
+                        assertIdScheme(
+                            idSchemeParam.getIdentifier(event.getAttributeOptionCombo()),
+                            actual,
+                            idSchemeParam,
+                            "attributeOptionCombo")),
+            "attributeCategoryOptions",
+            json ->
+                ((Executable)
+                    () -> {
+                      String field = "attributeCategoryOptions";
+                      List<String> expected =
+                          event.getAttributeOptionCombo().getCategoryOptions().stream()
+                              .map(co -> idSchemeParam.getIdentifier(co))
+                              .toList();
+                      assertNotEmpty(
+                          expected,
+                          String.format(
+                              "metadata corresponding to field \"%s\" has no value in test data for"
+                                  + " idScheme '%s'",
+                              field, idSchemeParam));
+                      assertTrue(
+                          json.has(field),
+                          () ->
+                              String.format(
+                                  "field \"%s\" is not in response %s for idScheme '%s'",
+                                  field, json, idSchemeParam));
+                      assertContainsOnly(
+                          expected, Arrays.asList(json.getString(field).string().split(",")));
+                    }));
     String fields = metadata.keySet().stream().collect(Collectors.joining(","));
     String idSchemes =
         metadata.keySet().stream()
             .map(m -> idSchemeRequestParams.get(m) + "IdScheme=" + idSchemeParam)
             .collect(Collectors.joining("&"));
-    Event qRYjLTiJTrA = get(Event.class, "QRYjLTiJTrA");
 
     JsonEvent actual =
-        GET(
-                "/tracker/events/{id}?fields={fields}&{idSchemes}",
-                qRYjLTiJTrA.getUid(),
-                fields,
-                idSchemes)
+        GET("/tracker/events/{id}?fields={fields}&{idSchemes}", event.getUid(), fields, idSchemes)
             .content(HttpStatus.OK)
             .as(JsonEvent.class);
 
-    assertMetadataIdScheme(metadata, actual, idSchemeParam, "event");
+    assertMetadataIdScheme(metadata, actual, "event");
   }
 
   public static Stream<TrackerIdSchemeParam> shouldExportMetadataUsingGivenIdSchemeProvider() {
@@ -200,32 +241,21 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
    * that its string value matches the requested {@code idSchemeParam}.
    */
   private void assertMetadataIdScheme(
-      Map<String, IdentifiableObject> expected,
+      Map<String, Function<JsonObject, Executable>> expected,
       JsonObject actual,
-      TrackerIdSchemeParam idSchemeParam,
       String objectName) {
     List<Executable> assertions =
-        expected.entrySet().stream()
-            .map(
-                e ->
-                    (Executable)
-                        () -> {
-                          assertIdScheme(e.getValue(), actual, idSchemeParam, e.getKey());
-                        })
-            .toList();
+        expected.entrySet().stream().map(e -> e.getValue().apply(actual)).toList();
     assertAll(objectName + " metadata assertions", assertions);
   }
 
-  private void assertIdScheme(
-      IdentifiableObject expected,
-      JsonObject actual,
-      TrackerIdSchemeParam idSchemeParam,
-      String field) {
+  private static void assertIdScheme(
+      String expected, JsonObject actual, TrackerIdSchemeParam idSchemeParam, String field) {
     assertNotEmpty(
-        idSchemeParam.getIdentifier(expected),
+        expected,
         String.format(
-            "metadata %s(%s) has no value in test data for idScheme '%s'",
-            expected.getClass().getSimpleName(), expected.getUid(), idSchemeParam));
+            "metadata corresponding to field \"%s\" has no value in test data for idScheme '%s'",
+            field, idSchemeParam));
     assertTrue(
         actual.has(field),
         () ->
@@ -233,7 +263,7 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
                 "field \"%s\" is not in response %s for idScheme '%s'",
                 field, actual, idSchemeParam));
     assertEquals(
-        idSchemeParam.getIdentifier(expected),
+        expected,
         actual.getString(field).string(),
         () ->
             String.format(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MetadataMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MetadataMapper.java
@@ -27,7 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -58,5 +62,21 @@ public interface MetadataMapper {
   default String map(
       CategoryOptionCombo categoryOptionCombo, @Context TrackerIdSchemeParams idSchemeParams) {
     return idSchemeParams.getCategoryOptionComboIdScheme().getIdentifier(categoryOptionCombo);
+  }
+
+  @Named("categoryOptionToString")
+  default String map(CategoryOption categoryOption, @Context TrackerIdSchemeParams idSchemeParams) {
+    return idSchemeParams.getCategoryOptionIdScheme().getIdentifier(categoryOption);
+  }
+
+  @Named("categoryOptionsToString")
+  default String map(Set<CategoryOption> categoryOptions, @Context TrackerIdSchemeParams context) {
+    if (categoryOptions == null || categoryOptions.isEmpty()) {
+      return null;
+    }
+
+    return categoryOptions.stream()
+        .map(co -> map(co, context))
+        .collect(Collectors.joining(TextUtils.COMMA));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -46,7 +46,6 @@ import org.mapstruct.Mapping;
 @Mapper(
     uses = {
       DataValueMapper.class,
-      CategoryOptionMapper.class,
       InstantMapper.class,
       UIDMapper.class,
       NoteMapper.class,
@@ -120,7 +119,10 @@ public interface EventMapper {
       target = "attributeOptionCombo",
       source = "attributeOptionCombo",
       qualifiedByName = "categoryOptionComboToString")
-  @Mapping(target = "attributeCategoryOptions", source = "attributeOptionCombo.categoryOptions")
+  @Mapping(
+      target = "attributeCategoryOptions",
+      source = "attributeOptionCombo.categoryOptions",
+      qualifiedByName = "categoryOptionsToString")
   @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")
   @Mapping(target = "updatedBy", source = "lastUpdatedByUserInfo")


### PR DESCRIPTION
support `/tracker/events?categoryOptionIdScheme`

This does not yet deal with the default category option in any special way. Default category options are automatically created [by DHIS2 itself](https://github.com/dhis2/dhis2-core/blob/88f29f8ea1547c14b6b0230f0b902c9fb916bf1c/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryService.java#L555-L556). They don't have `attributeValues` and users can also not add any.

This means that we will have to either
* treat them as not having the requested idScheme as part of the error handling we will soon add
* or create an exception and for example show their metadata attribute values as `default`

## Data model and category theory 😂 

Category option combos represent the combination of one or more category options. For example

Category option combo `XVl0bL5Bl4q` represents category options `B3nxOazOO2G` and `i4Nbp8S2G6A`.

Both are exposed in our API [view/Event](https://github.com/dhis2/dhis2-core/blob/601ceb4c743f9412dc50cfda6f7466ba7b1f1cb5/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java#L108-L110)
* `CategoryOptionCombo` in field `attributeOptionCombo` this is a one to one mapping
* `Set<CategoryOption>`s in field `attributeCategoryOptions` this is a many to one mapping where the `Set` of identifiers is concatenated to a comma separated string. Category option (CO) is the only type of metadata where multiple values are represented as a single value in the JSON event.

The [Event](https://github.com/dhis2/dhis2-core/blob/42b547164371bda1ff22f208f0cdde369ab227b8/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java#L81) model we return from our service has a `CategoryOptionCombo` field which in turn has a field with a `Set<CategoryOption>`.

Even though the DB can aggregate the COs for us into a single string per event we cannot pass that up to our view. Attribute values (used for idScheme ATTRIBUTE) make that even more complex as they are an object with many attribute/value pairs (stored as JSONB).

Bug https://github.com/dhis2/dhis2-core/pull/13253 made us aggregate the COs using the DB so that order and pagination is respected. We do need to unpack the COs to fulfill the [Event](https://github.com/dhis2/dhis2-core/blob/42b547164371bda1ff22f208f0cdde369ab227b8/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java#L81) type though.

Since we now not only need uid but code, name and `attributeValues` I aggregate them into a JSONB.

This is an example of category option combo XVl0bL5Bl4q for an event with the aggregated COs.

```
═[ RECORD 5 ]═══╪═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════>
uid             │ XVl0bL5Bl4q
attributevalues │ {}
code            │ COC_1153394
name            │ APHIAplus, Improve access to clean water
id              │ 1153394
co_values       │ {"B3nxOazOO2G": {"code": "APHIAplus", "name": "APHIAplus", "attributeValues": {}}, "i4Nbp8S2G6A": {"code": "Project01", "name": "Improve access to clean water", "attributeValues": {}>
co_count        │ 2
```

## Tests

Asserting is now more difficult as we need to assert a `Set<CategoryOption>` maps to the `Event.attributeCategoryOptions` using the correct `idScheme` irrespective of order! We do not guarantee the order of identifiers in `Event.attributeCategoryOptions`.

I will improve the metadata assertions when I am done with all `idSchemeParams`. Asserting `Set<DataValue> Event.dataValues` and then relationships will require them to change again.