### PR TITLE
fix: NPE when delete eventVisualization

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -766,7 +766,13 @@ public class DefaultPreheatService implements PreheatService {
           }
 
           objects.forEach(
-              o -> list.addAll(ReflectionUtils.invokeMethod(o, property.getGetterMethod())));
+              o -> {
+                Collection<Object> propertyValue =
+                    ReflectionUtils.invokeMethod(o, property.getGetterMethod());
+                if (!org.apache.commons.collections4.CollectionUtils.isEmpty(propertyValue)) {
+                  list.addAll(propertyValue);
+                }
+              });
           targets.put(property.getItemKlass(), list);
         } else {
           List<Object> list = new ArrayList<>();
@@ -776,7 +782,12 @@ public class DefaultPreheatService implements PreheatService {
           }
 
           objects.forEach(
-              o -> list.add(ReflectionUtils.invokeMethod(o, property.getGetterMethod())));
+              o -> {
+                Object item = ReflectionUtils.invokeMethod(o, property.getGetterMethod());
+                if (item != null) {
+                  list.add(item);
+                }
+              });
           targets.put(property.getKlass(), list);
         }
       }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -154,6 +154,27 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
+  void testDelete() {
+    // Given
+    String eventDateDimension = "eventDate";
+    String eventDate = "2021-07-21_2021-08-01";
+    String dimensionBody =
+        "{'dimension': '" + eventDateDimension + "', 'items': [{'id': '" + eventDate + "'}]}";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN','eventRepetitions':null, 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': ["
+            + dimensionBody
+            + "]}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    DELETE("/eventVisualizations/" + uid).content(OK);
+  }
+
+  @Test
   void testPostForMultiEventDates() {
     // Given
     String eventDateDimension = "eventDate";


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-18330
### Issue
- Use got NPE when trying to delete an EventVisualization in Line Listing App.
- During metadata import preheat, Java Reflection is used to add properties to collections without null check.

### Fix
- Added null check and also unit test

