### PR TITLE
ci: Do not require label to run api tests (2.40)

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [ opened, labeled, synchronize ]
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,7 +19,6 @@ jobs:
       CORE_IMAGE_NAME: "dhis2/core-pr:${{ github.event_name == 'pull_request' && github.event.number || 'local' }}"
     
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-api-tests')"
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11


### PR DESCRIPTION
API-TEST sometimes are not run automatically, even though they are required (it happens quite frequently with dependabot PRs) and it is needed to add the run-api-tests label in order to unblock the PR.
This PR aims to remove the dependency of the api-tests github action on the label