### PR TITLE
chore: remove unnecessary join on TE orgUnit DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -785,9 +785,6 @@ class JdbcEventStore implements EventStore {
         .append("te.trackedentityid as te_id, te.uid as ")
         .append(COLUMN_TRACKEDENTITY_UID)
         .append(
-            ", teou.uid as te_ou, teou.name as te_ou_name, te.created as te_created, te.inactive as"
-                + " te_inactive ")
-        .append(
             getFromWhereClause(
                 params,
                 mapSqlParameterSource,
@@ -834,8 +831,6 @@ class JdbcEventStore implements EventStore {
 
     fromBuilder
         .append("left join trackedentity te on te.trackedentityid=en.trackedentityid ")
-        .append(
-            "left join organisationunit teou on (te.organisationunitid=teou.organisationunitid) ")
         .append("left join userinfo au on (ev.assigneduserid=au.userinfoid) ");
 
     // JOIN attributes we need to filter on.


### PR DESCRIPTION
We allow ordering by `trackedEntity` (UID) and therefore add a left join on the TE. (There might be another reason see below).

https://github.com/dhis2/dhis2-core/blob/8b61e44d959a0d9c90386c10fcd62e6d53f4dc91/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L213

We do not use the TE orgUnit for anything AFAIK. Remove the left join on the TE orgUnit.

Not sure if anyone using the `EventService` needs the `enrollment.trackedEntity.uid` which is what we set using the left join on the TE. If not we could also only add that join if users order by `trackedEntity`.