### PR TITLE
ci: push test/dev images to dhis2/core-dev [skip ci]

### DIFF
--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -38,7 +38,6 @@ pipeline {
         DOCKER_IMAGE_NAME_PUBLISH_TARGET = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" // used to publish to Dockerhub
         // THIS MUST be kept in sync with the jib.from.image in ../dhis-2/dhis-web-server/pom.xml
         BASE_IMAGE = "tomcat:10.1.30-jre17"
-        IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME"
     }
 
     stages {
@@ -65,6 +64,7 @@ pipeline {
                 RP_UUID = credentials('report-portal-access-uuid')
                 RP_ENABLE = 'true'
                 RP_ATTRIBUTES = "version:${env.GIT_BRANCH};"
+                IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME_DEV"
                 DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME_DEV}:${DOCKER_IMAGE_TAG}"
             }
 
@@ -112,6 +112,10 @@ pipeline {
         }
 
         stage('Publish images') {
+            environment {
+                IMAGE_REPOSITORY = "$DOCKER_IMAGE_NAME"
+            }
+
             steps {
                 script {
                     // Remove -rc suffix in case it's there, will be added later if needed.


### PR DESCRIPTION
An issue was introduced with https://github.com/dhis2/dhis2-core/pull/18899 - development/test images built during the API test stage should be pushed to the `dhis2/core-dev` repo, not `dhis2/core`.

The error was spotted in this build - https://ci.dhis2.org/view/dhis2-core/job/dhis2-core-stable/job/patch%252F2.40.6/1/pipeline-console/

The fix was tested with a "Replay" of the build above and making the changes from this PR inline - https://ci.dhis2.org/view/dhis2-core/job/dhis2-core-stable/job/patch%252F2.40.6/2/replay/diff