### PR TITLE
feat: report metadata without identifier for idScheme DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
@@ -38,6 +38,7 @@ import lombok.NoArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -142,6 +143,27 @@ public class TrackerIdSchemeParams implements Serializable {
   @Nonnull
   public TrackerIdSchemeParam getCategoryOptionIdScheme() {
     return categoryOptionIdScheme != null ? categoryOptionIdScheme : idScheme;
+  }
+
+  /**
+   * Get the identifier using the matching {@code idScheme}. Defaults to {@link
+   * IdentifiableObject#getUid()} if the metadata has no dedicated {@code idScheme} parameter.
+   */
+  public <T extends IdentifiableObject & MetadataObject> String getIdentifier(T metadata) {
+    if (metadata instanceof DataElement dataElement) {
+      return getDataElementIdScheme().getIdentifier(dataElement);
+    } else if (metadata instanceof OrganisationUnit orgUnit) {
+      return getOrgUnitIdScheme().getIdentifier(orgUnit);
+    } else if (metadata instanceof Program program) {
+      return getProgramIdScheme().getIdentifier(program);
+    } else if (metadata instanceof ProgramStage programStage) {
+      return getProgramStageIdScheme().getIdentifier(programStage);
+    } else if (metadata instanceof CategoryOptionCombo categoryOptionCombo) {
+      return getCategoryOptionComboIdScheme().getIdentifier(categoryOptionCombo);
+    } else if (metadata instanceof CategoryOption categoryOption) {
+      return getCategoryOptionIdScheme().getIdentifier(categoryOption);
+    }
+    return metadata.getUid();
   }
 
   public TrackerIdSchemeParam getByClass(Class<?> klazz) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -499,9 +499,13 @@ class JdbcEventStore {
     if (StringUtils.isEmpty(dataValueResult)) {
       return null;
     }
+    String dataElement = getDataElementIdentifier(dataElementIdScheme, resultSet);
+    if (StringUtils.isEmpty(dataElement)) {
+      return null;
+    }
 
     EventDataValue eventDataValue = new EventDataValue();
-    eventDataValue.setDataElement(getDataElementIdentifier(dataElementIdScheme, resultSet));
+    eventDataValue.setDataElement(dataElement);
     JsonObject dataValueJson = JsonMixed.of(dataValueResult).asObject();
     eventDataValue.setValue(dataValueJson.getString("value").string(""));
     eventDataValue.setProvidedElsewhere(
@@ -536,7 +540,7 @@ class JdbcEventStore {
       case ATTRIBUTE:
         String attributeValuesString = resultSet.getString("de_attributevalues");
         if (StringUtils.isEmpty(attributeValuesString)) {
-          return "";
+          return null;
         }
         JsonObject attributeValuesJson = JsonMixed.of(attributeValuesString).asObject();
         String attributeUid = dataElementIdScheme.getAttributeUid();

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonWebMessage.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonWebMessage.java
@@ -52,6 +52,10 @@ public interface JsonWebMessage extends JsonObject {
     return getString("message").string();
   }
 
+  default String getDevMessage() {
+    return getString("devMessage").string();
+  }
+
   default String getDescription() {
     return getString("description").string();
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
@@ -18,6 +18,25 @@
       "trackedEntityTypeAttribute": true,
       "unique": true,
       "valueType": "TEXT"
+    },
+    {
+      "id": "i57a0734128",
+      "categoryOptionAttribute": true,
+      "categoryOptionComboAttribute": true,
+      "dataElementAttribute": true,
+      "name": "no metadata should have an attribute value for this attribute",
+      "organisationUnitAttribute": true,
+      "programAttribute": true,
+      "programStageAttribute": true,
+      "relationshipTypeAttribute": true,
+      "sharing": {
+        "owner": "PQD6wXJ2r5j",
+        "public": "rw------"
+      },
+      "trackedEntityAttributeAttribute": true,
+      "trackedEntityTypeAttribute": true,
+      "unique": true,
+      "valueType": "TEXT"
     }
   ],
   "categories": [

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrors.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrors.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+
+/**
+ * MappingErrors collects and reports metadata that does not have an identifier for the requested
+ * {@code idScheme}. Metadata will be reported using their {@code UID} as every metadata must have
+ * one.
+ */
+@RequiredArgsConstructor
+public class MappingErrors {
+  // Maximum number of missing identifiers that are reported. This to safeguard against requests
+  // with a large number of items like paging=false. Admins need to use other tools to fix their
+  // metadata if such large numbers do not have identifiers for the requested idScheme.
+  private static final int DISPLAY_MAX_UIDS = 20;
+
+  private final Map<Class<?>, Set<String>> errors = new HashMap<>();
+  private final TrackerIdSchemeParams idSchemeParams;
+
+  /**
+   * Add the metadata to the set of errors to report it as not having an identifier for the
+   * requested {@code idScheme}.
+   */
+  public <T extends IdentifiableObject & MetadataObject> void add(T metadata) {
+    errors.computeIfAbsent(metadata.getClass(), k -> new HashSet<>()).add(metadata.getUid());
+  }
+
+  public boolean hasErrors() {
+    return !errors.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    if (!hasErrors()) {
+      return "";
+    }
+
+    StringBuilder result =
+        new StringBuilder(
+            "Following metadata listed using their UIDs is missing identifiers for the requested"
+                + " idScheme:");
+
+    errors.forEach(
+        (metadataClass, uids) -> {
+          if (uids.isEmpty()) {
+            return;
+          }
+
+          result.append("\n");
+          result.append(metadataClass.getSimpleName());
+          result.append("[");
+          result.append(idSchemeParams.getByClass(metadataClass));
+          result.append("]=");
+
+          int count = 1;
+          int size = uids.size();
+          for (String uid : uids) {
+            if (count > DISPLAY_MAX_UIDS) {
+              result.append("...");
+              return;
+            }
+
+            result.append(uid);
+            if (count < size) {
+              result.append(",");
+            }
+            count++;
+          }
+        });
+    return result.toString();
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
+import org.hisp.dhis.webapi.controller.tracker.export.MappingErrors;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.UserMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.event.EventMapper;
@@ -85,5 +86,7 @@ public interface EnrollmentMapper {
   @Mapping(target = "attributes", source = "trackedEntity.trackedEntityAttributeValues")
   @Mapping(target = "notes", source = "notes")
   org.hisp.dhis.webapi.controller.tracker.view.Enrollment map(
-      Enrollment enrollment, @Context TrackerIdSchemeParams idSchemeParams);
+      @Context TrackerIdSchemeParams idSchemeParams,
+      @Context MappingErrors errors,
+      Enrollment enrollment);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
+import org.hisp.dhis.webapi.controller.tracker.export.MappingErrors;
 import org.hisp.dhis.webapi.controller.tracker.export.MetadataMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.UserMapper;
@@ -92,17 +93,11 @@ public interface EventMapper {
           entry("updatedBy", "lastUpdatedBy"));
 
   @Mapping(target = "event", source = "uid")
-  @Mapping(target = "program", source = "enrollment.program", qualifiedByName = "programToString")
-  @Mapping(
-      target = "programStage",
-      source = "programStage",
-      qualifiedByName = "programStageToString")
+  @Mapping(target = "program", source = "enrollment.program")
+  @Mapping(target = "programStage", source = "programStage")
   @Mapping(target = "enrollment", source = "enrollment.uid")
   @Mapping(target = "trackedEntity", source = "enrollment.trackedEntity.uid")
-  @Mapping(
-      target = "orgUnit",
-      source = "organisationUnit",
-      qualifiedByName = "organisationUnitToString")
+  @Mapping(target = "orgUnit", source = "organisationUnit")
   @Mapping(target = "occurredAt", source = "occurredDate")
   @Mapping(target = "scheduledAt", source = "scheduledDate")
   @Mapping(
@@ -115,14 +110,8 @@ public interface EventMapper {
   @Mapping(target = "createdAtClient", source = "createdAtClient")
   @Mapping(target = "updatedAt", source = "lastUpdated")
   @Mapping(target = "updatedAtClient", source = "lastUpdatedAtClient")
-  @Mapping(
-      target = "attributeOptionCombo",
-      source = "attributeOptionCombo",
-      qualifiedByName = "categoryOptionComboToString")
-  @Mapping(
-      target = "attributeCategoryOptions",
-      source = "attributeOptionCombo.categoryOptions",
-      qualifiedByName = "categoryOptionsToString")
+  @Mapping(target = "attributeOptionCombo", source = "attributeOptionCombo")
+  @Mapping(target = "attributeCategoryOptions", source = "attributeOptionCombo.categoryOptions")
   @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")
   @Mapping(target = "updatedBy", source = "lastUpdatedByUserInfo")
@@ -130,5 +119,5 @@ public interface EventMapper {
   @Mapping(target = "relationships", source = "relationshipItems")
   @Mapping(target = "notes", source = "notes")
   org.hisp.dhis.webapi.controller.tracker.view.Event map(
-      Event event, @Context TrackerIdSchemeParams idSchemeParams);
+      @Context TrackerIdSchemeParams idSchemeParams, @Context MappingErrors errors, Event event);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.writeGzip;
 import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.writeZip;
@@ -53,6 +54,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.Response.Status;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -71,12 +73,14 @@ import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler;
+import org.hisp.dhis.webapi.controller.tracker.export.MappingErrors;
 import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
 import org.hisp.dhis.webapi.controller.tracker.view.EventChangeLog;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -153,20 +157,24 @@ class EventsExportController {
       )
   ResponseEntity<Page<ObjectNode>> getEvents(
       EventRequestParams requestParams, TrackerIdSchemeParams idSchemeParams)
-      throws BadRequestException, ForbiddenException, NotFoundException {
+      throws BadRequestException, ForbiddenException, WebMessageException {
     validatePaginationParameters(requestParams);
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
 
     if (requestParams.isPaged()) {
       PageParams pageParams =
           new PageParams(
               requestParams.getPage(), requestParams.getPageSize(), requestParams.getTotalPages());
 
+      EventOperationParams eventOperationParams =
+          eventParamsMapper.map(requestParams, idSchemeParams);
       org.hisp.dhis.tracker.export.Page<Event> eventsPage =
           eventService.getEvents(eventOperationParams, pageParams);
+      MappingErrors errors = new MappingErrors(idSchemeParams);
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-          eventsPage.getItems().stream().map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams)).toList();
+          eventsPage.getItems().stream()
+              .map(ev -> EVENTS_MAPPER.map(idSchemeParams, errors, ev))
+              .toList();
+      ensureNoMappingErrors(errors);
       List<ObjectNode> objectNodes =
           fieldFilterService.toObjectNodes(events, requestParams.getFields());
 
@@ -176,9 +184,7 @@ class EventsExportController {
     }
 
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(events, requestParams.getFields());
 
@@ -192,16 +198,11 @@ class EventsExportController {
       EventRequestParams requestParams,
       TrackerIdSchemeParams idSchemeParams,
       HttpServletResponse response)
-      throws BadRequestException, IOException, ForbiddenException, NotFoundException {
+      throws BadRequestException, IOException, ForbiddenException, WebMessageException {
     validatePaginationParameters(requestParams);
 
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
-
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_JSON_FILE + GZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -219,16 +220,11 @@ class EventsExportController {
       EventRequestParams requestParams,
       TrackerIdSchemeParams idSchemeParams,
       HttpServletResponse response)
-      throws BadRequestException, ForbiddenException, IOException, NotFoundException {
+      throws BadRequestException, ForbiddenException, IOException, WebMessageException {
     validatePaginationParameters(requestParams);
 
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
-
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_JSON_FILE + ZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -250,14 +246,9 @@ class EventsExportController {
       TrackerIdSchemeParams idSchemeParams,
       HttpServletResponse response,
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
-      throws IOException, BadRequestException, ForbiddenException, NotFoundException {
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
-
+      throws IOException, BadRequestException, ForbiddenException, WebMessageException {
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_CSV_FILE);
     response.setContentType(CONTENT_TYPE_CSV);
@@ -271,14 +262,9 @@ class EventsExportController {
       TrackerIdSchemeParams idSchemeParams,
       HttpServletResponse response,
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader)
-      throws IOException, BadRequestException, ForbiddenException, NotFoundException {
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
-
+      throws IOException, BadRequestException, ForbiddenException, WebMessageException {
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_CSV_FILE + GZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -293,14 +279,9 @@ class EventsExportController {
       HttpServletResponse response,
       @RequestParam(required = false, defaultValue = "false") boolean skipHeader,
       TrackerIdSchemeParams idSchemeParams)
-      throws IOException, BadRequestException, ForbiddenException, NotFoundException {
-    EventOperationParams eventOperationParams =
-        eventParamsMapper.map(requestParams, idSchemeParams);
-
+      throws IOException, BadRequestException, ForbiddenException, WebMessageException {
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
-            .map(ev -> EVENTS_MAPPER.map(ev, idSchemeParams))
-            .toList();
+        getEventsList(requestParams, idSchemeParams);
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_CSV_FILE + ZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -316,12 +297,43 @@ class EventsExportController {
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
           List<FieldPath> fields,
       TrackerIdSchemeParams idSchemeParams)
-      throws NotFoundException, ForbiddenException {
+      throws NotFoundException, ForbiddenException, WebMessageException {
     EventParams eventParams = eventsMapper.map(fields);
+
+    MappingErrors errors = new MappingErrors(idSchemeParams);
     org.hisp.dhis.webapi.controller.tracker.view.Event event =
-        EVENTS_MAPPER.map(eventService.getEvent(uid, idSchemeParams, eventParams), idSchemeParams);
+        EVENTS_MAPPER.map(
+            idSchemeParams, errors, eventService.getEvent(uid, idSchemeParams, eventParams));
+    ensureNoMappingErrors(errors);
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(event, fields));
+  }
+
+  private List<org.hisp.dhis.webapi.controller.tracker.view.Event> getEventsList(
+      EventRequestParams requestParams, TrackerIdSchemeParams idSchemeParams)
+      throws BadRequestException, ForbiddenException, WebMessageException {
+    EventOperationParams eventOperationParams =
+        eventParamsMapper.map(requestParams, idSchemeParams);
+
+    MappingErrors errors = new MappingErrors(idSchemeParams);
+    List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
+        eventService.getEvents(eventOperationParams).stream()
+            .map(ev -> EVENTS_MAPPER.map(idSchemeParams, errors, ev))
+            .toList();
+    ensureNoMappingErrors(errors);
+    return events;
+  }
+
+  private static void ensureNoMappingErrors(MappingErrors errors) throws WebMessageException {
+    if (errors.hasErrors()) {
+      throw new WebMessageException(
+          createWebMessage(
+              "Not all metadata has an identifier for the requested idScheme. Either change the"
+                  + " requested idScheme or add the missing identifiers to the metadata.",
+              errors.toString(),
+              org.hisp.dhis.feedback.Status.ERROR,
+              HttpStatus.UNPROCESSABLE_ENTITY));
+    }
   }
 
   @GetMapping("/{event}/dataValues/{dataElement}/file")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
+import org.hisp.dhis.webapi.controller.tracker.export.MappingErrors;
 import org.hisp.dhis.webapi.controller.tracker.export.ProgramOwnerMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.UserMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.enrollment.EnrollmentMapper;
@@ -81,5 +82,7 @@ interface TrackedEntityMapper {
   @Mapping(target = "relationships", source = "relationshipItems")
   @Mapping(target = "attributes", source = "trackedEntityAttributeValues")
   org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity map(
-      TrackedEntity trackedEntity, @Context TrackerIdSchemeParams idSchemeParams);
+      @Context TrackerIdSchemeParams idSchemeParams,
+      @Context MappingErrors errors,
+      TrackedEntity trackedEntity);
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrorsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrorsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.junit.jupiter.api.Test;
+
+class MappingErrorsTest {
+  @Test
+  void shouldReportErrors() {
+    TrackerIdSchemeParams idSchemeParams =
+        TrackerIdSchemeParams.builder()
+            .idScheme(TrackerIdSchemeParam.NAME)
+            .programIdScheme(TrackerIdSchemeParam.CODE)
+            .programStageIdScheme(TrackerIdSchemeParam.ofAttribute("i4a244a8341"))
+            .build();
+
+    Program program1 = new Program();
+    program1.setUid(CodeGenerator.generateUid());
+
+    ProgramStage programStage1 = new ProgramStage();
+    programStage1.setUid(CodeGenerator.generateUid());
+
+    DataElement dataElement1 = new DataElement();
+    dataElement1.setUid(CodeGenerator.generateUid());
+    DataElement dataElement2 = new DataElement();
+    dataElement2.setUid(CodeGenerator.generateUid());
+
+    MappingErrors errors = new MappingErrors(idSchemeParams);
+
+    assertFalse(errors.hasErrors());
+    assertEquals("", errors.toString());
+
+    errors.add(program1);
+    assertTrue(errors.hasErrors());
+    errors.add(program1); // ensure no duplicates are reported
+    errors.add(programStage1);
+    errors.add(dataElement1);
+    errors.add(dataElement2);
+    assertTrue(errors.hasErrors());
+
+    assertAll(
+        () ->
+            assertContains(
+                "Following metadata listed using their UIDs is missing identifiers for the"
+                    + " requested idScheme:",
+                errors.toString()),
+        () -> assertContains("Program[CODE]=" + program1.getUid(), errors.toString()),
+        () ->
+            assertContains(
+                "ProgramStage[ATTRIBUTE:i4a244a8341]=" + programStage1.getUid(), errors.toString()),
+        // the order in which the uids are listed is not deterministic, only assert the uids are
+        // present for simplicity.
+        () -> assertContains("DataElement[NAME]=", errors.toString()),
+        () -> assertContains(dataElement1.getUid(), errors.toString()),
+        () -> assertContains(dataElement2.getUid(), errors.toString()));
+  }
+}


### PR DESCRIPTION
Report any metadata that does not have an identifier for the requested `idScheme`.

For example

`GET http://localhost:8080/api/tracker/events/FV4JCI73wO2?idScheme=ATTRIBUTE:Y1LUDU8sWBR`

gets response

```http
HTTP/1.1 422 

{
  "httpStatus": "Unprocessable Entity",
  "httpStatusCode": 422,
  "status": "ERROR",
  "message": "Not all metadata has an identifier for the requested idScheme. Either change the requested idScheme or add the missing identifiers to the metadata.",
  "devMessage": "Following metadata listed using their UIDs is missing identifiers for the requested idScheme:\nProgramStage[ATTRIBUTE:Y1LUDU8sWBR]=A03MvHHogjR\nCategoryOptionCombo[ATTRIBUTE:Y1LUDU8sWBR]=HllvX50cXC0\nCategoryOption[ATTRIBUTE:Y1LUDU8sWBR]=xYerKDKCefk\nProgram[ATTRIBUTE:Y1LUDU8sWBR]=IpHINAT79UW\nOrganisationUnit[ATTRIBUTE:Y1LUDU8sWBR]=DiszpKrYNg8"
}
```

if you process the `devMessage` via `| jq -r .devMessage` it looks like

```
Following metadata listed using their UIDs is missing identifiers for the requested idScheme:
ProgramStage[ATTRIBUTE:Y1LUDU8sWBR]=A03MvHHogjR
CategoryOptionCombo[ATTRIBUTE:Y1LUDU8sWBR]=HllvX50cXC0
CategoryOption[ATTRIBUTE:Y1LUDU8sWBR]=xYerKDKCefk
Program[ATTRIBUTE:Y1LUDU8sWBR]=IpHINAT79UW
OrganisationUnit[ATTRIBUTE:Y1LUDU8sWBR]=DiszpKrYNg8
```

We show at most 20 UIDs to shield against requests to retrieve all events. The following is an example (capped at 2 to illustrate) how it looks

```
Following metadata listed using their UIDs is missing identifiers for the requested idScheme:
ProgramStage[ATTRIBUTE:Y1LUDU8sWBR]=CWaAcQYKVpq,edqlbukwRfQ,...
CategoryOptionCombo[ATTRIBUTE:Y1LUDU8sWBR]=HllvX50cXC0
CategoryOption[ATTRIBUTE:Y1LUDU8sWBR]=xYerKDKCefk
Program[ATTRIBUTE:Y1LUDU8sWBR]=VBqh0ynB2wv,qDkgAbB5Jlk,...
OrganisationUnit[ATTRIBUTE:Y1LUDU8sWBR]=DiszpKrYNg8,g8upMTyEZGZ,...
```

Status 422 was the most fitting I found for this use case

> The HTTP 422 Unprocessable Content client error response status code indicates that the server understood the content type of the request content, and the syntax of the request content was correct, but it was unable to process the contained instructions.

Clients that receive a 422 response should expect that repeating the request without modification will fail with the same error.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422

* make `MetadataMapper` generic so it can map all the metadata we support while picking the correct `idScheme`
* extract common CSV related code in the controllers

## Limitations DataValues

We cannot report data elements! Reason is that `EventDataValues.dataElement` is of type `String` and not a `MetadataObject` like the other metadata. `EventDataValues.dataElement` is set to the identifier in the requested `idScheme`. We could insert the UID if we don't have another identifier. We would not have a reliable way to tell that the String is an identifier in the correct idScheme or a UID. So right now data values will not show up if we don't have an identifier for the requested idScheme. To fix that we would either need to make `EventDataValues.dataElement` a `DataElement` (basically undoing https://dhis2.atlassian.net/browse/DHIS2-4477) or make it a `MetadataIdentifier` which carries the `idScheme` information.