### PR TITLE
fix: hibernate schema validate config is not set

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -45,6 +45,7 @@ import org.hibernate.cache.jcache.MissingCacheStrategy;
 import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.hibernate.tool.schema.Action;
 import org.hisp.dhis.cache.DefaultHibernateCacheManager;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dbms.HibernateDbmsManager;
@@ -178,6 +179,10 @@ public class HibernateConfig {
           ConfigSettings.MISSING_CACHE_STRATEGY,
           MissingCacheStrategy.CREATE.getExternalRepresentation());
     }
+
+    properties.put(
+        AvailableSettings.HBM2DDL_AUTO,
+        Action.valueOf(dhisConfig.getProperty(ConfigurationKey.CONNECTION_SCHEMA).toUpperCase()));
 
     properties.put(
         AvailableSettings.SHOW_SQL, dhisConfig.getProperty(ConfigurationKey.HIBERNATE_SHOW_SQL));


### PR DESCRIPTION
### Issue
- We have the config `connection.schema` and default value is `validate` which means hibernate will throw an error on startup if a new property doesn’t exist in database.   For example: 
```Caused by: org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing column [test] in table [organisationunit]```
- However currently this is not working because the property is not set correctly.
- When value is `update` then hibernate will auto generate tables. This is only used in H2 test.
- Note that you will also get a postgresql exception for insert/select non exist column in database.
- This only affects 2.41 and 2.42. Before that we didn't use the `HibernateJpaAdapter` and set the property directly to Hibernate Session Factory.
### Fix
- Set the property `AvailableSettings.HBM2DDL_AUTO` with value taken from dhis config `connection.schema`