### PR TITLE
fix: defaults to PostgresBuilder on OrgUnitField [16705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/OrgUnitField.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/OrgUnitField.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.system.util.SqlUtils.quote;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.program.AnalyticsType;
 
@@ -84,7 +85,7 @@ public class OrgUnitField {
 
   private final OrgUnitFieldType type;
 
-  private SqlBuilder sqlBuilder;
+  private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
   public OrgUnitField(String field) {
     this.field = field;


### PR DESCRIPTION
### PR Changes

The `OrgUnitField` can now use a `SqlBuilder` to generate correctly quoted SQL. 
Set  `OrgUnitField` to use a default `PostgresSqlBuilder` to avoid NPE whenever the class is used without `SqlBuilder`.