### PR TITLE
fix: Add check, so it can be backported [DHIS2-18020]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
@@ -118,12 +118,22 @@ public class V2_42_21__Add_new_column_into_visualization_and_migrate_relative_pe
   }
 
   private boolean isMigrationAlreadyApplied(Context context) {
+    String schema = null;
+    try {
+      schema = context.getConnection().getSchema();
+    } catch (SQLException e) {
+      log.error("Schema check: ", e);
+    }
+
     final String checkColumnExists =
-        "select exists (select 1 from information_schema.columns where table_schema='public' and table_name='visualization' and column_name='relativeperiods')";
+        "select exists (select 1 from information_schema.columns where "
+            + (schema != null ? "table_schema='" + schema + "' and " : "")
+            + "table_name='eventvisualization' and column_name='relativeperiods')";
+
+    System.out.println("QUERY: " + checkColumnExists);
 
     try (Statement statement = context.getConnection().createStatement();
         ResultSet rs = statement.executeQuery(checkColumnExists)) {
-
       while (rs.next()) {
         return rs.getBoolean(1);
       }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
@@ -130,8 +130,6 @@ public class V2_42_21__Add_new_column_into_visualization_and_migrate_relative_pe
             + (schema != null ? "table_schema='" + schema + "' and " : "")
             + "table_name='eventvisualization' and column_name='relativeperiods')";
 
-    System.out.println("QUERY: " + checkColumnExists);
-
     try (Statement statement = context.getConnection().createStatement();
         ResultSet rs = statement.executeQuery(checkColumnExists)) {
       while (rs.next()) {

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v42/V2_42_21__Add_new_column_into_visualization_and_migrate_relative_periods.java
@@ -111,8 +111,27 @@ public class V2_42_21__Add_new_column_into_visualization_and_migrate_relative_pe
   }
 
   public void migrate(Context context) throws SQLException {
-    step1(context);
-    step2(context);
+    if (!isMigrationAlreadyApplied(context)) {
+      step1(context);
+      step2(context);
+    }
+  }
+
+  private boolean isMigrationAlreadyApplied(Context context) {
+    final String checkColumnExists =
+        "select exists (select 1 from information_schema.columns where table_schema='public' and table_name='visualization' and column_name='relativeperiods')";
+
+    try (Statement statement = context.getConnection().createStatement();
+        ResultSet rs = statement.executeQuery(checkColumnExists)) {
+
+      while (rs.next()) {
+        return rs.getBoolean(1);
+      }
+    } catch (SQLException e) {
+      log.error("Check failed: ", e);
+    }
+
+    return false;
   }
 
   /**
@@ -213,7 +232,7 @@ public class V2_42_21__Add_new_column_into_visualization_and_migrate_relative_pe
       ps.setLong(2, parentTableId);
       ps.executeUpdate();
 
-      // Clear the list of periods so it can be reused in the next iteration.
+      // Clear the list of periods, so it can be reused in the next iteration.
       periodList.clear();
     }
   }


### PR DESCRIPTION
We got a decison to backport this Jira, which has a Flyway migration.
For this reason we need to ensure this migration is not executed twice from one version to another.
The check added to this migration should ensure it runs only once.