### PR TITLE
fix: Map created date of notes as a timestamp [DHIS2-17864]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/NoteRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/NoteRowCallbackHandler.java
@@ -50,7 +50,7 @@ public class NoteRowCallbackHandler extends AbstractMapper<Note> {
     note.setUid(rs.getString("uid"));
     note.setNoteText(rs.getString("notetext"));
     note.setCreator(rs.getString("creator"));
-    note.setCreated(rs.getDate("created"));
+    note.setCreated(rs.getTimestamp("created"));
     return note;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.Assertions.assertHasTimeStamp;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNotes;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,7 +46,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -59,7 +59,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.note.Note;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Event;
@@ -927,47 +926,6 @@ class EventExporterTest extends TrackerTest {
     List<String> events = getEvents(params);
 
     assertContainsOnly(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
-  }
-
-  private static void assertNotes(List<Note> expected, List<Note> actual) {
-    assertContainsOnly(expected, actual);
-    Map<String, Note> expectedNotes =
-        expected.stream().collect(Collectors.toMap(Note::getUid, Function.identity()));
-    Map<String, Note> actualNotes =
-        actual.stream().collect(Collectors.toMap(Note::getUid, Function.identity()));
-    List<Executable> assertions =
-        expectedNotes.entrySet().stream()
-            .map(
-                entry ->
-                    (Executable)
-                        () -> {
-                          Note expectedNote = entry.getValue();
-                          Note actualNote = actualNotes.get(entry.getKey());
-                          assertAll(
-                              "note assertions " + expectedNote.getUid(),
-                              () ->
-                                  assertEquals(
-                                      expectedNote.getNoteText(),
-                                      actualNote.getNoteText(),
-                                      "noteText"),
-                              () ->
-                                  assertEquals(
-                                      expectedNote.getCreator(),
-                                      actualNote.getCreator(),
-                                      "creator"),
-                              () ->
-                                  assertEquals(
-                                      expectedNote.getCreated(),
-                                      actualNote.getCreated(),
-                                      "created"),
-                              () ->
-                                  assertEquals(
-                                      expectedNote.getLastUpdated(),
-                                      actualNote.getLastUpdated(),
-                                      "lastUpdated"));
-                        })
-            .toList();
-    assertAll("note assertions", assertions);
   }
 
   private DataElement dataElement(UID uid) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.tracker.Assertions.assertNotes;
 import static org.hisp.dhis.tracker.TrackerTestUtils.oneHourAfter;
 import static org.hisp.dhis.tracker.TrackerTestUtils.oneHourBefore;
 import static org.hisp.dhis.tracker.TrackerTestUtils.twoHoursAfter;
@@ -1311,7 +1312,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .findFirst();
     Set<Event> events = enrollmentA.get().getEvents();
     assertContainsOnly(Set.of(eventA), events);
-    assertContainsOnly(Set.of(note), events.stream().findFirst().get().getNotes());
+    assertNotes(eventA.getNotes(), events.stream().findFirst().get().getNotes());
   }
 
   @Test


### PR DESCRIPTION
Some fix done [here](https://github.com/dhis2/dhis2-core/pull/18949) but for the tracked entity endpoint.

In the `assertNotes` method the `assertEquals` on `lastUpdated` was removed as we are not mapping it to our tracker objects and its value was always null, but when saving a note using `IdentifiableObjectManager` `lastUpdated` field must be not null.