### PR TITLE
fix: Org Unit split being assigned to incorrect users [DHIS2-18423]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserOrgUnitProperty.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserOrgUnitProperty.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+/**
+ * @author Lars Helge Overland
+ */
+public enum UserOrgUnitProperty {
+  ORG_UNITS("organisationUnits"),
+  DATA_VIEW_ORG_UNITS("dataViewOrganisationUnits"),
+  TEI_SEARCH_ORG_UNITS("teiSearchOrganisationUnits");
+
+  private final String value;
+
+  UserOrgUnitProperty(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserOrgUnitProperty.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserOrgUnitProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.user;
 
-/**
- * @author Lars Helge Overland
- */
 public enum UserOrgUnitProperty {
   ORG_UNITS("organisationUnits"),
   DATA_VIEW_ORG_UNITS("dataViewOrganisationUnits"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -75,6 +75,11 @@ public class UserQueryParams {
 
   @ToString.Include private UserInvitationStatus invitationStatus;
 
+  /**
+   * WARNING: If this field has an empty collection, it can potentially result in all users being
+   * returned from the database. Check the generated query to make sure you're seeing expected
+   * queries and results.
+   */
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   private Set<UserGroup> userGroups = new HashSet<>();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -75,11 +75,7 @@ public class UserQueryParams {
 
   @ToString.Include private UserInvitationStatus invitationStatus;
 
-  /**
-   * WARNING: If this field has an empty collection, it can potentially result in all users being
-   * returned from the database. Check the generated query to make sure you're seeing expected
-   * queries and results.
-   */
+  /** If empty, no matching condition will be generated */
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   private Set<UserGroup> userGroups = new HashSet<>();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -903,5 +903,5 @@ public interface UserService {
    * @param uid {@link OrganisationUnit} {@link UID} to match on
    * @return matching {@link User}s
    */
-  List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid);
+  List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -41,11 +41,13 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
  * @author Chau Thu Tran
@@ -891,4 +893,15 @@ public interface UserService {
   boolean isEmailVerified(User currentUser);
 
   User getUserByVerificationToken(String token);
+
+  /**
+   * Method that retrieves all {@link User}s that have an entry for the {@link OrganisationUnit} in
+   * the given table
+   *
+   * @param orgUnitTable table to search (one of 'organisationUnits', 'dataViewOrganisationUnits',
+   *     'teiSearchOrganisationUnits')
+   * @param uid {@link OrganisationUnit} {@link UID} to match on
+   * @return matching {@link User}s
+   */
+  List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -898,10 +898,9 @@ public interface UserService {
    * Method that retrieves all {@link User}s that have an entry for the {@link OrganisationUnit} in
    * the given table
    *
-   * @param orgUnitTable table to search (one of 'organisationUnits', 'dataViewOrganisationUnits',
-   *     'teiSearchOrganisationUnits')
+   * @param orgUnitProperty {@link UserOrgUnitProperty} used to search
    * @param uid {@link OrganisationUnit} {@link UID} to match on
    * @return matching {@link User}s
    */
-  List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid);
+  List<User> getUsersWithOrgUnit(@Nonnull UserOrgUnitProperty orgUnitProperty, @Nonnull UID uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -38,6 +38,8 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
  * @author Nguyen Hong Duc
@@ -224,4 +226,15 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   User getUserByVerificationToken(String token);
 
   User getUserByVerifiedEmail(String email);
+
+  /**
+   * Method that retrieves all {@link User}s that have an entry for the {@link OrganisationUnit} in
+   * the given table
+   *
+   * @param orgUnitTable table to search (one of 'organisationUnits', 'dataViewOrganisationUnits',
+   *     'teiSearchOrganisationUnits')
+   * @param uid {@link OrganisationUnit} {@link UID} to match on
+   * @return matching {@link User}s
+   */
+  List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -228,13 +228,12 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   User getUserByVerifiedEmail(String email);
 
   /**
-   * Method that retrieves all {@link User}s that have an entry for the {@link OrganisationUnit} in
-   * the given table
+   * Retrieves all {@link User}s that have an entry for the {@link OrganisationUnit} in the given
+   * table
    *
-   * @param orgUnitTable table to search (one of 'organisationUnits', 'dataViewOrganisationUnits',
-   *     'teiSearchOrganisationUnits')
+   * @param orgUnitProperty {@link UserOrgUnitProperty} used to search
    * @param uid {@link OrganisationUnit} {@link UID} to match on
    * @return matching {@link User}s
    */
-  List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid);
+  List<User> getUsersWithOrgUnit(@Nonnull UserOrgUnitProperty orgUnitProperty, @Nonnull UID uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -236,5 +236,5 @@ public interface UserStore extends IdentifiableObjectStore<User> {
    * @param uid {@link OrganisationUnit} {@link UID} to match on
    * @return matching {@link User}s
    */
-  List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid);
+  List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid);
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.split.orgunit.OrgUnitSplitRequest;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserOrgUnitProperty;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 
@@ -94,7 +95,7 @@ public class MetadataOrgUnitSplitHandler {
     UID sourceOrgUnitUid = UID.of(request.getSource().getUid());
 
     List<User> dataCaptureUsers =
-        userService.getUsersWithOrgUnit("organisationUnits", sourceOrgUnitUid);
+        userService.getUsersWithOrgUnit(UserOrgUnitProperty.ORG_UNITS, sourceOrgUnitUid);
 
     dataCaptureUsers.forEach(
         u -> {
@@ -103,7 +104,7 @@ public class MetadataOrgUnitSplitHandler {
         });
 
     List<User> dataViewUsers =
-        userService.getUsersWithOrgUnit("dataViewOrganisationUnits", sourceOrgUnitUid);
+        userService.getUsersWithOrgUnit(UserOrgUnitProperty.DATA_VIEW_ORG_UNITS, sourceOrgUnitUid);
 
     dataViewUsers.forEach(
         u -> {
@@ -112,7 +113,7 @@ public class MetadataOrgUnitSplitHandler {
         });
 
     List<User> teiSearchOrgUnits =
-        userService.getUsersWithOrgUnit("teiSearchOrganisationUnits", sourceOrgUnitUid);
+        userService.getUsersWithOrgUnit(UserOrgUnitProperty.TEI_SEARCH_ORG_UNITS, sourceOrgUnitUid);
 
     teiSearchOrgUnits.forEach(
         u -> {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
@@ -29,14 +29,13 @@ package org.hisp.dhis.split.orgunit.handler;
 
 import com.google.common.collect.Sets;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.split.orgunit.OrgUnitSplitRequest;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserQueryParams;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 
@@ -92,11 +91,10 @@ public class MetadataOrgUnitSplitHandler {
   }
 
   public void splitUsers(OrgUnitSplitRequest request) {
-    Set<OrganisationUnit> source = Sets.newHashSet(request.getSource());
+    UID sourceOrgUnitUid = UID.of(request.getSource().getUid());
 
     List<User> dataCaptureUsers =
-        userService.getUsers(
-            new UserQueryParams().setCanSeeOwnRoles(true).setOrganisationUnits(source));
+        userService.getUsersWithOrgUnit("organisationUnits", sourceOrgUnitUid);
 
     dataCaptureUsers.forEach(
         u -> {
@@ -105,8 +103,7 @@ public class MetadataOrgUnitSplitHandler {
         });
 
     List<User> dataViewUsers =
-        userService.getUsers(
-            new UserQueryParams().setCanSeeOwnRoles(true).setDataViewOrganisationUnits(source));
+        userService.getUsersWithOrgUnit("dataViewOrganisationUnits", sourceOrgUnitUid);
 
     dataViewUsers.forEach(
         u -> {
@@ -115,8 +112,7 @@ public class MetadataOrgUnitSplitHandler {
         });
 
     List<User> teiSearchOrgUnits =
-        userService.getUsers(
-            new UserQueryParams().setCanSeeOwnRoles(true).setTeiSearchOrganisationUnits(source));
+        userService.getUsersWithOrgUnit("teiSearchOrganisationUnits", sourceOrgUnitUid);
 
     teiSearchOrgUnits.forEach(
         u -> {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -68,6 +68,7 @@ import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PasswordGenerator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.commons.filter.FilterUtils;
 import org.hisp.dhis.dataset.DataSet;
@@ -1575,6 +1576,11 @@ public class DefaultUserService implements UserService {
   @Transactional(readOnly = true)
   public User getUserByVerificationToken(String token) {
     return userStore.getUserByVerificationToken(token);
+  }
+
+  @Override
+  public List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid) {
+    return userStore.getUsersWithOrgUnit(orgUnitTable, uid);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1579,7 +1579,7 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
-  public List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid) {
+  public List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid) {
     return userStore.getUsersWithOrgUnit(orgUnitTable, uid);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1579,8 +1579,9 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
-  public List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid) {
-    return userStore.getUsersWithOrgUnit(orgUnitTable, uid);
+  public List<User> getUsersWithOrgUnit(
+      @Nonnull UserOrgUnitProperty orgUnitProperty, @Nonnull UID uid) {
+    return userStore.getUsersWithOrgUnit(orgUnitProperty, uid);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -79,6 +79,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccountExpiryInfo;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserInvitationStatus;
+import org.hisp.dhis.user.UserOrgUnitProperty;
 import org.hisp.dhis.user.UserQueryParams;
 import org.hisp.dhis.user.UserStore;
 import org.springframework.context.ApplicationEventPublisher;
@@ -645,14 +646,15 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   }
 
   @Override
-  public List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid) {
+  public List<User> getUsersWithOrgUnit(
+      @Nonnull UserOrgUnitProperty orgUnitProperty, @Nonnull UID uid) {
     return getQuery(
             """
             select distinct u from User u
             left join fetch u.%s ous
             where ous.uid = :uid
             """
-                .formatted(orgUnitTable))
+                .formatted(orgUnitProperty.getValue()))
         .setParameter("uid", uid.getValue())
         .getResultList();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -645,12 +645,12 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   }
 
   @Override
-  public List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid) {
+  public List<User> getUsersWithOrgUnit(@Nonnull String orgUnitTable, @Nonnull UID uid) {
     return getQuery(
             """
             select distinct u from User u
-            join u.%s ou
-            where ou.uid = :uid
+            left join fetch u.%s ous
+            where ous.uid = :uid
             """
                 .formatted(orgUnitTable))
         .setParameter("uid", uid.getValue())

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -63,6 +63,7 @@ import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hisp.dhis.cache.QueryCacheManager;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.commons.util.SqlHelper;
@@ -641,5 +642,18 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         getSession().createQuery("from User u where u.verifiedEmail = :email", User.class);
     query.setParameter("email", email);
     return query.uniqueResult();
+  }
+
+  @Override
+  public List<User> getUsersWithOrgUnit(String orgUnitTable, UID uid) {
+    return getQuery(
+            """
+            select distinct u from User u
+            join u.%s ou
+            where ou.uid = :uid
+            """
+                .formatted(orgUnitTable))
+        .setParameter("uid", uid.getValue())
+        .getResultList();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.user;
 
+import static io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator.assertSelectCount;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,20 +35,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.test.config.QueryCountDataSourceProxy;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -55,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @TestInstance(Lifecycle.PER_CLASS)
 @Transactional
+@ContextConfiguration(classes = {QueryCountDataSourceProxy.class})
 class UserStoreTest extends PostgresIntegrationTestBase {
   public static final String AUTH_A = "AuthA";
 
@@ -277,5 +284,38 @@ class UserStoreTest extends PostgresIntegrationTestBase {
 
     User foundUser = userStore.getUserByOpenId(openId1);
     assertEquals(userB.getUid(), foundUser.getUid());
+  }
+
+  @Test
+  @DisplayName("Get users by org unit uid with expected select count")
+  void getUsersByOrgUnitUidExpectedSelectCountTest() {
+    // given 2 org units & 4 users
+    OrganisationUnit ou1 = createOrganisationUnit("org unit test 1");
+    OrganisationUnit ou2 = createOrganisationUnit("org unit test 2");
+    organisationUnitService.addOrganisationUnit(ou1);
+    organisationUnitService.addOrganisationUnit(ou2);
+
+    User user1 = createAndAddUser("user1 test", ou1);
+    User user2 = createAndAddUser("user2 test", ou1);
+    User user3 = createAndAddUser("user3 test", ou2);
+    User user4 = createAndAddUser("user4 test no orgs");
+    userService.addUser(user1);
+    userService.addUser(user2);
+    userService.addUser(user3);
+    userService.addUser(user4);
+
+    // when retrieving users by org unit uid
+    SQLStatementCountValidator.reset();
+    List<User> users = userStore.getUsersWithOrgUnit("organisationUnits", UID.of(ou1));
+    // getting each org unit to assert later that no other select queries triggered
+    users.forEach(
+        u ->
+            assertTrue(
+                u.getOrganisationUnits().stream()
+                    .allMatch(ou -> ou.getUid().equals(ou1.getUid()))));
+
+    // then only 1 select query is triggered
+    assertSelectCount(1);
+    assertEquals(2, users.size());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
@@ -306,7 +306,7 @@ class UserStoreTest extends PostgresIntegrationTestBase {
 
     // when retrieving users by org unit uid
     SQLStatementCountValidator.reset();
-    List<User> users = userStore.getUsersWithOrgUnit("organisationUnits", UID.of(ou1));
+    List<User> users = userStore.getUsersWithOrgUnit(UserOrgUnitProperty.ORG_UNITS, UID.of(ou1));
     // getting each org unit to assert later that no other select queries triggered
     users.forEach(
         u ->


### PR DESCRIPTION
# Issue
Org Unit split feature is assigning the split org units to incorrect users (sometimes all the users in the DB in certain circumstances)

# Cause
After creating the `UserQueryParams` with the source `OrganisationUnit`, that `OrganisationUnit` was being overridden to use the `User`'s `OrganisationUnit`s carrying out the split.

In cases where the `User` either had no `organisationUnits`, `dataViewOrganisationUnits`, or `teiSearchOrganisationUnits`, then all the `User`s in the DB would be returned from the query, resulting in all `User`s getting the split `OrganisationUnit`s.

Fix avoids using:
- `UserService#handleUserQueryParams` which was overriding the source `OrganisationUnit` already set
-  `UserStore#getUsers` which tries to generate a handcrafted SQL query taking into consideration a multitude of options & checks using `UserQueryParams` (this looks too complex and tries to accommodate too many things). This resulted in returning all `User`s in the DB

# Fix
Use a dedicated query to fetch the `User`s to be actioned.
Fewer select queries are generated as a result of the fix, and is not proportionate to the number of users found (old query was triggering 1 extra query per user found - manual testing).
Warning added to `UserQueryParams` property.

# Testing
## Automated
2 integration tests added
- 1 for Org Unit split service: checking that the correct users get assigned the split org units
- 1 for the store: checking the generated select query count & retrieved users