### PR TITLE
feat: [DHIS2-18388] Add listener for specific cache invalidation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.cache;
 
-import java.time.Duration;
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.common.event.CacheInvalidationEvent;
 
 /**
  * The {@link CacheProvider} has a factory method for each {@link Cache} use case in DHIS2.
@@ -41,7 +41,6 @@ import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
  * @author Jan Bernitt
  */
 public interface CacheProvider {
-  <V> Cache<V> createAnalyticsResponseCache(Duration initialExpirationTime);
 
   <V> Cache<V> createAnalyticsCache();
 
@@ -55,11 +54,7 @@ public interface CacheProvider {
 
   <V> Cache<V> createInUserOrgUnitHierarchyCache();
 
-  <V> Cache<V> createInUserViewOrgUnitHierarchyCache();
-
   <V> Cache<V> createInUserSearchOrgUnitHierarchyCache();
-
-  <V> Cache<V> createUserCaptureOrgUnitThresholdCache();
 
   <V> Cache<V> createPeriodIdCache();
 
@@ -72,8 +67,6 @@ public interface CacheProvider {
   <V> Cache<V> createProgramOwnerCache();
 
   <V> Cache<V> createProgramTempOwnerCache();
-
-  <V> Cache<V> createUserIdCache();
 
   <V> Cache<V> createCurrentUserGroupInfoCache();
 
@@ -89,8 +82,6 @@ public interface CacheProvider {
 
   <V> Cache<V> createAnalyticsSqlCache();
 
-  <V> Cache<V> createDataElementCache();
-
   <V> Cache<V> createPropertyTransformerCache();
 
   <V> Cache<V> createProgramHasRulesCache();
@@ -101,9 +92,7 @@ public interface CacheProvider {
 
   void handleApplicationCachesCleared(ApplicationCacheClearedEvent event);
 
-  <V> Cache<V> createProgramWebHookNotificationTemplateCache();
-
-  <V> Cache<V> createProgramStageWebHookNotificationTemplateCache();
+  void handleCacheInvalidationEvent(CacheInvalidationEvent event);
 
   <V> Cache<V> createProgramOrgUnitAssociationCache();
 
@@ -112,8 +101,6 @@ public interface CacheProvider {
   <V> Cache<V> createDataSetOrgUnitAssociationCache();
 
   <V> Cache<V> createApiKeyCache();
-
-  <V> Cache<V> createProgramCache();
 
   <V> Cache<V> createTeAttributesCache();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
@@ -1,0 +1,43 @@
+package org.hisp.dhis.common.cache;
+
+/**
+ * Enum is used to make sure we do not use same region twice. Each method should have its own
+ * constant.
+ */
+@SuppressWarnings("squid:S115") // allow non enum-ish names
+public enum Region {
+    analyticsResponse,
+    defaultObjectCache,
+    isDataApproved,
+    allConstantsCache,
+    inUserOrgUnitHierarchy,
+    inUserSearchOrgUnitHierarchy,
+    periodIdCache,
+    userAccountRecoverAttempt,
+    userFailedLoginAttempt,
+    twoFaDisableFailedAttempt,
+    programOwner,
+    programTempOwner,
+    currentUserGroupInfoCache,
+    attrOptionComboIdCache,
+    googleAccessToken,
+    dataItemsPagination,
+    metadataAttributes,
+    canDataWriteCocCache,
+    analyticsSql,
+    propertyTransformerCache,
+    programHasRulesCache,
+    userGroupNameCache,
+    userDisplayNameCache,
+    pgmOrgUnitAssocCache,
+    catOptOrgUnitAssocCache,
+    dataSetOrgUnitAssocCache,
+    apiTokensCache,
+    teAttributesCache,
+    programTeAttributesCache,
+    userGroupUIDCache,
+    securityCache,
+    dataIntegritySummaryCache,
+    dataIntegrityDetailsCache,
+    queryAliasCache
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.common.cache;
 
 /**
@@ -6,38 +33,38 @@ package org.hisp.dhis.common.cache;
  */
 @SuppressWarnings("squid:S115") // allow non enum-ish names
 public enum Region {
-    analyticsResponse,
-    defaultObjectCache,
-    isDataApproved,
-    allConstantsCache,
-    inUserOrgUnitHierarchy,
-    inUserSearchOrgUnitHierarchy,
-    periodIdCache,
-    userAccountRecoverAttempt,
-    userFailedLoginAttempt,
-    twoFaDisableFailedAttempt,
-    programOwner,
-    programTempOwner,
-    currentUserGroupInfoCache,
-    attrOptionComboIdCache,
-    googleAccessToken,
-    dataItemsPagination,
-    metadataAttributes,
-    canDataWriteCocCache,
-    analyticsSql,
-    propertyTransformerCache,
-    programHasRulesCache,
-    userGroupNameCache,
-    userDisplayNameCache,
-    pgmOrgUnitAssocCache,
-    catOptOrgUnitAssocCache,
-    dataSetOrgUnitAssocCache,
-    apiTokensCache,
-    teAttributesCache,
-    programTeAttributesCache,
-    userGroupUIDCache,
-    securityCache,
-    dataIntegritySummaryCache,
-    dataIntegrityDetailsCache,
-    queryAliasCache
+  analyticsResponse,
+  defaultObjectCache,
+  isDataApproved,
+  allConstantsCache,
+  inUserOrgUnitHierarchy,
+  inUserSearchOrgUnitHierarchy,
+  periodIdCache,
+  userAccountRecoverAttempt,
+  userFailedLoginAttempt,
+  twoFaDisableFailedAttempt,
+  programOwner,
+  programTempOwner,
+  currentUserGroupInfoCache,
+  attrOptionComboIdCache,
+  googleAccessToken,
+  dataItemsPagination,
+  metadataAttributes,
+  canDataWriteCocCache,
+  analyticsSql,
+  propertyTransformerCache,
+  programHasRulesCache,
+  userGroupNameCache,
+  userDisplayNameCache,
+  pgmOrgUnitAssocCache,
+  catOptOrgUnitAssocCache,
+  dataSetOrgUnitAssocCache,
+  apiTokensCache,
+  teAttributesCache,
+  programTeAttributesCache,
+  userGroupUIDCache,
+  securityCache,
+  dataIntegritySummaryCache,
+  dataIntegrityDetailsCache,
+  queryAliasCache
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/event/CacheInvalidationEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/event/CacheInvalidationEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common.event;
+
+import lombok.Getter;
+import org.hisp.dhis.common.cache.Region;
+import org.springframework.context.ApplicationEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author Ameen Mohamed
+ */
+@Getter
+public class CacheInvalidationEvent extends ApplicationEvent {
+  private final Region region;
+  private final String key;
+
+  public CacheInvalidationEvent(Object source, @Nonnull Region region, @Nullable String key) {
+    super(source);
+    this.region = region;
+    this.key = key;
+  }
+
+  public CacheInvalidationEvent(Object source, @Nonnull Region region) {
+    super(source);
+    this.region = region;
+    this.key = null;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/event/CacheInvalidationEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/event/CacheInvalidationEvent.java
@@ -27,12 +27,11 @@
  */
 package org.hisp.dhis.common.event;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import org.hisp.dhis.common.cache.Region;
 import org.springframework.context.ApplicationEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * @author Ameen Mohamed

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
@@ -183,7 +182,6 @@ public class DefaultCacheProvider implements CacheProvider {
             .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
-
 
   @Override
   public <V> Cache<V> createInUserSearchOrgUnitHierarchyCache() {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -28,16 +28,18 @@
 package org.hisp.dhis.cache;
 
 import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hisp.dhis.commons.util.SystemUtils.isEnableCacheInTest;
 import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.common.event.CacheInvalidationEvent;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.event.EventListener;
@@ -55,8 +57,6 @@ public class DefaultCacheProvider implements CacheProvider {
   private static final long SIZE_1 = 1;
 
   private static final long SIZE_100 = 100;
-
-  private static final long SIZE_500 = 500;
 
   private static final long SIZE_1K = 1_000;
 
@@ -76,61 +76,6 @@ public class DefaultCacheProvider implements CacheProvider {
     this.environment = environment;
     this.cacheFactor =
         Double.parseDouble(dhisConfig.getProperty(ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR));
-  }
-
-  /**
-   * Enum is used to make sure we do not use same region twice. Each method should have its own
-   * constant.
-   */
-  @SuppressWarnings("squid:S115") // allow non enum-ish names
-  private enum Region {
-    analyticsResponse,
-    defaultObjectCache,
-    isDataApproved,
-    allConstantsCache,
-    inUserOrgUnitHierarchy,
-    isUserViewOrgUnitHierarchy,
-    inUserSearchOrgUnitHierarchy,
-    userCaptureOrgUnitCountThreshold,
-    periodIdCache,
-    userAccountRecoverAttempt,
-    userFailedLoginAttempt,
-    twoFaDisableFailedAttempt,
-    programOwner,
-    programTempOwner,
-    userIdCache,
-    currentUserGroupInfoCache,
-    userSetting,
-    attrOptionComboIdCache,
-    systemSetting,
-    googleAccessToken,
-    dataItemsPagination,
-    metadataAttributes,
-    canDataWriteCocCache,
-    analyticsSql,
-    dataElementCache,
-    propertyTransformerCache,
-    programHasRulesCache,
-    programRuleVariablesCache,
-    userGroupNameCache,
-    userDisplayNameCache,
-    programWebHookNotificationTemplateCache,
-    programStageWebHookNotificationTemplateCache,
-    pgmOrgUnitAssocCache,
-    catOptOrgUnitAssocCache,
-    dataSetOrgUnitAssocCache,
-    apiTokensCache,
-    programCache,
-    teAttributesCache,
-    programTeAttributesCache,
-    userGroupUIDCache,
-    oldTrackerSecurityCache,
-    securityCache,
-    runningJobsInfo,
-    jobCancelRequested,
-    dataIntegritySummaryCache,
-    dataIntegrityDetailsCache,
-    queryAliasCache
   }
 
   private final Map<String, Cache<?>> allCaches = new ConcurrentHashMap<>();
@@ -160,13 +105,19 @@ public class DefaultCacheProvider implements CacheProvider {
     allCaches.values().forEach(Cache::invalidateAll);
   }
 
+  @EventListener
   @Override
-  public <V> Cache<V> createAnalyticsResponseCache(Duration initialExpirationTime) {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.analyticsResponse.name())
-            .expireAfterWrite(initialExpirationTime.toMillis(), MILLISECONDS)
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
+  public void handleCacheInvalidationEvent(CacheInvalidationEvent event) {
+    Cache<?> cache = allCaches.get(event.getRegion().name());
+    if (cache == null) {
+      return;
+    }
+
+    if (StringUtils.isNotBlank(event.getKey())) {
+      cache.invalidate(event.getKey());
+    } else {
+      cache.invalidateAll();
+    }
   }
 
   @Override
@@ -233,33 +184,12 @@ public class DefaultCacheProvider implements CacheProvider {
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
 
-  @Override
-  public <V> Cache<V> createInUserViewOrgUnitHierarchyCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.isUserViewOrgUnitHierarchy.name())
-            .expireAfterWrite(3, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(SIZE_1K))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
-  }
 
   @Override
   public <V> Cache<V> createInUserSearchOrgUnitHierarchyCache() {
     return registerCache(
         this.<V>newBuilder()
             .forRegion(Region.inUserSearchOrgUnitHierarchy.name())
-            .expireAfterWrite(1, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(SIZE_1K))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
-  }
-
-  @Override
-  public <V> Cache<V> createUserCaptureOrgUnitThresholdCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.userCaptureOrgUnitCountThreshold.name())
             .expireAfterWrite(1, TimeUnit.HOURS)
             .withInitialCapacity((int) getActualSize(SIZE_1K))
             .forceInMemory()
@@ -319,17 +249,6 @@ public class DefaultCacheProvider implements CacheProvider {
         this.<V>newBuilder()
             .forRegion(Region.programTempOwner.name())
             .expireAfterWrite(30, TimeUnit.MINUTES)
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
-  }
-
-  @Override
-  public <V> Cache<V> createUserIdCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.userIdCache.name())
-            .expireAfterWrite(1, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(200))
-            .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
 
@@ -395,7 +314,6 @@ public class DefaultCacheProvider implements CacheProvider {
             .forRegion(Region.canDataWriteCocCache.name())
             .expireAfterWrite(3, TimeUnit.HOURS)
             .withInitialCapacity((int) getActualSize(SIZE_1K))
-            .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
 
@@ -405,17 +323,6 @@ public class DefaultCacheProvider implements CacheProvider {
         this.<V>newBuilder()
             .forRegion(Region.analyticsSql.name())
             .expireAfterWrite(10, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(SIZE_1K))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
-  }
-
-  @Override
-  public <V> Cache<V> createDataElementCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.dataElementCache.name())
-            .expireAfterWrite(60, TimeUnit.MINUTES)
             .withInitialCapacity((int) getActualSize(SIZE_1K))
             .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
@@ -466,28 +373,6 @@ public class DefaultCacheProvider implements CacheProvider {
   }
 
   @Override
-  public <V> Cache<V> createProgramWebHookNotificationTemplateCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.programWebHookNotificationTemplateCache.name())
-            .expireAfterWrite(3, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(20))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_500))));
-  }
-
-  @Override
-  public <V> Cache<V> createProgramStageWebHookNotificationTemplateCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.programStageWebHookNotificationTemplateCache.name())
-            .expireAfterWrite(3, TimeUnit.HOURS)
-            .withInitialCapacity((int) getActualSize(20))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_500))));
-  }
-
-  @Override
   public <V> Cache<V> createProgramOrgUnitAssociationCache() {
     return registerCache(
         this.<V>newBuilder()
@@ -525,16 +410,6 @@ public class DefaultCacheProvider implements CacheProvider {
             .expireAfterWrite(1, TimeUnit.HOURS)
             .withInitialCapacity((int) getActualSize(SIZE_1K))
             .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
-  }
-
-  @Override
-  public <V> Cache<V> createProgramCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.programCache.name())
-            .expireAfterWrite(1, TimeUnit.MINUTES)
-            .withInitialCapacity((int) getActualSize(SIZE_1K))
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
@@ -1,0 +1,92 @@
+package org.hisp.dhis.cache;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.common.cache.Region;
+import org.hisp.dhis.common.event.CacheInvalidationEvent;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultCacheProviderTest {
+
+  @Mock private DhisConfigurationProvider dhisConfigurationProvider;
+
+  @Mock private CacheBuilderProvider cacheBuilderProvider;
+
+  @Mock private CacheBuilder<Object> cacheBuilder;
+
+  @Mock private Cache<Object> mockCache;
+
+  MockEnvironment environment = new MockEnvironment();
+
+  private DefaultCacheProvider defaultCacheProvider;
+
+  @BeforeEach
+  public void setUp() {
+    environment.setActiveProfiles("nonTestProfile");
+    when(dhisConfigurationProvider.getProperty(ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR)).thenReturn("0.5");
+    defaultCacheProvider =
+        new DefaultCacheProvider(cacheBuilderProvider, environment, dhisConfigurationProvider);
+
+  }
+
+  private void registerCache(Region region, Runnable cacheCreator) {
+    when(cacheBuilder.getRegion()).thenReturn(region.name());
+    when(cacheBuilder.forRegion(any())).thenReturn(cacheBuilder);
+    when(cacheBuilder.expireAfterWrite(anyLong(),any())).thenReturn(cacheBuilder);
+    when(cacheBuilder.withMaximumSize(anyLong())).thenReturn(cacheBuilder);
+    when(cacheBuilderProvider.newCacheBuilder()).thenReturn(cacheBuilder);
+    when(cacheBuilder.build()).thenReturn(mockCache);
+    cacheCreator.run();
+  }
+
+  @Test
+  void testInvalidateSpecificKey() {
+
+    registerCache(Region.isDataApproved, ()-> defaultCacheProvider.createIsDataApprovedCache());
+    String key = "specificKeyInRegionToInvalidate";
+    CacheInvalidationEvent event =
+        new CacheInvalidationEvent(this, Region.isDataApproved, key);
+
+    defaultCacheProvider.handleCacheInvalidationEvent(event);
+
+    verify(mockCache).invalidate(key);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void testInvalidateAllKeysInRegion() {
+    when(cacheBuilder.withInitialCapacity(anyInt())).thenReturn(cacheBuilder);
+    registerCache(Region.canDataWriteCocCache, ()-> defaultCacheProvider.createCanDataWriteCocCache());
+
+    CacheInvalidationEvent event = new CacheInvalidationEvent(this, Region.canDataWriteCocCache);
+
+    defaultCacheProvider.handleCacheInvalidationEvent(event);
+
+    verify(mockCache).invalidateAll();
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void testInvalidateUncachedRegion() {
+    CacheInvalidationEvent event =
+        new CacheInvalidationEvent(this, Region.canDataWriteCocCache);
+
+    defaultCacheProvider.handleCacheInvalidationEvent(event);
+
+    verifyNoInteractions(mockCache);
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.cache;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -37,16 +64,16 @@ public class DefaultCacheProviderTest {
   @BeforeEach
   public void setUp() {
     environment.setActiveProfiles("nonTestProfile");
-    when(dhisConfigurationProvider.getProperty(ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR)).thenReturn("0.5");
+    when(dhisConfigurationProvider.getProperty(ConfigurationKey.SYSTEM_CACHE_MAX_SIZE_FACTOR))
+        .thenReturn("0.5");
     defaultCacheProvider =
         new DefaultCacheProvider(cacheBuilderProvider, environment, dhisConfigurationProvider);
-
   }
 
   private void registerCache(Region region, Runnable cacheCreator) {
     when(cacheBuilder.getRegion()).thenReturn(region.name());
     when(cacheBuilder.forRegion(any())).thenReturn(cacheBuilder);
-    when(cacheBuilder.expireAfterWrite(anyLong(),any())).thenReturn(cacheBuilder);
+    when(cacheBuilder.expireAfterWrite(anyLong(), any())).thenReturn(cacheBuilder);
     when(cacheBuilder.withMaximumSize(anyLong())).thenReturn(cacheBuilder);
     when(cacheBuilderProvider.newCacheBuilder()).thenReturn(cacheBuilder);
     when(cacheBuilder.build()).thenReturn(mockCache);
@@ -56,10 +83,9 @@ public class DefaultCacheProviderTest {
   @Test
   void testInvalidateSpecificKey() {
 
-    registerCache(Region.isDataApproved, ()-> defaultCacheProvider.createIsDataApprovedCache());
+    registerCache(Region.isDataApproved, () -> defaultCacheProvider.createIsDataApprovedCache());
     String key = "specificKeyInRegionToInvalidate";
-    CacheInvalidationEvent event =
-        new CacheInvalidationEvent(this, Region.isDataApproved, key);
+    CacheInvalidationEvent event = new CacheInvalidationEvent(this, Region.isDataApproved, key);
 
     defaultCacheProvider.handleCacheInvalidationEvent(event);
 
@@ -70,7 +96,8 @@ public class DefaultCacheProviderTest {
   @Test
   void testInvalidateAllKeysInRegion() {
     when(cacheBuilder.withInitialCapacity(anyInt())).thenReturn(cacheBuilder);
-    registerCache(Region.canDataWriteCocCache, ()-> defaultCacheProvider.createCanDataWriteCocCache());
+    registerCache(
+        Region.canDataWriteCocCache, () -> defaultCacheProvider.createCanDataWriteCocCache());
 
     CacheInvalidationEvent event = new CacheInvalidationEvent(this, Region.canDataWriteCocCache);
 
@@ -82,8 +109,7 @@ public class DefaultCacheProviderTest {
 
   @Test
   void testInvalidateUncachedRegion() {
-    CacheInvalidationEvent event =
-        new CacheInvalidationEvent(this, Region.canDataWriteCocCache);
+    CacheInvalidationEvent event = new CacheInvalidationEvent(this, Region.canDataWriteCocCache);
 
     defaultCacheProvider.handleCacheInvalidationEvent(event);
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/DefaultCacheProviderTest.java
@@ -47,7 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 @ExtendWith(MockitoExtension.class)
-public class DefaultCacheProviderTest {
+class DefaultCacheProviderTest {
 
   @Mock private DhisConfigurationProvider dhisConfigurationProvider;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -115,7 +115,7 @@ public class SharingController {
 
   @Autowired private EntityManager entityManager;
 
-  @Autowired private  ApplicationEventPublisher eventPublisher;
+  @Autowired private ApplicationEventPublisher eventPublisher;
 
   // -------------------------------------------------------------------------
   // Resources

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -50,6 +51,8 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
+import org.hisp.dhis.common.cache.Region;
+import org.hisp.dhis.common.event.CacheInvalidationEvent;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -76,6 +79,7 @@ import org.hisp.dhis.webapi.webdomain.sharing.SharingUserAccess;
 import org.hisp.dhis.webapi.webdomain.sharing.SharingUserGroupAccess;
 import org.hisp.dhis.webapi.webdomain.sharing.comparator.SharingUserGroupAccessNameComparator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -110,6 +114,8 @@ public class SharingController {
   @Autowired private SchemaService schemaService;
 
   @Autowired private EntityManager entityManager;
+
+  @Autowired private  ApplicationEventPublisher eventPublisher;
 
   // -------------------------------------------------------------------------
   // Resources
@@ -344,6 +350,8 @@ public class SharingController {
           (Visualization) object,
           sharing.getObject().getUserAccesses(),
           sharing.getObject().getUserGroupAccesses());
+    } else if (object instanceof CategoryOption) {
+      eventPublisher.publishEvent(new CacheInvalidationEvent(this, Region.canDataWriteCocCache));
     }
 
     return ok("Access control set");


### PR DESCRIPTION
- Added a new Publishable event object ( `CacheInvalidationEvent extends ApplicationEvent` ) which can be used to publish event to invalidate either specific cache regions completely or a specific key in that cache region.
- Added a new listener method in `DefaultCacheProvider` that listens to  `CacheInvalidationEvent`'s and invalidates cache regions (or specific key in that region)
- Moved the `Region` enum from dhis-support-system into dhis-api as it would need to be used across modules to be able to publish a cache invalidation event. 
- Cleaned up unused methods from `DefaultCacheProvider` and corresponding cache `Region` enums 
- Published a CacheInvalidationEvent for the Region.canDataWriteCocCache whenever Sharing settings are updated for any CategoryOption (this would fix [this issue](https://dhis2.atlassian.net/browse/DHIS2-9912) in v42). But the intention is to  serve an example to solve cache staleness issue using the new event and listener.
- Added some basic unit tests on the listener side. 
- Refrained from adding Integration tests involving both publisher and listener. As that might be flaky due to listener's eventually consistent nature and forcing the use some amount of sleeps to get around it.

