### PR TITLE
feat: Implement sorting on event change logs [DHIS2-18012]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -133,9 +133,9 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   public void addPropertyChangeLog(
       @Nonnull Event currentEvent, @Nonnull Event event, @Nonnull String username) {
     logIfChanged(
-        "occurredDate", Event::getOccurredDate, this::formatDate, currentEvent, event, username);
+        "occurredAt", Event::getOccurredDate, this::formatDate, currentEvent, event, username);
     logIfChanged(
-        "scheduledDate", Event::getScheduledDate, this::formatDate, currentEvent, event, username);
+        "scheduledAt", Event::getScheduledDate, this::formatDate, currentEvent, event, username);
     logIfChanged(
         "geometry", Event::getGeometry, this::formatGeometry, currentEvent, event, username);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,7 +47,7 @@ public class EventChangeLogOperationParams {
     // does not support. The repeated order field and private order method prevent access to order
     // via the builder.
     // Order should be added via the orderBy builder methods.
-    private EventChangeLogOperationParamsBuilder order(List<Order> order) {
+    private EventChangeLogOperationParamsBuilder order(Order order) {
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -44,8 +44,6 @@ public class EventChangeLogOperationParams {
 
   public static class EventChangeLogOperationParamsBuilder {
 
-    private Order order;
-
     // Do not remove this unused method. This hides the order field from the builder which Lombok
     // does not support. The repeated order field and private order method prevent access to order
     // via the builder.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,11 +40,11 @@ import org.hisp.dhis.tracker.export.Order;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EventChangeLogOperationParams {
 
-  private List<Order> order;
+  private Order order;
 
   public static class EventChangeLogOperationParamsBuilder {
 
-    private final List<Order> order = new ArrayList<>();
+    private Order order;
 
     // Do not remove this unused method. This hides the order field from the builder which Lombok
     // does not support. The repeated order field and private order method prevent access to order
@@ -56,7 +55,7 @@ public class EventChangeLogOperationParams {
     }
 
     public EventChangeLogOperationParamsBuilder orderBy(String field, SortDirection direction) {
-      this.order.add(new Order(field, direction));
+      this.order = new Order(field, direction);
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -169,7 +169,7 @@ public class HibernateEventChangeLogStore {
     entityManager.createQuery(hql).setParameter("event", event).executeUpdate();
   }
 
-  private String sortExpressions(Order order) {
+  private static String sortExpressions(Order order) {
     if (order == null) {
       return DEFAULT_ORDER;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -35,6 +35,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.hibernate.Session;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.SortDirection;
@@ -81,7 +83,8 @@ public class HibernateEventChangeLogStore {
     entityManager.unwrap(Session.class).save(eventChangeLog);
   }
 
-  public Page<EventChangeLog> getEventChangeLogs(UID event, Order order, PageParams pageParams) {
+  public Page<EventChangeLog> getEventChangeLogs(
+      @Nonnull UID event, @Nullable Order order, @Nonnull PageParams pageParams) {
 
     String hql =
         String.format(
@@ -166,7 +169,7 @@ public class HibernateEventChangeLogStore {
     entityManager.createQuery(hql).setParameter("event", event).executeUpdate();
   }
 
-  private static String sortExpressions(Order order) {
+  private String sortExpressions(Order order) {
     if (order == null) {
       return DEFAULT_ORDER;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -61,9 +61,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 class EventChangeLogServiceTest extends TrackerTest {
 
   @Autowired private EventChangeLogService eventChangeLogService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -316,18 +316,15 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(
             UID.of(event), defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledDateLogs = getChangeLogsByProperty(changeLogs, "scheduledDate");
-    List<EventChangeLog> occurredDateLogs = getChangeLogsByProperty(changeLogs, "occurredDate");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
 
-    assertNumberOfChanges(1, scheduledDateLogs);
-    assertNumberOfChanges(1, occurredDateLogs);
+    assertNumberOfChanges(1, scheduledAtLogs);
+    assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
         () ->
-            assertPropertyCreate(
-                "scheduledDate", "2022-04-22 06:00:38.343", scheduledDateLogs.get(0)),
-        () ->
-            assertPropertyCreate(
-                "occurredDate", "2022-04-20 06:00:38.343", occurredDateLogs.get(0)));
+            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
   }
 
   @Test
@@ -340,30 +337,27 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledDateLogs = getChangeLogsByProperty(changeLogs, "scheduledDate");
-    List<EventChangeLog> occurredDateLogs = getChangeLogsByProperty(changeLogs, "occurredDate");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
 
-    assertNumberOfChanges(2, scheduledDateLogs);
-    assertNumberOfChanges(2, occurredDateLogs);
+    assertNumberOfChanges(2, scheduledAtLogs);
+    assertNumberOfChanges(2, occurredAtLogs);
     assertAll(
         () ->
             assertPropertyUpdate(
-                "scheduledDate",
+                "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
-                scheduledDateLogs.get(0)),
+                scheduledAtLogs.get(0)),
         () ->
-            assertPropertyCreate(
-                "scheduledDate", "2022-04-22 06:00:38.343", scheduledDateLogs.get(1)),
+            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
         () ->
             assertPropertyUpdate(
-                "occurredDate",
+                "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
-                occurredDateLogs.get(0)),
-        () ->
-            assertPropertyCreate(
-                "occurredDate", "2022-04-20 06:00:38.343", occurredDateLogs.get(1)));
+                occurredAtLogs.get(0)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(1)));
   }
 
   @Test
@@ -375,21 +369,17 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledDateLogs = getChangeLogsByProperty(changeLogs, "scheduledDate");
-    List<EventChangeLog> occurredDateLogs = getChangeLogsByProperty(changeLogs, "occurredDate");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
 
-    assertNumberOfChanges(2, scheduledDateLogs);
-    assertNumberOfChanges(1, occurredDateLogs);
+    assertNumberOfChanges(2, scheduledAtLogs);
+    assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
         () ->
-            assertPropertyDelete(
-                "scheduledDate", "2022-04-22 06:00:38.343", scheduledDateLogs.get(0)),
+            assertPropertyDelete("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
         () ->
-            assertPropertyCreate(
-                "scheduledDate", "2022-04-22 06:00:38.343", scheduledDateLogs.get(1)),
-        () ->
-            assertPropertyCreate(
-                "occurredDate", "2022-04-20 06:00:38.343", occurredDateLogs.get(0)));
+            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
   }
 
   @Test
@@ -638,18 +628,18 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(0)),
         () ->
             assertPropertyUpdate(
-                "occurredDate",
+                "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(1)),
-        () -> assertPropertyCreate("occurredDate", "2022-04-20 06:00:38.343", changeLogs.get(2)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(2)),
         () ->
             assertPropertyUpdate(
-                "scheduledDate",
+                "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(3)),
-        () -> assertPropertyCreate("scheduledDate", "2022-04-22 06:00:38.343", changeLogs.get(4)));
+        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(4)));
   }
 
   @Test
@@ -672,18 +662,18 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
     assertAll(
         () ->
             assertPropertyUpdate(
-                "scheduledDate",
+                "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(0)),
-        () -> assertPropertyCreate("scheduledDate", "2022-04-22 06:00:38.343", changeLogs.get(1)),
+        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),
         () ->
             assertPropertyUpdate(
-                "occurredDate",
+                "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(2)),
-        () -> assertPropertyCreate("occurredDate", "2022-04-20 06:00:38.343", changeLogs.get(3)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(3)),
         () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(4)));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderEventChangeLogTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.event;
+
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.Page;
+import org.hisp.dhis.tracker.export.PageParams;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.user.User;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class OrderEventChangeLogTest extends TrackerTest {
+
+  @Autowired private EventChangeLogService eventChangeLogService;
+
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  private User importUser;
+
+  private TrackerImportParams importParams;
+
+  private final PageParams defaultPageParams = new PageParams(null, null, false);
+
+  private final DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  private TrackerObjects trackerObjects;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    injectSecurityContextUser(getAdminUser());
+    setUpMetadata("tracker/simple_metadata.json");
+
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
+
+    importParams = TrackerImportParams.builder().build();
+    trackerObjects = fromJson("tracker/event_and_enrollment.json");
+
+    assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
+  }
+
+  private static Stream<Arguments> provideDateAndUsernameOrderParams() {
+    return Stream.of(
+        Arguments.of("createdAt", SortDirection.DESC),
+        Arguments.of("username", SortDirection.DESC),
+        Arguments.of("username", SortDirection.ASC));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideDateAndUsernameOrderParams")
+  void shouldSortChangeLogsByCreatedAtDescWhenOrderingByDateOrUsername(
+      String field, SortDirection sortDirection) throws ForbiddenException, NotFoundException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy(field, sortDirection).build();
+    Event event = getEvent("QRYjLTiJTrA");
+    String dataElementUid = getFirstDataElement(event);
+
+    updateDataValues(event, dataElementUid, "20", "25");
+
+    List<EventChangeLog> changeLogs =
+        getDataElementChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("QRYjLTiJTrA"), params, defaultPageParams));
+
+    assertNumberOfChanges(3, changeLogs);
+    assertAll(
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(0)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(1)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(2)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByCreatedAtAsc()
+      throws ForbiddenException, NotFoundException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("createdAt", SortDirection.ASC).build();
+
+    Event event = getEvent("QRYjLTiJTrA");
+    String dataElementUid = getFirstDataElement(event);
+
+    updateDataValues(event, dataElementUid, "20", "25");
+
+    List<EventChangeLog> changeLogs =
+        getDataElementChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("QRYjLTiJTrA"), params, defaultPageParams));
+
+    assertNumberOfChanges(3, changeLogs);
+    assertAll(
+        () -> assertDataElementCreate(dataElementUid, "15", changeLogs.get(0)),
+        () -> assertDataElementUpdate(dataElementUid, "15", "20", changeLogs.get(1)),
+        () -> assertDataElementUpdate(dataElementUid, "20", "25", changeLogs.get(2)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByDataElementAsc()
+      throws ForbiddenException, NotFoundException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("dataElement", SortDirection.ASC).build();
+    Event event = getEvent("kWjSezkXHVp");
+
+    updateDataValues(event, "GieVkTxp4HH", "20", "25");
+    updateDataValues(event, "GieVkTxp4HG", "20");
+
+    List<EventChangeLog> changeLogs =
+        getDataElementChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("kWjSezkXHVp"), params, defaultPageParams));
+
+    assertNumberOfChanges(5, changeLogs);
+    assertAll(
+        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(0)),
+        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(1)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(2)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(3)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(4)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByDataElementDesc()
+      throws ForbiddenException, NotFoundException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("dataElement", SortDirection.DESC).build();
+    Event event = getEvent("kWjSezkXHVp");
+
+    updateDataValues(event, "GieVkTxp4HH", "20", "25");
+    updateDataValues(event, "GieVkTxp4HG", "20");
+
+    List<EventChangeLog> changeLogs =
+        getDataElementChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("kWjSezkXHVp"), params, defaultPageParams));
+
+    assertNumberOfChanges(5, changeLogs);
+    assertAll(
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(0)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(1)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(2)),
+        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(3)),
+        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(4)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByPropertyAsc()
+      throws ForbiddenException, NotFoundException, IOException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("property", SortDirection.ASC).build();
+    UID event = UID.of("QRYjLTiJTrA");
+
+    LocalDateTime currentTime = LocalDateTime.now();
+    updateEventDates(event, currentTime.toDate().toInstant());
+
+    List<EventChangeLog> changeLogs =
+        getAllPropertyChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("QRYjLTiJTrA"), params, defaultPageParams));
+
+    assertNumberOfChanges(5, changeLogs);
+    assertAll(
+        () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(0)),
+        () ->
+            assertPropertyUpdate(
+                "occurredAt",
+                "2022-04-20 06:00:38.343",
+                currentTime.toString(formatter),
+                changeLogs.get(1)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(2)),
+        () ->
+            assertPropertyUpdate(
+                "scheduledAt",
+                "2022-04-22 06:00:38.343",
+                currentTime.toString(formatter),
+                changeLogs.get(3)),
+        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(4)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByPropertyDesc()
+      throws ForbiddenException, NotFoundException, IOException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("property", SortDirection.DESC).build();
+    UID event = UID.of("QRYjLTiJTrA");
+
+    LocalDateTime currentTime = LocalDateTime.now();
+    updateEventDates(event, currentTime.toDate().toInstant());
+
+    List<EventChangeLog> changeLogs =
+        getAllPropertyChangeLogs(
+            eventChangeLogService.getEventChangeLog(
+                UID.of("QRYjLTiJTrA"), params, defaultPageParams));
+
+    assertNumberOfChanges(5, changeLogs);
+    assertAll(
+        () ->
+            assertPropertyUpdate(
+                "scheduledAt",
+                "2022-04-22 06:00:38.343",
+                currentTime.toString(formatter),
+                changeLogs.get(0)),
+        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),
+        () ->
+            assertPropertyUpdate(
+                "occurredAt",
+                "2022-04-20 06:00:38.343",
+                currentTime.toString(formatter),
+                changeLogs.get(2)),
+        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(3)),
+        () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(4)));
+  }
+
+  private void updateDataValue(String event, String dataElementUid, String newValue) {
+    trackerObjects.getEvents().stream()
+        .filter(e -> e.getEvent().getValue().equalsIgnoreCase(event))
+        .findFirst()
+        .flatMap(
+            e ->
+                e.getDataValues().stream()
+                    .filter(
+                        dv -> dv.getDataElement().getIdentifier().equalsIgnoreCase(dataElementUid))
+                    .findFirst())
+        .ifPresent(dv -> dv.setValue(newValue));
+    assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
+  }
+
+  private void updateEventDates(UID event, Instant newDate) throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
+    trackerObjects.getEvents().stream()
+        .filter(e -> e.getEvent().equals(event))
+        .findFirst()
+        .ifPresent(
+            e -> {
+              e.setOccurredAt(newDate);
+              e.setScheduledAt(newDate);
+            });
+    assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
+  }
+
+  private Event getEvent(String uid) {
+    Event event = manager.get(Event.class, uid);
+    assertNotNull(event);
+    return event;
+  }
+
+  private static void assertNumberOfChanges(int expected, List<EventChangeLog> changeLogs) {
+    assertNotNull(changeLogs);
+    assertEquals(
+        expected,
+        changeLogs.size(),
+        String.format(
+            "Expected to find %s elements in the event change log list, found %s instead: %s",
+            expected, changeLogs.size(), changeLogs));
+  }
+
+  private void assertDataElementCreate(
+      String dataElement, String currentValue, EventChangeLog changeLog) {
+    assertAll(
+        () -> assertUser(importUser, changeLog),
+        () -> assertEquals("CREATE", changeLog.getChangeLogType().name()),
+        () -> assertDataElementChange(dataElement, null, currentValue, changeLog));
+  }
+
+  private void assertPropertyCreate(
+      String property, String currentValue, EventChangeLog changeLog) {
+    assertAll(
+        () -> assertUser(importUser, changeLog),
+        () -> assertEquals("CREATE", changeLog.getChangeLogType().name()),
+        () -> assertPropertyChange(property, null, currentValue, changeLog));
+  }
+
+  private void assertDataElementUpdate(
+      String dataElement, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertUpdate(dataElement, null, previousValue, currentValue, changeLog, importUser);
+  }
+
+  private void assertPropertyUpdate(
+      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertUpdate(null, property, previousValue, currentValue, changeLog, importUser);
+  }
+
+  private void assertUpdate(
+      String dataElement,
+      String property,
+      String previousValue,
+      String currentValue,
+      EventChangeLog changeLog,
+      User user) {
+    assertAll(
+        () -> assertUser(user, changeLog),
+        () -> assertEquals("UPDATE", changeLog.getChangeLogType().name()),
+        () -> {
+          if (dataElement != null) {
+            assertDataElementChange(dataElement, previousValue, currentValue, changeLog);
+          } else {
+            assertPropertyChange(property, previousValue, currentValue, changeLog);
+          }
+        });
+  }
+
+  private static void assertDataElementChange(
+      String dataElement, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertEquals(
+        dataElement,
+        changeLog.getDataElement() != null ? changeLog.getDataElement().getUid() : null);
+    assertEquals(previousValue, changeLog.getPreviousValue());
+    assertEquals(currentValue, changeLog.getCurrentValue());
+  }
+
+  private static void assertPropertyChange(
+      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertEquals(property, changeLog.getEventProperty());
+    assertEquals(previousValue, changeLog.getPreviousValue());
+    assertEquals(currentValue, changeLog.getCurrentValue());
+  }
+
+  private static void assertUser(User user, EventChangeLog changeLog) {
+    assertAll(
+        () -> assertEquals(user.getUsername(), changeLog.getCreatedBy().getUsername()),
+        () ->
+            assertEquals(
+                user.getFirstName(),
+                changeLog.getCreatedBy() == null ? null : changeLog.getCreatedBy().getFirstName()),
+        () ->
+            assertEquals(
+                user.getSurname(),
+                changeLog.getCreatedBy() == null ? null : changeLog.getCreatedBy().getSurname()),
+        () ->
+            assertEquals(
+                user.getUid(),
+                changeLog.getCreatedBy() == null ? null : changeLog.getCreatedBy().getUid()));
+  }
+
+  private List<EventChangeLog> getDataElementChangeLogs(Page<EventChangeLog> changeLogs) {
+    return changeLogs.getItems().stream().filter(cl -> cl.getDataElement() != null).toList();
+  }
+
+  private List<EventChangeLog> getAllPropertyChangeLogs(Page<EventChangeLog> changeLogs) {
+    return changeLogs.getItems().stream().filter(cl -> cl.getEventProperty() != null).toList();
+  }
+
+  private void updateDataValues(Event event, String dataElementUid, String... values) {
+    for (String value : values) {
+      updateDataValue(event.getUid(), dataElementUid, value);
+    }
+  }
+
+  private String getFirstDataElement(Event event) {
+    return event.getEventDataValues().iterator().next().getDataElement();
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderEventChangeLogTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class OrderEventChangeLogTest extends TrackerTest {
+class OrderEventChangeLogTest extends TrackerTest {
 
   @Autowired private EventChangeLogService eventChangeLogService;
 

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -883,7 +883,6 @@
       "deleted": false,
       "dataValues": [
         {
-          "created": "2022-04-22T06:00:34.319",
           "dataElement": {
             "idScheme": "UID",
             "identifier": "GieVkTxp4HH"
@@ -892,7 +891,6 @@
           "providedElsewhere": false
         },
         {
-          "created": "2022-04-22T06:00:38.339",
           "dataElement": {
             "idScheme": "UID",
             "identifier": "GieVkTxp4HG"

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -888,7 +888,16 @@
             "idScheme": "UID",
             "identifier": "GieVkTxp4HH"
           },
-          "value": "14",
+          "value": "15",
+          "providedElsewhere": false
+        },
+        {
+          "created": "2022-04-22T06:00:38.339",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HG"
+          },
+          "value": "10",
           "providedElsewhere": false
         }
       ],

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -188,10 +188,10 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         () -> assertUpdate(dataElement, "value 1", "value 2", dataValueChangeLogs.get(2)),
         () ->
             assertPropertyCreateExists(
-                "occurredDate", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
+                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
         () ->
             assertPropertyCreateExists(
-                "scheduledDate", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+                "scheduledAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
   }
 
   @Test
@@ -217,10 +217,10 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         () -> assertDelete(dataElement, "value 3", dataValueChangeLogs.get(2)),
         () ->
             assertPropertyCreateExists(
-                "occurredDate", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
+                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
         () ->
             assertPropertyCreateExists(
-                "scheduledDate", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+                "scheduledAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
   }
 
   @Test


### PR DESCRIPTION
This PR introduces sorting change logs by creation date, username, data element, or event property.

Unlike other endpoints, this one allows sorting by only one element at a time. If the chosen element is not the creation date, a secondary sort will be applied by creation date to ensure the change logs are presented in a timely order.