### PR TITLE
chore: highlight default category option (combo) in idScheme error DHIS2-14968

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.ErrorCodeException;
 import org.hisp.dhis.common.UID;
@@ -216,14 +217,44 @@ public final class Assertions {
   }
 
   /**
+   * Asserts that the given string is not null and has a non-zero length.
+   *
+   * @param actual the string.
+   * @param messageSupplier fails with this supplied message
+   */
+  public static void assertNotEmpty(String actual, Supplier<String> messageSupplier) {
+    assertNotNull(actual, messageSupplier);
+    assertTrue(!actual.isEmpty(), messageSupplier);
+  }
+
+  /**
+   * Asserts that the given character sequence is NOT contained within the actual string.
+   *
+   * @param expected expected character sequence not to be contained within the actual string
+   * @param actual actual string which should not contain the expected character sequence
+   */
+  public static void assertNotContains(CharSequence expected, String actual) {
+    assertNotEmpty(
+        actual,
+        () ->
+            String.format(
+                "expected actual NOT to contain '%s', use assertIsEmpty if that is what you expect",
+                expected));
+    assertFalse(
+        actual.contains(expected),
+        () ->
+            String.format(
+                "expected actual NOT to contain '%s', got '%s' instead", expected, actual));
+  }
+
+  /**
    * Asserts that the given character sequence is contained within the actual string.
    *
    * @param expected expected character sequence to be contained within the actual string
    * @param actual actual string which should contain the expected character sequence
    */
   public static void assertContains(CharSequence expected, String actual) {
-    assertNotNull(
-        actual, () -> String.format("expected actual to contain '%s', got null instead", expected));
+    assertNotEmpty(actual, () -> String.format("expected actual to contain '%s'", expected));
     assertTrue(
         actual.contains(expected),
         () -> String.format("expected actual to contain '%s', got '%s' instead", expected, actual));

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrorsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrorsTest.java
@@ -28,11 +28,15 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.hisp.dhis.test.utils.Assertions.assertNotContains;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
@@ -77,6 +81,10 @@ class MappingErrorsTest {
 
     assertAll(
         () ->
+            assertNotContains(
+                "default category option (combo)s cannot be exported using idScheme=ATTRIBUTE",
+                errors.toString()),
+        () ->
             assertContains(
                 "Following metadata listed using their UIDs is missing identifiers for the"
                     + " requested idScheme:",
@@ -90,5 +98,72 @@ class MappingErrorsTest {
         () -> assertContains("DataElement[NAME]=", errors.toString()),
         () -> assertContains(dataElement1.getUid(), errors.toString()),
         () -> assertContains(dataElement2.getUid(), errors.toString()));
+  }
+
+  @Test
+  void shouldReportDefaultCategoryOptionComboCannotBeExortedUsingIdSchemAttribute() {
+    CategoryOptionCombo defaultCategoryOptionCombo = new CategoryOptionCombo();
+    defaultCategoryOptionCombo.setName(CategoryOptionCombo.DEFAULT_NAME);
+    defaultCategoryOptionCombo.setUid(CodeGenerator.generateUid());
+    CategoryCombo defaultCategoryCombo = new CategoryCombo();
+    defaultCategoryCombo.setName(CategoryOptionCombo.DEFAULT_NAME);
+    defaultCategoryOptionCombo.setCategoryCombo(defaultCategoryCombo);
+    assertTrue(
+        defaultCategoryOptionCombo.isDefault(),
+        "this test needs the CategoryOptionCombo to be the default one");
+
+    TrackerIdSchemeParams idSchemeParams =
+        TrackerIdSchemeParams.builder()
+            .categoryOptionComboIdScheme(TrackerIdSchemeParam.ofAttribute("i4a244a8341"))
+            .build();
+
+    MappingErrors errors = new MappingErrors(idSchemeParams);
+
+    errors.add(defaultCategoryOptionCombo);
+
+    assertTrue(errors.hasErrors());
+    assertAll(
+        () ->
+            assertContains(
+                "CategoryOptionCombo[ATTRIBUTE:i4a244a8341]="
+                    + defaultCategoryOptionCombo.getUid()
+                    + "(default)",
+                errors.toString()),
+        () ->
+            assertContains(
+                "default category option (combo)s cannot be exported using idScheme=ATTRIBUTE",
+                errors.toString()));
+  }
+
+  @Test
+  void shouldReportDefaultCategoryOptionCannotBeExortedUsingIdSchemAttribute() {
+    CategoryOption defaultCategoryOption = new CategoryOption();
+    defaultCategoryOption.setName(CategoryOption.DEFAULT_NAME);
+    defaultCategoryOption.setUid(CodeGenerator.generateUid());
+    assertTrue(
+        defaultCategoryOption.isDefault(),
+        "this test needs the CategoryOption to be the default one");
+
+    TrackerIdSchemeParams idSchemeParams =
+        TrackerIdSchemeParams.builder()
+            .categoryOptionIdScheme(TrackerIdSchemeParam.ofAttribute("i4a244a8341"))
+            .build();
+
+    MappingErrors errors = new MappingErrors(idSchemeParams);
+
+    errors.add(defaultCategoryOption);
+
+    assertTrue(errors.hasErrors());
+    assertAll(
+        () ->
+            assertContains(
+                "CategoryOption[ATTRIBUTE:i4a244a8341]="
+                    + defaultCategoryOption.getUid()
+                    + "(default)",
+                errors.toString()),
+        () ->
+            assertContains(
+                "default category option (combo)s cannot be exported using idScheme=ATTRIBUTE",
+                errors.toString()));
   }
 }


### PR DESCRIPTION
Make it clear that default category option (combo) cannot be exported using `idScheme=ATTRIBUTE`

```sh
curl -s 'http://localhost:8080/api/tracker/events/FV4JCI73wO2?categoryOptionComboIdScheme=ATTRIBUTE:Y1LUDU8sWBR' | jq -r .devMessage
```

```sh
Following metadata listed using their UIDs is missing identifiers for the requested idScheme:

CategoryOptionCombo[ATTRIBUTE:Y1LUDU8sWBR]=HllvX50cXC0(default)

Data linked to default category option (combo)s cannot be exported using idScheme=ATTRIBUTE as they cannot have any attribute values.
```

```sh
curl -s 'http://localhost:8080/api/tracker/events/FV4JCI73wO2?categoryOptionIdScheme=ATTRIBUTE:Y1LUDU8sWBR' | jq -r .devMessage
```

```sh
Following metadata listed using their UIDs is missing identifiers for the requested idScheme:

CategoryOption[ATTRIBUTE:Y1LUDU8sWBR]=xYerKDKCefk(default)

Data linked to default category option (combo)s cannot be exported using idScheme=ATTRIBUTE as they cannot have any attribute values.

```