### PR TITLE
fix: dataElementIdScheme should not filter events DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -650,7 +650,6 @@ left join
     ) as eventdatavalue(dataelement_uid, value)
     on true
 left join dataelement de on de.uid = eventdatavalue.dataelement_uid
-where eventdatavalue.dataelement_uid is not null
 """);
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -128,6 +128,17 @@ public final class Assertions {
   }
 
   /**
+   * Asserts that the given collection is not null and empty.
+   *
+   * @param actual the collection.
+   * @param message fails with this message
+   */
+  public static void assertIsEmpty(Collection<?> actual, String message) {
+    assertNotNull(actual, message);
+    assertTrue(actual.isEmpty(), message);
+  }
+
+  /**
    * Asserts that the given collection is not null and not empty.
    *
    * @param actual the collection.

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -75,6 +76,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.tracker.JsonEvent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -149,6 +151,7 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
   @MethodSource(value = "shouldExportMetadataUsingGivenIdSchemeProvider")
   void shouldExportMetadataUsingGivenIdScheme(TrackerIdSchemeParam idSchemeParam) {
     Event event = get(Event.class, "QRYjLTiJTrA");
+    assertNotEmpty(event.getEventDataValues(), "test expects an event with data values");
 
     // maps JSON fields to idScheme request parameters
     Map<String, String> idSchemeRequestParams =
@@ -264,6 +267,19 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
             .as(JsonEvent.class);
 
     assertMetadataIdScheme(metadata, actual, idSchemeParam, "event");
+  }
+
+  @Test
+  void shouldExportEventUsingNonUIDDataElementIdSchemeEvenIfItHasNoDataValues() {
+    Event event = get(Event.class, "jxgFyJEMUPf");
+    assertIsEmpty(event.getEventDataValues(), "test expects an event with no data values");
+
+    JsonEvent actual =
+        GET("/tracker/events/{id}?fields=event,dataValues&dataElementIdScheme=NAME", event.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonEvent.class);
+
+    assertEquals("jxgFyJEMUPf", actual.getEvent());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
`dataElementIdScheme!=UID` filters out events without a data value while it should not.

I don't remember exactly at what stage I needed the `where`, maybe when I tried approach https://github.com/dhis2/dhis2-core/pull/19123.

`dataElementIdScheme` was introduced in

https://github.com/dhis2/dhis2-core/pull/19153

`dataElementIdScheme!=UID` adds a join from the JSONB dataValues keys on dataelement in the parent query. There cannot be an empty JSON key. The JSON key is a data element UID that is validated on import.