### PR TITLE
feat: Add filtering capabilities in events change log [DHIS2-18012]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
@@ -165,7 +166,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   }
 
   @Override
-  public Set<String> getFilterableFields() {
+  public Set<Pair<String, Class<?>>> getFilterableFields() {
     return hibernateEventChangeLogStore.getFilterableFields();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -69,8 +69,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
     // check existence and access
     eventService.getEvent(event);
 
-    return hibernateEventChangeLogStore.getEventChangeLogs(
-        event, operationParams.getOrder(), pageParams);
+    return hibernateEventChangeLogStore.getEventChangeLogs(event, operationParams, pageParams);
   }
 
   @Transactional
@@ -163,6 +162,11 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   @Transactional(readOnly = true)
   public Set<String> getOrderableFields() {
     return hibernateEventChangeLogStore.getOrderableFields();
+  }
+
+  @Override
+  public Set<String> getFilterableFields() {
+    return hibernateEventChangeLogStore.getFilterableFields();
   }
 
   private <T> void logIfChanged(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -27,10 +27,12 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.tracker.export.Order;
 
@@ -40,19 +42,29 @@ import org.hisp.dhis.tracker.export.Order;
 public class EventChangeLogOperationParams {
 
   private Order order;
+  private Map.Entry<String, QueryFilter> filterEntry;
 
   public static class EventChangeLogOperationParamsBuilder {
 
-    // Do not remove this unused method. This hides the order field from the builder which Lombok
-    // does not support. The repeated order field and private order method prevent access to order
-    // via the builder.
-    // Order should be added via the orderBy builder methods.
+    // Do not remove these unused methods. They hide the order and filter fields from the builder
+    // which Lombok
+    // does not support.
+    // They should be added via their respective orderBy and filterBy builder methods.
     private EventChangeLogOperationParamsBuilder order(Order order) {
+      return this;
+    }
+
+    private EventChangeLogOperationParamsBuilder filterMap(Map<String, QueryFilter> filterMap) {
       return this;
     }
 
     public EventChangeLogOperationParamsBuilder orderBy(String field, SortDirection direction) {
       this.order = new Order(field, direction);
+      return this;
+    }
+
+    public EventChangeLogOperationParamsBuilder filterBy(String field, QueryFilter filter) {
+      this.filterEntry = Map.entry(field, filter);
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -54,7 +54,7 @@ public class EventChangeLogOperationParams {
       return this;
     }
 
-    private EventChangeLogOperationParamsBuilder filterMap(Pair<String, QueryFilter> filterMap) {
+    private EventChangeLogOperationParamsBuilder filter(Pair<String, QueryFilter> filter) {
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogOperationParams.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.tracker.export.Order;
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.export.Order;
 public class EventChangeLogOperationParams {
 
   private Order order;
-  private Map.Entry<String, QueryFilter> filterEntry;
+  private Pair<String, QueryFilter> filter;
 
   public static class EventChangeLogOperationParamsBuilder {
 
@@ -54,7 +54,7 @@ public class EventChangeLogOperationParams {
       return this;
     }
 
-    private EventChangeLogOperationParamsBuilder filterMap(Map<String, QueryFilter> filterMap) {
+    private EventChangeLogOperationParamsBuilder filterMap(Pair<String, QueryFilter> filterMap) {
       return this;
     }
 
@@ -64,7 +64,7 @@ public class EventChangeLogOperationParams {
     }
 
     public EventChangeLogOperationParamsBuilder filterBy(String field, QueryFilter filter) {
-      this.filterEntry = Map.entry(field, filter);
+      this.filter = Pair.of(field, filter);
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
@@ -85,9 +85,17 @@ public interface EventChangeLogService {
 
   /**
    * Fields the {@link #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)} can order
-   * event change logs by. Ordering by fields other than these is considered a programmer error.
+   * event change logs by. Ordering by fields other than these, is considered a programmer error.
    * Validation of user provided field names should occur before calling {@link
    * #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)}.
    */
   Set<String> getOrderableFields();
+
+  /**
+   * Fields the {@link #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)} can
+   * filter event change logs by. Filtering by fields other than these, is considered a programmer
+   * error. Validation of user provided field names should occur before calling {@link
+   * #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)}.
+   */
+  Set<String> getFilterableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export.event;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
@@ -97,5 +98,5 @@ public interface EventChangeLogService {
    * error. Validation of user provided field names should occur before calling {@link
    * #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)}.
    */
-  Set<String> getFilterableFields();
+  Set<Pair<String, Class<?>>> getFilterableFields();
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -302,30 +302,18 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     assertContainsOnly(List.of(dataElement), changeLogDataElements);
   }
 
-  @Test
-  void shouldFilterChangeLogsWhenFilteringByOccurredAt()
-      throws ForbiddenException, NotFoundException {
-    EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder()
-            .filterBy("property", new QueryFilter(QueryOperator.EQ, "occurredAt"))
-            .build();
-
-    Page<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), params, defaultPageParams);
-
-    Set<String> changeLogOccurredAtProperties =
-        changeLogs.getItems().stream()
-            .map(EventChangeLog::getEventProperty)
-            .collect(Collectors.toSet());
-    assertContainsOnly(List.of("occurredAt"), changeLogOccurredAtProperties);
+  private Stream<Arguments> provideEventProperties() {
+    return Stream.of(
+        Arguments.of("occurredAt"), Arguments.of("scheduledAt"), Arguments.of("geometry"));
   }
 
-  @Test
-  void shouldFilterChangeLogsWhenFilteringByScheduledAt()
+  @ParameterizedTest
+  @MethodSource("provideEventProperties")
+  void shouldFilterChangeLogsWhenFilteringByOccurredAt(String filterValue)
       throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder()
-            .filterBy("property", new QueryFilter(QueryOperator.EQ, "scheduledAt"))
+            .filterBy("property", new QueryFilter(QueryOperator.EQ, filterValue))
             .build();
 
     Page<EventChangeLog> changeLogs =
@@ -335,25 +323,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
         changeLogs.getItems().stream()
             .map(EventChangeLog::getEventProperty)
             .collect(Collectors.toSet());
-    assertContainsOnly(List.of("scheduledAt"), changeLogOccurredAtProperties);
-  }
-
-  @Test
-  void shouldFilterChangeLogsWhenFilteringByGeometry()
-      throws ForbiddenException, NotFoundException {
-    EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder()
-            .filterBy("property", new QueryFilter(QueryOperator.EQ, "geometry"))
-            .build();
-
-    Page<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), params, defaultPageParams);
-
-    Set<String> changeLogOccurredAtProperties =
-        changeLogs.getItems().stream()
-            .map(EventChangeLog::getEventProperty)
-            .collect(Collectors.toSet());
-    assertContainsOnly(List.of("geometry"), changeLogOccurredAtProperties);
+    assertContainsOnly(List.of(filterValue), changeLogOccurredAtProperties);
   }
 
   private void updateDataValue(String event, String dataElementUid, String newValue) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -309,7 +309,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
 
   @ParameterizedTest
   @MethodSource("provideEventProperties")
-  void shouldFilterChangeLogsWhenFilteringByOccurredAt(String filterValue)
+  void shouldFilterChangeLogsWhenFilteringByProperties(String filterValue)
       throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder()

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -224,6 +224,24 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
   }
 
   @Test
+  void shouldGetEventChangeLogsWhenFilteringByProperty() {
+    JsonList<JsonEventChangeLog> changeLogs =
+        GET("/tracker/events/{id}/changeLogs?filter=property:eq:occurredAt", event.getUid())
+            .content(HttpStatus.OK)
+            .getList("changeLogs", JsonEventChangeLog.class);
+    List<JsonEventChangeLog> eventPropertyChangeLogs =
+        changeLogs.stream()
+            .filter(log -> log.getChange().getEventProperty().getProperty() != null)
+            .toList();
+
+    assertAll(
+        () -> assertHasSize(1, eventPropertyChangeLogs),
+        () ->
+            assertPropertyCreateExists(
+                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+  }
+
+  @Test
   void shouldGetChangeLogPagerWithNextElementWhenMultipleElementsImportedAndFirstPageRequested() {
     JsonPage changeLogs =
         GET(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
@@ -51,4 +51,6 @@ public class ChangeLogRequestParams implements FieldsRequestParam {
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 
   private List<OrderCriteria> order = new ArrayList<>();
+
+  private String filter;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -48,6 +48,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
@@ -278,24 +279,28 @@ public class RequestParamsValidator {
    * values are {@code supportedFieldNames}. Only one field name at a time can be specified. If the
    * endpoint supports UIDs use {@link #parseFilters(String)}.
    */
-  public static void validateFilter(String filter, Set<String> supportedFieldNames)
+  public static void validateFilter(String filter, Set<Pair<String, Class<?>>> supportedFields)
       throws BadRequestException {
     if (filter == null) {
       return;
     }
 
     String[] split = filter.split(":");
+    Set<String> supportedFieldNames =
+        supportedFields.stream().map(Pair::getKey).collect(Collectors.toSet());
 
     if (split.length != 3) {
       throw new BadRequestException(
-          "Invalid filter => %s. Expected format is [field]:eq:[value]." + filter);
+          String.format(
+              "Invalid filter => %s. Expected format is [field]:eq:[value]. Supported fields are '%s'. Only one of them can be specified at a time",
+              filter, String.join(", ", supportedFieldNames)));
     }
 
     if (!supportedFieldNames.contains(split[0])) {
       throw new BadRequestException(
           String.format(
               "Invalid filter field. Supported fields are '%s'. Only one of them can be specified at a time",
-              String.join(", ", supportedFieldNames.stream().sorted().toList())));
+              String.join(", ", supportedFieldNames)));
     }
 
     if (!split[1].equalsIgnoreCase(SUPPORTED_CHANGELOG_FILTER_OPERATOR)) {
@@ -303,6 +308,17 @@ public class RequestParamsValidator {
           String.format(
               "Invalid filter operator. The only supported operator is '%s'.",
               SUPPORTED_CHANGELOG_FILTER_OPERATOR));
+    }
+
+    for (Pair<String, Class<?>> filterField : supportedFields) {
+      if (filterField.getKey().equalsIgnoreCase(split[0])
+          && filterField.getValue() == UID.class
+          && !CodeGenerator.isValidUid(filterField.getKey())) {
+        throw new BadRequestException(
+            String.format(
+                "Incorrect filter value provided as UID: %s. UID must be an alphanumeric string of 11 characters starting with a letter.",
+                split[2]));
+      }
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParamsMapper.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValida
 
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -55,7 +56,7 @@ class ChangeLogRequestParamsMapper {
    */
   static EventChangeLogOperationParams map(
       Set<String> orderableFields,
-      Set<String> filterableFields,
+      Set<Pair<String, Class<?>>> filterableFields,
       ChangeLogRequestParams requestParams)
       throws BadRequestException {
     validatePaginationBounds(requestParams.getPage(), requestParams.getPageSize());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParamsMapper.java
@@ -27,11 +27,14 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateFilter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationBounds;
 
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.event.EventChangeLogOperationParams;
 import org.hisp.dhis.tracker.export.event.EventChangeLogOperationParams.EventChangeLogOperationParamsBuilder;
@@ -51,13 +54,17 @@ class ChangeLogRequestParamsMapper {
    * done in {@link EventMapper} is not necessary for change logs.
    */
   static EventChangeLogOperationParams map(
-      Set<String> orderableFields, ChangeLogRequestParams requestParams)
+      Set<String> orderableFields,
+      Set<String> filterableFields,
+      ChangeLogRequestParams requestParams)
       throws BadRequestException {
     validatePaginationBounds(requestParams.getPage(), requestParams.getPageSize());
     validateOrderParams(requestParams.getOrder(), orderableFields);
+    validateFilter(requestParams.getFilter(), filterableFields);
 
     EventChangeLogOperationParamsBuilder builder = EventChangeLogOperationParams.builder();
     mapOrderParam(builder, requestParams.getOrder());
+    mapFilterParam(builder, requestParams.getFilter());
     return builder.build();
   }
 
@@ -68,5 +75,12 @@ class ChangeLogRequestParamsMapper {
     }
 
     orders.forEach(order -> builder.orderBy(order.getField(), order.getDirection()));
+  }
+
+  private static void mapFilterParam(EventChangeLogOperationParamsBuilder builder, String filter) {
+    if (filter != null) {
+      String[] split = filter.split(":");
+      builder.filterBy(split[0], new QueryFilter(QueryOperator.EQ, split[2]));
+    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -370,7 +370,10 @@ class EventsExportController {
       HttpServletRequest request)
       throws NotFoundException, BadRequestException, ForbiddenException {
     EventChangeLogOperationParams operationParams =
-        ChangeLogRequestParamsMapper.map(eventChangeLogService.getOrderableFields(), requestParams);
+        ChangeLogRequestParamsMapper.map(
+            eventChangeLogService.getOrderableFields(),
+            eventChangeLogService.getFilterableFields(),
+            requestParams);
     PageParams pageParams =
         new PageParams(requestParams.getPage(), requestParams.getPageSize(), false);
 


### PR DESCRIPTION
This PR introduces filtering for change logs. These filters differ slightly from the ones we currently use:

- They accept only one field at a time.
- They support only the equals operator.
- Filtering is limited to username, data element, or property.

Another key difference is that while our current filters are [UID based](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java#L112), these new filters are string based.

Although the only supported operator is `eq`, I’ve retained the filter format [field]:[operator]:[filter] used in other endpoints. This way, if we need to support additional operators in the future, it won’t require a breaking change.

`validateFilter(String, Set<String>)` is used only for event change logs, but it will be used for attributes as soon as we refactor those change logs, that's why I added it to `RequestParamsValidator`

Note: ACL validation for data elements is not yet implemented. I will address this in a separate ticket once we decide how data sharing validation on data elements should be handled.