### PR TITLE
fix: not apply identifiable token filter to uid length < 4

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
@@ -61,7 +61,9 @@ public class TokenOperator<T extends Comparable<? super T>> extends Operator<T> 
   @Override
   public <Y> Predicate getPredicate(CriteriaBuilder builder, Root<Y> root, QueryPath queryPath) {
     String value = caseSensitive ? getValue(String.class) : getValue(String.class).toLowerCase();
-
+    if (skipUidToken(value, queryPath)) {
+      return null;
+    }
     Predicate defaultSearch =
         builder.equal(
             builder.function(
@@ -93,5 +95,16 @@ public class TokenOperator<T extends Comparable<? super T>> extends Operator<T> 
   @Override
   public boolean test(Object value) {
     return TokenUtils.test(value, getValue(String.class), caseSensitive, matchMode);
+  }
+
+  /**
+   * Return
+   *
+   * @param value
+   * @param query
+   * @return
+   */
+  private boolean skipUidToken(String value, QueryPath query) {
+    return "uid".equals(query.getProperty().getFieldName()) && value.length() < 4;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/TokenOperatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/TokenOperatorTest.java
@@ -28,11 +28,15 @@
 package org.hisp.dhis.query;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.query.operators.MatchMode;
 import org.hisp.dhis.query.operators.NotTokenOperator;
 import org.hisp.dhis.query.operators.TokenOperator;
+import org.hisp.dhis.query.planner.QueryPath;
+import org.hisp.dhis.schema.Property;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,6 +46,16 @@ import org.junit.jupiter.api.Test;
  * @author Jan Bernitt
  */
 class TokenOperatorTest {
+
+  @Test
+  @DisplayName("Uid Token filter must have at least 4 characters. Otherwise return null.")
+  void testUidLength() {
+    TokenOperator operator = new TokenOperator("ABC", false, MatchMode.ANYWHERE);
+    Property property = new Property();
+    property.setFieldName("uid");
+    QueryPath queryPath = new QueryPath(property, true);
+    assertNull(operator.getPredicate(null, null, queryPath));
+  }
 
   @Test
   void nullValue() {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17098

### Issue
- `identifiable:token:aaa` check for `name`, `code` and `uid`.
- If the token value is too short, it might be contained by a `uid` which isn't what user wants.

### Fix
- Add a check to skip `uid` filter if token value is < 4

### Test
- Added unit test
- Manual test by send GET to [api/dataElements?fields=:identifiable&filter=identifiable:token:ER](https://debug.dhis2.org/2.40dev/api/dataElements?fields=:identifiable&filter=identifiable:token:ER)