### PR TITLE
fix: Fix Date Validation to Fail for Future Enrollment Dates (Including Tomorrow)[DHIS2-15683]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/DateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/DateValidator.java
@@ -36,7 +36,7 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1025;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1052;
 
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Objects;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
@@ -84,13 +84,13 @@ class DateValidator implements Validator<Enrollment> {
     final LocalDate now = LocalDate.now();
     if (Objects.nonNull(enrollment.getEnrolledAt())
         && Boolean.FALSE.equals(program.getSelectEnrollmentDatesInFuture())
-        && enrollment.getEnrolledAt().atOffset(ZoneOffset.UTC).toLocalDate().isAfter(now)) {
+        && enrollment.getEnrolledAt().atZone(ZoneId.systemDefault()).toLocalDate().isAfter(now)) {
       reporter.addError(enrollment, E1020, enrollment.getEnrolledAt());
     }
 
     if (Objects.nonNull(enrollment.getOccurredAt())
         && Boolean.FALSE.equals(program.getSelectIncidentDatesInFuture())
-        && enrollment.getOccurredAt().atOffset(ZoneOffset.UTC).toLocalDate().isAfter(now)) {
+        && enrollment.getOccurredAt().atZone(ZoneId.systemDefault()).toLocalDate().isAfter(now)) {
       reporter.addError(enrollment, E1021, enrollment.getOccurredAt());
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/DateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/DateValidatorTest.java
@@ -103,7 +103,7 @@ class DateValidatorTest {
 
   @Test
   void testDatesMustNotBeInTheFuture() {
-    final Instant dateInTheFuture = now().plus(Duration.ofDays(2));
+    final Instant dateInTheFuture = now().plus(Duration.ofDays(1));
     Enrollment enrollment =
         Enrollment.builder()
             .enrollment(UID.generate())
@@ -122,8 +122,7 @@ class DateValidatorTest {
   }
 
   @Test
-  void testDatesMustNotBeInTheFuture1() {
-    // Get "tomorrow" based on the system's default time zone
+  void testDatesWithNoTimeZoneMustNotBeInTheFuture() {
     ZoneId systemZone = ZoneId.systemDefault();
     LocalDate tomorrow = LocalDate.now(systemZone).plusDays(1);
     Instant dateTomorrow = tomorrow.atStartOfDay(systemZone).toInstant();
@@ -137,11 +136,7 @@ class DateValidatorTest {
             .enrolledAt(dateTomorrow)
             .build();
 
-    // Mock a program that does not allow future enrollment/incident dates
-    Program program = new Program();
-    program.setSelectEnrollmentDatesInFuture(false);
-    program.setSelectIncidentDatesInFuture(false);
-    when(preheat.getProgram(enrollment.getProgram())).thenReturn(program);
+    when(preheat.getProgram(enrollment.getProgram())).thenReturn(new Program());
 
     // Run validation
     validator.validate(reporter, bundle, enrollment);


### PR DESCRIPTION
This PR addresses an issue where enrollment dates (`enrolledAt` and `occurredAt`) set to **tomorrow** were not correctly identified as future dates during validation. The validation logic has been updated to ensure that:

### **Changes**:

-   **Date Validator**: The validator now uses the server’s local time zone (`ZoneId.systemDefault()`) to compare enrollment dates, preventing discrepancies caused by UTC assumptions.
-   **Test Update**: Adjusted the test to verify that dates set to tomorrow are correctly identified as future dates and trigger validation errors.