### PR TITLE
chore: add explicit dependency:analyze-only after unit tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
       - name: Run dependency analysis
-        run: mvn dependency:analyze-only --file ./dhis-2/pom.xml
+        run: mvn dependency:analyze --file ./dhis-2/pom.xml
         timeout-minutes: 2
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run unit tests
         run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
+      - name: Run dependency analysis
+        run: mvn dependency:analyze-only --file ./dhis-2/pom.xml
+        timeout-minutes: 2
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
My noob attempt to add a extra step after the junit test run to check maven dependencies. 