### PR TITLE
fix: /events?dataElementIdScheme!=UID for shared data elements DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -536,7 +536,8 @@ class JdbcEventStore {
       case CODE:
         return resultSet.getString("de_code");
       case NAME:
-        return resultSet.getString("de_name");
+        return resultSet.getString("de_uid");
+      // return resultSet.getString("de_name");
       case ATTRIBUTE:
         String attributeValuesString = resultSet.getString("de_attributevalues");
         if (StringUtils.isEmpty(attributeValuesString)) {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -66,6 +66,19 @@ public final class Assertions {
    * @param actual the actual collection.
    */
   public static <E> void assertContainsOnly(Collection<E> expected, Collection<E> actual) {
+    assertContainsOnly(expected, actual, "assertContainsOnly found mismatch");
+  }
+
+  /**
+   * Asserts that the given collection contains exactly the given items in any order.
+   *
+   * @param <E> the type.
+   * @param expected the expected items.
+   * @param actual the actual collection.
+   * @param heading the assertAll heading
+   */
+  public static <E> void assertContainsOnly(
+      Collection<E> expected, Collection<E> actual, String heading) {
     assertNotNull(
         actual,
         () -> String.format("Expected collection to contain %s, got null instead", expected));
@@ -73,7 +86,7 @@ public final class Assertions {
     List<E> missing = CollectionUtils.difference(expected, actual);
     List<E> extra = CollectionUtils.difference(actual, expected);
     assertAll(
-        "assertContainsOnly found mismatch",
+        heading,
         () ->
             assertTrue(
                 missing.isEmpty(), () -> String.format("Expected %s to be in %s", missing, actual)),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Stream;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
@@ -57,8 +58,10 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.render.RenderFormat;
@@ -282,6 +285,35 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
     assertEquals("jxgFyJEMUPf", actual.getEvent());
   }
 
+  @Test
+  void shouldExportEventsUsingNonUIDDataElementIdScheme() {
+    Event event1 = get(Event.class, "QRYjLTiJTrA");
+    Event event2 = get(Event.class, "kWjSezkXHVp");
+    assertNotEmpty(
+        CollectionUtils.intersection(
+            event1.getEventDataValues().stream()
+                .map(EventDataValue::getDataElement)
+                .collect(Collectors.toSet()),
+            event2.getEventDataValues().stream()
+                .map(EventDataValue::getDataElement)
+                .collect(Collectors.toSet())),
+        "test expects both events to have at least one data value for the same data element");
+
+    JsonList<JsonEvent> jsonEvents =
+        GET("/tracker/events?events=QRYjLTiJTrA,kWjSezkXHVp&fields=event,dataValues&dataElementIdScheme=NAME")
+            .content(HttpStatus.OK)
+            .getList("events", JsonEvent.class);
+
+    Map<String, JsonEvent> events =
+        jsonEvents.stream().collect(Collectors.toMap(JsonEvent::getEvent, Function.identity()));
+    assertContainsOnly(List.of(event1.getUid(), event2.getUid()), events.keySet());
+
+    TrackerIdSchemeParam idSchemeParam = TrackerIdSchemeParam.NAME;
+    assertAll(
+        () -> assertDataValues(events.get("QRYjLTiJTrA"), event1, idSchemeParam),
+        () -> assertDataValues(events.get("kWjSezkXHVp"), event2, idSchemeParam));
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"/{id}?", "?events={id}&paging=true&", "?events={id}&paging=false&"})
   void shouldReportMetadataWhichDoesNotHaveAnIdentifierForGivenIdScheme(String urlPortion) {
@@ -348,6 +380,35 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
             String.format(
                 "field \"%s\" does not have required idScheme '%s' in response",
                 field, idSchemeParam));
+  }
+
+  private void assertDataValues(
+      JsonEvent actual, Event expected, TrackerIdSchemeParam idSchemeParam) {
+    String field = "dataValues";
+    List<String> expectedDataElement =
+        expected.getEventDataValues().stream()
+            .map(dv -> idSchemeParam.getIdentifier(get(DataElement.class, dv.getDataElement())))
+            .toList();
+    assertNotEmpty(
+        expectedDataElement,
+        String.format(
+            "metadata corresponding to field \"%s\" has no value in test data for"
+                + " idScheme '%s'",
+            field, idSchemeParam));
+    assertTrue(
+        actual.has(field),
+        () ->
+            String.format(
+                "field \"%s\" is not in response %s for idScheme '%s'",
+                field, actual, idSchemeParam));
+    List<String> actualDataElement =
+        actual
+            .getList(field, JsonObject.class)
+            .toList(el -> el.getString("dataElement").string(""));
+    assertContainsOnly(
+        expectedDataElement,
+        actualDataElement,
+        "mismatch in data elements of event " + expected.getUid());
   }
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {


### PR DESCRIPTION
added in https://github.com/dhis2/dhis2-core/pull/19153

The issue was that if two events like `blZxytttTqq` and `ehxNi0D67uQ` in the SL DB have `dataValues` for the same data element only one of the events would be exported with that dataValue/element.

Example DB `eventdatavalues` JSONB column for `blZxytttTqq` and `ehxNi0D67uQ`

```json
{
  "D7m8vpzxHDJ": {
    "value": "P+"
  },
  "HmkXnHJxcD1": {
    "value": "Relapse"
  }
}
```


```json
{
  "D7m8vpzxHDJ": {
    "value": "PE"
  },
  "HmkXnHJxcD1": {
    "value": "Relapse"
  }
}
```

I made the mistake of assuming I can aggregate event `dataValues` like we do notes in the `ResultSetExtractor` of the `JdbcEventStore`. 

https://github.com/dhis2/dhis2-core/blob/34c2cff315fe04208c9241cf7dd0175ab8ac7be6/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L290

That works for notes as they are kept in the set using their note uids which are unique across events. For `dataValues/Elements` we obviously need a `Set` scoped per event as multiple events can have a value for the same data element 🤦🏻 .