### PR TITLE
Tracked Entity Analytics table population fixes for Doris (DHIS2-16705)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
@@ -27,18 +27,31 @@
  */
 package org.hisp.dhis.analytics.config;
 
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableManager;
 import org.hisp.dhis.analytics.AnalyticsTableService;
+import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.DefaultAnalyticsTableService;
+import org.hisp.dhis.analytics.table.JdbcTrackedEntityEventsAnalyticsTableManager;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilderProvider;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilderProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.system.database.DatabaseInfoProvider;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * @author Luciano Fiandesio
@@ -48,6 +61,46 @@ public class ServiceConfig {
   @Bean
   public SqlBuilder sqlBuilder(SqlBuilderProvider provider) {
     return provider.getSqlBuilder();
+  }
+
+  @Bean
+  public AnalyticsSqlBuilder analyticsSqlBuilder(AnalyticsSqlBuilderProvider provider) {
+    return provider.getAnalyticsSqlBuilder();
+  }
+
+  @Bean("org.hisp.dhis.analytics.TrackedEntityEventsAnalyticsTableManager")
+  public AnalyticsTableManager jdbcTrackedEntityEventsAnalyticsTableManager(
+      IdentifiableObjectManager idObjectManager,
+      OrganisationUnitService organisationUnitService,
+      CategoryService categoryService,
+      SystemSettingsProvider settingsProvider,
+      DataApprovalLevelService dataApprovalLevelService,
+      ResourceTableService resourceTableService,
+      AnalyticsTableHookService tableHookService,
+      PartitionManager partitionManager,
+      DatabaseInfoProvider databaseInfoProvider,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
+      TrackedEntityTypeService trackedEntityTypeService,
+      AnalyticsTableSettings analyticsTableSettings,
+      PeriodDataProvider periodDataProvider,
+      SqlBuilder sqlBuilder,
+      AnalyticsSqlBuilder analyticsSqlBuilder) {
+    return new JdbcTrackedEntityEventsAnalyticsTableManager(
+        idObjectManager,
+        organisationUnitService,
+        categoryService,
+        settingsProvider,
+        dataApprovalLevelService,
+        resourceTableService,
+        tableHookService,
+        partitionManager,
+        databaseInfoProvider,
+        jdbcTemplate,
+        trackedEntityTypeService,
+        analyticsTableSettings,
+        periodDataProvider,
+        sqlBuilder,
+        analyticsSqlBuilder);
   }
 
   @Bean("org.hisp.dhis.analytics.TrackedEntityAnalyticsTableService")

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -32,9 +32,7 @@ import static org.hisp.dhis.analytics.table.util.PartitionUtils.getEndDate;
 import static org.hisp.dhis.analytics.table.util.PartitionUtils.getStartDate;
 import static org.hisp.dhis.commons.util.TextUtils.format;
 import static org.hisp.dhis.db.model.DataType.CHARACTER_11;
-import static org.hisp.dhis.db.model.DataType.INTEGER;
 import static org.hisp.dhis.db.model.DataType.TEXT;
-import static org.hisp.dhis.db.model.constraint.Nullable.NOT_NULL;
 import static org.hisp.dhis.util.DateUtils.toLongDate;
 
 import java.util.Collection;
@@ -738,24 +736,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
     variableNames.forEach(name -> map.putIfAbsent(name, qualify(name)));
 
     return TextUtils.replace(template, map);
-  }
-
-  protected AnalyticsTableColumn getPartitionColumn() {
-    return AnalyticsTableColumn.builder()
-        .name("year")
-        .dataType(INTEGER)
-        .nullable(NOT_NULL)
-        // The expression should use sqlBuilder, but the concept of functions (like YEAR)
-        // is part of the previous PR (https://github.com/dhis2/dhis2-core/pull/19131/files)
-        .selectExpression(
-            """
-            CASE
-                WHEN ev.status = 'SCHEDULE' THEN YEAR(ev.scheduleddate)
-                ELSE YEAR(ev.occurreddate)
-            END
-            """)
-        .skipIndex(Skip.SKIP)
-        .build();
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -460,7 +460,6 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
     return filterDimensionColumns(columns);
   }
 
-  @Override
   protected AnalyticsTableColumn getPartitionColumn() {
     return AnalyticsTableColumn.builder()
         .name("year")

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -223,9 +223,6 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
             .toList());
 
     columns.addAll(getOrganisationUnitGroupSetColumns());
-    if (sqlBuilder.supportsDeclarativePartitioning()) {
-      columns.add(getPartitionColumn());
-    }
 
     return columns;
   }
@@ -279,7 +276,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
           " cast(${columnName} as ${type})",
           Map.of("columnName", columnName, "type", sqlBuilder.dataTypeTimestamp()));
     }
-    if (valueType.isGeo() && isSpatialSupport()) {
+    if (valueType.isGeo() && isSpatialSupport() && sqlBuilder.supportsGeospatialData()) {
       return replace(
           """
           \s ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (${columnName}) || ',

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.model.AnalyticsTable;
 import org.hisp.dhis.analytics.table.model.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
+import org.hisp.dhis.analytics.table.model.Skip;
 import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -114,24 +115,6 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
               .name("enrollmentstatus")
               .dataType(VARCHAR_50)
               .selectExpression("en.status")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("enrollmentgeometry")
-              .dataType(GEOMETRY)
-              .selectExpression("en.geometry")
-              .indexType(IndexType.GIST)
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("enrollmentlongitude")
-              .dataType(DOUBLE)
-              .selectExpression(
-                  "case when 'POINT' = GeometryType(en.geometry) then ST_X(en.geometry) end")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("enrollmentlatitude")
-              .dataType(DOUBLE)
-              .selectExpression(
-                  "case when 'POINT' = GeometryType(en.geometry) then ST_Y(en.geometry) end")
               .build(),
           AnalyticsTableColumn.builder()
               .name("uidlevel1")
@@ -243,7 +226,7 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
 
   private List<AnalyticsTableColumn> getColumns() {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
-    columns.addAll(FIXED_COLS);
+    columns.addAll(getFixedCols());
     columns.add(getOrganisationUnitNameHierarchyColumn());
     if (sqlBuilder.supportsDeclarativePartitioning()) {
       columns.add(getPartitionColumn());
@@ -290,7 +273,7 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
                 and te.lastupdated < '${startTime}' \
                 left join ${program} p on en.programid=p.programid \
                 left join analytics_rs_orgunitstructure ous on en.organisationunitid=ous.organisationunitid \
-                where exists (select 1 from event ev where ev.deleted = false \
+                where exists (select 1 from ${event} ev where ev.deleted = false \
                 and ev.enrollmentid = en.enrollmentid \
                 and ev.status in (${statuses})) \
                 and en.occurreddate is not null \
@@ -302,5 +285,47 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
                     "statuses", join(",", EXPORTABLE_EVENT_STATUSES))));
 
     invokeTimeAndLog(sql.toString(), "Populating table: '{}'", tableName);
+  }
+
+  private List<AnalyticsTableColumn> getFixedCols() {
+    List<AnalyticsTableColumn> columns = new ArrayList<>();
+    columns.addAll(FIXED_COLS);
+    if (sqlBuilder.supportsGeospatialData()) {
+      columns.addAll(getGeospatialCols());
+    }
+    return columns;
+  }
+
+  private List<AnalyticsTableColumn> getGeospatialCols() {
+
+    return List.of(
+        AnalyticsTableColumn.builder()
+            .name("enrollmentgeometry")
+            .dataType(GEOMETRY)
+            .selectExpression("en.geometry")
+            .indexType(IndexType.GIST)
+            .build(),
+        AnalyticsTableColumn.builder()
+            .name("enrollmentlongitude")
+            .dataType(DOUBLE)
+            .selectExpression(
+                "case when 'POINT' = GeometryType(en.geometry) then ST_X(en.geometry) end")
+            .build(),
+        AnalyticsTableColumn.builder()
+            .name("enrollmentlatitude")
+            .dataType(DOUBLE)
+            .selectExpression(
+                "case when 'POINT' = GeometryType(en.geometry) then ST_Y(en.geometry) end")
+            .build());
+  }
+
+  private AnalyticsTableColumn getPartitionColumn() {
+    return AnalyticsTableColumn.builder()
+        .name("year")
+        .dataType(INTEGER)
+        .nullable(NOT_NULL)
+        .selectExpression("extract(year from en.occurreddate)")
+        .skipIndex(Skip.SKIP)
+        .build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
@@ -71,6 +71,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.db.model.IndexType;
 import org.hisp.dhis.db.model.Logged;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
@@ -82,10 +83,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component("org.hisp.dhis.analytics.TrackedEntityEventsAnalyticsTableManager")
 public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTableManager {
 
   private static final List<AnalyticsTableColumn> FIXED_COLS =
@@ -197,6 +196,7 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
   private static final String AND = " and (";
 
   private final TrackedEntityTypeService trackedEntityTypeService;
+  private final AnalyticsSqlBuilder analyticsSqlBuilder;
 
   public JdbcTrackedEntityEventsAnalyticsTableManager(
       IdentifiableObjectManager idObjectManager,
@@ -212,7 +212,8 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
-      SqlBuilder sqlBuilder) {
+      SqlBuilder sqlBuilder,
+      AnalyticsSqlBuilder analyticsSqlBuilder) {
     super(
         idObjectManager,
         organisationUnitService,
@@ -228,6 +229,7 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
         periodDataProvider,
         sqlBuilder);
     this.trackedEntityTypeService = trackedEntityTypeService;
+    this.analyticsSqlBuilder = analyticsSqlBuilder;
   }
 
   /**
@@ -288,7 +290,7 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
     return AnalyticsTableColumn.builder()
         .name("eventdatavalues")
         .dataType(JSONB)
-        .selectExpression("ev.eventdatavalues")
+        .selectExpression(analyticsSqlBuilder.getEventDataValues())
         .skipIndex(Skip.SKIP)
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+/**
+ * Interface for resolving specific SQL queries for analytics, that requires custom logic that can't
+ * be resolved by the default <code>SqlBuilder</code> implementations.
+ */
+public interface AnalyticsSqlBuilder {
+  /**
+   * Returns the correct SQL based on the underlying database for fetching the event data values.
+   *
+   * @return a SQL snippet.
+   */
+  String getEventDataValues();
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilderProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilderProvider.java
@@ -61,9 +61,6 @@ public class AnalyticsSqlBuilderProvider {
    */
   private AnalyticsSqlBuilder getSqlBuilder(AnalyticsTableSettings config) {
     Database database = config.getAnalyticsDatabase();
-    String catalog = config.getAnalyticsDatabaseCatalog();
-    String driverFilename = config.getAnalyticsDatabaseDriverFilename();
-
     Objects.requireNonNull(database);
 
     return switch (database) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilderProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilderProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+import java.util.Objects;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.db.model.Database;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.stereotype.Service;
+
+/** Provider of {@link AnalyticsSqlBuilder} implementations. */
+@Service
+public class AnalyticsSqlBuilderProvider {
+  private final AnalyticsSqlBuilder analyticsSqlBuilder;
+
+  public AnalyticsSqlBuilderProvider(AnalyticsTableSettings config) {
+    Objects.requireNonNull(config);
+    this.analyticsSqlBuilder = getSqlBuilder(config);
+  }
+
+  /**
+   * Returns a {@link AnalyticsSqlBuilder} implementation based on the system configuration.
+   *
+   * @return a {@link AnalyticsSqlBuilder}.
+   */
+  public AnalyticsSqlBuilder getAnalyticsSqlBuilder() {
+    return analyticsSqlBuilder;
+  }
+
+  /**
+   * Returns the appropriate {@link AnalyticsSqlBuilder} implementation based on the system
+   * configuration.
+   *
+   * @param config the {@link DhisConfigurationProvider}.
+   * @return a {@link AnalyticsSqlBuilder}.
+   */
+  private AnalyticsSqlBuilder getSqlBuilder(AnalyticsTableSettings config) {
+    Database database = config.getAnalyticsDatabase();
+    String catalog = config.getAnalyticsDatabaseCatalog();
+    String driverFilename = config.getAnalyticsDatabaseDriverFilename();
+
+    Objects.requireNonNull(database);
+
+    return switch (database) {
+      case DORIS -> new DorisAnalyticsSqlBuilder();
+      case CLICKHOUSE -> new ClickhouseAnalyticsSqlBuilder();
+      default -> new PostgresAnalyticsSqlBuilder();
+    };
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/ClickhouseAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/ClickhouseAnalyticsSqlBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+public class ClickhouseAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
+  @Override
+  public String getEventDataValues() {
+    return "ev.eventdatavalues";
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+public class DorisAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
+  @Override
+  public String getEventDataValues() {
+    return "ev.eventdatavalues";
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgresAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgresAnalyticsSqlBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+public class PostgresAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
+
+  /**
+   * Returns a subquery that expand the event datavalue jsonb with two additional fields:
+   *
+   * <ul>
+   *   <li>value_name: the name of the organisation unit that the datavalue is associated with
+   *   <li>value_code: the code of the organisation unit that the datavalue is associated with
+   * </ul>
+   *
+   * @return a SQL subquery.
+   */
+  @Override
+  public String getEventDataValues() {
+    return """
+        (select json_object_agg(l2.keys, l2.datavalue) as value
+        from (
+            select l1.uid,
+            l1.keys,
+            json_strip_nulls(json_build_object(
+            'value', l1.eventdatavalues -> l1.keys ->> 'value',
+            'created', l1.eventdatavalues -> l1.keys ->> 'created',
+            'storedBy', l1.eventdatavalues -> l1.keys ->> 'storedBy',
+            'lastUpdated', l1.eventdatavalues -> l1.keys ->> 'lastUpdated',
+            'providedElsewhere', l1.eventdatavalues -> l1.keys -> 'providedElsewhere',
+            'value_name', (select ou.name
+                from organisationunit ou
+                where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'),
+            'value_code', (select ou.code
+                from organisationunit ou
+                where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'))) as datavalue
+            from (select inner_evt.*, jsonb_object_keys(inner_evt.eventdatavalues) keys
+            from event inner_evt) as l1) as l2
+        where l2.uid = ev.uid
+        group by l2.uid)::jsonb
+        """;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
+import org.hisp.dhis.db.sql.PostgresAnalyticsSqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
@@ -78,6 +79,7 @@ class JdbcTrackedEntityEventsAnalyticsTableManagerTest {
   @Mock private AnalyticsTableSettings analyticsTableSettings;
   @Mock private PeriodDataProvider periodDataProvider;
   @Spy private PostgreSqlBuilder sqlBuilder;
+  @Spy private PostgresAnalyticsSqlBuilder analyticsSqlBuilder;
   @Mock private PartitionManager partitionManager;
   @Mock private SystemSettingsProvider systemSettingsProvider;
   @Mock private IdentifiableObjectManager identifiableObjectManager;
@@ -120,24 +122,49 @@ class JdbcTrackedEntityEventsAnalyticsTableManagerTest {
 
     tableManager.populateTable(params, partition);
 
+    String subQuery =
+        """
+                (select json_object_agg(l2.keys, l2.datavalue) as value
+                        from (
+                            select l1.uid,
+                            l1.keys,
+                            json_strip_nulls(json_build_object(
+                            'value', l1.eventdatavalues -> l1.keys ->> 'value',
+                            'created', l1.eventdatavalues -> l1.keys ->> 'created',
+                            'storedBy', l1.eventdatavalues -> l1.keys ->> 'storedBy',
+                            'lastUpdated', l1.eventdatavalues -> l1.keys ->> 'lastUpdated',
+                            'providedElsewhere', l1.eventdatavalues -> l1.keys -> 'providedElsewhere',
+                            'value_name', (select ou.name
+                                from organisationunit ou
+                                where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'),
+                            'value_code', (select ou.code
+                                from organisationunit ou
+                                where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'))) as datavalue
+                            from (select inner_evt.*, jsonb_object_keys(inner_evt.eventdatavalues) keys
+                            from event inner_evt) as l1) as l2
+                        where l2.uid = ev.uid
+                        group by l2.uid)::jsonb
+                        """;
+
     String expectedSql =
         """
-            insert into analytics_te_event_tetuid_temp ("trackedentity","program","enrollment","programstage","event","occurreddate","lastupdated","created",
-            "scheduleddate","status","uidlevel1","uidlevel2","uidlevel3","uidlevel4","ou","ouname","oucode","oulevel","eventdatavalues","eventgeometry",
-            "evlongitude","evlatitude","ounamehierarchy") select distinct te.uid,p.uid,en.uid,ps.uid,ev.uid,ev.occurreddate,ev.lastupdated,
-            ev.created,ev.scheduleddate,ev.status,ous.uidlevel1,ous.uidlevel2,ous.uidlevel3,ous.uidlevel4,ous.organisationunituid,ous.name,ous.code,ous.level,
-            ev.eventdatavalues,
-            ev.geometry,case when 'POINT' = GeometryType(ev.geometry) then ST_X(ev.geometry) end,case when 'POINT' = GeometryType(ev.geometry) then ST_Y(ev.geometry) end,concat_ws(' / ',) as ounamehierarchy
-            from "event" ev inner join "enrollment" en on en.enrollmentid=ev.enrollmentid
-            and en.deleted = false inner join "trackedentity" te on te.trackedentityid=en.trackedentityid
-            and te.deleted = false and te.trackedentitytypeid = 0
-            and te.lastupdated < '2019-08-01T00:00:00' left join "programstage" ps on ev.programstageid=ps.programstageid
-            left join "program" p on ps.programid=p.programid
-            left join analytics_rs_orgunitstructure ous on ev.organisationunitid=ous.organisationunitid
-            where ev.status in ('COMPLETED','ACTIVE','SCHEDULE')
-            and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) >= 'null'
-            and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) < 'null'
-            and ev.deleted = false""";
+                        insert into analytics_te_event_tetuid_temp ("trackedentity","program","enrollment","programstage","event","occurreddate","lastupdated","created",
+                        "scheduleddate","status","uidlevel1","uidlevel2","uidlevel3","uidlevel4","ou","ouname","oucode","oulevel","eventdatavalues","eventgeometry",
+                        "evlongitude","evlatitude","ounamehierarchy") select distinct te.uid,p.uid,en.uid,ps.uid,ev.uid,ev.occurreddate,ev.lastupdated,
+                        ev.created,ev.scheduleddate,ev.status,ous.uidlevel1,ous.uidlevel2,ous.uidlevel3,ous.uidlevel4,ous.organisationunituid,ous.name,ous.code,ous.level,
+                        %s,
+                        ev.geometry,case when 'POINT' = GeometryType(ev.geometry) then ST_X(ev.geometry) end,case when 'POINT' = GeometryType(ev.geometry) then ST_Y(ev.geometry) end,concat_ws(' / ',) as ounamehierarchy
+                        from "event" ev inner join "enrollment" en on en.enrollmentid=ev.enrollmentid
+                        and en.deleted = false inner join "trackedentity" te on te.trackedentityid=en.trackedentityid
+                        and te.deleted = false and te.trackedentitytypeid = 0
+                        and te.lastupdated < '2019-08-01T00:00:00' left join "programstage" ps on ev.programstageid=ps.programstageid
+                        left join "program" p on ps.programid=p.programid
+                        left join analytics_rs_orgunitstructure ous on ev.organisationunitid=ous.organisationunitid
+                        where ev.status in ('COMPLETED','ACTIVE','SCHEDULE')
+                        and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) >= 'null'
+                        and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) < 'null'
+                        and ev.deleted = false"""
+            .formatted(subQuery);
 
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     verify(jdbcTemplate, times(1)).execute(sqlCaptor.capture()); // verify it was called twice

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.table;
+
+import static java.time.LocalDate.now;
+import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS;
+import static org.hisp.dhis.analytics.util.SqlComparisonUtils.normalizeSql;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsTable;
+import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.system.database.DatabaseInfoProvider;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class JdbcTrackedEntityEventsAnalyticsTableManagerTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+  @Mock private AnalyticsTableSettings analyticsTableSettings;
+  @Mock private PeriodDataProvider periodDataProvider;
+  @Spy private PostgreSqlBuilder sqlBuilder;
+  @Mock private PartitionManager partitionManager;
+  @Mock private SystemSettingsProvider systemSettingsProvider;
+  @Mock private IdentifiableObjectManager identifiableObjectManager;
+  @Mock private TrackedEntityTypeService trackedEntityTypeService;
+  @Mock private TrackedEntityAttributeService trackedEntityAttributeService;
+  @Mock private CategoryService categoryService;
+  @Mock private DataApprovalLevelService dataApprovalLevelService;
+  @Mock private OrganisationUnitService organisationUnitService;
+  @Mock private ResourceTableService resourceTableService;
+  @Mock private AnalyticsTableHookService analyticsTableHookService;
+  @Mock private DatabaseInfoProvider databaseInfoProvider;
+
+  @InjectMocks private JdbcTrackedEntityEventsAnalyticsTableManager tableManager;
+
+  private static final Date START_TIME = new DateTime(2019, 8, 1, 0, 0).toDate();
+
+  @Test
+  void testTableName() {
+    assertEquals(TRACKED_ENTITY_INSTANCE_EVENTS.getTableName(), tableManager.getTableName());
+  }
+
+  @Test
+  void testPopulate() {
+
+    TrackedEntityType tet = mock(TrackedEntityType.class);
+    when(tet.getUid()).thenReturn("tetUid");
+    when(trackedEntityTypeService.getAllTrackedEntityType()).thenReturn(List.of(tet));
+
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
+
+    when(jdbcTemplate.queryForList(startsWith("select temp.supportedyear from"), any(Class.class)))
+        .thenReturn(new ArrayList<>(List.of(2018, 2019)));
+
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder().lastYears(2).startTime(START_TIME).build();
+    List<AnalyticsTable> analyticsTables = tableManager.getAnalyticsTables(params);
+    assertFalse(analyticsTables.isEmpty());
+    AnalyticsTablePartition partition = new AnalyticsTablePartition(analyticsTables.get(0));
+
+    tableManager.populateTable(params, partition);
+
+    String expectedSql =
+        """
+            insert into analytics_te_event_tetuid_temp ("trackedentity","program","enrollment","programstage","event","occurreddate","lastupdated","created",
+            "scheduleddate","status","uidlevel1","uidlevel2","uidlevel3","uidlevel4","ou","ouname","oucode","oulevel","eventdatavalues","eventgeometry",
+            "evlongitude","evlatitude","ounamehierarchy") select distinct te.uid,p.uid,en.uid,ps.uid,ev.uid,ev.occurreddate,ev.lastupdated,
+            ev.created,ev.scheduleddate,ev.status,ous.uidlevel1,ous.uidlevel2,ous.uidlevel3,ous.uidlevel4,ous.organisationunituid,ous.name,ous.code,ous.level,
+            ev.eventdatavalues,
+            ev.geometry,case when 'POINT' = GeometryType(ev.geometry) then ST_X(ev.geometry) end,case when 'POINT' = GeometryType(ev.geometry) then ST_Y(ev.geometry) end,concat_ws(' / ',) as ounamehierarchy
+            from "event" ev inner join "enrollment" en on en.enrollmentid=ev.enrollmentid
+            and en.deleted = false inner join "trackedentity" te on te.trackedentityid=en.trackedentityid
+            and te.deleted = false and te.trackedentitytypeid = 0
+            and te.lastupdated < '2019-08-01T00:00:00' left join "programstage" ps on ev.programstageid=ps.programstageid
+            left join "program" p on ps.programid=p.programid
+            left join analytics_rs_orgunitstructure ous on ev.organisationunitid=ous.organisationunitid
+            where ev.status in ('COMPLETED','ACTIVE','SCHEDULE')
+            and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) >= 'null'
+            and (CASE WHEN 'SCHEDULE' = ev.status THEN ev.scheduleddate ELSE ev.occurreddate END) < 'null'
+            and ev.deleted = false""";
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbcTemplate, times(1)).execute(sqlCaptor.capture()); // verify it was called twice
+    assertEquals(normalizeSql(expectedSql), normalizeSql(sqlCaptor.getAllValues().get(0))); // che
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.analytics.table;
 import static java.time.LocalDate.now;
 import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS;
 import static org.hisp.dhis.analytics.util.SqlComparisonUtils.normalizeSql;
-import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.hisp.dhis.period.PeriodDataProvider.PeriodSource.DATABASE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/SqlComparisonUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/SqlComparisonUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+public class SqlComparisonUtils {
+
+  /**
+   * Normalizes a SQL string by removing excess whitespace and standardizing formatting. This
+   * method:
+   *
+   * <ul>
+   *   <li>Replaces multiple spaces with a single space
+   *   <li>Removes spaces around commas, equals signs, and parentheses
+   *   <li>Converts the string to lowercase
+   *   <li>Trims leading and trailing whitespace
+   * </ul>
+   *
+   * @param sql the SQL string to normalize
+   * @return the normalized SQL string
+   */
+  public static String normalizeSql(String sql) {
+    return sql.replaceAll("\\s+", " ") // Replace multiple spaces with single space
+        .replaceAll("\\s*,\\s*", ",") // Remove spaces around commas
+        .replaceAll("\\s*=\\s*", "=") // Remove spaces around equals
+        .replaceAll("\\s*\\(\\s*", "(") // Remove spaces around parentheses
+        .replaceAll("\\s*\\)\\s*", ")")
+        .trim()
+        .toLowerCase(); // Convert to lowercase if case-insensitive comparison is desired
+  }
+}


### PR DESCRIPTION
### PR Description

Remaining fixes for Tracked Entity analytics table population for Apache Doris.

### Changes

- removed `getPartitionColumn` from `AbstractJdbcTableManager`
- add `year` partition column to `JdbcTrackedEntityAnalyticsTableManager`
- dynamic column creation for `JdbcTrackedEntityEnrollmentsAnalyticsTableManager`
- add `year` partition column to `JdbcTrackedEntityEnrollmentsAnalyticsTableManager`
- dynamic column creation for `JdbcTrackedEntityEventsAnalyticsTableManager`
- remove json subquery for `JdbcTrackedEntityEventsAnalyticsTableManager` that is used when the datatype is `ORG_UNIT` (only for Doris)
- introduce a `AnalyticsSqlBuilder` interface and implementations to deal with the cases where platform-specific SQL has to be emitted and the standard `SqlBuilder` is too "generic" to resolve it
