### PR TITLE
fix: EventDataValue mapping with idScheme!=UID DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -512,7 +512,7 @@ class JdbcEventStore {
     eventDataValue.setValue(dataValueJson.getString("value").string(""));
     eventDataValue.setProvidedElsewhere(
         dataValueJson.getBoolean("providedElsewhere").booleanValue(false));
-    eventDataValue.setStoredBy(dataValueJson.getString("storedBy").string(""));
+    eventDataValue.setStoredBy(dataValueJson.getString("storedBy").string(null));
 
     eventDataValue.setCreated(DateUtils.parseDate(dataValueJson.getString("created").string("")));
     if (dataValueJson.has("createdByUserInfo")) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,6 +49,16 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.util.DateUtils;
 
 public class JsonAssertions {
+
+  public static void assertUser(JsonUser expected, JsonUser actual, String property) {
+    assertAll(
+        property,
+        () -> assertEquals(expected.getUid(), actual.getUid(), "uid"),
+        () -> assertEquals(expected.getUsername(), actual.getUsername(), "username"),
+        () -> assertEquals(expected.getFirstName(), actual.getFirstName(), "firstName"),
+        () -> assertEquals(expected.getSurname(), actual.getSurname(), "surname"),
+        () -> assertEquals(expected.getDisplayName(), actual.getDisplayName(), "displayName"));
+  }
 
   public static JsonRelationship assertFirstRelationship(
       Relationship expected, JsonList<JsonRelationship> actual) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonDataValue.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonDataValue.java
@@ -38,4 +38,28 @@ public interface JsonDataValue extends JsonObject {
   default String getValue() {
     return getString("value").string();
   }
+
+  default String getCreatedAt() {
+    return getString("createdAt").string();
+  }
+
+  default String getUpdatedAt() {
+    return getString("updatedAt").string();
+  }
+
+  default String getStoredBy() {
+    return getString("storedBy").string();
+  }
+
+  default boolean getProvidedElsewhere() {
+    return getBoolean("providedElsewhere").bool();
+  }
+
+  default JsonUser getCreatedBy() {
+    return get("createdBy").as(JsonUser.class);
+  }
+
+  default JsonUser getUpdatedBy() {
+    return get("updatedBy").as(JsonUser.class);
+  }
 }


### PR DESCRIPTION
Event `dataValue.storedBy` is set on import

https://github.com/dhis2/dhis2-core/blob/9b6d958cd3c5c179ae95b3e2b59246b88c1d9381/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java#L229

This might not always have been the case. At least in SL DB there are `dataValues` without that property in the JSONB.

`event.eventdatavalues` being JSONB leads to a different query when `dataElementIdScheme!=UID` see  https://github.com/dhis2/dhis2-core/pull/19153. This then requires different code to aggregate the rows into the event and its `dataValues`.

I defaulted to the empty string using `dataValueJson.getString("storedBy").string("")` which meant it was exported as such. This was different than when requesting `idScheme=UID` where no `storedBy` in the DB means no `storedBy` property in the JSON. This PR aligns `dataElementIdScheme!=UID` with `dataElementIdScheme==UID`.