### PR TITLE
fix: Remove doubled api string in location header [DHIS2-12536](2.39)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -230,7 +230,7 @@ public class EnrollmentController {
         if (!importSummary.getStatus().equals(ImportStatus.ERROR)) {
           importSummaries(importSummaries)
               .setHttpStatus(HttpStatus.CREATED)
-              .setLocation("/api/" + "enrollments" + "/" + importSummary.getReference());
+              .setLocation("enrollments/" + importSummary.getReference());
         }
       }
 
@@ -277,7 +277,7 @@ public class EnrollmentController {
         if (!importSummary.getStatus().equals(ImportStatus.ERROR)) {
           importSummaries(importSummaries)
               .setHttpStatus(HttpStatus.CREATED)
-              .setLocation("/api/" + "enrollments" + "/" + importSummary.getReference());
+              .setLocation("enrollments/" + importSummary.getReference());
         }
       }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -398,7 +398,7 @@ public class TrackedEntityInstanceController {
           .setLocation(
               singleSummary == null
                   ? null
-                  : "/api/" + "trackedEntityInstances" + "/" + singleSummary.getReference());
+                  : "trackedEntityInstances/" + singleSummary.getReference());
     }
     return jobConfigurationReport(jobId).setLocation("/system/tasks/" + TEI_IMPORT);
   }


### PR DESCRIPTION
`headers.location` in old tracker importer was wrong for tracked entity and enrollment.