### PR TITLE
fix: Remove doubled api string in location header [DHIS2-12536](2.41)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentController.java
@@ -233,7 +233,7 @@ public class EnrollmentController {
         if (!importSummary.getStatus().equals(ImportStatus.ERROR)) {
           importSummaries(importSummaries)
               .setHttpStatus(HttpStatus.CREATED)
-              .setLocation("/api/" + "enrollments" + "/" + importSummary.getReference());
+              .setLocation("enrollments/" + importSummary.getReference());
         }
       }
 
@@ -280,7 +280,7 @@ public class EnrollmentController {
         if (!importSummary.getStatus().equals(ImportStatus.ERROR)) {
           importSummaries(importSummaries)
               .setHttpStatus(HttpStatus.CREATED)
-              .setLocation("/api/" + "enrollments" + "/" + importSummary.getReference());
+              .setLocation("enrollments/" + importSummary.getReference());
         }
       }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
@@ -457,7 +457,7 @@ public class TrackedEntityInstanceController {
           .setLocation(
               singleSummary == null
                   ? null
-                  : "/api/" + "trackedEntityInstances" + "/" + singleSummary.getReference());
+                  : "trackedEntityInstances/" + singleSummary.getReference());
     }
     return jobConfigurationReport(jobId);
   }


### PR DESCRIPTION
`headers.location` in old tracker importer was wrong for tracked entity and enrollment.