### PR TITLE
Fix:Data integrity check for data capture orgunits within data view orgunits

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml
@@ -31,60 +31,21 @@ section: Users
 section_order: 1
 summary_sql: >-
   WITH user_data_orgunits AS (
-      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
-      FROM organisationunit
-      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
-      WHERE path IS NOT NULL
-      GROUP BY userinfoid
+  SELECT u.userinfoid, array_agg(ou.path) AS data_orgunits_paths
+  FROM usermembership u
+  JOIN organisationunit ou ON ou.organisationunitid = u.organisationunitid
+  WHERE ou.path IS NOT NULL
+  GROUP BY userinfoid
   ),
   user_view_orgunits AS (
-      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
-      FROM organisationunit
-      JOIN userdatavieworgunits ON organisationunit.organisationunitid = userdatavieworgunits.organisationunitid
-      WHERE path IS NOT NULL
-      GROUP BY userinfoid
+  SELECT u.userinfoid, array_agg(ou.path) AS view_orgunit_paths
+  FROM userdatavieworgunits u
+  JOIN organisationunit ou ON ou.organisationunitid = u.organisationunitid
+  WHERE path IS NOT NULL
+  GROUP BY userinfoid
   ),
-  usercount as (
-      SELECT COUNT(*) as usercount FROM userinfo
-  )
-  SELECT COUNT(ui.uid) as value, 
-  100.0 * COUNT(ui.uid) / NULLIF(usercount.usercount, 0) as percent
-  FROM userinfo ui
-  INNER JOIN (
-  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
-  FROM user_data_orgunits u
-  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
-  LEFT JOIN LATERAL (
-      SELECT path AS dop
-      FROM unnest(u.data_orgunits_paths) AS path
-      WHERE NOT EXISTS (
-          SELECT 1
-          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
-          WHERE path LIKE view_path || '%'
-      )
-  ) invalid_paths ON true
-  GROUP BY u.userinfoid
-  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
-  ) x on x.userinfoid = ui.userinfoid
-  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
-  JOIN usercount on true
-  GROUP BY usercount.usercount;
-details_sql: >-
-  WITH user_data_orgunits AS (
-      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
-      FROM organisationunit 
-      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
-      WHERE organisationunit.path IS NOT NULL
-      GROUP BY userinfoid
-  ),
-  user_view_orgunits AS (
-      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
-      FROM organisationunit
-      JOIN userdatavieworgunits ON organisationunit.organisationunitid = userdatavieworgunits.organisationunitid
-      WHERE path IS NOT NULL
-      GROUP BY userinfoid
-  )
-  SELECT ui.uid, 
+  rs as (
+  SELECT ui.uid,
   ui.username as name,
   NULL as comment,
   array_agg(ou.name) as refs
@@ -94,13 +55,54 @@ details_sql: >-
   FROM user_data_orgunits u
   INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
   LEFT JOIN LATERAL (
-      SELECT path AS dop
-      FROM unnest(u.data_orgunits_paths) AS path
-      WHERE NOT EXISTS (
-          SELECT 1
-          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
-          WHERE path LIKE view_path || '%'
-      )
+  SELECT path AS dop
+  FROM unnest(u.data_orgunits_paths) AS path
+  WHERE NOT EXISTS (
+  SELECT 1
+  FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+  WHERE path LIKE view_path || '%'
+  )
+  ) invalid_paths ON true
+  GROUP BY u.userinfoid
+  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
+  ) x on x.userinfoid = ui.userinfoid
+  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
+  GROUP BY ui.uid, ui.username)
+  SELECT COUNT(*) as count, 
+     100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userinfo), 0) as percent
+        FROM rs;
+details_sql: >-
+  WITH user_data_orgunits AS (
+  SELECT u.userinfoid, array_agg(ou.path) AS data_orgunits_paths
+  FROM usermembership u
+  JOIN organisationunit ou ON ou.organisationunitid = u.organisationunitid
+  WHERE ou.path IS NOT NULL
+  GROUP BY userinfoid
+  ),
+  user_view_orgunits AS (
+  SELECT u.userinfoid, array_agg(ou.path) AS view_orgunit_paths
+  FROM userdatavieworgunits u
+  JOIN organisationunit ou ON ou.organisationunitid = u.organisationunitid
+  WHERE path IS NOT NULL
+  GROUP BY userinfoid
+  )
+  SELECT ui.uid,
+  ui.username as name,
+  NULL as comment,
+  array_agg(ou.name) as refs
+  FROM userinfo ui
+  INNER JOIN (
+  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
+  FROM user_data_orgunits u
+  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
+  LEFT JOIN LATERAL (
+  SELECT path AS dop
+  FROM unnest(u.data_orgunits_paths) AS path
+  WHERE NOT EXISTS (
+  SELECT 1
+  FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+  WHERE path LIKE view_path || '%'
+  )
   ) invalid_paths ON true
   GROUP BY u.userinfoid
   HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
@@ -110,12 +112,14 @@ details_sql: >-
 details_id_type: users
 severity: SEVERE
 introduction: >
-  Users who can enter data should be able to view their own data. This situation occurs when a user has 
-  a data capture organisation unit which is not within the data view organisation unit hierarchy.
+  Users who can enter data should be able to view their own data. This check identifies users who have
+  a data capture organisation unit which is not within  one of their data view organisation unit hierarchy.
   This can lead to a situation where a user can enter data, but cannot view the data that they have entered.
 recommendation: >
   Users should at least have access to view the data that they have entered. Using the results
   of the details SQL view, identify the affected users and the organisation units where they
   have access to enter data. The user should have at least all of their data capture organisation units
   specified in their data view organisation units. Alternatively, you can set the data view organisation units
-  to be at a higher level in the hierarchy.
+  to be at a higher level in the hierarchy. Setting the data view organisation unit to a level above the data
+    capture organisation unit will allow the user to view all data entered at the data view organisation unit
+    and below.

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.dataintegrity;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +38,6 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.test.webapi.json.domain.JsonDataIntegrityDetails;
-import org.hisp.dhis.test.webapi.json.domain.JsonUser;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -120,8 +118,8 @@ class DataIntegrityUsersCaptureOrgunitNotInDataView extends AbstractDataIntegrit
                 + "'}]}"));
 
     JsonArray users = GET("/users").content().getArray("users");
-    assertEquals( 4, users.size());
-    //1 user out of 4, thus 25% of users have data integrity issues
+    assertEquals(4, users.size());
+    // 1 user out of 4, thus 25% of users have data integrity issues
     assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 25, userBUid, "janedoe", null, true);
 
     JsonDataIntegrityDetails details = getDetails(CHECK_NAME);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
@@ -40,8 +40,8 @@ import org.hisp.dhis.test.webapi.json.domain.JsonDataIntegrityDetails;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integrity check to identify users who have a data view organisation unit, but who cannot access
- * data which they have possibly entered at a higher level of the hierarchy. {@see
+ * Integrity check to identify users who have a data view organisation unit which does not have
+ * access to their data entry organisation units. {@see
  * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml}
  *
  * @author Jason P. Pickering
@@ -116,9 +116,9 @@ class DataIntegrityUsersCaptureOrgunitNotInDataView extends AbstractDataIntegrit
                 + userRoleUid
                 + "'}]}"));
 
-    // Note that there are already two users which exist due to the overall test setup, thus, five
+    // Note that there are already two users which exist due to the overall test setup, thus, four
     // users in total. Only userB should be flagged.
-    assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 20, userBUid, "janedoe", null, true);
+    assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 25, userBUid, "janedoe", null, true);
 
     JsonDataIntegrityDetails details = getDetails(CHECK_NAME);
     JsonList<JsonDataIntegrityDetails.JsonDataIntegrityIssue> issues = details.getIssues();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.dataintegrity;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,9 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.test.webapi.json.domain.JsonDataIntegrityDetails;
+import org.hisp.dhis.test.webapi.json.domain.JsonUser;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -116,8 +119,9 @@ class DataIntegrityUsersCaptureOrgunitNotInDataView extends AbstractDataIntegrit
                 + userRoleUid
                 + "'}]}"));
 
-    // Note that there are already two users which exist due to the overall test setup, thus, four
-    // users in total. Only userB should be flagged.
+    JsonArray users = GET("/users").content().getArray("users");
+    assertEquals( 4, users.size());
+    //1 user out of 4, thus 25% of users have data integrity issues
     assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 25, userBUid, "janedoe", null, true);
 
     JsonDataIntegrityDetails details = getDetails(CHECK_NAME);


### PR DESCRIPTION
This check was intended to identify users who can enter data in certain orgunits, but which not been given the privilege to view the data in the analysis modules. The query was not working as it should and has been adjusted.