### PR TITLE
fix: [DHIS2-15272] Handle final expiring day for expiryPeriodType and expiryDays

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
@@ -115,8 +115,11 @@ class DateValidator implements Validator<Event> {
 
     if (eventPeriod
         .getEndDate()
-        .toInstant()
-        .plus(ofDays(program.getExpiryDays()))
+        .toInstant() // This will be 00:00 time of the period end date.
+        .plus(
+            ofDays(
+                program.getExpiryDays()
+                    + 1L)) // Extra day added to account for final 24 hours of expiring day
         .isBefore(Instant.now())) {
       reporter.addError(event, E1047, event);
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
@@ -237,6 +237,21 @@ class DateValidatorTest extends TestBase {
   }
 
   @Test
+  void shouldPassValidationForEventWhenDateBelongsPastEventPeriodButWithinExpiryDays() {
+    when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
+        .thenReturn(getProgramWithRegistration(7));
+    Event event = new Event();
+    event.setEvent(UID.generate());
+    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
+    event.setOccurredAt(sevenDaysAgo());
+    event.setStatus(EventStatus.ACTIVE);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
   void shouldPassValidationForEventWhenScheduledDateBelongsToFuturePeriod() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));


### PR DESCRIPTION
Additional handling for the final expiring day.

If expiryPeriodType is Monthly. And expiryPeriodDays is 10. 
For an event occured in October 20th (for example), we would want to be able to edit the event upto and including November 10th. 

Since the period end date of the event is calculated as 202X-10-31 00:00:00 and adding 10 days will take it to 202X-11-10 00:00:00. If now() is after this, we say the event is locked to edit. But this means the event will be locked during the daytime of 10th November while user expectation is to be able to edit it even during the final day (until 23:59:59). To include the final 24 hours, we add one more day to the expiry check logic.