### PR TITLE
fix: OpenAPI - object list extraction [DHIS2-17200]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.hierarchy.HierarchyViolationException;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
@@ -304,7 +305,7 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @return the count of member OrganisationUnits.
    */
   Long getOrganisationUnitHierarchyMemberCount(
-      OrganisationUnit parent, Object member, String collectionName);
+      OrganisationUnit parent, Object member, String collectionName) throws BadRequestException;
 
   OrganisationUnitDataSetAssociationSet getOrganisationUnitDataSetAssociationSet(User user);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.commons.filter.FilterUtils;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.hierarchy.HierarchyViolationException;
 import org.hisp.dhis.organisationunit.comparator.OrganisationUnitLevelComparator;
 import org.hisp.dhis.setting.UserSettings;
@@ -354,7 +355,9 @@ public class DefaultOrganisationUnitService implements OrganisationUnitService {
   @Override
   @Transactional(readOnly = true)
   public Long getOrganisationUnitHierarchyMemberCount(
-      OrganisationUnit parent, Object member, String collectionName) {
+      OrganisationUnit parent, Object member, String collectionName) throws BadRequestException {
+    if (!collectionName.matches("[a-zA-Z0-9_]{1,30}"))
+      throw new BadRequestException("Not a valid property name: " + collectionName);
     return organisationUnitStore.getOrganisationUnitHierarchyMemberCount(
         parent, member, collectionName);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectListParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectListParams.java
@@ -52,25 +52,50 @@ import org.hisp.dhis.common.OpenApi;
 @EqualsAndHashCode(callSuper = true)
 public class GetObjectListParams extends GetObjectParams {
 
+  @OpenApi.Description(
+      """
+      Filter results using `filter={property}:{operator}[:{value}]` expressions as described in detail in
+      [Metadata-object-filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_object_filter).
+    """)
   @JsonProperty("filter")
   @CheckForNull
   List<String> filters;
 
+  @OpenApi.Description(
+      """
+    Adds ordering to the result list.
+    Case-sensitive: `{property}:asc`, `{property}:desc`
+    Case-insensitive: `{property}:iasc`, `{property}:idesc`
+    Only supports properties that are both persisted and simple.
+    """)
   @JsonProperty("order")
   @CheckForNull
   List<String> orders;
 
-  @JsonProperty Junction.Type rootJunction = Junction.Type.AND;
+  @OpenApi.Description("Combine `filter`s with `AND` (default) or `OR` logic.")
+  @JsonProperty
+  Junction.Type rootJunction = Junction.Type.AND;
 
-  @JsonProperty boolean paging = true;
-  @JsonProperty int page = 1;
-  @JsonProperty int pageSize = 50;
+  @OpenApi.Description(
+      "Use paging controlled by `page` and `pageSize` or return all matches (use with caution).")
+  @JsonProperty
+  boolean paging = true;
 
-  /**
-   * A special filter that matches the query term against the ID and code (equals) and against name
-   * (contains). Can be used in combination with regular filters.
-   */
-  @JsonProperty String query;
+  @OpenApi.Description("The page number to show.")
+  @JsonProperty
+  int page = 1;
+
+  @OpenApi.Description("The maximum number of elements on a page.")
+  @JsonProperty
+  int pageSize = 50;
+
+  @OpenApi.Description(
+      """
+   Adds a filter equivalent to the following three `filter`s combined _OR_ (independent of `rootJunction`):
+   `id:eq:{query}`, `code:eq:{query}`, `name:like:{query}`. Can be used in addition to regular `filter`s.
+    """)
+  @JsonProperty
+  String query;
 
   @OpenApi.Ignore
   @CheckForNull

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectListParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectListParams.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import org.hisp.dhis.common.OpenApi;
 
 /**
  * Base for parameters supported by CRUD {@code CRUD.getObjectList}.
@@ -70,6 +71,18 @@ public class GetObjectListParams extends GetObjectParams {
    * (contains). Can be used in combination with regular filters.
    */
   @JsonProperty String query;
+
+  @OpenApi.Ignore
+  @CheckForNull
+  public List<String> getFilters() {
+    return filters;
+  }
+
+  @OpenApi.Ignore
+  @CheckForNull
+  public List<String> getOrders() {
+    return orders;
+  }
 
   @Nonnull
   @JsonIgnore

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/GetObjectParams.java
@@ -60,6 +60,11 @@ public class GetObjectParams {
    */
   private static final String FIELD_SPLIT = ",(?![^\\[\\]]*\\]|[^\\(\\)]*\\)|([a-zA-Z0-9]+,?)+\\))";
 
+  @OpenApi.Description(
+      """
+    Limit the response to specific field(s).\s
+    See [Metadata-field-filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter).
+    """)
   @OpenApi.Shared.Inline
   @OpenApi.Property(OpenApi.PropertyNames[].class)
   @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -304,6 +304,8 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
       hql += hlp.whereAnd() + " u.selfRegistered = true ";
     }
 
+    // TODO(JB) shoundn't UserInvitationStatus.NONE match "u.invitation = false" and null mean no
+    // filter at all?
     if (UserInvitationStatus.ALL.equals(params.getInvitationStatus())) {
       hql += hlp.whereAnd() + " u.invitation = true ";
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.http.HttpClientAdapter.Accept;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertGreaterOrEqual;
@@ -43,10 +44,19 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMap;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.webapi.openapi.OpenApiObject;
+import org.hisp.dhis.webapi.openapi.OpenApiObject.ParameterObject;
+import org.hisp.dhis.webapi.openapi.OpenApiObject.ResponseObject;
+import org.hisp.dhis.webapi.openapi.OpenApiObject.SchemaObject;
 import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
@@ -149,6 +159,55 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
             .findFirst()
             .orElse(JsonMixed.of("{}"));
     assertEquals(50, pageSize.getNumber("schema.default").integer());
+  }
+
+  /** Check shared parameter objects handling works */
+  @Test
+  void testGetOpenApiDocument_ParameterObjects() {
+    OpenApiObject doc =
+        GET("/openapi/openapi.json?scope=entity:OrganisationUnit")
+            .content()
+            .as(OpenApiObject.class);
+    JsonList<ParameterObject> parameters =
+        doc.$paths().get("/api/organisationUnits/").get().parameters();
+    Set<String> allRefs =
+        parameters.stream()
+            .map(p -> p.getString("$ref"))
+            .filter(JsonValue::exists)
+            .map(JsonString::string)
+            .collect(toSet());
+    // check one of each group to make sure the inheritance handling works as expected
+    assertTrue(
+        allRefs.containsAll(
+            Set.of(
+                "#/components/parameters/GetObjectListParams.filter",
+                "#/components/parameters/GetOrganisationUnitObjectListParams.level",
+                "#/components/parameters/GetObjectParams.defaults")));
+    // check "fields" is inlined (no reference) as it depend on the entity type
+    assertTrue(parameters.stream().anyMatch(p -> "fields".equals(p.getString("name").string())));
+  }
+
+  /** Tests the "generics" handling of object list response */
+  @Test
+  void testGetOpenApiDocument_GetObjectListResponse() {
+    OpenApiObject doc =
+        GET("/openapi/openapi.json?scope=entity:OrganisationUnit")
+            .content()
+            .as(OpenApiObject.class);
+    ResponseObject response =
+        doc.$paths().get("/api/organisationUnits/").get().responses().get("200");
+    JsonMap<SchemaObject> properties =
+        response.content().get("application/json").schema().properties();
+
+    assertEquals(
+        Set.of("pager", "organisationUnits"),
+        properties.keys().collect(toSet()),
+        "there should only be a pager and an entity list property");
+
+    SchemaObject listSchema = properties.get("organisationUnits");
+    assertEquals("array", listSchema.$type());
+    assertEquals(
+        "#/components/schemas/OrganisationUnit", listSchema.items().getString("$ref").string());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -505,7 +505,7 @@ public abstract class AbstractFullReadOnlyController<
     // by default: nothing special to do
   }
 
-  protected void getEntityListPostProcess(P params, List<T> entities) {}
+  protected void getEntityListPostProcess(P params, List<T> entities) throws BadRequestException {}
 
   private long countGetObjectList(P params, List<Criterion> additionalFilters)
       throws BadRequestException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -50,7 +50,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import lombok.Value;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -159,16 +158,15 @@ public abstract class AbstractFullReadOnlyController<
   // GET Full
   // --------------------------------------------------------------------------
 
-  @Value
   @OpenApi.Shared(value = false)
-  protected static class ObjectListResponse {
+  protected static class GetObjectListResponse {
     @OpenApi.Property Pager pager;
 
     @OpenApi.Property(name = "path$", value = OpenApi.EntityType[].class)
     List<Object> entries;
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping
   public @ResponseBody ResponseEntity<StreamingJsonRoot<T>> getObjectList(
       P params, HttpServletResponse response, @CurrentUser UserDetails currentUser)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -122,7 +122,12 @@ public class MessageConversationController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetMessageConversationObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        "Adds a _fuzzy_ search filter for the query term in subject, message text or sender name")
     String queryString;
+
+    @OpenApi.Description(
+        "The operator used when using the `queryString` filter (default is `token`)")
     String queryOperator;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -87,9 +87,16 @@ public class DataElementOperandController {
   @EqualsAndHashCode(callSuper = true)
   @OpenApi.Property
   public static final class GetDataElementOperandObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        "When set all existing operands are the basis of the result list (takes precedence).")
     boolean persisted;
+
+    @OpenApi.Description(
+        "Whether to include totals when loading operands by `dataSet` or data element groups from `filter`s.")
     boolean totals;
 
+    @OpenApi.Description(
+        "When set the operands linked to the specified dataset are the basis for the result list.")
     @OpenApi.Property({UID.class, DataSet.class})
     String dataSet;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -85,6 +85,7 @@ public class DataElementOperandController {
 
   @Data
   @EqualsAndHashCode(callSuper = true)
+  @OpenApi.Property
   public static final class GetDataElementOperandObjectListParams extends GetObjectListParams {
     boolean persisted;
     boolean totals;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -123,7 +123,7 @@ public class DimensionController
    * DimensionalObject} and there is no specific {@link InternalHibernateGenericStore} to retrieve
    * them from.
    */
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @Override
   @GetMapping
   public @ResponseBody ResponseEntity<StreamingJsonRoot<DimensionalObject>> getObjectList(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -77,6 +77,8 @@ public class ProgramController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static class GetProgramObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        "Limit the results to programs accessible to the current user based on data sharing read access instead of metadata sharing read access.")
     boolean userFilter;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -87,6 +87,11 @@ public class TrackedEntityAttributeController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetTrackedEntityAttributeObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        """
+      Limits the results to searchable attributes of type `TEXT`, `LONG_TEXT`, `PHONE_NUMBER`, `EMAIL`, `USERNAME`, `URL`
+      as well as unique attributes. Can be combined with further `filter`s.
+      """)
     boolean indexableOnly;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -120,6 +120,7 @@ public class OrganisationUnitController
 
   @Data
   @EqualsAndHashCode(callSuper = true)
+  @OpenApi.Property
   public static final class GetOrganisationUnitObjectListParams extends GetObjectListParams {
     @OpenApi.Property(UID.class)
     String memberObject;
@@ -146,7 +147,7 @@ public class OrganisationUnitController
     return ok("Organisation units merged");
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping(value = "/{uid}", params = "includeChildren=true")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getIncludeChildren(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -157,7 +158,7 @@ public class OrganisationUnitController
     return getChildren(uid, params, response, currentUser);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping("/{uid}/children")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getChildren(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -173,7 +174,7 @@ public class OrganisationUnitController
     return getObjectListWith(params, response, currentUser, children);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping(value = "/{uid}", params = "level")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getObjectWithLevel(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -185,7 +186,7 @@ public class OrganisationUnitController
     return getChildrenWithLevel(uid, level, params, response, currentUser);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping(value = "/{uid}/children", params = "level")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getChildrenWithLevel(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -200,7 +201,7 @@ public class OrganisationUnitController
     return getObjectListWith(params, response, currentUser, childrenWithLevel);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping(value = "/{uid}", params = "includeDescendants=true")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getIncludeDescendants(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -211,7 +212,7 @@ public class OrganisationUnitController
     return getDescendants(uid, params, response, currentUser);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping("/{uid}/descendants")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getDescendants(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -223,7 +224,7 @@ public class OrganisationUnitController
     return getObjectListWith(params, response, currentUser, List.of(descendants));
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping(value = "/{uid}", params = "includeAncestors=true")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getIncludeAncestors(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -234,7 +235,7 @@ public class OrganisationUnitController
     return getAncestors(uid, params, response, currentUser);
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping("/{uid}/ancestors")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getAncestors(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,
@@ -252,7 +253,7 @@ public class OrganisationUnitController
     return getObjectListWith(params, response, currentUser, List.of(ancestors));
   }
 
-  @OpenApi.Response(ObjectListResponse.class)
+  @OpenApi.Response(GetObjectListResponse.class)
   @GetMapping("/{uid}/parents")
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OrganisationUnit>> getParents(
       @OpenApi.Param(UID.class) @PathVariable("uid") String uid,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -126,7 +126,7 @@ public class OrganisationUnitController
     String memberObject;
 
     String memberCollection;
-    Integer parentLevel;
+    @OpenApi.Ignore Integer parentLevel;
     Integer level;
     Integer maxLevel;
     boolean withinUserHierarchy;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -152,21 +152,64 @@ public class UserController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetUserObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        "Limits results to users with the given phone number (shorthand for `filter=phoneNumber:eq:{value}`)")
     String phoneNumber;
+
+    @OpenApi.Description(
+        "Limits results to users that are members of a group the current user can manage.")
     boolean canManage;
+
+    @OpenApi.Description(
+        "Limits result to users that have no authority the current user doesn't have as well.")
     boolean authSubset;
+
+    @OpenApi.Description(
+        "Limits results to users that were logged in on or after the given date(-time) (shorthand for `filter=lastLogin:ge:{date}`).")
     Date lastLogin;
+
+    @OpenApi.Description(
+        "Limits results to users that haven't logged in for at least this number of months.")
     Integer inactiveMonths;
+
+    @OpenApi.Description(
+        "Limits results to users that haven't logged in since this date(-time) (shorthand for `filter=lastLogin:lt:{date}`).")
     Date inactiveSince;
+
+    @OpenApi.Description(
+        "Limits results to users that have self registered (shorthand for `filter=selfRegistered:eq:true`)")
     boolean selfRegistered;
+
+    @OpenApi.Description(
+        """
+      Limits results to users that with the provided invitation status
+      (`ALL` equals `filter=invitation:eq:true`, `EXPIRED` also requires the invitation to have expired by now).""")
     UserInvitationStatus invitationStatus;
+
+    @OpenApi.Description("Shorthand for `orgUnitBoundary=DATA_CAPTURE`")
     boolean userOrgUnits;
-    boolean includeChildren;
+
+    @OpenApi.Description(
+        """
+      Limits results to users that have a common organisation unit connection with the current user.
+      The `orgUnitBoundary` determines if the data capture, data view or search sets are considered.
+      When `includeChildren=true` is used the comparison includes the subtree of all units in the compared set.
+      """)
     UserOrgUnitType orgUnitBoundary;
 
+    @OpenApi.Description("See `orgUnitBoundary`")
+    boolean includeChildren;
+
+    @OpenApi.Description(
+        """
+      Limits results to users that have data capture connection to the given organisation unit.
+      The compared set can be changed using `orgUnitBoundary`.
+      """)
     @OpenApi.Property({UID.class, OrganisationUnit.class})
     String ou;
 
+    @OpenApi.Description(
+        "Shorthand for `canManage=true` + `authSubset=true` (takes precedence over individual parameters)")
     boolean manage;
 
     @JsonIgnore
@@ -192,11 +235,6 @@ public class UserController
     if (!params.isUsingAnySpecialFilters()) return null;
     UserQueryParams queryParams = toUserQueryParams(params);
 
-    String ou = params.getOu();
-    if (ou != null) {
-      queryParams.addOrganisationUnit(organisationUnitService.getOrganisationUnit(ou));
-    }
-
     if (params.isManage()) {
       queryParams.setCanManage(true);
       queryParams.setAuthSubset(true);
@@ -217,7 +255,12 @@ public class UserController
     res.setInvitationStatus(params.getInvitationStatus());
     res.setUserOrgUnits(params.isUserOrgUnits());
     res.setIncludeOrgUnitChildren(params.isIncludeChildren());
-    res.setOrgUnitBoundary(params.getOrgUnitBoundary());
+    String ou = params.getOu();
+    if (ou != null) {
+      res.addOrganisationUnit(organisationUnitService.getOrganisationUnit(ou));
+    }
+    UserOrgUnitType boundary = params.getOrgUnitBoundary();
+    if (boundary != null) res.setOrgUnitBoundary(boundary);
     return res;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -66,6 +66,11 @@ public class UserRoleController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetUserRoleObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        """
+      Limits results to those roles that the current user can issue/grant to other users.
+      Can be combined with further `filter`s.
+      """)
     boolean canIssue;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
@@ -73,6 +73,11 @@ public class ValidationRuleController
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetValidationRuleObjectListParams extends GetObjectListParams {
+    @OpenApi.Description(
+        """
+      Limits results to validation rules that are connected to the given dataset.
+      Can be combined with further `filter`s.
+      """)
     @OpenApi.Property({UID.class, DataSet.class})
     String dataSet;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
@@ -471,8 +471,8 @@ final class ApiExtractor {
       } else if (isOfSuitableParamsObjectType(p)) {
         if (isOfConstructableParamsObjectType(p.getParameterizedType())) {
           extractParams(endpoint, p.getType());
-        } else if (p.getParameterizedType() instanceof TypeVariable<?> var
-            && var.getName().equals("P")) {
+        } else if (p.getParameterizedType() instanceof TypeVariable<?> v
+            && v.getName().equals("P")) {
           // Note: this makes simplified assumptions and works using an approximation of the type
           // variable substitution
           // it only works under the assumption that the parameter is called P and is always the 2nd

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.OpenApi;
@@ -292,6 +293,7 @@ public interface OpenApiObject extends JsonObject {
       return parameters().stream()
           .map(ParameterObject::resolve)
           .map(ParameterObject::name)
+          .filter(Objects::nonNull)
           .collect(toUnmodifiableSet());
     }
 


### PR DESCRIPTION
### Summary
The CRUD `getObjectList` method has 2 major complications for the OpenAPI analysis

* it uses a type variable as parameter object
* it has a "virtual" response type that gets substituted based in the current value of `@EntityType`

Type variable parameter objects were not supported before so a simple version was added that only supports this particular case.

The response broke due to too many properties escaping the parameter type analysis as it would pick up a property from the annotated field (which was renamed) and another one from the getter (which lacked the renaming annotation and therefore wasn't ignored). Therefore the de-duplication is now based on the Java property name, not the name the property gets after considering potential renames from an annotation.

I also added OpenAPI descriptions to all special parameters.

### Shared Parameter and Inheritance
Previously there was no support for inheritance which worked but would result in each subclass repeating (duplicating) the parameter properties defined in supertypes. With the changes in this PR a shared parameter will use the declaring class simple name as the "namespace" if no explicit name is defined via `@OpenApi.Shared(name="SchemaName")`.

### Automatic Testing
Added a few new OpenAPI tests to make sure the added or fixed features keep working

### Manual Testing
* check e.g. `/api/openapi/openapi.html?scope=entity:Attribute&skipCache=true&source=true&scope=entity:OrganisationUnit#OrganisationUnit.getObjectList` , there should be plenty of parameters with description, the return type should be summarized as `<object{#,organisationUnits:array[OrganisationUnit]}>`
* check e.g. `/api/openapi/openapi.json?scope=entity:OrganisationUnit` if you know OpenAPI speak