### PR TITLE
fix: /tracker/events?dataElementIdScheme!=UID with relationships DHIS2-14968

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -609,14 +609,12 @@ class JdbcEventStore {
       PageParams pageParams,
       MapSqlParameterSource mapSqlParameterSource,
       User user) {
-    StringBuilder sqlBuilder = new StringBuilder("select ");
+    StringBuilder sqlBuilder = new StringBuilder("select *");
     if (TrackerIdScheme.UID
         != queryParams.getIdSchemeParams().getDataElementIdScheme().getIdScheme()) {
       sqlBuilder.append(
-          "event.*, cm.*,eventdatavalue.value as ev_eventdatavalue, de.uid as de_uid, de.code as"
+          ", eventdatavalue.value as ev_eventdatavalue, de.uid as de_uid, de.code as"
               + " de_code, de.name as de_name, de.attributevalues as de_attributevalues");
-    } else {
-      sqlBuilder.append("*");
     }
     sqlBuilder.append(" from (");
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -288,6 +288,21 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
   }
 
   @Test
+  void shouldExportEventUsingNonUIDDataElementIdSchemeIfItHasRelationships() {
+    Event event = get(Event.class, "pTzf9KYMk72");
+    assertNotEmpty(event.getRelationshipItems(), "test expects an event with relationships");
+
+    JsonEvent actual =
+        GET(
+                "/tracker/events/{id}?fields=event,relationships&dataElementIdScheme=NAME",
+                event.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonEvent.class);
+
+    assertEquals("pTzf9KYMk72", actual.getEvent());
+  }
+
+  @Test
   void shouldExportEventsUsingNonUIDDataElementIdScheme() {
     Event event1 = get(Event.class, "QRYjLTiJTrA");
     Event event2 = get(Event.class, "kWjSezkXHVp");


### PR DESCRIPTION
introduced in https://github.com/dhis2/dhis2-core/pull/19153

`/tracker/events?dataElementIdScheme!=UID&fields=relationships`

causes the result set mapping to fail as the relationship subquery projection is not in our parent query projection.

Remember the rough anatomy of an event query

```sql
select *
from
    (
        select
            ev.uid as ev_uid,
            ou.uid as orgunit_uid,
            ou.code as orgunit_code,
            ou.name as orgunit_name,
            ou.attributevalues as orgunit_attributevalues,
...
        from event ev
        inner join enrollment en on en.enrollmentid = ev.enrollmentid
        inner join program p on p.programid = en.programid
        inner join programstage ps on ps.programstageid = ev.programstageid
        ...
        order by ev_id desc
        limit 50
        offset 0
    ) as event
left join
    (
        select
            evn.eventid as evn_id,
            n.noteid as note_id,
            n.notetext as note_text,
...
        from event_notes evn
        inner join note n on evn.noteid = n.noteid
...
    ) as cm
    on event.ev_id = cm.evn_id
order by ev_id desc
```

The main `event` subquery is always present. Other subqueries are added depending on the request parameters like `fields=relationships`. The parent query `select *` ensures all columns from these subqueries are available in the result set.

Me narrowing the top level select in https://github.com/dhis2/dhis2-core/pull/19153 causes the result set mapper to fail.

## Constraints

* We add different subqueries into our query that are then expected to add their projections in the parent query projection with `select *`.
* We cannot put the left join on dataelement into the main subquery as it would result in rows=nr datavalues x event. This main subquery needs to return one row per event as it also contains our order and pagination using limit/offset.

```sql
    (
        select
            ev.uid as ev_uid,
            ou.uid as orgunit_uid,
            ou.code as orgunit_code
```
* We cannot make a subquery in the parent query like we do for notes 

```sql
left join
    (
        select
            evn.eventid as evn_id,
            n.noteid as note_id,
            n.notetext as note_text,
...
        from event_notes evn
        inner join note n on evn.noteid = n.noteid
...
    ) as cm
```

to only `select` the columns we want using an alias like we do with `note_text`... The reason is the move the JSONB

https://github.com/dhis2/dhis2-core/pull/2741/files#diff-1a1b17f620b0d919a27f799b9e4d5674854040de981d0487bacbbc98dcae5a35R19-R24

and that we do not have access to the event id in the JSONB. To make a subquery like for notes I would need to join on the event table again which would make performance worse. Or I would have to join on the event table and repeat all the filters 🤯 

## Solution

I choose to revert to the `select *`. This means that the `dataelement` and `eventdatavalue` columns are then added to the projection without an alias. This looks something like

```sh
─[ RECORD 1 ]──────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────>
ev_uid             │ ehxNi0D67uQ
ev_eventdatavalues │ {"D7m8vpzxHDJ": {"value": "PE", "created": "2014-07-25T10:55:50.53", "storedBy": null, "lastUpdated": "2014-07-25T10:55:50.53", "providedElsewhere": false}, "Hm>
dataelement_uid    │ D7m8vpzxHDJ
value              │ {"value": "PE", "created": "2014-07-25T10:55:50.53", "storedBy": null, "lastUpdated": "2014-07-25T10:55:50.53", "providedElsewhere": false}
dataelementid      │ 1150453
name               │ TB Disease Classification
shortname          │ TB Disease Class.
code               │ DE_1150453
description        │ ¤
valuetype          │ TEXT
aggregationtype    │ AVERAGE
parentid           │ ¤
categorycomboid    │ 3
url                │
domaintype         │ TRACKER
lastupdated        │ 2014-11-11 21:56:05.411
zeroissignificant  │ f
formname           │ Disease Classification
uid                │ D7m8vpzxHDJ
```

as you can see `uid` is the `dataelement.uid`.

One alternative would be to find all subquery aliases and explicitly add them in the `select`. The drawback is what we've already seen that if we forget one a combination of features like `dataElementIdScheme=NAME&fields=relationships` in this case would trigger this bug.