### PR TITLE
fix:Adjust SQL for data integrity check of COCs without names

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/category_option_combinations_no_names.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/category_option_combinations_no_names.yaml
@@ -31,13 +31,18 @@ section: Categories
 section_order: 8
 summary_sql: >-
   WITH coc_no_names as (
-  SELECT uid,name FROM categoryoptioncombo WHERE name IS NULL OR name = ''
+  SELECT uid FROM categoryoptioncombo WHERE name IS NULL OR name = ''
   )
   SELECT COUNT(*) as value,
-  100 * COUNT(*) / NULLIF( (SELECT COUNT(*) FROM categoryoptioncombo), 0)  as percent
+  100.0 * COUNT(*) / NULLIF( (SELECT COUNT(*) FROM categoryoptioncombo), 0)  as percent
   FROM coc_no_names;
 details_sql: >-
-  SELECT uid,name FROM categoryoptioncombo WHERE name IS NULL OR name = '';
+  SELECT coc.uid,
+  array_to_string(array_agg(co.name),';') as name FROM categoryoptioncombo coc
+  INNER JOIN categoryoptioncombos_categoryoptions cocs_co on cocs_co.categoryoptioncomboid = coc.categoryoptioncomboid
+  INNER JOIN categoryoption co on co.categoryoptionid = cocs_co.categoryoptionid
+  WHERE coc.name IS NULL OR coc.name = ''
+  GROUP BY coc.uid;
 details_id_type: categoryOptionCombos
 severity: SEVERE
 introduction: >

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityCategoryOptionCombosNoNamesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityCategoryOptionCombosNoNamesControllerTest.java
@@ -78,7 +78,7 @@ class DataIntegrityCategoryOptionCombosNoNames extends AbstractDataIntegrityInte
     checkDataIntegritySummary(check, 1, 50, true);
 
     assertHasDataIntegrityIssues(
-        "categoryOptionCombos", check, 50, redCategoryOptionComboId, "", "", true);
+        "categoryOptionCombos", check, 50, redCategoryOptionComboId, "Red", "", true);
   }
 
   @Test


### PR DESCRIPTION
This check identifies COCs without names, but in the user interface, we use the name (which is of course blank). This creates issues with seeing anything useful in the UI. 

The SQL has been adjusted so that we use the string array of category options instead. This should hopefully be more reliable, but if the category options also have blank names, then it will still of course be a problem. We may need to consider some fallback in the UI? 

![image](https://github.com/user-attachments/assets/e9bd570e-32f5-4008-8d8c-e339e3ecdf7c)
