### PR TITLE
chore: propagate SqlBuilder to Antlr Expression visitor [DHIS-16705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -59,10 +59,11 @@ import org.hisp.dhis.period.PeriodType;
 /** Provides methods targeting the generation of SQL statements for periods and time fields. */
 public abstract class TimeFieldSqlRenderer {
   protected final SqlBuilder sqlBuilder;
-  protected final StatementBuilder statementBuilder = new DefaultStatementBuilder();
+  protected final StatementBuilder statementBuilder;
 
   protected TimeFieldSqlRenderer(SqlBuilder sqlBuilder) {
     this.sqlBuilder = sqlBuilder;
+    this.statementBuilder = new DefaultStatementBuilder(sqlBuilder);
   }
 
   /**
@@ -173,7 +174,7 @@ public abstract class TimeFieldSqlRenderer {
   /**
    * Returns a string representing the SQL condition for the given {@link ColumnWithDateRange}.
    *
-   * @param dateRangeColumn
+   * @param dateRangeColumn the {@link ColumnWithDateRange}
    * @return the SQL statement
    */
   private String getDateRangeCondition(ColumnWithDateRange dateRangeColumn) {

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -64,6 +64,10 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-jdbc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-sql</artifactId>
+    </dependency>
     <!-- Other -->
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
@@ -29,7 +29,18 @@ package org.hisp.dhis.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.constant.ConstantService;
+import org.hisp.dhis.db.SqlBuilderProvider;
+import org.hisp.dhis.db.sql.SqlBuilder;
+import org.hisp.dhis.expression.DefaultExpressionService;
+import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.DefaultResourceBundleManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
 import org.hisp.dhis.message.MessageSender;
@@ -44,6 +55,11 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  */
 @Configuration("coreServiceConfig")
 public class ServiceConfig {
+
+  @Bean
+  public SqlBuilder sqlBuilder(SqlBuilderProvider provider) {
+    return provider.getSqlBuilder();
+  }
 
   @Bean("taskScheduler")
   public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
@@ -70,5 +86,26 @@ public class ServiceConfig {
   @Bean("org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager")
   public ResourceBundleManager resourceBundleManager() {
     return new DefaultResourceBundleManager();
+  }
+
+  @Bean("org.hisp.dhis.expression.ExpressionService")
+  public ExpressionService expressionService(
+      @Qualifier("org.hisp.dhis.expression.ExpressionStore")
+          HibernateGenericStore<Expression> expressionStore,
+      ConstantService constantService,
+      DimensionService dimensionService,
+      IdentifiableObjectManager idObjectManager,
+      I18nManager i18nManager,
+      CacheProvider cacheProvider,
+      SqlBuilder sqlBuilder) {
+
+    return new DefaultExpressionService(
+        expressionStore,
+        constantService,
+        dimensionService,
+        idObjectManager,
+        i18nManager,
+        cacheProvider,
+        sqlBuilder);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
@@ -29,18 +29,7 @@ package org.hisp.dhis.config;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.DeliveryChannel;
-import org.hisp.dhis.common.DimensionService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.constant.ConstantService;
-import org.hisp.dhis.db.SqlBuilderProvider;
-import org.hisp.dhis.db.sql.SqlBuilder;
-import org.hisp.dhis.expression.DefaultExpressionService;
-import org.hisp.dhis.expression.Expression;
-import org.hisp.dhis.expression.ExpressionService;
-import org.hisp.dhis.hibernate.HibernateGenericStore;
-import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.DefaultResourceBundleManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
 import org.hisp.dhis.message.MessageSender;
@@ -55,11 +44,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  */
 @Configuration("coreServiceConfig")
 public class ServiceConfig {
-
-  @Bean
-  public SqlBuilder sqlBuilder(SqlBuilderProvider provider) {
-    return provider.getSqlBuilder();
-  }
 
   @Bean("taskScheduler")
   public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
@@ -86,26 +70,5 @@ public class ServiceConfig {
   @Bean("org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager")
   public ResourceBundleManager resourceBundleManager() {
     return new DefaultResourceBundleManager();
-  }
-
-  @Bean("org.hisp.dhis.expression.ExpressionService")
-  public ExpressionService expressionService(
-      @Qualifier("org.hisp.dhis.expression.ExpressionStore")
-          HibernateGenericStore<Expression> expressionStore,
-      ConstantService constantService,
-      DimensionService dimensionService,
-      IdentifiableObjectManager idObjectManager,
-      I18nManager i18nManager,
-      CacheProvider cacheProvider,
-      SqlBuilder sqlBuilder) {
-
-    return new DefaultExpressionService(
-        expressionStore,
-        constantService,
-        dimensionService,
-        idObjectManager,
-        i18nManager,
-        cacheProvider,
-        sqlBuilder);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -111,6 +111,7 @@ import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.expression.dataitem.DimItemDataElementAndOperand;
 import org.hisp.dhis.expression.dataitem.DimItemIndicator;
 import org.hisp.dhis.expression.dataitem.DimItemProgramAttribute;
@@ -178,6 +179,8 @@ public class DefaultExpressionService implements ExpressionService {
   private final IdentifiableObjectManager idObjectManager;
 
   private final I18nManager i18nManager;
+
+  private final SqlBuilder sqlBuilder;
 
   // -------------------------------------------------------------------------
   // Static data
@@ -279,13 +282,15 @@ public class DefaultExpressionService implements ExpressionService {
       DimensionService dimensionService,
       IdentifiableObjectManager idObjectManager,
       I18nManager i18nManager,
-      CacheProvider cacheProvider) {
+      CacheProvider cacheProvider,
+      SqlBuilder sqlBuilder) {
     checkNotNull(expressionStore);
     checkNotNull(constantService);
     checkNotNull(dimensionService);
     checkNotNull(idObjectManager);
     checkNotNull(i18nManager);
     checkNotNull(cacheProvider);
+    checkNotNull(sqlBuilder);
 
     this.expressionStore = expressionStore;
     this.constantService = constantService;
@@ -293,6 +298,7 @@ public class DefaultExpressionService implements ExpressionService {
     this.idObjectManager = idObjectManager;
     this.i18nManager = i18nManager;
     this.constantMapCache = cacheProvider.createAllConstantsCache();
+    this.sqlBuilder = sqlBuilder;
   }
 
   // -------------------------------------------------------------------------
@@ -726,6 +732,7 @@ public class DefaultExpressionService implements ExpressionService {
         .params(params)
         .info(params.getExpressionInfo())
         .state(initialParsingState)
+        .sqlBuilder(sqlBuilder)
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -34,36 +34,7 @@ import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.expression.ExpressionParams.DEFAULT_EXPRESSION_PARAMS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
-import static org.hisp.dhis.parser.expression.ParserUtils.COMMON_EXPRESSION_ITEMS;
 import static org.hisp.dhis.parser.expression.ProgramExpressionParams.DEFAULT_PROGRAM_EXPRESSION_PARAMS;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AVG;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.A_BRACE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.COUNT;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_CONDITION;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_COUNT;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_COUNT_IF_CONDITION;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_COUNT_IF_VALUE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_DAYS_BETWEEN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_HAS_VALUE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_MAX_VALUE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_MINUTES_BETWEEN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_MIN_VALUE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_MONTHS_BETWEEN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_OIZP;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_RELATIONSHIP_COUNT;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_WEEKS_BETWEEN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_YEARS_BETWEEN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_ZING;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.D2_ZPVC;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.HASH_BRACE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MAX;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MIN;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PS_EVENTDATE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STAGE_OFFSET;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.SUM;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.VARIANCE;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.V_BRACE;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
@@ -74,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.Parser;
@@ -92,35 +64,7 @@ import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
 import org.hisp.dhis.parser.expression.ProgramExpressionParams;
-import org.hisp.dhis.parser.expression.function.RepeatableProgramStageOffset;
-import org.hisp.dhis.parser.expression.function.VectorAvg;
-import org.hisp.dhis.parser.expression.function.VectorCount;
-import org.hisp.dhis.parser.expression.function.VectorMax;
-import org.hisp.dhis.parser.expression.function.VectorMin;
-import org.hisp.dhis.parser.expression.function.VectorStddevSamp;
-import org.hisp.dhis.parser.expression.function.VectorSum;
-import org.hisp.dhis.parser.expression.function.VectorVariance;
 import org.hisp.dhis.parser.expression.literal.SqlLiteral;
-import org.hisp.dhis.program.dataitem.ProgramItemAttribute;
-import org.hisp.dhis.program.dataitem.ProgramItemPsEventdate;
-import org.hisp.dhis.program.dataitem.ProgramItemStageElement;
-import org.hisp.dhis.program.function.D2Condition;
-import org.hisp.dhis.program.function.D2Count;
-import org.hisp.dhis.program.function.D2CountIfCondition;
-import org.hisp.dhis.program.function.D2CountIfValue;
-import org.hisp.dhis.program.function.D2DaysBetween;
-import org.hisp.dhis.program.function.D2HasValue;
-import org.hisp.dhis.program.function.D2MaxValue;
-import org.hisp.dhis.program.function.D2MinValue;
-import org.hisp.dhis.program.function.D2MinutesBetween;
-import org.hisp.dhis.program.function.D2MonthsBetween;
-import org.hisp.dhis.program.function.D2Oizp;
-import org.hisp.dhis.program.function.D2RelationshipCount;
-import org.hisp.dhis.program.function.D2WeeksBetween;
-import org.hisp.dhis.program.function.D2YearsBetween;
-import org.hisp.dhis.program.function.D2Zing;
-import org.hisp.dhis.program.function.D2Zpvc;
-import org.hisp.dhis.program.variable.ProgramVariableItem;
 import org.hisp.dhis.system.util.SqlUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -149,7 +93,7 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
 
   private final SqlBuilder sqlBuilder;
 
-  public static ImmutableMap<Integer, ExpressionItem> PROGRAM_INDICATOR_ITEMS;
+  @Getter private final ImmutableMap<Integer, ExpressionItem> programIndicatorItems;
 
   public DefaultProgramIndicatorService(
       ProgramIndicatorStore programIndicatorStore,
@@ -182,60 +126,7 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
     this.analyticsSqlCache = cacheProvider.createAnalyticsSqlCache();
     this.sqlBuilder = sqlBuilder;
 
-    PROGRAM_INDICATOR_ITEMS = buildExpressionMap();
-  }
-
-  private ImmutableMap<Integer, ExpressionItem> buildExpressionMap() {
-    return ImmutableMap.<Integer, ExpressionItem>builder()
-
-        // Common functions
-
-        .putAll(COMMON_EXPRESSION_ITEMS)
-
-        // Program functions
-
-        .put(
-            D2_CONDITION,
-            new D2Condition().withSqlBuilder(sqlBuilder)) // TODO shall we use constructor instead
-        .put(D2_COUNT, new D2Count().withSqlBuilder(sqlBuilder))
-        .put(D2_COUNT_IF_CONDITION, new D2CountIfCondition().withSqlBuilder(sqlBuilder))
-        .put(D2_COUNT_IF_VALUE, new D2CountIfValue().withSqlBuilder(sqlBuilder))
-        .put(D2_DAYS_BETWEEN, new D2DaysBetween().withSqlBuilder(sqlBuilder))
-        .put(D2_HAS_VALUE, new D2HasValue().withSqlBuilder(sqlBuilder))
-        .put(D2_MAX_VALUE, new D2MaxValue().withSqlBuilder(sqlBuilder))
-        .put(D2_MINUTES_BETWEEN, new D2MinutesBetween().withSqlBuilder(sqlBuilder))
-        .put(D2_MIN_VALUE, new D2MinValue().withSqlBuilder(sqlBuilder))
-        .put(D2_MONTHS_BETWEEN, new D2MonthsBetween().withSqlBuilder(sqlBuilder))
-        .put(D2_OIZP, new D2Oizp().withSqlBuilder(sqlBuilder))
-        .put(D2_RELATIONSHIP_COUNT, new D2RelationshipCount().withSqlBuilder(sqlBuilder))
-        .put(D2_WEEKS_BETWEEN, new D2WeeksBetween().withSqlBuilder(sqlBuilder))
-        .put(D2_YEARS_BETWEEN, new D2YearsBetween().withSqlBuilder(sqlBuilder))
-        .put(D2_ZING, new D2Zing().withSqlBuilder(sqlBuilder))
-        .put(D2_ZPVC, new D2Zpvc().withSqlBuilder(sqlBuilder))
-
-        // Program functions for custom aggregation
-
-        .put(AVG, new VectorAvg())
-        .put(COUNT, new VectorCount())
-        .put(MAX, new VectorMax())
-        .put(MIN, new VectorMin())
-        .put(STDDEV, new VectorStddevSamp())
-        .put(SUM, new VectorSum())
-        .put(VARIANCE, new VectorVariance())
-
-        // Data items
-
-        .put(HASH_BRACE, new ProgramItemStageElement().withSqlBuilder(sqlBuilder))
-        .put(A_BRACE, new ProgramItemAttribute().withSqlBuilder(sqlBuilder))
-        .put(PS_EVENTDATE, new ProgramItemPsEventdate().withSqlBuilder(sqlBuilder))
-
-        // Program variables
-
-        .put(V_BRACE, new ProgramVariableItem().withSqlBuilder(sqlBuilder))
-
-        // . functions
-        .put(STAGE_OFFSET, new RepeatableProgramStageOffset())
-        .build();
+    this.programIndicatorItems = new ExpressionMapBuilder(sqlBuilder).getExpressionItemMap();
   }
 
   // -------------------------------------------------------------------------
@@ -531,7 +422,7 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
         .programStageService(programStageService)
         .i18nSupplier(Suppliers.memoize(i18nManager::getI18n))
         .constantMap(expressionService.getConstantMap())
-        .itemMap(PROGRAM_INDICATOR_ITEMS)
+        .itemMap(programIndicatorItems)
         .itemMethod(itemMethod)
         .params(params)
         .progParams(progParams)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ExpressionMapBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ExpressionMapBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import static org.hisp.dhis.parser.expression.ParserUtils.COMMON_EXPRESSION_ITEMS;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
+import org.hisp.dhis.db.sql.SqlBuilder;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.function.RepeatableProgramStageOffset;
+import org.hisp.dhis.parser.expression.function.VectorAvg;
+import org.hisp.dhis.parser.expression.function.VectorCount;
+import org.hisp.dhis.parser.expression.function.VectorMax;
+import org.hisp.dhis.parser.expression.function.VectorMin;
+import org.hisp.dhis.parser.expression.function.VectorStddevSamp;
+import org.hisp.dhis.parser.expression.function.VectorSum;
+import org.hisp.dhis.parser.expression.function.VectorVariance;
+import org.hisp.dhis.program.dataitem.ProgramItemAttribute;
+import org.hisp.dhis.program.dataitem.ProgramItemPsEventdate;
+import org.hisp.dhis.program.dataitem.ProgramItemStageElement;
+import org.hisp.dhis.program.function.D2Condition;
+import org.hisp.dhis.program.function.D2Count;
+import org.hisp.dhis.program.function.D2CountIfCondition;
+import org.hisp.dhis.program.function.D2CountIfValue;
+import org.hisp.dhis.program.function.D2DaysBetween;
+import org.hisp.dhis.program.function.D2HasValue;
+import org.hisp.dhis.program.function.D2MaxValue;
+import org.hisp.dhis.program.function.D2MinValue;
+import org.hisp.dhis.program.function.D2MinutesBetween;
+import org.hisp.dhis.program.function.D2MonthsBetween;
+import org.hisp.dhis.program.function.D2Oizp;
+import org.hisp.dhis.program.function.D2RelationshipCount;
+import org.hisp.dhis.program.function.D2WeeksBetween;
+import org.hisp.dhis.program.function.D2YearsBetween;
+import org.hisp.dhis.program.function.D2Zing;
+import org.hisp.dhis.program.function.D2Zpvc;
+import org.hisp.dhis.program.variable.ProgramVariableItem;
+
+/**
+ * This component encapsulates the creation of the immutable expressions map. The map contains all
+ * the expression items that are used in the program expressions.
+ */
+@Getter
+public class ExpressionMapBuilder {
+
+  private final ImmutableMap<Integer, ExpressionItem> expressionItemMap;
+
+  public ExpressionMapBuilder(SqlBuilder sqlBuilder) {
+    expressionItemMap =
+        ImmutableMap.<Integer, ExpressionItem>builder()
+
+            // Common functions
+
+            .putAll(COMMON_EXPRESSION_ITEMS)
+
+            // Program functions
+
+            .put(D2_CONDITION, new D2Condition().withSqlBuilder(sqlBuilder))
+            .put(D2_COUNT, new D2Count().withSqlBuilder(sqlBuilder))
+            .put(D2_COUNT_IF_CONDITION, new D2CountIfCondition().withSqlBuilder(sqlBuilder))
+            .put(D2_COUNT_IF_VALUE, new D2CountIfValue().withSqlBuilder(sqlBuilder))
+            .put(D2_DAYS_BETWEEN, new D2DaysBetween().withSqlBuilder(sqlBuilder))
+            .put(D2_HAS_VALUE, new D2HasValue().withSqlBuilder(sqlBuilder))
+            .put(D2_MAX_VALUE, new D2MaxValue().withSqlBuilder(sqlBuilder))
+            .put(D2_MINUTES_BETWEEN, new D2MinutesBetween().withSqlBuilder(sqlBuilder))
+            .put(D2_MIN_VALUE, new D2MinValue().withSqlBuilder(sqlBuilder))
+            .put(D2_MONTHS_BETWEEN, new D2MonthsBetween().withSqlBuilder(sqlBuilder))
+            .put(D2_OIZP, new D2Oizp().withSqlBuilder(sqlBuilder))
+            .put(D2_RELATIONSHIP_COUNT, new D2RelationshipCount().withSqlBuilder(sqlBuilder))
+            .put(D2_WEEKS_BETWEEN, new D2WeeksBetween().withSqlBuilder(sqlBuilder))
+            .put(D2_YEARS_BETWEEN, new D2YearsBetween().withSqlBuilder(sqlBuilder))
+            .put(D2_ZING, new D2Zing().withSqlBuilder(sqlBuilder))
+            .put(D2_ZPVC, new D2Zpvc().withSqlBuilder(sqlBuilder))
+
+            // Program functions for custom aggregation
+
+            .put(AVG, new VectorAvg())
+            .put(COUNT, new VectorCount())
+            .put(MAX, new VectorMax())
+            .put(MIN, new VectorMin())
+            .put(STDDEV, new VectorStddevSamp())
+            .put(SUM, new VectorSum())
+            .put(VARIANCE, new VectorVariance())
+
+            // Data items
+
+            .put(HASH_BRACE, new ProgramItemStageElement().withSqlBuilder(sqlBuilder))
+            .put(A_BRACE, new ProgramItemAttribute().withSqlBuilder(sqlBuilder))
+            .put(PS_EVENTDATE, new ProgramItemPsEventdate().withSqlBuilder(sqlBuilder))
+
+            // Program variables
+
+            .put(V_BRACE, new ProgramVariableItem().withSqlBuilder(sqlBuilder))
+
+            // . functions
+            .put(STAGE_OFFSET, new RepeatableProgramStageOffset())
+            .build();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
@@ -30,13 +30,13 @@ package org.hisp.dhis.program;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.common.ValueType.NUMBER;
-import static org.hisp.dhis.parser.expression.ParserUtils.castSql;
 import static org.hisp.dhis.parser.expression.ParserUtils.replaceSqlNull;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.program.dataitem.ProgramItemAttribute;
@@ -57,6 +57,8 @@ import org.hisp.dhis.system.util.ValidationUtils;
  * @author Jim Grace
  */
 public abstract class ProgramExpressionItem implements ExpressionItem {
+
+  private SqlBuilder sqlBuilder;
 
   @Override
   public final Object getExpressionInfo(ExprContext ctx, CommonExpressionVisitor visitor) {
@@ -122,6 +124,11 @@ public abstract class ProgramExpressionItem implements ExpressionItem {
     if (dataType == NUMERIC || dataType == BOOLEAN) {
       dataType = visitor.getParams().getDataType() == BOOLEAN ? BOOLEAN : NUMERIC;
     }
-    return replaceSqlNull(castSql(column, dataType), dataType);
+    return replaceSqlNull(sqlBuilder.cast(column, dataType), dataType);
+  }
+
+  protected ExpressionItem withSqlBuilder(SqlBuilder sqlBuilder) {
+    this.sqlBuilder = sqlBuilder;
+    return this;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -108,6 +108,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -127,7 +128,7 @@ class ExpressionServiceTest extends TestBase {
 
   @Mock private CacheProvider cacheProvider;
 
-  private PostgreSqlBuilder postgreSqlBuilder;
+  @Spy private PostgreSqlBuilder sqlBuilder;
 
   private DefaultExpressionService target;
 
@@ -252,7 +253,7 @@ class ExpressionServiceTest extends TestBase {
             idObjectManager,
             i18nManager,
             cacheProvider,
-            postgreSqlBuilder);
+            sqlBuilder);
 
     categoryOptionA = new CategoryOption("Under 5");
     categoryOptionB = new CategoryOption("Over 5");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -89,6 +89,7 @@ import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
@@ -125,6 +126,8 @@ class ExpressionServiceTest extends TestBase {
   @Mock private I18nManager i18nManager;
 
   @Mock private CacheProvider cacheProvider;
+
+  private PostgreSqlBuilder postgreSqlBuilder;
 
   private DefaultExpressionService target;
 
@@ -248,7 +251,8 @@ class ExpressionServiceTest extends TestBase {
             dimensionService,
             idObjectManager,
             i18nManager,
-            cacheProvider);
+            cacheProvider,
+            postgreSqlBuilder);
 
     categoryOptionA = new CategoryOption("Under 5");
     categoryOptionB = new CategoryOption("Over 5");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
-import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.hisp.dhis.program.variable.vEventCount.DEFAULT_COUNT_CONDITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,6 +57,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -72,6 +72,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -114,6 +115,8 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
   @Mock private ProgramStageService programStageService;
 
   @Mock private DimensionService dimensionService;
+
+  @Spy private PostgreSqlBuilder sqlBuilder;
 
   @BeforeEach
   public void setUp() {
@@ -797,10 +800,11 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
             .programIndicatorService(programIndicatorService)
             .programStageService(programStageService)
             .i18nSupplier(() -> new I18n(null, null))
-            .itemMap(PROGRAM_INDICATOR_ITEMS)
+            .itemMap(new ExpressionMapBuilder(sqlBuilder).getExpressionItemMap())
             .itemMethod(itemMethod)
             .params(params)
             .progParams(progParams)
+            .sqlBuilder(new PostgreSqlBuilder())
             .build();
 
     visitor.setExpressionLiteral(exprLiteral);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -241,6 +241,7 @@ class ProgramSqlGeneratorItemsTest extends TestBase {
             .itemMethod(itemMethod)
             .params(params)
             .progParams(progParams)
+            .sqlBuilder(sqlBuilder)
             .build();
 
     visitor.setExpressionLiteral(exprLiteral);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
-import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +50,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -99,6 +100,8 @@ class ProgramSqlGeneratorItemsTest extends TestBase {
   @Mock private IdentifiableObjectManager idObjectManager;
 
   @Mock private DimensionService dimensionService;
+
+  @Spy private PostgreSqlBuilder sqlBuilder;
 
   @BeforeEach
   public void setUp() {
@@ -234,7 +237,7 @@ class ProgramSqlGeneratorItemsTest extends TestBase {
             .programStageService(programStageService)
             .i18nSupplier(() -> new I18n(null, null))
             .constantMap(constantMap)
-            .itemMap(PROGRAM_INDICATOR_ITEMS)
+            .itemMap(new ExpressionMapBuilder(sqlBuilder).getExpressionItemMap())
             .itemMethod(itemMethod)
             .params(params)
             .progParams(progParams)

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
-import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.hisp.dhis.program.variable.vEventCount.DEFAULT_COUNT_CONDITION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -46,6 +45,7 @@ import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.literal.DefaultLiteral;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -81,6 +82,8 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
   @Mock private DimensionService dimensionService;
 
   @Mock private I18n i18n;
+
+  @Spy private PostgreSqlBuilder sqlBuilder;
 
   private CommonExpressionVisitor subject;
 
@@ -304,10 +307,11 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
             .programIndicatorService(programIndicatorService)
             .programStageService(programStageService)
             .i18nSupplier(() -> new I18n(null, null))
-            .itemMap(PROGRAM_INDICATOR_ITEMS)
+            .itemMap(new ExpressionMapBuilder(sqlBuilder).getExpressionItemMap())
             .itemMethod(ITEM_GET_SQL)
             .params(params)
             .progParams(progParams)
+            .sqlBuilder(sqlBuilder)
             .build();
 
     subject.setExpressionLiteral(exprLiteral);

--- a/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
@@ -31,6 +31,10 @@
       <groupId>org.hisp.dhis.parser</groupId>
       <artifactId>dhis-antlr-expression-parser</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-sql</artifactId>
+    </dependency>
 
     <!-- Application -->
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.parser.expression;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +45,7 @@ import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.constant.Constant;
+import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.expression.ExpressionInfo;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
@@ -60,9 +63,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
  */
 @Getter
 @Setter
-@Builder(toBuilder = true)
 public class CommonExpressionVisitor extends AntlrExpressionVisitor {
-  private final StatementBuilder statementBuilder = new DefaultStatementBuilder();
+
+  private StatementBuilder statementBuilder;
 
   private IdentifiableObjectManager idObjectManager;
 
@@ -74,6 +77,8 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
 
   private TrackedEntityAttributeService attributeService;
 
+  private SqlBuilder sqlBuilder;
+
   /**
    * A {@link Supplier} object that can return a {@link I18n} instance when needed. This is done
    * because retrieving a {@link I18n} instance can be expensive and is not needed for most parsing
@@ -82,7 +87,7 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
   private Supplier<I18n> i18nSupplier;
 
   /** Map of constant values to use in evaluating the expression. */
-  @Builder.Default private Map<String, Constant> constantMap = new HashMap<>();
+  private Map<String, Constant> constantMap = new HashMap<>();
 
   /** Map of ExprItem object instances to call for each expression item. */
   private Map<Integer, ExpressionItem> itemMap;
@@ -91,26 +96,67 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
   private ExpressionItemMethod itemMethod;
 
   /** Parameters to evaluate the expression to a value. */
-  @Builder.Default private ExpressionParams params = ExpressionParams.builder().build();
+  private ExpressionParams params;
 
   /** Parameters to generate SQL from a program expression. */
-  @Builder.Default
-  private ProgramExpressionParams progParams = ProgramExpressionParams.builder().build();
+  private ProgramExpressionParams progParams;
 
   /** State variables during an expression evaluation. */
-  @Builder.Default private ExpressionState state = new ExpressionState();
+  private ExpressionState state;
 
   /**
    * Information found from parsing the raw expression (contains nothing that is the result of data
    * or metadata found in the database).
    */
-  @Builder.Default private ExpressionInfo info = new ExpressionInfo();
+  private ExpressionInfo info;
 
   /**
    * Used to collect the string replacements to build a description. This may contain names of
    * metadata from the database.
    */
-  @Builder.Default private Map<String, String> itemDescriptions = new HashMap<>();
+  private Map<String, String> itemDescriptions;
+
+  // -------------------------------------------------------------------------
+  // Custom constructor
+  // -------------------------------------------------------------------------
+
+  @Builder(toBuilder = true)
+  public CommonExpressionVisitor(
+      IdentifiableObjectManager idObjectManager,
+      DimensionService dimensionService,
+      ProgramIndicatorService programIndicatorService,
+      ProgramStageService programStageService,
+      TrackedEntityAttributeService attributeService,
+      SqlBuilder sqlBuilder,
+      Supplier<I18n> i18nSupplier,
+      Map<String, Constant> constantMap,
+      Map<Integer, ExpressionItem> itemMap,
+      ExpressionItemMethod itemMethod,
+      ExpressionParams params,
+      ProgramExpressionParams progParams,
+      ExpressionState state,
+      ExpressionInfo info,
+      Map<String, String> itemDescriptions) {
+
+    checkNotNull(sqlBuilder);
+
+    this.statementBuilder = new DefaultStatementBuilder(sqlBuilder);
+    this.idObjectManager = idObjectManager;
+    this.dimensionService = dimensionService;
+    this.programIndicatorService = programIndicatorService;
+    this.programStageService = programStageService;
+    this.attributeService = attributeService;
+    this.sqlBuilder = sqlBuilder;
+    this.i18nSupplier = i18nSupplier;
+    this.constantMap = constantMap != null ? constantMap : new HashMap<>();
+    this.itemMap = itemMap;
+    this.itemMethod = itemMethod;
+    this.params = params != null ? params : ExpressionParams.builder().build();
+    this.progParams = progParams != null ? progParams : ProgramExpressionParams.builder().build();
+    this.state = state != null ? state : new ExpressionState();
+    this.info = info != null ? info : new ExpressionInfo();
+    this.itemDescriptions = itemDescriptions != null ? itemDescriptions : new HashMap<>();
+  }
 
   // -------------------------------------------------------------------------
   // Visitor logic

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
@@ -233,7 +233,8 @@ public class ClickHouseSqlBuilder extends AbstractSqlBuilder {
   public String cast(String column, DataType dataType) {
     return switch (dataType) {
       case NUMERIC -> String.format("toDecimal64(%s, 8)", column); // 8 decimal places precision
-      case BOOLEAN -> String.format("toUInt8(%s) != 0", column);   // ClickHouse uses UInt8 for boolean
+      case BOOLEAN ->
+          String.format("toUInt8(%s) != 0", column); // ClickHouse uses UInt8 for boolean
       case TEXT -> String.format("toString(%s)", column);
     };
   }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
@@ -232,9 +232,9 @@ public class ClickHouseSqlBuilder extends AbstractSqlBuilder {
   @Override
   public String cast(String column, DataType dataType) {
     return switch (dataType) {
-      case NUMERIC -> "toDecimal64(" + column + ", 8)"; // 8 decimal places precision
-      case BOOLEAN -> "toUInt8(" + column + ") != 0"; // ClickHouse uses UInt8 for boolean
-      case TEXT -> "toString(" + column + ")";
+      case NUMERIC -> String.format("toDecimal64(%s, 8)", column); // 8 decimal places precision
+      case BOOLEAN -> String.format("toUInt8(%s) != 0", column);   // ClickHouse uses UInt8 for boolean
+      case TEXT -> String.format("toString(%s)", column);
     };
   }
 

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.db.model.Column;
 import org.hisp.dhis.db.model.Index;
 import org.hisp.dhis.db.model.Table;
@@ -226,6 +227,15 @@ public class ClickHouseSqlBuilder extends AbstractSqlBuilder {
   public String jsonExtractNested(String json, String... expression) {
     String path = String.join(".", expression);
     return String.format("JSONExtractString(%s, '%s')", json, path);
+  }
+
+  @Override
+  public String cast(String column, DataType dataType) {
+    return switch (dataType) {
+      case NUMERIC -> "toDecimal64(" + column + ", 8)"; // 8 decimal places precision
+      case BOOLEAN -> "toUInt8(" + column + ") != 0"; // ClickHouse uses UInt8 for boolean
+      case TEXT -> "toString(" + column + ")";
+    };
   }
 
   // Statements

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.db.model.Column;
 import org.hisp.dhis.db.model.Index;
 import org.hisp.dhis.db.model.Table;
@@ -229,6 +230,15 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
   public String jsonExtractNested(String column, String... expression) {
     String path = "$." + String.join(".", expression);
     return String.format("json_unquote(json_extract(%s, '%s'))", column, path);
+  }
+
+  @Override
+  public String cast(String column, DataType dataType) {
+    return switch (dataType) {
+      case NUMERIC -> "CAST(" + column + " AS DECIMAL)";
+      case BOOLEAN -> "CAST(" + column + " AS DECIMAL) != 0";
+      case TEXT -> "CAST(" + column + " AS CHAR)";
+    };
   }
 
   // Statements

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -235,9 +235,9 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
   @Override
   public String cast(String column, DataType dataType) {
     return switch (dataType) {
-      case NUMERIC -> "CAST(" + column + " AS DECIMAL)";
-      case BOOLEAN -> "CAST(" + column + " AS DECIMAL) != 0";
-      case TEXT -> "CAST(" + column + " AS CHAR)";
+      case NUMERIC -> String.format("CAST(%s AS DECIMAL)", column);
+      case BOOLEAN -> String.format("CAST(%s AS DECIMAL) != 0", column);
+      case TEXT -> String.format("CAST(%s AS CHAR)", column);
     };
   }
 

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.db.sql;
 
 import static org.hisp.dhis.commons.util.TextUtils.removeLastComma;
 
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.db.model.Collation;
 import org.hisp.dhis.db.model.Column;
 import org.hisp.dhis.db.model.Index;
@@ -247,6 +248,16 @@ public class PostgreSqlBuilder extends AbstractSqlBuilder {
   @Override
   public String jsonExtractNested(String column, String... expression) {
     return String.format("%s #>> '{%s}'", column, String.join(", ", expression));
+  }
+
+  @Override
+  public String cast(String column, DataType dataType) {
+    return column
+        + switch (dataType) {
+          case NUMERIC -> "::numeric";
+          case BOOLEAN -> "::numeric!=0";
+          case TEXT -> "::text";
+        };
   }
 
   // Statements

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.db.sql;
 
 import java.util.Collection;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.db.model.Index;
 import org.hisp.dhis.db.model.Table;
 
@@ -286,6 +287,16 @@ public interface SqlBuilder {
    * @return a SQL expression to extract the specified nested value from the JSON column.
    */
   String jsonExtractNested(String json, String... expression);
+
+  /**
+   * Generates a database-specific SQL casting expression for the given column or expression.
+   *
+   * @param column The column or expression to be cast. Must not be null.
+   * @param dataType The target data type for the cast operation. Must not be null.
+   * @return A String containing the database-specific SQL casting expression.
+   * @see DataType
+   */
+  String cast(String column, DataType dataType);
 
   // Statements
 

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
@@ -289,7 +289,7 @@ public interface SqlBuilder {
   String jsonExtractNested(String json, String... expression);
 
   /**
-   * Generates a database-specific SQL casting expression for the given column or expression.
+   * Generates a SQL casting expression for the given column or expression.
    *
    * @param column The column or expression to be cast. Must not be null.
    * @param dataType The target data type for the cast operation. Must not be null.


### PR DESCRIPTION
## Description

This PR attempts at propagating the `SqlBuilder` into the Antlr parser, so that parser can generate SQL expression compatible with the underlying analytics database.

### Changes

- ~~Configure the `ExpressionService` Spring Bean into a `ServiceConfig`, so that the `SqlBuilder` can be injected explicitly.~~
- Modified `DefaultProgramIndicatorService` so that the expression map is now built externally (see `ExpressionMapBuilder`). This allow to use the new `withSqlBuilder` method on the expressions in the map and pass the `SqlBuilder` to each expression.
- Add a "fluent" `withSqlBuilder` method to `ProgramExpressionItem`.
- Use a custom builder for `CommonExpressionVisitor` to make possible to initialize the existing `DefaultStatementBuilder` with `SqlBuilder`
- Add a new `cast` function to `SqlBuilder` to hanlde SQL casting