### PR TITLE
refactor: Centralize isGeoSpatial property logic [DHIS2-16705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -78,7 +77,6 @@ public class ServiceConfig {
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
@@ -94,7 +92,6 @@ public class ServiceConfig {
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         trackedEntityTypeService,
         analyticsTableSettings,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -161,7 +161,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
           columnExpression);
     } else if (valueType.isDate()) {
       return getCastExpression(columnExpression, DATE_REGEXP, sqlBuilder.dataTypeTimestamp());
-    } else if (valueType.isGeo() && spatialSupport) {
+    } else if (valueType.isGeo() && isSpatialSupport()) {
       return String.format(
           """
           ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (%s) || ', "crs":{"type":"name", "properties":{"name":"EPSG:4326"}}}')""",
@@ -251,7 +251,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
   protected List<AnalyticsTableColumn> getColumnForAttribute(TrackedEntityAttribute attribute) {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
 
-    DataType dataType = getColumnType(attribute.getValueType(), spatialSupport);
+    DataType dataType = getColumnType(attribute.getValueType(), isSpatialSupport());
     String selectExpression = getSelectExpressionForAttribute(attribute.getValueType(), "value");
     String dataFilterClause = getDataFilterClause(attribute);
     String sql = getSelectSubquery(attribute, selectExpression, dataFilterClause);
@@ -287,7 +287,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
     String fromClause =
         qualifyVariables("from ${organisationunit} ou where ou.uid = (select value");
 
-    if (spatialSupport) {
+    if (isSpatialSupport()) {
       String selectExpression = "ou.geometry " + fromClause;
       String ouGeoSql = getSelectSubquery(attribute, selectExpression, dataFilterClause);
       columns.add(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -74,7 +74,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
       JdbcTemplate jdbcTemplate,
-      AnalyticsTableSettings analyticsExportSettings,
+      AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
       SqlBuilder sqlBuilder) {
     super(
@@ -87,7 +87,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
         tableHookService,
         partitionManager,
         jdbcTemplate,
-        analyticsExportSettings,
+        analyticsTableSettings,
         periodDataProvider,
         sqlBuilder);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -144,8 +144,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
 
   protected final SqlBuilder sqlBuilder;
 
-  protected final boolean spatialSupport;
-
   protected AbstractJdbcTableManager(
       IdentifiableObjectManager idObjectManager,
       OrganisationUnitService organisationUnitService,
@@ -171,7 +169,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
     this.analyticsTableSettings = analyticsTableSettings;
     this.periodDataProvider = periodDataProvider;
     this.sqlBuilder = sqlBuilder;
-    this.spatialSupport = isSpatialSupport(analyticsTableSettings, sqlBuilder);
   }
 
   /**
@@ -358,6 +355,15 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
   // -------------------------------------------------------------------------
   // Protected supportive methods
   // -------------------------------------------------------------------------
+
+  /**
+   * Indicates whether spatial support is available.
+   *
+   * @return true if spatial support is available.
+   */
+  protected boolean isSpatialSupport() {
+    return analyticsTableSettings.isSpatialSupport() && sqlBuilder.supportsGeospatialData();
+  }
 
   /** Returns the analytics table name. */
   protected String getTableName() {
@@ -756,17 +762,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
   // -------------------------------------------------------------------------
   // Private supportive methods
   // -------------------------------------------------------------------------
-
-  /**
-   * Indicates whether spatial support is available.
-   *
-   * @param settings the {@link AnalyticsTableSettings}.
-   * @param sqlBuilder the {@link SqlBuilder}.
-   * @return true if spatial support is available.
-   */
-  protected boolean isSpatialSupport(AnalyticsTableSettings settings, SqlBuilder sqlBuilder) {
-    return settings.isSpatialSupport() && sqlBuilder.supportsGeospatialData();
-  }
 
   /**
    * Executes a SQL statement silently without throwing any exceptions. Instead exceptions are

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.analytics.AnalyticsTableHook;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -92,6 +93,7 @@ import org.springframework.util.Assert;
  * @author Lars Helge Overland
  */
 @Slf4j
+@RequiredArgsConstructor
 public abstract class AbstractJdbcTableManager implements AnalyticsTableManager {
   /**
    * Matches the following patterns:
@@ -143,33 +145,6 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
   protected final PeriodDataProvider periodDataProvider;
 
   protected final SqlBuilder sqlBuilder;
-
-  protected AbstractJdbcTableManager(
-      IdentifiableObjectManager idObjectManager,
-      OrganisationUnitService organisationUnitService,
-      CategoryService categoryService,
-      SystemSettingsProvider settingsProvider,
-      DataApprovalLevelService dataApprovalLevelService,
-      ResourceTableService resourceTableService,
-      AnalyticsTableHookService tableHookService,
-      PartitionManager partitionManager,
-      JdbcTemplate jdbcTemplate,
-      AnalyticsTableSettings analyticsTableSettings,
-      PeriodDataProvider periodDataProvider,
-      SqlBuilder sqlBuilder) {
-    this.idObjectManager = idObjectManager;
-    this.organisationUnitService = organisationUnitService;
-    this.categoryService = categoryService;
-    this.settingsProvider = settingsProvider;
-    this.dataApprovalLevelService = dataApprovalLevelService;
-    this.resourceTableService = resourceTableService;
-    this.tableHookService = tableHookService;
-    this.partitionManager = partitionManager;
-    this.jdbcTemplate = jdbcTemplate;
-    this.analyticsTableSettings = analyticsTableSettings;
-    this.periodDataProvider = periodDataProvider;
-    this.sqlBuilder = sqlBuilder;
-  }
 
   /**
    * Encapsulates the SQL logic to get the correct date column based on the event status. If new

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -77,7 +77,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -171,7 +170,6 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
@@ -185,7 +183,6 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -64,7 +64,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -102,7 +101,6 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
@@ -116,7 +114,6 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
@@ -56,7 +56,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -113,7 +112,6 @@ public class JdbcCompletenessTargetTableManager extends AbstractJdbcTableManager
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
@@ -127,7 +125,6 @@ public class JdbcCompletenessTargetTableManager extends AbstractJdbcTableManager
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -76,7 +76,7 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
-      AnalyticsTableSettings analyticsExportSettings,
+      AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
       SqlBuilder sqlBuilder) {
     super(
@@ -89,7 +89,7 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
         tableHookService,
         partitionManager,
         jdbcTemplate,
-        analyticsExportSettings,
+        analyticsTableSettings,
         periodDataProvider,
         sqlBuilder);
     fixedColumns = EnrollmentAnalyticsColumn.getColumns(sqlBuilder);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -76,7 +75,6 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider,
@@ -90,7 +88,6 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsExportSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -110,7 +110,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
-      AnalyticsTableSettings analyticsExportSettings,
+      AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
       SqlBuilder sqlBuilder) {
     super(
@@ -123,7 +123,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         tableHookService,
         partitionManager,
         jdbcTemplate,
-        analyticsExportSettings,
+        analyticsTableSettings,
         periodDataProvider,
         sqlBuilder);
     fixedColumns = EventAnalyticsColumn.getColumns(sqlBuilder);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -138,7 +138,9 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
   @Transactional
   public List<AnalyticsTable> getAnalyticsTables(AnalyticsTableUpdateParams params) {
     log.info(
-        "Get tables using earliest: {}, spatial support: {}", params.getFromDate(), spatialSupport);
+        "Get tables using earliest: {}, spatial support: {}",
+        params.getFromDate(),
+        isSpatialSupport());
 
     List<Integer> availableDataYears =
         periodDataProvider.getAvailableYears(analyticsTableSettings.getPeriodSource());
@@ -482,7 +484,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
       DataElement dataElement, boolean withLegendSet) {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
 
-    DataType dataType = getColumnType(dataElement.getValueType(), spatialSupport);
+    DataType dataType = getColumnType(dataElement.getValueType(), isSpatialSupport());
     String columnExpression =
         sqlBuilder.jsonExtractNested("eventdatavalues", dataElement.getUid(), "value");
     String selectExpression = getSelectExpression(dataElement.getValueType(), columnExpression);
@@ -526,7 +528,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
     String fromClause =
         qualifyVariables("from ${organisationunit} ou where ou.uid = " + columnExpression);
 
-    if (spatialSupport) {
+    if (isSpatialSupport()) {
       String fromType = "ou.geometry " + fromClause;
       String geoSql = getSelectForInsert(dataElement, fromType, dataFilterClause);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
@@ -57,7 +57,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -88,7 +87,6 @@ public class JdbcOrgUnitTargetTableManager extends AbstractJdbcTableManager {
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
@@ -102,7 +100,6 @@ public class JdbcOrgUnitTargetTableManager extends AbstractJdbcTableManager {
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -121,7 +121,7 @@ public class JdbcOwnershipAnalyticsTableManager extends AbstractEventJdbcTableMa
       PartitionManager partitionManager,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       JdbcConfiguration jdbcConfiguration,
-      AnalyticsTableSettings analyticsExportSettings,
+      AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
       SqlBuilder sqlBuilder) {
     super(
@@ -134,7 +134,7 @@ public class JdbcOwnershipAnalyticsTableManager extends AbstractEventJdbcTableMa
         tableHookService,
         partitionManager,
         jdbcTemplate,
-        analyticsExportSettings,
+        analyticsTableSettings,
         periodDataProvider,
         sqlBuilder);
     this.jdbcConfiguration = jdbcConfiguration;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -64,7 +64,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.quick.JdbcConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -120,7 +119,6 @@ public class JdbcOwnershipAnalyticsTableManager extends AbstractEventJdbcTableMa
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       JdbcConfiguration jdbcConfiguration,
       AnalyticsTableSettings analyticsExportSettings,
@@ -135,7 +133,6 @@ public class JdbcOwnershipAnalyticsTableManager extends AbstractEventJdbcTableMa
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsExportSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -75,7 +75,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -105,7 +104,6 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       TrackedEntityAttributeService trackedEntityAttributeService,
@@ -121,7 +119,6 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,
@@ -216,7 +213,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
                 tea ->
                     AnalyticsTableColumn.builder()
                         .name(tea.getUid())
-                        .dataType(getColumnType(tea.getValueType(), isSpatialSupport()))
+                        .dataType(getColumnType(tea.getValueType(), spatialSupport))
                         .selectExpression(
                             castBasedOnType(tea.getValueType(), quote(tea.getUid()) + ".value"))
                         .build())
@@ -270,7 +267,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
           " cast(${columnName} as ${type})",
           Map.of("columnName", columnName, "type", sqlBuilder.dataTypeTimestamp()));
     }
-    if (valueType.isGeo() && isSpatialSupport() && sqlBuilder.supportsGeospatialData()) {
+    if (valueType.isGeo() && spatialSupport && sqlBuilder.supportsGeospatialData()) {
       return replace(
           """
           \s ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (${columnName}) || ',

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -213,7 +213,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
                 tea ->
                     AnalyticsTableColumn.builder()
                         .name(tea.getUid())
-                        .dataType(getColumnType(tea.getValueType(), spatialSupport))
+                        .dataType(getColumnType(tea.getValueType(), isSpatialSupport()))
                         .selectExpression(
                             castBasedOnType(tea.getValueType(), quote(tea.getUid()) + ".value"))
                         .build())
@@ -267,7 +267,7 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractJdbcTableMan
           " cast(${columnName} as ${type})",
           Map.of("columnName", columnName, "type", sqlBuilder.dataTypeTimestamp()));
     }
-    if (valueType.isGeo() && spatialSupport && sqlBuilder.supportsGeospatialData()) {
+    if (valueType.isGeo() && isSpatialSupport() && sqlBuilder.supportsGeospatialData()) {
       return replace(
           """
           \s ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (${columnName}) || ',

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
@@ -67,7 +67,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -176,7 +175,6 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
@@ -191,7 +189,6 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
@@ -78,7 +78,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -206,7 +205,6 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
@@ -222,7 +220,6 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
@@ -62,7 +62,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -109,7 +108,6 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      DatabaseInfoProvider databaseInfoProvider,
       @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
@@ -123,7 +121,6 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
         resourceTableService,
         tableHookService,
         partitionManager,
-        databaseInfoProvider,
         jdbcTemplate,
         analyticsTableSettings,
         periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableSettings.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableSettings.java
@@ -141,7 +141,7 @@ public class AnalyticsTableSettings {
    */
   public boolean isSpatialSupport() {
     DatabaseInfo info = databaseInfoProvider.getDatabaseInfo();
-    return info != null ? info.isSpatialSupport() : false;
+    return info != null && info.isSpatialSupport();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableSettings.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableSettings.java
@@ -53,6 +53,8 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.period.PeriodDataProvider.PeriodSource;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.system.database.DatabaseInfo;
+import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,6 +69,8 @@ public class AnalyticsTableSettings {
   private final DhisConfigurationProvider config;
 
   private final SystemSettingsProvider settingsProvider;
+
+  private final DatabaseInfoProvider databaseInfoProvider;
 
   /**
    * Returns the setting indicating whether resource and analytics tables should be logged or
@@ -128,6 +132,16 @@ public class AnalyticsTableSettings {
    */
   public Set<String> getSkipColumnDimensions() {
     return toSet(config.getProperty(ANALYTICS_TABLE_SKIP_COLUMN));
+  }
+
+  /**
+   * Indicates whether spatial database support is available.
+   *
+   * @return true if spatial database support is available.
+   */
+  public boolean isSpatialSupport() {
+    DatabaseInfo info = databaseInfoProvider.getDatabaseInfo();
+    return info != null ? info.isSpatialSupport() : false;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.table;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.ValueType;
@@ -49,7 +50,7 @@ class AbstractEventJdbcTableManagerTest {
 
   @BeforeEach
   public void beforeEach() {
-    manager.spatialSupport = true;
+    when(manager.isSpatialSupport(any(), any())).thenReturn(true);
   }
 
   @Test
@@ -124,8 +125,6 @@ class AbstractEventJdbcTableManagerTest {
 
   @Test
   void testGetSelectExpressionGeometry() {
-    when(manager.isSpatialSupport()).thenReturn(Boolean.TRUE);
-
     String expected =
         """
         ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (eventdatavalues #>> '{C6bh7GevJfH, value}') || ', "crs":{"type":"name", "properties":{"name":"EPSG:4326"}}}')""";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
@@ -28,9 +28,9 @@
 package org.hisp.dhis.analytics.table;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
@@ -38,11 +38,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractEventJdbcTableManagerTest {
+
+  @Mock private AnalyticsTableSettings settings;
 
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
@@ -50,7 +53,8 @@ class AbstractEventJdbcTableManagerTest {
 
   @BeforeEach
   public void beforeEach() {
-    when(manager.isSpatialSupport(any(), any())).thenReturn(true);
+    when(settings.isSpatialSupport()).thenReturn(true);
+    when(manager.isSpatialSupport()).thenReturn(true);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
@@ -34,7 +34,6 @@ import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -50,12 +49,6 @@ class AbstractEventJdbcTableManagerTest {
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
   @InjectMocks private JdbcEventAnalyticsTableManager manager;
-
-  @BeforeEach
-  public void beforeEach() {
-    when(settings.isSpatialSupport()).thenReturn(true);
-    when(manager.isSpatialSupport()).thenReturn(true);
-  }
 
   @Test
   void testGetCastExpression() {
@@ -129,6 +122,8 @@ class AbstractEventJdbcTableManagerTest {
 
   @Test
   void testGetSelectExpressionGeometry() {
+    when(manager.isSpatialSupport()).thenReturn(true);
+
     String expected =
         """
         ST_GeomFromGeoJSON('{"type":"Point", "coordinates":' || (eventdatavalues #>> '{C6bh7GevJfH, value}') || ', "crs":{"type":"name", "properties":{"name":"EPSG:4326"}}}')""";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -62,7 +62,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -111,7 +110,6 @@ class JdbcAnalyticsTableManagerTest {
             mock(ResourceTableService.class),
             mock(AnalyticsTableHookService.class),
             mock(PartitionManager.class),
-            mock(DatabaseInfoProvider.class),
             jdbcTemplate,
             analyticsTableSettings,
             periodDataProvider,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -62,8 +62,6 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfo;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,8 +79,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 class JdbcEnrollmentAnalyticsTableManagerTest {
   @Mock private IdentifiableObjectManager idObjectManager;
 
-  @Mock private DatabaseInfoProvider databaseInfoProvider;
-
   @Mock private JdbcTemplate jdbcTemplate;
 
   @Mock private AnalyticsTableSettings analyticsTableSettings;
@@ -97,7 +93,7 @@ class JdbcEnrollmentAnalyticsTableManagerTest {
 
   @BeforeEach
   public void setUp() {
-    when(databaseInfoProvider.getDatabaseInfo()).thenReturn(DatabaseInfo.builder().build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     SystemSettingsProvider settingsProvider = mock(SystemSettingsProvider.class);
     lenient().when(settingsProvider.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
     subject =
@@ -110,7 +106,6 @@ class JdbcEnrollmentAnalyticsTableManagerTest {
             mock(ResourceTableService.class),
             mock(AnalyticsTableHookService.class),
             mock(PartitionManager.class),
-            databaseInfoProvider,
             jdbcTemplate,
             analyticsTableSettings,
             periodDataProvider,
@@ -120,8 +115,6 @@ class JdbcEnrollmentAnalyticsTableManagerTest {
   @Test
   void verifyTeiTypeOrgUnitFetchesOuUidWhenPopulatingEventAnalyticsTable() {
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
     Program p1 = createProgram('A');
 
     TrackedEntityAttribute tea = createTrackedEntityAttribute('a', ValueType.ORGANISATION_UNIT);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
@@ -71,8 +71,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfo;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,15 +96,13 @@ class JdbcEventAnalyticsTableManagerDorisTest {
 
   @Mock private SystemSettings settings;
 
-  @Mock private DatabaseInfoProvider databaseInfoProvider;
-
   @Mock private JdbcTemplate jdbcTemplate;
+
+  @Mock private AnalyticsTableSettings analyticsTableSettings;
 
   @Mock private ResourceTableService resourceTableService;
 
   @Mock private PeriodDataProvider periodDataProvider;
-
-  @Mock private AnalyticsTableSettings analyticsTableSettings;
 
   @Spy private SqlBuilder sqlBuilder = new DorisSqlBuilder("dhis2", "driver");
 
@@ -141,7 +137,6 @@ class JdbcEventAnalyticsTableManagerDorisTest {
   void setUp() {
     today = Date.from(LocalDate.of(2019, 7, 6).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    when(databaseInfoProvider.getDatabaseInfo()).thenReturn(DatabaseInfo.builder().build());
     when(settingsProvider.getCurrentSettings()).thenReturn(settings);
     when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
     when(analyticsTableSettings.getPeriodSource()).thenReturn(PeriodSource.DATABASE);
@@ -149,8 +144,6 @@ class JdbcEventAnalyticsTableManagerDorisTest {
 
   @Test
   void verifyGetTableWithDataElements() {
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
     Program program = createProgram('A');
 
     DataElement deA = createDataElement('A', ValueType.TEXT, AggregationType.SUM);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -99,8 +99,6 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfo;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.test.random.BeanRandomizer;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.joda.time.DateTime;
@@ -129,8 +127,6 @@ class JdbcEventAnalyticsTableManagerTest {
   @Mock private SystemSettingsProvider settingsProvider;
 
   @Mock private SystemSettings settings;
-
-  @Mock private DatabaseInfoProvider databaseInfoProvider;
 
   @Mock private JdbcTemplate jdbcTemplate;
 
@@ -174,7 +170,6 @@ class JdbcEventAnalyticsTableManagerTest {
   public void setUp() {
     today = Date.from(LocalDate.of(2019, 7, 6).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    when(databaseInfoProvider.getDatabaseInfo()).thenReturn(DatabaseInfo.builder().build());
     when(settingsProvider.getCurrentSettings()).thenReturn(settings);
     when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
   }
@@ -357,8 +352,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   @Test
   void verifyGetTableWithDataElements() {
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program program = createProgram('A');
 
     DataElement d1 = createDataElement('Z', ValueType.TEXT, AggregationType.SUM);
@@ -487,8 +481,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   @Test
   void verifyGetTableWithTrackedEntityAttribute() {
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program program = createProgram('A');
 
     TrackedEntityAttribute tea1 = rnd.nextObject(TrackedEntityAttribute.class);
@@ -565,8 +558,7 @@ class JdbcEventAnalyticsTableManagerTest {
   @Test
   void verifyDataElementTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable() {
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program programA = createProgram('A');
 
     DataElement d5 = createDataElement('G', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
@@ -614,8 +606,7 @@ class JdbcEventAnalyticsTableManagerTest {
   @Test
   void verifyTeiTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable() {
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program programA = createProgram('A');
 
     TrackedEntityAttribute tea = createTrackedEntityAttribute('a', ValueType.ORGANISATION_UNIT);
@@ -663,8 +654,7 @@ class JdbcEventAnalyticsTableManagerTest {
   @Test
   void verifyOrgUnitOwnershipJoinsWhenPopulatingEventAnalyticsTable() {
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program programA = createProgram('A');
 
     TrackedEntityAttribute tea = createTrackedEntityAttribute('a', ValueType.ORGANISATION_UNIT);
@@ -881,8 +871,7 @@ class JdbcEventAnalyticsTableManagerTest {
   @Test
   void verifyTeaTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable() {
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    when(databaseInfoProvider.getDatabaseInfo())
-        .thenReturn(DatabaseInfo.builder().spatialSupport(true).build());
+    when(analyticsTableSettings.isSpatialSupport()).thenReturn(true);
     Program programA = createProgram('A');
 
     TrackedEntityAttribute tea = createTrackedEntityAttribute('a', ValueType.ORGANISATION_UNIT);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
@@ -52,8 +52,6 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfo;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -69,20 +67,34 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @ExtendWith(MockitoExtension.class)
 class JdbcTrackedEntityAnalyticsTableManagerTest {
   @Mock private JdbcTemplate jdbcTemplate;
+
   @Mock private AnalyticsTableSettings analyticsTableSettings;
+
   @Mock private PeriodDataProvider periodDataProvider;
+
   @Mock private SqlBuilder sqlBuilder;
+
   @Mock private PartitionManager partitionManager;
+
   @Mock private SystemSettingsProvider systemSettingsProvider;
+
   @Mock private IdentifiableObjectManager identifiableObjectManager;
+
   @Mock private TrackedEntityTypeService trackedEntityTypeService;
+
   @Mock private TrackedEntityAttributeService trackedEntityAttributeService;
+
   @Mock private CategoryService categoryService;
+
+  @Mock private AnalyticsTableSettings settings;
+
   @Mock private DataApprovalLevelService dataApprovalLevelService;
+
   @Mock private OrganisationUnitService organisationUnitService;
+
   @Mock private ResourceTableService resourceTableService;
+
   @Mock private AnalyticsTableHookService analyticsTableHookService;
-  @Mock private DatabaseInfoProvider databaseInfoProvider;
 
   @InjectMocks private JdbcTrackedEntityAnalyticsTableManager tableManager;
 
@@ -131,10 +143,6 @@ class JdbcTrackedEntityAnalyticsTableManagerTest {
     when(analyticsTableSettings.getTableLogged()).thenReturn(Logged.LOGGED);
 
     when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
-
-    DatabaseInfo databaseInfo = mock(DatabaseInfo.class);
-    when(databaseInfo.isSpatialSupport()).thenReturn(false);
-    when(databaseInfoProvider.getDatabaseInfo()).thenReturn(databaseInfo);
 
     List<AnalyticsTable> analyticsTables = tableManager.getAnalyticsTables(params);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
@@ -140,8 +140,6 @@ class JdbcTrackedEntityAnalyticsTableManagerTest {
 
     when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
 
-    when(analyticsTableSettings.getTableLogged()).thenReturn(Logged.LOGGED);
-
     when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
 
     List<AnalyticsTable> analyticsTables = tableManager.getAnalyticsTables(params);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.db.model.Column;
-import org.hisp.dhis.db.model.Logged;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
@@ -135,10 +134,6 @@ class JdbcTrackedEntityAnalyticsTableManagerTest {
 
     when(trackedEntityAttributeService.getProgramTrackedEntityAttributes(List.of(program)))
         .thenReturn(List.of());
-
-    when(analyticsTableSettings.getTableLogged()).thenReturn(Logged.LOGGED);
-
-    when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
 
     when(identifiableObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManagerTest.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
@@ -76,21 +75,34 @@ import org.springframework.jdbc.core.JdbcTemplate;
 class JdbcTrackedEntityEventsAnalyticsTableManagerTest {
 
   @Mock private JdbcTemplate jdbcTemplate;
+
   @Mock private AnalyticsTableSettings analyticsTableSettings;
+
   @Mock private PeriodDataProvider periodDataProvider;
+
   @Spy private PostgreSqlBuilder sqlBuilder;
+
   @Spy private PostgresAnalyticsSqlBuilder analyticsSqlBuilder;
+
   @Mock private PartitionManager partitionManager;
+
   @Mock private SystemSettingsProvider systemSettingsProvider;
+
   @Mock private IdentifiableObjectManager identifiableObjectManager;
+
   @Mock private TrackedEntityTypeService trackedEntityTypeService;
+
   @Mock private TrackedEntityAttributeService trackedEntityAttributeService;
+
   @Mock private CategoryService categoryService;
+
   @Mock private DataApprovalLevelService dataApprovalLevelService;
+
   @Mock private OrganisationUnitService organisationUnitService;
+
   @Mock private ResourceTableService resourceTableService;
+
   @Mock private AnalyticsTableHookService analyticsTableHookService;
-  @Mock private DatabaseInfoProvider databaseInfoProvider;
 
   @InjectMocks private JdbcTrackedEntityEventsAnalyticsTableManager tableManager;
 
@@ -103,7 +115,6 @@ class JdbcTrackedEntityEventsAnalyticsTableManagerTest {
 
   @Test
   void testPopulate() {
-
     TrackedEntityType tet = mock(TrackedEntityType.class);
     when(tet.getUid()).thenReturn("tetUid");
     when(trackedEntityTypeService.getAllTrackedEntityType()).thenReturn(List.of(tet));

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.external.conf;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +35,11 @@ import java.util.Properties;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.model.GoogleAccessToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 
 /**
- * Provider of DHIS 2 configuration properties specified in the {@code dhis.conf} file.
+ * Provider of DHIS 2 configuration properties specified in the {@code dhis.conf} file. The property
+ * values are loaded on application startup and can be assumed to not change during runtime.
  *
  * @author Lars Helge Overland
  */

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DhisConfigurationProvider.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.external.conf;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,6 @@ import java.util.Properties;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.model.GoogleAccessToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 
 /**
  * Provider of DHIS 2 configuration properties specified in the {@code dhis.conf} file. The property


### PR DESCRIPTION
Centralizes the `isGeospatial` logic. Removes the non-final geospatial class-level property which is prone to race conditions and unintended consequences in the case where the property is changed by application code.