### PR TITLE
chore: OpenAPI - exclude user property from BaseIdentifiableObject

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -360,7 +360,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
-  @OpenApi.Property(UserPropertyTransformer.UserDto.class)
+  @OpenApi.Ignore
   @JsonProperty
   @JsonSerialize(using = UserPropertyTransformer.JacksonSerialize.class)
   @JsonDeserialize(using = UserPropertyTransformer.JacksonDeserialize.class)


### PR DESCRIPTION
Ass discussed the `user` property that mainly is an alias for `createdBy` should be phased out. First step is to remove it from the OpenAPI generated documentation. 