### PR TITLE
fix: [DHIS2-18551] (2.39) Fix access check when registering TEI

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -46,6 +46,8 @@ public interface TrackerAccessManager {
 
   List<String> canWrite(User user, TrackedEntityInstance trackedEntityInstance);
 
+  List<String> canCreate(User user, TrackedEntityInstance trackedEntity);
+
   List<String> canRead(
       User user,
       TrackedEntityInstance trackedEntityInstance,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -188,11 +188,15 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     List<String> errors = new ArrayList<>();
     if (!aclService.canDataWrite(user, trackedEntity.getTrackedEntityType())) {
       errors.add(
-              "User has no data write access to tracked entity type: " + trackedEntity.getTrackedEntityType().getUid());
+          "User has no data write access to tracked entity type: "
+              + trackedEntity.getTrackedEntityType().getUid());
     }
 
-    if ( trackedEntity.getOrganisationUnit() != null && !organisationUnitService.isInUserHierarchy(user,  trackedEntity.getOrganisationUnit())) {
-      errors.add("User has no write access to organisation unit: " +  trackedEntity.getOrganisationUnit().getUid());
+    if (trackedEntity.getOrganisationUnit() != null
+        && !organisationUnitService.isInUserHierarchy(user, trackedEntity.getOrganisationUnit())) {
+      errors.add(
+          "User has no write access to organisation unit: "
+              + trackedEntity.getOrganisationUnit().getUid());
     }
 
     return errors;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -688,7 +688,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
       return importSummary;
     }
 
-    List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoEntityInstance);
+    List<String> errors = trackerAccessManager.canCreate(importOptions.getUser(), daoEntityInstance);
 
     if (!errors.isEmpty()) {
       return new ImportSummary(ImportStatus.ERROR, errors.toString()).incrementIgnored();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -688,7 +688,8 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
       return importSummary;
     }
 
-    List<String> errors = trackerAccessManager.canCreate(importOptions.getUser(), daoEntityInstance);
+    List<String> errors =
+        trackerAccessManager.canCreate(importOptions.getUser(), daoEntityInstance);
 
     if (!errors.isEmpty()) {
       return new ImportSummary(ImportStatus.ERROR, errors.toString()).incrementIgnored();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -602,14 +602,15 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     trackedEntityInstance.setTrackedEntityInstance(CodeGenerator.generateUid());
     trackedEntityInstance.setOrgUnit(organisationUnitA.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
+
     ImportSummary importSummary =
         trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
+
     assertEquals(ImportStatus.SUCCESS, importSummary.getStatus());
   }
 
   @Test
   void shouldFailWhenRegisteringPersonOutsideCaptureScope() {
-
     trackedEntityType.setSharing(Sharing.builder().publicAccess("rwrw----").build());
     regularUser.setOrganisationUnits(Set.of(organisationUnitB));
     injectSecurityContext(regularUser);
@@ -617,8 +618,10 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     trackedEntityInstance.setTrackedEntityInstance(CodeGenerator.generateUid());
     trackedEntityInstance.setOrgUnit(organisationUnitA.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
+
     ImportSummary importSummary =
         trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
+
     assertEquals(ImportStatus.ERROR, importSummary.getStatus());
     assertEquals(1, importSummary.getImportCount().getIgnored());
     assertEquals(
@@ -635,8 +638,10 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     trackedEntityInstance.setTrackedEntityInstance(CodeGenerator.generateUid());
     trackedEntityInstance.setOrgUnit(organisationUnitB.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
+
     ImportSummary importSummary =
         trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
+
     assertEquals(ImportStatus.ERROR, importSummary.getStatus());
     assertEquals(1, importSummary.getImportCount().getIgnored());
     assertEquals(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -618,13 +618,13 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     trackedEntityInstance.setOrgUnit(organisationUnitA.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
     ImportSummary importSummary =
-            trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
+        trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
     assertEquals(ImportStatus.ERROR, importSummary.getStatus());
     assertEquals(1, importSummary.getImportCount().getIgnored());
     assertEquals(
-            String.format("[User has no write access to organisation unit: %s]",
-                    organisationUnitA.getUid()),
-            importSummary.getDescription());
+        String.format(
+            "[User has no write access to organisation unit: %s]", organisationUnitA.getUid()),
+        importSummary.getDescription());
   }
 
   @Test
@@ -636,13 +636,14 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     trackedEntityInstance.setOrgUnit(organisationUnitA.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
     ImportSummary importSummary =
-            trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
+        trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);
     assertEquals(ImportStatus.ERROR, importSummary.getStatus());
     assertEquals(1, importSummary.getImportCount().getIgnored());
     assertEquals(
-            String.format("[User has no data write access to tracked entity type: %s]",
-                    trackedEntityType.getUid()),
-            importSummary.getDescription());
+        String.format(
+            "[User has no data write access to tracked entity type: %s]",
+            trackedEntityType.getUid()),
+        importSummary.getDescription());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -633,7 +633,7 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
     injectSecurityContext(regularUser);
     TrackedEntityInstance trackedEntityInstance = new TrackedEntityInstance();
     trackedEntityInstance.setTrackedEntityInstance(CodeGenerator.generateUid());
-    trackedEntityInstance.setOrgUnit(organisationUnitA.getUid());
+    trackedEntityInstance.setOrgUnit(organisationUnitB.getUid());
     trackedEntityInstance.setTrackedEntityType(trackedEntityType.getUid());
     ImportSummary importSummary =
         trackedEntityInstanceService.addTrackedEntityInstance(trackedEntityInstance, null);


### PR DESCRIPTION
When registering a new TEI, there is no context of a program. But the old Tracker API goes ahead and checks program ownership for “all the programs in the system”. This itself was only part of the problem.

There is a cache used to store programOwnerOu for a TEI-Program combination. For TE creation, when the TE is yet to be created, it will not have an id (the primary key column which is obtained after a TE is persisted). So during the time of TE creation, the entity object will always have an id of 0. This 0 is used as part of the key to cache programOwners. This means any subsequent TEI registration will also have 0 as the id and will pick up the  "wrong owner OU" from the cache(the first one that got into the cache).

So irrelevant access checks + incorrect cache hits was the root cause of the original issue.

This PR fixes this by making sure programOwnership is not checked when registering a new TEI and rather simply check if the user has TE.orgUnit in their Capture Scope and if the user has Data Write access to the TE.TEType

This fix is consistent with the new Tracker API, in master. In v42(master), [when creating a new TE](https://github.com/dhis2/dhis2-core/blob/39b5511344023394c1099048e1e49659f15628bb/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java#L94), it only checks if the user has dataWrite access to the TeType and nothing of ownership is checked. It has separate access check flows when the TE is being created vs when the TE is being updated.
