### PR TITLE
task: Rename eventProperty to eventField [DHIS2-18549]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/EventChangeLog.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/EventChangeLog.hbm.xml
@@ -18,7 +18,7 @@
     <many-to-one name="dataElement" class="org.hisp.dhis.dataelement.DataElement" column="dataelementid"
       foreign-key="fk_eventchangelog_dataelementid" />
 
-    <property name="eventProperty" length="100" />
+    <property name="eventField" length="100" />
 
     <property name="previousValue" length="50000" />
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -133,7 +133,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   }
 
   private <T> void logIfChanged(
-      String fieldName,
+      String field,
       Function<Event, T> valueExtractor,
       Function<T, String> formatter,
       Event currentEvent,
@@ -148,27 +148,27 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
 
       EventChangeLog eventChangeLog =
           new EventChangeLog(
-              event, null, fieldName, currentValue, newValue, changeLogType, new Date(), userName);
+              event, null, field, currentValue, newValue, changeLogType, new Date(), userName);
 
       hibernateEventChangeLogStore.addEventChangeLog(eventChangeLog);
     }
   }
 
   private ChangeLogType getChangeLogType(String oldValue, String newValue) {
-    if (isNewField(oldValue, newValue)) {
+    if (isFieldCreated(oldValue, newValue)) {
       return ChangeLogType.CREATE;
-    } else if (isUpdateField(oldValue, newValue)) {
+    } else if (isFieldUpdated(oldValue, newValue)) {
       return ChangeLogType.UPDATE;
     } else {
       return ChangeLogType.DELETE;
     }
   }
 
-  private boolean isNewField(String originalValue, String payloadValue) {
+  private boolean isFieldCreated(String originalValue, String payloadValue) {
     return originalValue == null && payloadValue != null;
   }
 
-  private boolean isUpdateField(String originalValue, String payloadValue) {
+  private boolean isFieldUpdated(String originalValue, String payloadValue) {
     return originalValue != null && payloadValue != null;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -99,7 +99,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
 
   @Override
   @Transactional
-  public void addPropertyChangeLog(
+  public void addFieldChangeLog(
       @Nonnull Event currentEvent, @Nonnull Event event, @Nonnull String username) {
     logIfChanged(
         "occurredAt", Event::getOccurredDate, this::formatDate, currentEvent, event, username);
@@ -133,7 +133,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   }
 
   private <T> void logIfChanged(
-      String propertyName,
+      String fieldName,
       Function<Event, T> valueExtractor,
       Function<T, String> formatter,
       Event currentEvent,
@@ -148,34 +148,27 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
 
       EventChangeLog eventChangeLog =
           new EventChangeLog(
-              event,
-              null,
-              propertyName,
-              currentValue,
-              newValue,
-              changeLogType,
-              new Date(),
-              userName);
+              event, null, fieldName, currentValue, newValue, changeLogType, new Date(), userName);
 
       hibernateEventChangeLogStore.addEventChangeLog(eventChangeLog);
     }
   }
 
   private ChangeLogType getChangeLogType(String oldValue, String newValue) {
-    if (isNewProperty(oldValue, newValue)) {
+    if (isNewField(oldValue, newValue)) {
       return ChangeLogType.CREATE;
-    } else if (isUpdateProperty(oldValue, newValue)) {
+    } else if (isUpdateField(oldValue, newValue)) {
       return ChangeLogType.UPDATE;
     } else {
       return ChangeLogType.DELETE;
     }
   }
 
-  private boolean isNewProperty(String originalValue, String payloadValue) {
+  private boolean isNewField(String originalValue, String payloadValue) {
     return originalValue == null && payloadValue != null;
   }
 
-  private boolean isUpdateProperty(String originalValue, String payloadValue) {
+  private boolean isUpdateField(String originalValue, String payloadValue) {
     return originalValue != null && payloadValue != null;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
@@ -46,7 +46,7 @@ public class EventChangeLog {
 
   private DataElement dataElement;
 
-  private String eventProperty;
+  private String eventField;
 
   private String previousValue;
 
@@ -63,40 +63,40 @@ public class EventChangeLog {
   public EventChangeLog(
       Event event,
       DataElement dataElement,
-      String eventProperty,
+      String eventField,
       String previousValue,
       String currentValue,
       ChangeLogType changeLogType,
       Date created,
       String createdByUsername) {
-    this(event, dataElement, eventProperty, previousValue, currentValue, changeLogType, created);
+    this(event, dataElement, eventField, previousValue, currentValue, changeLogType, created);
     this.createdByUsername = createdByUsername;
   }
 
   public EventChangeLog(
       Event event,
       DataElement dataElement,
-      String eventProperty,
+      String eventField,
       String previousValue,
       String currentValue,
       ChangeLogType changeLogType,
       Date created,
       UserInfoSnapshot createdBy) {
-    this(event, dataElement, eventProperty, previousValue, currentValue, changeLogType, created);
+    this(event, dataElement, eventField, previousValue, currentValue, changeLogType, created);
     this.createdBy = createdBy;
   }
 
   private EventChangeLog(
       Event event,
       DataElement dataElement,
-      String eventProperty,
+      String eventField,
       String previousValue,
       String currentValue,
       ChangeLogType changeLogType,
       Date created) {
     this.event = event;
     this.dataElement = dataElement;
-    this.eventProperty = eventProperty;
+    this.eventField = eventField;
     this.previousValue = previousValue;
     this.currentValue = currentValue;
     this.changeLogType = changeLogType;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
@@ -58,7 +58,7 @@ public interface EventChangeLogService {
       ChangeLogType changeLogType,
       String userName);
 
-  void addPropertyChangeLog(
+  void addFieldChangeLog(
       @Nonnull Event currentEvent, @Nonnull Event event, @Nonnull String userName);
 
   void deleteTrackedEntityDataValueChangeLog(Event event);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -56,7 +56,7 @@ public class HibernateEventChangeLogStore {
   private static final String COLUMN_CHANGELOG_CREATED = "ecl.created";
   private static final String COLUMN_CHANGELOG_USER = "ecl.createdByUsername";
   private static final String COLUMN_CHANGELOG_DATA_ELEMENT = "d.uid";
-  private static final String COLUMN_CHANGELOG_PROPERTY = "ecl.eventProperty";
+  private static final String COLUMN_CHANGELOG_FIELD = "ecl.eventField";
 
   private static final String DEFAULT_ORDER =
       COLUMN_CHANGELOG_CREATED + " " + SortDirection.DESC.getValue();
@@ -73,13 +73,13 @@ public class HibernateEventChangeLogStore {
           entry("createdAt", COLUMN_CHANGELOG_CREATED),
           entry("username", COLUMN_CHANGELOG_USER),
           entry("dataElement", COLUMN_CHANGELOG_DATA_ELEMENT),
-          entry("property", COLUMN_CHANGELOG_PROPERTY));
+          entry("field", COLUMN_CHANGELOG_FIELD));
 
   private static final Map<Pair<String, Class<?>>, String> FILTERABLE_FIELDS =
       Map.ofEntries(
           entry(Pair.of("username", String.class), COLUMN_CHANGELOG_USER),
           entry(Pair.of("dataElement", UID.class), COLUMN_CHANGELOG_DATA_ELEMENT),
-          entry(Pair.of("property", String.class), COLUMN_CHANGELOG_PROPERTY));
+          entry(Pair.of("field", String.class), COLUMN_CHANGELOG_FIELD));
 
   private final EntityManager entityManager;
 
@@ -102,7 +102,7 @@ public class HibernateEventChangeLogStore {
         """
           select ecl.event,
                  ecl.dataElement,
-                 ecl.eventProperty,
+                 ecl.eventField,
                  ecl.previousValue,
                  ecl.currentValue,
                  ecl.changeLogType,
@@ -147,7 +147,7 @@ public class HibernateEventChangeLogStore {
                 row -> {
                   Event e = (Event) row[0];
                   DataElement dataElement = (DataElement) row[1];
-                  String eventProperty = (String) row[2];
+                  String eventField = (String) row[2];
                   String previousValue = (String) row[3];
                   String currentValue = (String) row[4];
                   ChangeLogType changeLogType = (ChangeLogType) row[5];
@@ -160,7 +160,7 @@ public class HibernateEventChangeLogStore {
                   return new EventChangeLog(
                       e,
                       dataElement,
-                      eventProperty,
+                      eventField,
                       previousValue,
                       currentValue,
                       changeLogType,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -215,6 +215,6 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
       throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());
     }
 
-    return attributes.stream().map(a -> UID.of(a.getUid())).collect(Collectors.toSet());
+    return attributes.stream().map(UID::of).collect(Collectors.toSet());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -170,7 +170,7 @@ public class EventPersister
       Event currentEntity,
       UserDetails user) {
     handleDataValues(entityManager, preheat, event.getDataValues(), payloadEntity, user);
-    eventChangeLogService.addPropertyChangeLog(currentEntity, payloadEntity, user.getUsername());
+    eventChangeLogService.addFieldChangeLog(currentEntity, payloadEntity, user.getUsername());
   }
 
   private void handleDataValues(

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_33__Rename_event_change_log_property_to_field.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_33__Rename_event_change_log_property_to_field.sql
@@ -1,0 +1,3 @@
+-- DHIS2-18549
+
+alter table eventchangelog rename eventproperty to eventfield;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -292,26 +292,25 @@ class EventChangeLogServiceTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenNewDatePropertyValueAdded()
+  void shouldReturnEventFieldChangeLogWhenNewDateFieldValueAdded()
       throws ForbiddenException, NotFoundException {
     String event = "QRYjLTiJTrA";
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(
             UID.of(event), defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
-    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByField(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByField(changeLogs, "occurredAt");
 
     assertNumberOfChanges(1, scheduledAtLogs);
     assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
-        () ->
-            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
-        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
+        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
+        () -> assertFieldCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenExistingDatePropertyUpdated()
+  void shouldReturnEventFieldChangeLogWhenExistingDateFieldUpdated()
       throws IOException, ForbiddenException, NotFoundException {
     UID event = UID.of("QRYjLTiJTrA");
     LocalDateTime currentTime = LocalDateTime.now();
@@ -320,31 +319,30 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
-    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByField(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByField(changeLogs, "occurredAt");
 
     assertNumberOfChanges(2, scheduledAtLogs);
     assertNumberOfChanges(2, occurredAtLogs);
     assertAll(
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
                 scheduledAtLogs.get(0)),
+        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
         () ->
-            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
-        () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
                 occurredAtLogs.get(0)),
-        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(1)));
+        () -> assertFieldCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(1)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenExistingDatePropertyDeleted()
+  void shouldReturnEventFieldChangeLogWhenExistingDateFieldDeleted()
       throws ForbiddenException, NotFoundException {
     UID event = UID.of("QRYjLTiJTrA");
 
@@ -352,56 +350,53 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> scheduledAtLogs = getChangeLogsByProperty(changeLogs, "scheduledAt");
-    List<EventChangeLog> occurredAtLogs = getChangeLogsByProperty(changeLogs, "occurredAt");
+    List<EventChangeLog> scheduledAtLogs = getChangeLogsByField(changeLogs, "scheduledAt");
+    List<EventChangeLog> occurredAtLogs = getChangeLogsByField(changeLogs, "occurredAt");
 
     assertNumberOfChanges(2, scheduledAtLogs);
     assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
-        () ->
-            assertPropertyDelete("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
-        () ->
-            assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
-        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
+        () -> assertFieldDelete("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(0)),
+        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:38.343", scheduledAtLogs.get(1)),
+        () -> assertFieldCreate("occurredAt", "2022-04-20 06:00:38.343", occurredAtLogs.get(0)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenNewGeometryPointPropertyValueAdded()
+  void shouldReturnEventFieldChangeLogWhenNewGeometryPointFieldValueAdded()
       throws ForbiddenException, NotFoundException {
     String event = "QRYjLTiJTrA";
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(
             UID.of(event), defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> geometryChangeLogs = getChangeLogsByProperty(changeLogs, "geometry");
+    List<EventChangeLog> geometryChangeLogs = getChangeLogsByField(changeLogs, "geometry");
 
     assertNumberOfChanges(1, geometryChangeLogs);
     assertAll(
-        () ->
-            assertPropertyCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(0)));
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(0)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenNewGeometryPolygonPropertyValueAdded()
+  void shouldReturnEventFieldChangeLogWhenNewGeometryPolygonFieldValueAdded()
       throws ForbiddenException, NotFoundException {
     String event = "YKmfzHdjUDL";
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(
             UID.of(event), defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> geometryChangeLogs = getChangeLogsByProperty(changeLogs, "geometry");
+    List<EventChangeLog> geometryChangeLogs = getChangeLogsByField(changeLogs, "geometry");
 
     assertNumberOfChanges(1, geometryChangeLogs);
     assertAll(
         () ->
-            assertPropertyCreate(
+            assertFieldCreate(
                 "geometry",
                 "(-11.416855, 8.132308), (-11.445351, 8.089312), (-11.383896, 8.089652), (-11.416855, 8.132308)",
                 geometryChangeLogs.get(0)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenExistingGeometryPointPropertyUpdated()
+  void shouldReturnEventFieldChangeLogWhenExistingGeometryPointFieldUpdated()
       throws ForbiddenException, NotFoundException {
     UID event = UID.of("QRYjLTiJTrA");
 
@@ -410,22 +405,21 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> geometryChangeLogs = getChangeLogsByProperty(changeLogs, "geometry");
+    List<EventChangeLog> geometryChangeLogs = getChangeLogsByField(changeLogs, "geometry");
 
     assertNumberOfChanges(2, geometryChangeLogs);
     assertAll(
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "geometry",
                 "(-11.419700, 8.103900)",
                 "(16.435547, 49.264220)",
                 geometryChangeLogs.get(0)),
-        () ->
-            assertPropertyCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(1)));
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(1)));
   }
 
   @Test
-  void shouldReturnEventPropertiesChangeLogWhenExistingGeometryPointPropertyDeleted()
+  void shouldReturnEventFieldChangeLogWhenExistingGeometryPointFieldDeleted()
       throws ForbiddenException, NotFoundException {
     UID event = UID.of("QRYjLTiJTrA");
 
@@ -433,13 +427,12 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(event, defaultOperationParams, defaultPageParams);
-    List<EventChangeLog> geometryChangeLogs = getChangeLogsByProperty(changeLogs, "geometry");
+    List<EventChangeLog> geometryChangeLogs = getChangeLogsByField(changeLogs, "geometry");
 
     assertNumberOfChanges(2, geometryChangeLogs);
     assertAll(
-        () -> assertPropertyDelete("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(0)),
-        () ->
-            assertPropertyCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(1)));
+        () -> assertFieldDelete("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(0)),
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", geometryChangeLogs.get(1)));
   }
 
   private void updateDataValue(String event, String dataElementUid, String newValue) {
@@ -554,12 +547,11 @@ class EventChangeLogServiceTest extends TrackerTest {
         () -> assertDataElementChange(dataElement, null, currentValue, changeLog));
   }
 
-  private void assertPropertyCreate(
-      String property, String currentValue, EventChangeLog changeLog) {
+  private void assertFieldCreate(String field, String currentValue, EventChangeLog changeLog) {
     assertAll(
         () -> assertUser(importUser, changeLog),
         () -> assertEquals("CREATE", changeLog.getChangeLogType().name()),
-        () -> assertPropertyChange(property, null, currentValue, changeLog));
+        () -> assertFieldChange(field, null, currentValue, changeLog));
   }
 
   private void assertDataElementUpdate(
@@ -567,14 +559,14 @@ class EventChangeLogServiceTest extends TrackerTest {
     assertUpdate(dataElement, null, previousValue, currentValue, changeLog, importUser);
   }
 
-  private void assertPropertyUpdate(
-      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
-    assertUpdate(null, property, previousValue, currentValue, changeLog, importUser);
+  private void assertFieldUpdate(
+      String field, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertUpdate(null, field, previousValue, currentValue, changeLog, importUser);
   }
 
   private void assertUpdate(
       String dataElement,
-      String property,
+      String field,
       String previousValue,
       String currentValue,
       EventChangeLog changeLog,
@@ -586,7 +578,7 @@ class EventChangeLogServiceTest extends TrackerTest {
           if (dataElement != null) {
             assertDataElementChange(dataElement, previousValue, currentValue, changeLog);
           } else {
-            assertPropertyChange(property, previousValue, currentValue, changeLog);
+            assertFieldChange(field, previousValue, currentValue, changeLog);
           }
         });
   }
@@ -596,13 +588,12 @@ class EventChangeLogServiceTest extends TrackerTest {
     assertDelete(dataElement, null, previousValue, changeLog);
   }
 
-  private void assertPropertyDelete(
-      String property, String previousValue, EventChangeLog changeLog) {
-    assertDelete(null, property, previousValue, changeLog);
+  private void assertFieldDelete(String field, String previousValue, EventChangeLog changeLog) {
+    assertDelete(null, field, previousValue, changeLog);
   }
 
   private void assertDelete(
-      String dataElement, String property, String previousValue, EventChangeLog changeLog) {
+      String dataElement, String field, String previousValue, EventChangeLog changeLog) {
     assertAll(
         () -> assertUser(importUser, changeLog),
         () -> assertEquals("DELETE", changeLog.getChangeLogType().name()),
@@ -610,7 +601,7 @@ class EventChangeLogServiceTest extends TrackerTest {
           if (dataElement != null) {
             assertDataElementChange(dataElement, previousValue, null, changeLog);
           } else {
-            assertPropertyChange(property, previousValue, null, changeLog);
+            assertFieldChange(field, previousValue, null, changeLog);
           }
         });
   }
@@ -624,9 +615,9 @@ class EventChangeLogServiceTest extends TrackerTest {
     assertEquals(currentValue, changeLog.getCurrentValue());
   }
 
-  private static void assertPropertyChange(
-      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
-    assertEquals(property, changeLog.getEventProperty());
+  private static void assertFieldChange(
+      String field, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertEquals(field, changeLog.getEventField());
     assertEquals(previousValue, changeLog.getPreviousValue());
     assertEquals(currentValue, changeLog.getCurrentValue());
   }
@@ -652,10 +643,10 @@ class EventChangeLogServiceTest extends TrackerTest {
     return changeLogs.getItems().stream().filter(cl -> cl.getDataElement() != null).toList();
   }
 
-  private List<EventChangeLog> getChangeLogsByProperty(
-      Page<EventChangeLog> changeLogs, String propertyName) {
+  private List<EventChangeLog> getChangeLogsByField(
+      Page<EventChangeLog> changeLogs, String fieldName) {
     return changeLogs.getItems().stream()
-        .filter(cl -> cl.getEventProperty() != null && cl.getEventProperty().equals(propertyName))
+        .filter(cl -> cl.getEventField() != null && cl.getEventField().equals(fieldName))
         .toList();
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -198,71 +198,71 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByPropertyAsc()
+  void shouldSortChangeLogsWhenOrderingByFieldAsc()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("property", SortDirection.ASC).build();
+        EventChangeLogOperationParams.builder().orderBy("field", SortDirection.ASC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();
     updateEventDates(event, currentTime.toDate().toInstant());
 
     List<EventChangeLog> changeLogs =
-        getAllPropertyChangeLogs(
+        getAllFieldChangeLogs(
             eventChangeLogService.getEventChangeLog(
                 UID.of("QRYjLTiJTrA"), params, defaultPageParams));
 
     assertNumberOfChanges(5, changeLogs);
     assertAll(
-        () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(0)),
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(0)),
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(1)),
-        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(2)),
+        () -> assertFieldCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(2)),
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(3)),
-        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(4)));
+        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(4)));
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByPropertyDesc()
+  void shouldSortChangeLogsWhenOrderingByFieldDesc()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("property", SortDirection.DESC).build();
+        EventChangeLogOperationParams.builder().orderBy("field", SortDirection.DESC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();
     updateEventDates(event, currentTime.toDate().toInstant());
 
     List<EventChangeLog> changeLogs =
-        getAllPropertyChangeLogs(
+        getAllFieldChangeLogs(
             eventChangeLogService.getEventChangeLog(
                 UID.of("QRYjLTiJTrA"), params, defaultPageParams));
 
     assertNumberOfChanges(5, changeLogs);
     assertAll(
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "scheduledAt",
                 "2022-04-22 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(0)),
-        () -> assertPropertyCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),
+        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),
         () ->
-            assertPropertyUpdate(
+            assertFieldUpdate(
                 "occurredAt",
                 "2022-04-20 06:00:38.343",
                 currentTime.toString(formatter),
                 changeLogs.get(2)),
-        () -> assertPropertyCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(3)),
-        () -> assertPropertyCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(4)));
+        () -> assertFieldCreate("occurredAt", "2022-04-20 06:00:38.343", changeLogs.get(3)),
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(4)));
   }
 
   @Test
@@ -302,28 +302,28 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     assertContainsOnly(List.of(dataElement), changeLogDataElements);
   }
 
-  private Stream<Arguments> provideEventProperties() {
+  private Stream<Arguments> provideEventField() {
     return Stream.of(
         Arguments.of("occurredAt"), Arguments.of("scheduledAt"), Arguments.of("geometry"));
   }
 
   @ParameterizedTest
-  @MethodSource("provideEventProperties")
-  void shouldFilterChangeLogsWhenFilteringByProperties(String filterValue)
+  @MethodSource("provideEventField")
+  void shouldFilterChangeLogsWhenFilteringByField(String filterValue)
       throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder()
-            .filterBy("property", new QueryFilter(QueryOperator.EQ, filterValue))
+            .filterBy("field", new QueryFilter(QueryOperator.EQ, filterValue))
             .build();
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), params, defaultPageParams);
 
-    Set<String> changeLogOccurredAtProperties =
+    Set<String> changeLogOccurredAtFields =
         changeLogs.getItems().stream()
-            .map(EventChangeLog::getEventProperty)
+            .map(EventChangeLog::getEventField)
             .collect(Collectors.toSet());
-    assertContainsOnly(List.of(filterValue), changeLogOccurredAtProperties);
+    assertContainsOnly(List.of(filterValue), changeLogOccurredAtFields);
   }
 
   private void updateDataValue(String event, String dataElementUid, String newValue) {
@@ -385,12 +385,11 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
         () -> assertDataElementChange(dataElement, null, currentValue, changeLog));
   }
 
-  private void assertPropertyCreate(
-      String property, String currentValue, EventChangeLog changeLog) {
+  private void assertFieldCreate(String field, String currentValue, EventChangeLog changeLog) {
     assertAll(
         () -> assertUser(importUser, changeLog),
         () -> assertEquals("CREATE", changeLog.getChangeLogType().name()),
-        () -> assertPropertyChange(property, null, currentValue, changeLog));
+        () -> assertFieldChange(field, null, currentValue, changeLog));
   }
 
   private void assertDataElementUpdate(
@@ -398,14 +397,14 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     assertUpdate(dataElement, null, previousValue, currentValue, changeLog, importUser);
   }
 
-  private void assertPropertyUpdate(
-      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
-    assertUpdate(null, property, previousValue, currentValue, changeLog, importUser);
+  private void assertFieldUpdate(
+      String field, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertUpdate(null, field, previousValue, currentValue, changeLog, importUser);
   }
 
   private void assertUpdate(
       String dataElement,
-      String property,
+      String field,
       String previousValue,
       String currentValue,
       EventChangeLog changeLog,
@@ -417,7 +416,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
           if (dataElement != null) {
             assertDataElementChange(dataElement, previousValue, currentValue, changeLog);
           } else {
-            assertPropertyChange(property, previousValue, currentValue, changeLog);
+            assertFieldChange(field, previousValue, currentValue, changeLog);
           }
         });
   }
@@ -431,9 +430,9 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     assertEquals(currentValue, changeLog.getCurrentValue());
   }
 
-  private static void assertPropertyChange(
-      String property, String previousValue, String currentValue, EventChangeLog changeLog) {
-    assertEquals(property, changeLog.getEventProperty());
+  private static void assertFieldChange(
+      String field, String previousValue, String currentValue, EventChangeLog changeLog) {
+    assertEquals(field, changeLog.getEventField());
     assertEquals(previousValue, changeLog.getPreviousValue());
     assertEquals(currentValue, changeLog.getCurrentValue());
   }
@@ -459,8 +458,8 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     return changeLogs.getItems().stream().filter(cl -> cl.getDataElement() != null).toList();
   }
 
-  private List<EventChangeLog> getAllPropertyChangeLogs(Page<EventChangeLog> changeLogs) {
-    return changeLogs.getItems().stream().filter(cl -> cl.getEventProperty() != null).toList();
+  private List<EventChangeLog> getAllFieldChangeLogs(Page<EventChangeLog> changeLogs) {
+    return changeLogs.getItems().stream().filter(cl -> cl.getEventField() != null).toList();
   }
 
   private void updateDataValues(Event event, String dataElementUid, String... values) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEventChangeLog.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEventChangeLog.java
@@ -49,8 +49,8 @@ public interface JsonEventChangeLog extends JsonObject {
       return get("dataValue").as(JsonDataValue.class);
     }
 
-    default JsonEventProperty getEventProperty() {
-      return get("eventProperty").as(JsonEventProperty.class);
+    default JsonEventField getEventField() {
+      return get("eventField").as(JsonEventField.class);
     }
   }
 
@@ -68,9 +68,9 @@ public interface JsonEventChangeLog extends JsonObject {
     }
   }
 
-  interface JsonEventProperty extends JsonObject {
-    default String getProperty() {
-      return getString("property").string();
+  interface JsonEventField extends JsonObject {
+    default String getField() {
+      return getString("field").string();
     }
 
     default String getPreviousValue() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -174,24 +174,23 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         changeLogs.stream()
             .filter(log -> log.getChange().getDataValue().getDataElement() != null)
             .toList();
-    List<JsonEventChangeLog> eventPropertyChangeLogs =
+    List<JsonEventChangeLog> eventFieldChangeLogs =
         changeLogs.stream()
-            .filter(log -> log.getChange().getEventProperty().getProperty() != null)
+            .filter(log -> log.getChange().getEventField().getField() != null)
             .toList();
 
     assertHasSize(3, dataValueChangeLogs);
-    assertHasSize(2, eventPropertyChangeLogs);
+    assertHasSize(2, eventFieldChangeLogs);
 
     assertAll(
         () -> assertDelete(dataElement, "value 3", dataValueChangeLogs.get(0)),
         () -> assertUpdate(dataElement, "value 2", "value 3", dataValueChangeLogs.get(1)),
         () -> assertUpdate(dataElement, "value 1", "value 2", dataValueChangeLogs.get(2)),
         () ->
-            assertPropertyCreateExists(
-                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
+            assertFieldCreateExists("occurredAt", "2023-01-10 00:00:00.000", eventFieldChangeLogs),
         () ->
-            assertPropertyCreateExists(
-                "scheduledAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+            assertFieldCreateExists(
+                "scheduledAt", "2023-01-10 00:00:00.000", eventFieldChangeLogs));
   }
 
   @Test
@@ -204,41 +203,39 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         changeLogs.stream()
             .filter(log -> log.getChange().getDataValue().getDataElement() != null)
             .toList();
-    List<JsonEventChangeLog> eventPropertyChangeLogs =
+    List<JsonEventChangeLog> eventFieldChangeLogs =
         changeLogs.stream()
-            .filter(log -> log.getChange().getEventProperty().getProperty() != null)
+            .filter(log -> log.getChange().getEventField().getField() != null)
             .toList();
 
     assertHasSize(3, dataValueChangeLogs);
-    assertHasSize(2, eventPropertyChangeLogs);
+    assertHasSize(2, eventFieldChangeLogs);
     assertAll(
         () -> assertUpdate(dataElement, "value 1", "value 2", dataValueChangeLogs.get(0)),
         () -> assertUpdate(dataElement, "value 2", "value 3", dataValueChangeLogs.get(1)),
         () -> assertDelete(dataElement, "value 3", dataValueChangeLogs.get(2)),
         () ->
-            assertPropertyCreateExists(
-                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs),
+            assertFieldCreateExists("occurredAt", "2023-01-10 00:00:00.000", eventFieldChangeLogs),
         () ->
-            assertPropertyCreateExists(
-                "scheduledAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+            assertFieldCreateExists(
+                "scheduledAt", "2023-01-10 00:00:00.000", eventFieldChangeLogs));
   }
 
   @Test
-  void shouldGetEventChangeLogsWhenFilteringByProperty() {
+  void shouldGetEventChangeLogsWhenFilteringByField() {
     JsonList<JsonEventChangeLog> changeLogs =
-        GET("/tracker/events/{id}/changeLogs?filter=property:eq:occurredAt", event.getUid())
+        GET("/tracker/events/{id}/changeLogs?filter=field:eq:occurredAt", event.getUid())
             .content(HttpStatus.OK)
             .getList("changeLogs", JsonEventChangeLog.class);
-    List<JsonEventChangeLog> eventPropertyChangeLogs =
+    List<JsonEventChangeLog> eventFieldChangeLogs =
         changeLogs.stream()
-            .filter(log -> log.getChange().getEventProperty().getProperty() != null)
+            .filter(log -> log.getChange().getEventField().getField() != null)
             .toList();
 
     assertAll(
-        () -> assertHasSize(1, eventPropertyChangeLogs),
+        () -> assertHasSize(1, eventFieldChangeLogs),
         () ->
-            assertPropertyCreateExists(
-                "occurredAt", "2023-01-10 00:00:00.000", eventPropertyChangeLogs));
+            assertFieldCreateExists("occurredAt", "2023-01-10 00:00:00.000", eventFieldChangeLogs));
   }
 
   @Test
@@ -479,7 +476,7 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
             assertEquals(dataElement.getUid(), actual.getChange().getDataValue().getDataElement()),
         () -> assertEquals(previousValue, actual.getChange().getDataValue().getPreviousValue()),
         () -> assertEquals(currentValue, actual.getChange().getDataValue().getCurrentValue()),
-        () -> JsonAssertions.assertHasNoMember(actual.getChange(), "eventProperty"));
+        () -> JsonAssertions.assertHasNoMember(actual.getChange(), "eventField"));
   }
 
   private static void assertPagerLink(String actual, int page, int pageSize, String start) {
@@ -490,12 +487,12 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         () -> assertContains("pageSize=" + pageSize, actual));
   }
 
-  private static void assertPropertyCreateExists(
-      String property, String currentValue, List<JsonEventChangeLog> changeLogs) {
+  private static void assertFieldCreateExists(
+      String field, String currentValue, List<JsonEventChangeLog> changeLogs) {
     assertTrue(
-        changeLogs.stream().anyMatch(cl -> isEventPropertyCreate(cl, property, currentValue)),
+        changeLogs.stream().anyMatch(cl -> isEventFieldCreate(cl, field, currentValue)),
         "Expected a "
-            + property
+            + field
             + " change with value "
             + currentValue
             + " among the change log entries.");
@@ -504,11 +501,11 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
         "Data value change not expected to be present, but it was");
   }
 
-  private static boolean isEventPropertyCreate(
-      JsonEventChangeLog actual, String property, String currentValue) {
+  private static boolean isEventFieldCreate(
+      JsonEventChangeLog actual, String field, String currentValue) {
     return actual.getType().equals(ChangeLogType.CREATE.name())
-        && actual.getChange().getEventProperty().getProperty().equals(property)
-        && actual.getChange().getEventProperty().getCurrentValue().equals(currentValue)
-        && actual.getChange().getEventProperty().getPreviousValue() == null;
+        && actual.getChange().getEventField().getField().equals(field)
+        && actual.getChange().getEventField().getCurrentValue().equals(currentValue)
+        && actual.getChange().getEventField().getPreviousValue() == null;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventChangeLogMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventChangeLogMapper.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.export.event;
 
 import org.hisp.dhis.webapi.controller.tracker.view.EventChangeLog;
 import org.hisp.dhis.webapi.controller.tracker.view.EventChangeLog.DataValueChange;
-import org.hisp.dhis.webapi.controller.tracker.view.EventChangeLog.PropertyChange;
+import org.hisp.dhis.webapi.controller.tracker.view.EventChangeLog.FieldChange;
 import org.hisp.dhis.webapi.controller.tracker.view.UIDMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.User;
 import org.mapstruct.Mapper;
@@ -47,9 +47,9 @@ public interface EventChangeLogMapper {
       source = "eventChangeLog",
       qualifiedByName = "mapIfDataValueChangeExists")
   @Mapping(
-      target = "change.eventProperty",
+      target = "change.eventField",
       source = "eventChangeLog",
-      qualifiedByName = "mapIfEventPropertyChangeExists")
+      qualifiedByName = "mapIfEventFieldChangeExists")
   EventChangeLog map(org.hisp.dhis.tracker.export.event.EventChangeLog eventChangeLog);
 
   @Mapping(target = "uid", source = "createdBy.uid")
@@ -73,18 +73,17 @@ public interface EventChangeLogMapper {
     return mapDataValueChange(eventChangeLog);
   }
 
-  @Mapping(target = "property", source = "eventProperty")
+  @Mapping(target = "field", source = "eventField")
   @Mapping(target = "previousValue", source = "previousValue")
   @Mapping(target = "currentValue", source = "currentValue")
-  PropertyChange mapEventPropertyChange(
-      org.hisp.dhis.tracker.export.event.EventChangeLog eventChangeLog);
+  FieldChange mapEventFieldChange(org.hisp.dhis.tracker.export.event.EventChangeLog eventChangeLog);
 
-  @Named("mapIfEventPropertyChangeExists")
-  default PropertyChange mapIfEventPropertyExists(
+  @Named("mapIfEventFieldChangeExists")
+  default FieldChange mapIfEventFieldExists(
       org.hisp.dhis.tracker.export.event.EventChangeLog eventChangeLog) {
-    if (eventChangeLog.getEventProperty() == null) {
+    if (eventChangeLog.getEventField() == null) {
       return null;
     }
-    return mapEventPropertyChange(eventChangeLog);
+    return mapEventFieldChange(eventChangeLog);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/EventChangeLog.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/EventChangeLog.java
@@ -38,15 +38,15 @@ public record EventChangeLog(
     @JsonProperty Change change) {
 
   public record Change(
-      @JsonProperty DataValueChange dataValue, @JsonProperty PropertyChange eventProperty) {}
+      @JsonProperty DataValueChange dataValue, @JsonProperty FieldChange eventField) {}
 
   public record DataValueChange(
       @JsonProperty UID dataElement,
       @JsonProperty String previousValue,
       @JsonProperty String currentValue) {}
 
-  public record PropertyChange(
-      @JsonProperty String property,
+  public record FieldChange(
+      @JsonProperty String field,
       @JsonProperty String previousValue,
       @JsonProperty String currentValue) {}
 }


### PR DESCRIPTION
As agreed on slack, I'm renaming `eventProperty` to `eventField`, to align with our current behavior in the API.