### PR TITLE
fix: Complete cleanup of event and enrollment references across all associated tables during deletion

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -124,6 +124,7 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           "delete from trackedentitydatavalueaudit where eventid in " + eventSelect,
           "delete from eventchangelog where eventid in " + eventSelect,
           "delete from programmessage where eventid in " + eventSelect,
+          "delete from programnotificationinstance where eventid in " + eventSelect,
           // finally delete the events
           "delete from event where deleted is true"
         };
@@ -205,6 +206,7 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           "delete from trackedentitydatavalueaudit where eventid in " + eventSelect,
           "delete from eventchangelog where eventid in " + eventSelect,
           "delete from programmessage where eventid in " + eventSelect,
+          "delete from programnotificationinstance where eventid in " + eventSelect,
           // delete other entries linked to enrollments
           "delete from relationshipitem where enrollmentid in " + enrollmentSelect,
           "delete from programmessage where enrollmentid in " + enrollmentSelect,

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -210,6 +210,7 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           // delete other entries linked to enrollments
           "delete from relationshipitem where enrollmentid in " + enrollmentSelect,
           "delete from programmessage where enrollmentid in " + enrollmentSelect,
+          "delete from programnotificationinstance where enrollmentid in " + enrollmentSelect,
           "delete from event where enrollmentid in " + enrollmentSelect,
           // finally delete the enrollments themselves
           "delete from enrollment where deleted is true"


### PR DESCRIPTION
This PR addresses an issue where the deletion functionality for events and enrollments does not remove references from all associated tables