### PR TITLE
feat: enable continuous execution for GeoJSON imports [DHIS2-16702]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -241,7 +241,8 @@ public enum JobType {
         || this == TRACKER_IMPORT_JOB
         || this == DATA_INTEGRITY
         || this == DATA_INTEGRITY_DETAILS
-        || this == SMS_INBOUND_PROCESSING;
+        || this == SMS_INBOUND_PROCESSING
+        || this == GEOJSON_IMPORT;
   }
 
   public boolean hasJobParameters() {


### PR DESCRIPTION
### Summary
Just switches from sequential to continuous execution. That means the delay between one job done and next job of the same type started is now zero as opposed to up to 30sec in the worst case. This is so multiple small GeoJSON imports do finish quicker. 

### Manual Testing
* goto import/export app and perform a GeoJSON import
* check the import works as before

The real difference in behaviour can only be observed when issuing multiple imports in quick succession. This maybe can be done using multiple tabs prepared with different imports and then pressing the button to import around the same time. Then one could check that one of them started right when the other one was finished. The job progress API can be used to see the timestamps. 