### PR TITLE
fix: [DHIS2-18527] (2.40) Fix deleted relationship getting returned in event

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -668,7 +668,7 @@ public abstract class AbstractEventService implements EventService {
     if (eventParams.isIncludeRelationships()) {
       event.setRelationships(
           programStageInstance.getRelationshipItems().stream()
-              .filter(Objects::nonNull)
+              .filter(ri -> Objects.nonNull(ri) && !ri.getRelationship().isDeleted())
               .map(
                   r ->
                       relationshipService.findRelationship(


### PR DESCRIPTION
In event fetching API ( `api/tracker/event/{uid}` ) , when `includeRelationship` is set to true. The service fetches all relationships without respecting the `deleted` flag. 

This PR corrects this.

In collection event fetching API ( `api/tracker/events=event={uid}` ) this issue does not exist.