### PR TITLE
fix: [DHIS2-18527] (2.41) Fix deleted relationship getting returned in event

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -693,7 +693,7 @@ public abstract class AbstractEventService
     if (eventParams.isIncludeRelationships()) {
       event.setRelationships(
           programStageInstance.getRelationshipItems().stream()
-              .filter(Objects::nonNull)
+              .filter(ri -> Objects.nonNull(ri) && !ri.getRelationship().isDeleted())
               .map(
                   r ->
                       relationshipService.findRelationship(


### PR DESCRIPTION
Forward porting the fix from https://github.com/dhis2/dhis2-core/pull/19397 
But this is Deprecated in v41. Still fixing it anyway.

The Test Classes for this Deprecated area has already been removed in v41. Hence not spending anytime to write new Test Classes for this Deprecated area for v41. 