### PR TITLE
fix: make system-settings test time-zone independent

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -31,7 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -40,6 +42,7 @@ import java.util.Set;
 import org.hisp.dhis.analytics.AnalyticsCacheTtlMode;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.jsontree.JsonBoolean;
+import org.hisp.dhis.jsontree.JsonDate;
 import org.hisp.dhis.jsontree.JsonInteger;
 import org.hisp.dhis.jsontree.JsonMap;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -113,8 +116,9 @@ class SystemSettingsTest {
     assertFalse(booleanValue.as(JsonBoolean.class).booleanValue());
     JsonString dateValue = asJson.get("keyLastMetaDataSyncSuccess");
     assertTrue(dateValue.isString());
-    assertEquals("1970-01-01T", dateValue.string().substring(0, 11));
-    assertEquals(":00:00.000", dateValue.string().substring(13));
+    assertEquals(
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneId.systemDefault()),
+        dateValue.as(JsonDate.class).date());
     JsonString enumValue = asJson.get("keyCacheStrategy");
     assertTrue(enumValue.isString());
     assertEquals(CacheStrategy.CACHE_1_MINUTE, enumValue.parsed(CacheStrategy::valueOf));


### PR DESCRIPTION
System settings use local server zone when formatting the date string so one cannot expect a UTC (neutral) date and time therefore this is compared against a local date time which also uses the system default time zone.