### PR TITLE
fix: auto-repair default icons when there is a orphan file resource [DHIS2-18606]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
@@ -40,6 +40,7 @@ import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
@@ -114,11 +115,13 @@ public class DefaultIconService implements IconService {
     try {
       FileResource fr = FileResource.ofKey(ICON, key, MEDIA_TYPE_SVG);
       fr.setUid(fileResourceId);
+      Optional<FileResource> existing = fileResourceService.findByStorageKey(fr.getStorageKey());
+      if (existing.isPresent()) fr = existing.get();
       fr.setAssigned(true);
       try (InputStream image = resource.getInputStream()) {
         fileResourceService.syncSaveFileResource(fr, image);
       }
-      return fileResourceId;
+      return fr.getUid();
     } catch (IOException ex) {
       ignoredAfterFailure.add(origin);
       throw new ConflictException("Failed to create default icon resource: " + ex.getMessage());


### PR DESCRIPTION
### Summary
If a default icon is missing in the `icon` table there might still be a `fileresource` entry for that icon. In such case that `FileResource` is now reused but the content is restored to make sure the icon exists.

This is a similar but different issue to the "phantom" icons where the `fileresource` did exist but the content is gone whereas here the content might still exist.