### PR TITLE
feat: data integrity check to find broken icons [DHIS2-18606]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -84,3 +84,4 @@ checks:
   - users/user_roles_no_authorities.yaml
   - users/user_roles_with_no_users.yaml
   - users/users_with_invalid_usernames.yaml
+  - file_resources/file_resources_no_icon.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/file_resources/file_resources_no_icon.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/file_resources/file_resources_no_icon.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: file_resources_no_icon
+description: File resources of type ICON that have no entry in the icon table
+section: File resources
+section_order: 1
+summary_sql: >-
+  SELECT count(*) FROM fileresource f 
+  WHERE domain = 'ICON' 
+  AND NOT EXISTS (SELECT 1 FROM icon i WHERE i.fileresourceid = f.fileresourceid);
+details_sql: >
+  SELECT f.uid, f.name as name, f.storagekey as comment FROM fileresource f 
+  WHERE domain = 'ICON' 
+  AND NOT EXISTS (SELECT 1 FROM icon i WHERE i.fileresourceid = f.fileresourceid);
+details_id_type: users
+severity: WARNING
+introduction: >
+  A file resource of type ICON should always have a corresponding icon entry.
+recommendation: >
+  The easiest solution is to delete the file resource and re-add the icon anew if it is still needed.
+  If the file resource is of unknown origin and should be kept a corresponding icon entry needs to be
+  created manually. This likely requires SQL level access as usually icon and file resource are 
+  maintained together when using the API.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2128,6 +2128,7 @@ data_integrity.user_roles_no_authorities.name=User roles with no authorities
 data_integrity.user_roles_with_no_users.name=User roles with no users
 data_integrity.option_groups_empty.users=Option groups with no options
 data_integrity.push_analysis_no_recipients.name=Push analyses without recipients
+data_integrity.file_resources_no_icon.name=File resources that are missing an icon
 
 
 # -- End Data Integrity Checks--------------------------------------------#


### PR DESCRIPTION
A data integrity check that finds file resources of type ICON that lack an icon entry. 
While this auto-repairs for default icons there might be other icons with this issue.

![Data-Administration-DHIS2-12-10-2024_03_32_PM](https://github.com/user-attachments/assets/7a805acb-ef1a-4e6b-aea3-0c5dccfa8142)
