### PR TITLE
fix: message conversation list based on user messages [DHIS2-18605]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -180,8 +180,11 @@ public class MessageConversationController
 
   @Override
   protected List<UID> getPreQueryMatches(GetMessageConversationObjectListParams params) {
+    if (params.getQuery() != null) return null;
+    List<org.hisp.dhis.message.MessageConversation> allUserMessages =
+        messageService.getMessageConversations();
     String query = params.getQueryString();
-    if (query == null) return null;
+    if (query == null) return allUserMessages.stream().map(UID::of).toList();
 
     String op = params.getQueryOperator();
     if (op == null) op = "token";
@@ -197,7 +200,8 @@ public class MessageConversationController
             .setPaging(false)
             .setRootJunction(Junction.Type.OR)
             .setFilters(filters);
-    Query subQuery = queryService.getQueryFromUrl(getEntityClass(), subQueryParams);
+    Query subQuery =
+        queryService.getQueryFromUrl(getEntityClass(), subQueryParams).setObjects(allUserMessages);
     // Note: in theory these filters could be added to the main query
     // but the OR concerns both DB and in-memory properties
     // which would break if added to the main query ATM


### PR DESCRIPTION
In my previous refactoring in #19046 I missed that `MessageService#getMessageConversations()` did not return all messages but just the current user's conversations. So this list needs to be the stating point.

But there is an exception to that. When `query=` was used the starting point are all conversations matching the query. This can be combined with `filter` but not with `queryString` and `queryOperator` which are a different kind of "fuzzy" search for the user's conversions (which also can be combined with `filter`). 