### PR TITLE
feat: Create note endpoints in tracker [DHIS2-17579]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
@@ -11,7 +11,13 @@
     <id name="id" column="noteid">
       <generator class="native" />
     </id>
-    &identifiableProperties;
+
+    <property name="uid" column="uid" unique="true" not-null="true" />
+
+    <property name="created" type="timestamp" not-null="true" update="false" />
+
+    <many-to-one name="lastUpdatedBy" class="org.hisp.dhis.user.User"
+                 column="lastupdatedby" foreign-key="fk_lastupdateby_userid" />
 
     <property name="noteText" column="notetext" type="text" />
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -132,7 +132,6 @@ class JdbcEventStore {
        n.created as note_created,\
        n.creator as note_creator,\
        n.uid as note_uid,\
-       n.lastupdated as note_lastupdated,\
        userinfo.userinfoid as note_user_id,\
        userinfo.code as note_user_code,\
        userinfo.uid as note_user_uid,\
@@ -466,8 +465,6 @@ class JdbcEventStore {
                 noteLastUpdatedBy.setSurname(resultSet.getString("note_user_surname"));
                 note.setLastUpdatedBy(noteLastUpdatedBy);
               }
-
-              note.setLastUpdated(resultSet.getTimestamp("note_lastupdated"));
 
               event.getNotes().add(note);
               notes.add(resultSet.getString("note_id"));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
@@ -302,13 +303,18 @@ public class TrackerObjectsMapper {
       @Nonnull TrackerPreheat preheat,
       @Nonnull org.hisp.dhis.tracker.imports.domain.Note note,
       @Nonnull UserDetails user) {
+
+    return map(note, preheat.getUserByUid(user.getUid()).orElse(null));
+  }
+
+  public static @Nonnull Note map(
+      @Nonnull org.hisp.dhis.tracker.imports.domain.Note note, @Nullable User user) {
     Date now = new Date();
 
     Note dbNote = new Note();
     dbNote.setUid(note.getNote().getValue());
     dbNote.setCreated(now);
-    dbNote.setLastUpdated(now);
-    dbNote.setLastUpdatedBy(preheat.getUserByUid(user.getUid()).orElse(null));
+    dbNote.setLastUpdatedBy(user);
     dbNote.setCreator(note.getStoredBy());
     dbNote.setNoteText(note.getValue());
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/DefaultNoteService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/DefaultNoteService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.note;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.imports.domain.Note;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultNoteService implements NoteService {
+  private final EnrollmentService enrollmentService;
+
+  private final EventService eventService;
+
+  private final JdbcNoteStore noteStore;
+
+  @Transactional
+  @Override
+  public void addNoteForEnrollment(Note note, UID enrollment)
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    // Check enrollment existence and access
+    enrollmentService.getEnrollment(enrollment);
+    validateNote(note);
+
+    noteStore.saveEnrollmentNote(enrollment, note, CurrentUserUtil.getCurrentUserDetails());
+  }
+
+  @Transactional
+  @Override
+  public void addNoteForEvent(Note note, UID event)
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    // Check event existence and access
+    eventService.getEvent(event);
+    validateNote(note);
+
+    noteStore.saveEventNote(event, note, CurrentUserUtil.getCurrentUserDetails());
+  }
+
+  private void validateNote(Note note) throws BadRequestException {
+    if (isEmpty(note.getValue())) {
+      throw new BadRequestException("Value cannot be empty");
+    }
+
+    if (noteStore.exists(note.getNote())) {
+      throw new BadRequestException(String.format("Note `%s` already exists.", note.getNote()));
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -87,7 +87,7 @@ public class JdbcNoteStore {
             "select count(1) from note where uid = :uid",
             Map.of("uid", note.getValue()),
             Integer.class);
-    return count == null || count > 0;
+    return count != null && count > 0;
   }
 
   private long saveNote(@Nonnull Note note, @Nonnull UserDetails user) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.note;
+
+import java.util.Date;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.tracker.imports.bundle.persister.PersistenceException;
+import org.hisp.dhis.tracker.imports.domain.Note;
+import org.hisp.dhis.user.UserDetails;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JdbcNoteStore {
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public void saveEnrollmentNote(
+      @Nonnull UID enrollment, @Nonnull Note note, @Nonnull UserDetails user) {
+    long noteId = saveNote(note, user);
+    String sql =
+        """
+                INSERT INTO enrollment_notes(enrollmentid, noteid, sort_order)
+                VALUES ((select enrollmentid from enrollment where uid = :enrollment),
+                        :noteId,
+                        coalesce(
+                                    (select max(sort_order) + 1
+                                    from enrollment_notes
+                                    where enrollmentid = (select enrollmentid from enrollment where uid = :enrollment)
+                                    ),
+                                1)
+                        )
+            """;
+    jdbcTemplate.update(sql, Map.of("enrollment", enrollment.getValue(), "noteId", noteId));
+  }
+
+  public void saveEventNote(@Nonnull UID event, @Nonnull Note note, @Nonnull UserDetails user) {
+    long noteId = saveNote(note, user);
+    String sql =
+        """
+            INSERT INTO event_notes(eventid, noteid, sort_order)
+            VALUES ((select eventid from event where uid = :event),
+                    :noteId,
+                    coalesce(
+                                (select max(sort_order) + 1
+                                from event_notes
+                                where eventid = (select eventid from event where uid = :event)
+                                ),
+                            1)
+                    )
+        """;
+    jdbcTemplate.update(sql, Map.of("event", event.getValue(), "noteId", noteId));
+  }
+
+  boolean exists(@Nonnull UID note) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            "select count(1) from note where uid = :uid",
+            Map.of("uid", note.getValue()),
+            Integer.class);
+    return count == null || count > 0;
+  }
+
+  private long saveNote(@Nonnull Note note, @Nonnull UserDetails user) {
+    String sql =
+        """
+            INSERT INTO public.note(noteid, notetext, creator, lastupdatedby, uid, created)
+            VALUES (nextVal('note_id_sequence'),
+                    :text,
+                    :creator,
+                    (select userinfoid from userinfo where uid = :lastUpdatedBy),
+                    :uid,
+                    :created)
+            RETURNING noteid
+        """;
+
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("text", note.getValue());
+    params.addValue("creator", note.getStoredBy());
+    params.addValue("lastUpdatedBy", user.getUid());
+    params.addValue("uid", note.getNote().getValue());
+    params.addValue("created", new Date());
+
+    Long noteId = jdbcTemplate.queryForObject(sql, params, Long.class);
+
+    if (noteId == null) {
+      throw new PersistenceException("Note could not be saved");
+    }
+
+    return noteId;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -94,7 +94,7 @@ public class JdbcNoteStore {
     String sql =
         """
             INSERT INTO public.note(noteid, notetext, creator, lastupdatedby, uid, created)
-            VALUES (nextVal('note_id_sequence'),
+            VALUES (nextVal('note_sequence'),
                     :text,
                     :creator,
                     (select userinfoid from userinfo where uid = :lastUpdatedBy),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/NoteService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/NoteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,40 +25,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.tracker.imports.note;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.tracker.imports.domain.Note;
 
-/**
- * Notes are text-only objects attached to Events and Enrollments. An Event or Enrollment may have
- * multiple notes.
- *
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@OpenApi.Shared(name = "TrackerNote")
-@OpenApi.Identifiable(as = org.hisp.dhis.note.Note.class)
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Note {
-  @OpenApi.Property({UID.class, org.hisp.dhis.note.Note.class})
-  @JsonProperty
-  @Builder.Default
-  private UID note = UID.generate();
+public interface NoteService {
+  void addNoteForEnrollment(Note note, UID enrollment)
+      throws ForbiddenException, NotFoundException, BadRequestException;
 
-  @JsonProperty private Instant storedAt;
-
-  @JsonProperty private String value;
-
-  @JsonProperty private User createdBy;
-
-  @JsonProperty private String storedBy;
+  void addNoteForEvent(Note note, UID event)
+      throws ForbiddenException, NotFoundException, BadRequestException;
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_34__Create_sequence_for_note_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_34__Create_sequence_for_note_table.sql
@@ -1,5 +1,5 @@
-create sequence if not exists note_id_sequence;
-select setval('note_id_sequence', coalesce((select max(noteid) from note), 1)) FROM note;
+create sequence if not exists note_sequence;
+select setval('note_sequence', coalesce((select max(noteid) from note), 1)) FROM note;
 
 alter table if exists note drop column code;
 alter table if exists note drop column lastupdated;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_34__Create_sequence_for_note_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_34__Create_sequence_for_note_table.sql
@@ -1,0 +1,5 @@
+create sequence if not exists note_id_sequence;
+select setval('note_id_sequence', coalesce((select max(noteid) from note), 1)) FROM note;
+
+alter table if exists note drop column code;
+alter table if exists note drop column lastupdated;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.note;
+
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.List;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.Note;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class NoteServiceTest extends TrackerTest {
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private EventService eventService;
+
+  @Autowired private EnrollmentService enrollmentService;
+
+  @Autowired private NoteService noteService;
+
+  private UserDetails userDetails;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    setUpMetadata("tracker/simple_metadata.json");
+
+    User importUser = userService.getUser("tTgjgobT1oS");
+    userDetails = UserDetails.fromUser(importUser);
+    injectSecurityContext(userDetails);
+
+    TrackerImportParams params = TrackerImportParams.builder().build();
+    assertNoErrors(
+        trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
+  }
+
+  @BeforeEach
+  void initUser() {
+    injectSecurityContext(userDetails);
+  }
+
+  @Test
+  void shouldCreateEnrollmentNote()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    Note note = note();
+    noteService.addNoteForEnrollment(note, UID.of("nxP7UnKhomJ"));
+
+    manager.clear();
+    manager.flush();
+
+    Enrollment dbEnrollment = enrollmentService.getEnrollment(UID.of("nxP7UnKhomJ"));
+    assertNotes(List.of(note), dbEnrollment.getNotes(), userDetails);
+  }
+
+  @Test
+  void shouldFailToCreateEnrollmentNoteWhenNoteValueIsNull() {
+    Note note = note();
+    note.setValue(null);
+
+    assertThrows(
+        BadRequestException.class,
+        () -> noteService.addNoteForEnrollment(note, UID.of("nxP7UnKhomJ")));
+  }
+
+  @Test
+  void shouldFailToCreateEnrollmentNoteWhenEnrollmentIsNotPresent() {
+    Note note = note();
+    assertThrows(
+        NotFoundException.class,
+        () -> noteService.addNoteForEnrollment(note, UID.of("jPP9AnKh34U")));
+  }
+
+  @Test
+  void shouldFailToCreateDuplicateEnrollmentNote()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    Note note = note();
+    noteService.addNoteForEnrollment(note, UID.of("nxP8UnKhomJ"));
+    assertThrows(
+        BadRequestException.class,
+        () -> noteService.addNoteForEnrollment(note, UID.of("nxP8UnKhomJ")));
+  }
+
+  @Test
+  void shouldFailToCreateEnrollmentNoteIfUserHasNoAccessToEnrollment() {
+    User importUser = userService.getUser("nIidJVYpQQK");
+    injectSecurityContext(UserDetails.fromUser(importUser));
+
+    Note note = note();
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> noteService.addNoteForEnrollment(note, UID.of("nxP7UnKhomJ")));
+  }
+
+  @Test
+  void shouldCreateEventNote() throws ForbiddenException, NotFoundException, BadRequestException {
+    Note note = note();
+    noteService.addNoteForEvent(note, UID.of("pTzf9KYMk72"));
+
+    manager.clear();
+    manager.flush();
+
+    Event dbEvent = eventService.getEvent(UID.of("pTzf9KYMk72"));
+    assertNotes(List.of(note), dbEvent.getNotes(), userDetails);
+  }
+
+  @Test
+  void shouldFailToCreateEventNoteWhenNoteValueIsNull() {
+    Note note = note();
+    note.setValue(null);
+
+    assertThrows(
+        BadRequestException.class, () -> noteService.addNoteForEvent(note, UID.of("pTzf9KYMk72")));
+  }
+
+  @Test
+  void shouldFailToCreateEventNoteWhenEnrollmentIsNotPresent() {
+    Note note = note();
+    assertThrows(
+        NotFoundException.class, () -> noteService.addNoteForEvent(note, UID.of("jPP9AnKh34U")));
+  }
+
+  @Test
+  void shouldFailToCreateDuplicateEventNote()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    Note note = note();
+    noteService.addNoteForEvent(note, UID.of("D9PbzJY8bJM"));
+    assertThrows(
+        BadRequestException.class, () -> noteService.addNoteForEvent(note, UID.of("D9PbzJY8bJM")));
+  }
+
+  @Test
+  void shouldFailToCreateEventNoteIfUserHasNoAccessToEvent() {
+    User importUser = userService.getUser("nIidJVYpQQK");
+    injectSecurityContext(UserDetails.fromUser(importUser));
+
+    Note note = note();
+
+    assertThrows(
+        NotFoundException.class, () -> noteService.addNoteForEvent(note, UID.of("pTzf9KYMk72")));
+  }
+
+  private void assertNotes(
+      List<Note> notes, List<org.hisp.dhis.note.Note> dbNotes, UserDetails updatedBy) {
+    for (org.hisp.dhis.tracker.imports.domain.Note note : notes) {
+      org.hisp.dhis.note.Note dbNote =
+          dbNotes.stream()
+              .filter(n -> n.getUid().equals(note.getNote().getValue()))
+              .findFirst()
+              .orElse(null);
+      assertNotNull(dbNote);
+      assertEquals(note.getValue(), dbNote.getNoteText());
+      assertEquals(note.getStoredBy(), dbNote.getCreator());
+      assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
+    }
+  }
+
+  private Note note() {
+    return Note.builder()
+        .note(UID.generate())
+        .storedBy("This is the creator")
+        .value("This is a note")
+        .build();
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -336,7 +336,6 @@ class EventImportValidationTest extends TrackerTest {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertTrue(note.getLastUpdated().getTime() > now.getTime());
               assertNull(note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });
@@ -360,7 +359,6 @@ class EventImportValidationTest extends TrackerTest {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertTrue(note.getLastUpdated().getTime() > now.getTime());
               assertNull(note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.imports;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import java.util.Set;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.UserAccess;
+import org.hisp.dhis.webapi.controller.tracker.JsonNote;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestBase {
+  private User importUser;
+
+  private Event event;
+
+  private Enrollment enrollment;
+
+  @BeforeAll
+  void setUp() {
+    importUser = makeUser("o");
+    manager.save(importUser, false);
+
+    CategoryOptionCombo coc = categoryService.getDefaultCategoryOptionCombo();
+
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
+    manager.save(orgUnit);
+
+    importUser.addOrganisationUnit(orgUnit);
+    manager.update(importUser);
+
+    Program program = createProgram('A');
+    program.getSharing().addUserAccess(new UserAccess(importUser, AccessStringHelper.DATA_READ));
+    manager.save(program, false);
+
+    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
+    manager.save(trackedEntityType);
+
+    ProgramStage programStage = createProgramStage('A', program);
+    programStage
+        .getSharing()
+        .addUserAccess(new UserAccess(importUser, AccessStringHelper.DATA_READ));
+    manager.save(programStage, false);
+
+    TrackedEntity te = createTrackedEntity(orgUnit);
+    te.setTrackedEntityType(trackedEntityType);
+    manager.save(te);
+
+    enrollment = enrollment(te, program, orgUnit);
+    event = event(enrollment, programStage, coc);
+    enrollment.setEvents(Set.of(event));
+    manager.update(enrollment);
+  }
+
+  @BeforeEach
+  void injectUser() {
+    injectSecurityContextUser(importUser);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenValueIsNullForEventNote() {
+    JsonWebMessage webMessage =
+        POST(
+                "/tracker/events/" + event.getUid() + "/note",
+                """
+
+                    {
+                       "creator": "I am the creator"
+                    }
+                    """)
+            .content(HttpStatus.BAD_REQUEST)
+            .as(JsonWebMessage.class);
+
+    assertEquals("Value cannot be empty", webMessage.getMessage());
+  }
+
+  @Test
+  void shouldCreateEventNote() {
+    JsonNote note =
+        POST(
+                "/tracker/events/" + event.getUid() + "/note",
+                """
+
+                        {
+                           "value": "This is a note"
+                        }
+                        """)
+            .content(HttpStatus.OK)
+            .as(JsonNote.class);
+
+    assertEquals("This is a note", note.getValue());
+    assertTrue(CodeGenerator.isValidUid(note.getNote()));
+  }
+
+  @Test
+  void shouldCreateEventNoteWhenNoteUidIsProvided() {
+    UID noteUid = UID.generate();
+    JsonNote note =
+        POST(
+                "/tracker/events/" + event.getUid() + "/note",
+                """
+
+                        {
+                           "note": "%s",
+                           "value": "This is a note"
+                        }
+                        """
+                    .formatted(noteUid.getValue()))
+            .content(HttpStatus.OK)
+            .as(JsonNote.class);
+
+    assertEquals("This is a note", note.getValue());
+    assertEquals(noteUid.getValue(), note.getNote());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenValueIsNullForEnrollmentNote() {
+    JsonWebMessage webMessage =
+        POST(
+                "/tracker/enrollments/" + enrollment.getUid() + "/note",
+                """
+
+                        {
+                           "creator": "I am the creator"
+                        }
+                        """)
+            .content(HttpStatus.BAD_REQUEST)
+            .as(JsonWebMessage.class);
+
+    assertEquals("Value cannot be empty", webMessage.getMessage());
+  }
+
+  @Test
+  void shouldCreateEnrollmentNote() {
+    JsonNote note =
+        POST(
+                "/tracker/enrollments/" + enrollment.getUid() + "/note",
+                """
+
+                        {
+                           "value": "This is a note"
+                        }
+                        """)
+            .content(HttpStatus.OK)
+            .as(JsonNote.class);
+
+    assertEquals("This is a note", note.getValue());
+    assertTrue(CodeGenerator.isValidUid(note.getNote()));
+  }
+
+  @Test
+  void shouldCreateEnrollmentNoteWhenNoteUidIsProvided() {
+    UID noteUid = UID.generate();
+    JsonNote note =
+        POST(
+                "/tracker/enrollments/" + enrollment.getUid() + "/note",
+                """
+
+                        {
+                           "note": "%s",
+                           "value": "This is a note"
+                        }
+                        """
+                    .formatted(noteUid.getValue()))
+            .content(HttpStatus.OK)
+            .as(JsonNote.class);
+
+    assertEquals("This is a note", note.getValue());
+    assertEquals(noteUid.getValue(), note.getNote());
+  }
+
+  private Event event(Enrollment enrollment, ProgramStage programStage, CategoryOptionCombo coc) {
+    Event eventA = new Event(enrollment, programStage, enrollment.getOrganisationUnit(), coc);
+    eventA.setAutoFields();
+    manager.save(eventA);
+    return eventA;
+  }
+
+  private Enrollment enrollment(TrackedEntity te, Program program, OrganisationUnit orgUnit) {
+    Enrollment enrollmentA = new Enrollment(program, te, orgUnit);
+    enrollmentA.setAutoFields();
+    enrollmentA.setEnrollmentDate(new Date());
+    enrollmentA.setOccurredDate(new Date());
+    enrollmentA.setStatus(EnrollmentStatus.COMPLETED);
+    enrollmentA.setFollowup(true);
+    manager.save(enrollmentA, false);
+    te.setEnrollments(Set.of(enrollmentA));
+    manager.save(te, false);
+    return enrollmentA;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/NoteMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/NoteMapper.java
@@ -35,6 +35,10 @@ import org.mapstruct.Mapper;
 
 @Mapper(uses = {InstantMapper.class, UserMapper.class})
 public interface NoteMapper extends DomainMapper<Note, org.hisp.dhis.tracker.imports.domain.Note> {
+  default org.hisp.dhis.tracker.imports.domain.Note from(Note note) {
+    return from(note, TrackerIdSchemeParams.builder().build());
+  }
+
   org.hisp.dhis.tracker.imports.domain.Note from(
       org.hisp.dhis.tracker.imports.domain.Note note,
       @Context TrackerIdSchemeParams idSchemeParams);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.notification.Notification;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
+import org.hisp.dhis.tracker.imports.note.NoteService;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.Status;
@@ -100,6 +101,8 @@ class TrackerImportControllerTest {
 
   @Mock private UserService userService;
 
+  @Mock private NoteService noteService;
+
   private RenderService renderService;
 
   @BeforeEach
@@ -120,7 +123,8 @@ class TrackerImportControllerTest {
             notifier,
             jobSchedulerService,
             jobConfigurationService,
-            new ObjectMapper());
+            new ObjectMapper(),
+            noteService);
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)


### PR DESCRIPTION
Added endpoint to create a `note` for `enrollments` and `events`:
- `POST tracker/enrollments/{uid}/note`
- `POST tracker/events/{uid}/note`

A new service and a new store using JDBC are created.
The validation applied are:
- Verify that event/enrollment exists
- Verify that user has read access to event/enrollment
- Verify that field `value` for the `note` is not empty
- Verify that a `note` with the same `uid` does not already exist

***Inconsistency between the 2 endpoints***
To check that the event/enrollment exists and that the user has all the right permissions we are using services (`EnrollmentService.getEnrollment(uid)` and `EventService.getEvent(uid)`) but they do behave differently when an entity without the right permission is accessed:
- `EnrollmentService` throws a 403
- `EventService` throws a 404

This is part of a biggest discussion and it will not be fixed here