### PR TITLE
feat: implement special logout url for linked accounts feature

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.security.oidc;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
+import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_LOGOUT_URL;
 import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_RELOGIN_URL;
 import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_LOGOUT_REDIRECT_URL;
 import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_OAUTH2_LOGIN_ENABLED;
@@ -101,15 +102,22 @@ public class DhisOidcLogoutSuccessHandler implements LogoutSuccessHandler {
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException, ServletException {
 
-    String currentUsername = request.getParameter("current");
     String usernameToSwitchTo = request.getParameter("switch");
+    String linkedAccountsLogoutUrl = config.getProperty(LINKED_ACCOUNTS_LOGOUT_URL);
+    if (isNullOrEmpty(linkedAccountsLogoutUrl)) {
+      // Fallback if not defined in config
+      linkedAccountsLogoutUrl = "/";
+    }
 
-    if (isNullOrEmpty(currentUsername) || isNullOrEmpty(usernameToSwitchTo)) {
-      setOidcLogoutUrl();
+    if (isNullOrEmpty(usernameToSwitchTo)) {
+      // No switch parameter present: redirect to linked_accounts.logout_url
+      this.handler.setDefaultTargetUrl(linkedAccountsLogoutUrl);
     } else {
-
-      userStore.setActiveLinkedAccounts(currentUsername, usernameToSwitchTo);
-
+      // switch parameter present: switch accounts and then redirect to re-login URL
+      String currentUsername = request.getParameter("current");
+      if (!isNullOrEmpty(currentUsername)) {
+        userStore.setActiveLinkedAccounts(currentUsername, usernameToSwitchTo);
+      }
       this.handler.setDefaultTargetUrl(config.getProperty(LINKED_ACCOUNTS_RELOGIN_URL));
     }
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -675,6 +675,9 @@ public enum ConfigurationKey {
   LINKED_ACCOUNTS_ENABLED("linked_accounts.enabled", Constants.OFF, false),
 
   LINKED_ACCOUNTS_RELOGIN_URL("linked_accounts.relogin_url", "", false),
+
+  LINKED_ACCOUNTS_LOGOUT_URL("linked_accounts.logout_url", "", false),
+
   SWITCH_USER_FEATURE_ENABLED("switch_user_feature.enabled", Constants.OFF, false),
   SWITCH_USER_ALLOW_LISTED_IPS(
       "switch_user_allow_listed_ips", "localhost,127.0.0.1,[0:0:0:0:0:0:0:1]", false),

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -52,7 +52,6 @@ import org.jboss.aerogear.security.otp.Totp;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.*;
@@ -65,7 +64,6 @@ import org.subethamail.wiser.WiserMessage;
 
 @Tag("logintests")
 @Slf4j
-@Disabled
 public class LoginTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final RestTemplate restTemplate = new RestTemplate();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -52,6 +52,7 @@ import org.jboss.aerogear.security.otp.Totp;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.*;
@@ -64,6 +65,7 @@ import org.subethamail.wiser.WiserMessage;
 
 @Tag("logintests")
 @Slf4j
+@Disabled
 public class LoginTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
## Summary
Implements a new special linked account logout URL as a system configuration variable.
When all the config is set and logout is called, this user gets forwarded to this URL, but only if the logout is not called with the special 'switch' parameter used for switching users with linked accounts.

## Manual test
1. Enable `'oidc.oauth2.login.enabled'` and `'linked_accounts.enabled'`
2. Set the wanted logout URL as `'linked_accounts.logout_url'` in dhis.conf
3. Start the server
4. Log in
5. Log out
6. Observe you get redirected to the URL set in `'linked_accounts.logout_url'`