### PR TITLE
feat: Sort data elements and event fields as single unit [DHIS2-18012]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -64,14 +64,14 @@ public class HibernateEventChangeLogStore {
 
   /**
    * Event change logs can be ordered by given fields which correspond to fields on {@link
-   * EventChangeLog}. Maps fields to DB columns, except for dataItem. In that case we need to sort
-   * by concatenation, to treat the dataElement and eventField as a single entity.
+   * EventChangeLog}. Maps fields to DB columns, except when sorting by 'change'. In that case we
+   * need to sort by concatenation, to treat the dataElement and eventField as a single entity.
    */
   private static final Map<String, String> ORDERABLE_FIELDS =
       Map.ofEntries(
           entry("createdAt", COLUMN_CHANGELOG_CREATED),
           entry("username", COLUMN_CHANGELOG_USER),
-          entry("dataItem", ORDER_DATA_ITEM_EXPRESSION));
+          entry("change", ORDER_DATA_ITEM_EXPRESSION));
 
   private static final Map<Pair<String, Class<?>>, String> FILTERABLE_FIELDS =
       Map.ofEntries(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -57,7 +57,7 @@ public class HibernateEventChangeLogStore {
   private static final String COLUMN_CHANGELOG_USER = "ecl.createdByUsername";
   private static final String COLUMN_CHANGELOG_DATA_ELEMENT = "d.uid";
   private static final String COLUMN_CHANGELOG_FIELD = "ecl.eventField";
-  private static final String ORDER_DATA_ITEM_EXPRESSION =
+  private static final String ORDER_CHANGE_EXPRESSION =
       "CONCAT(COALESCE(d.formname, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
   private static final String DEFAULT_ORDER =
       COLUMN_CHANGELOG_CREATED + " " + SortDirection.DESC.getValue();
@@ -71,7 +71,7 @@ public class HibernateEventChangeLogStore {
       Map.ofEntries(
           entry("createdAt", COLUMN_CHANGELOG_CREATED),
           entry("username", COLUMN_CHANGELOG_USER),
-          entry("change", ORDER_DATA_ITEM_EXPRESSION));
+          entry("change", ORDER_CHANGE_EXPRESSION));
 
   private static final Map<Pair<String, Class<?>>, String> FILTERABLE_FIELDS =
       Map.ofEntries(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -58,7 +58,7 @@ public class HibernateEventChangeLogStore {
   private static final String COLUMN_CHANGELOG_DATA_ELEMENT = "d.uid";
   private static final String COLUMN_CHANGELOG_FIELD = "ecl.eventField";
   private static final String ORDER_CHANGE_EXPRESSION =
-      "CONCAT(COALESCE(d.formname, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
+      "CONCAT(COALESCE(d.formName, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
   private static final String DEFAULT_ORDER =
       COLUMN_CHANGELOG_CREATED + " " + SortDirection.DESC.getValue();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -58,7 +58,7 @@ public class HibernateEventChangeLogStore {
   private static final String COLUMN_CHANGELOG_DATA_ELEMENT = "d.uid";
   private static final String COLUMN_CHANGELOG_FIELD = "ecl.eventField";
   private static final String ORDER_DATA_ITEM_EXPRESSION =
-      "CONCAT(COALESCE(d.shortName, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
+      "CONCAT(COALESCE(d.formname, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
   private static final String DEFAULT_ORDER =
       COLUMN_CHANGELOG_CREATED + " " + SortDirection.DESC.getValue();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -57,23 +57,21 @@ public class HibernateEventChangeLogStore {
   private static final String COLUMN_CHANGELOG_USER = "ecl.createdByUsername";
   private static final String COLUMN_CHANGELOG_DATA_ELEMENT = "d.uid";
   private static final String COLUMN_CHANGELOG_FIELD = "ecl.eventField";
-
+  private static final String ORDER_DATA_ITEM_EXPRESSION =
+      "CONCAT(COALESCE(d.shortName, ''), COALESCE(" + COLUMN_CHANGELOG_FIELD + ", ''))";
   private static final String DEFAULT_ORDER =
       COLUMN_CHANGELOG_CREATED + " " + SortDirection.DESC.getValue();
 
   /**
    * Event change logs can be ordered by given fields which correspond to fields on {@link
-   * EventChangeLog}. Maps fields to DB columns. The order implementation for change logs is
-   * different from other tracker exporters {@link EventChangeLog} is the view which is already
-   * returned from the service/store. Tracker exporter services return a representation we have to
-   * map to a view model. This mapping is not necessary for change logs.
+   * EventChangeLog}. Maps fields to DB columns, except for dataItem. In that case we need to sort
+   * by concatenation, to treat the dataElement and eventField as a single entity.
    */
   private static final Map<String, String> ORDERABLE_FIELDS =
       Map.ofEntries(
           entry("createdAt", COLUMN_CHANGELOG_CREATED),
           entry("username", COLUMN_CHANGELOG_USER),
-          entry("dataElement", COLUMN_CHANGELOG_DATA_ELEMENT),
-          entry("field", COLUMN_CHANGELOG_FIELD));
+          entry("dataItem", ORDER_DATA_ITEM_EXPRESSION));
 
   private static final Map<Pair<String, Class<?>>, String> FILTERABLE_FIELDS =
       Map.ofEntries(

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
@@ -529,6 +529,7 @@
       "lastUpdated": "2015-03-31T11:22:51.642",
       "name": "Height in cm",
       "shortName": "Height in cm",
+      "formName": "Height in cm",
       "url": "",
       "valueType": "NUMBER"
     },
@@ -549,6 +550,7 @@
       "lastUpdated": "2015-03-31T11:22:51.642",
       "name": "Height in mm",
       "shortName": "Height in mm",
+      "formName": "Height in mm",
       "url": "",
       "valueType": "NUMBER"
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -160,17 +160,19 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
     updateDataValues(event, "GieVkTxp4HG", "20");
 
     List<EventChangeLog> changeLogs =
-        getDataElementChangeLogs(
-            eventChangeLogService.getEventChangeLog(
-                UID.of("kWjSezkXHVp"), params, defaultPageParams));
+        eventChangeLogService
+            .getEventChangeLog(UID.of("kWjSezkXHVp"), params, defaultPageParams)
+            .getItems();
 
-    assertNumberOfChanges(5, changeLogs);
+    assertNumberOfChanges(7, changeLogs);
     assertAll(
         () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(0)),
         () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(1)),
         () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(2)),
         () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(3)),
-        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(4)));
+        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(4)),
+        () -> assertFieldCreate("occurredAt", "2022-04-22 06:00:38.343", changeLogs.get(5)),
+        () -> assertFieldCreate("scheduledAt", "2022-04-26 06:00:34.323", changeLogs.get(6)));
   }
 
   @Test
@@ -188,6 +190,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
             .getEventChangeLog(UID.of("kWjSezkXHVp"), params, defaultPageParams)
             .getItems();
 
+    assertNumberOfChanges(7, changeLogs);
     assertAll(
         () -> assertFieldCreate("scheduledAt", "2022-04-26 06:00:34.323", changeLogs.get(0)),
         () -> assertFieldCreate("occurredAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -153,7 +153,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   void shouldSortChangeLogsWhenOrderingByDataElementAsc()
       throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.ASC).build();
+        EventChangeLogOperationParams.builder().orderBy("change", SortDirection.ASC).build();
     Event event = getEvent("kWjSezkXHVp");
 
     updateDataValues(event, "GieVkTxp4HH", "20", "25");
@@ -176,10 +176,9 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByDataItemDesc()
-      throws ForbiddenException, NotFoundException {
+  void shouldSortChangeLogsWhenOrderingByChangeDesc() throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.DESC).build();
+        EventChangeLogOperationParams.builder().orderBy("change", SortDirection.DESC).build();
     Event event = getEvent("kWjSezkXHVp");
 
     updateDataValues(event, "GieVkTxp4HH", "20", "25");
@@ -202,10 +201,10 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByDataItemAscAndChangesOnlyToEventFields()
+  void shouldSortChangeLogsWhenOrderingByChangeAscAndChangesOnlyToEventFields()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.ASC).build();
+        EventChangeLogOperationParams.builder().orderBy("change", SortDirection.ASC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();
@@ -236,10 +235,10 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByDataItemDescAndChangesOnlyToEventFields()
+  void shouldSortChangeLogsWhenOrderingByChangeDescAndChangesOnlyToEventFields()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.DESC).build();
+        EventChangeLogOperationParams.builder().orderBy("change", SortDirection.DESC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -153,31 +153,7 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   void shouldSortChangeLogsWhenOrderingByDataElementAsc()
       throws ForbiddenException, NotFoundException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataElement", SortDirection.ASC).build();
-    Event event = getEvent("kWjSezkXHVp");
-
-    updateDataValues(event, "GieVkTxp4HH", "20", "25");
-    updateDataValues(event, "GieVkTxp4HG", "20");
-
-    List<EventChangeLog> changeLogs =
-        getDataElementChangeLogs(
-            eventChangeLogService.getEventChangeLog(
-                UID.of("kWjSezkXHVp"), params, defaultPageParams));
-
-    assertNumberOfChanges(5, changeLogs);
-    assertAll(
-        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(0)),
-        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(1)),
-        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(2)),
-        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(3)),
-        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(4)));
-  }
-
-  @Test
-  void shouldSortChangeLogsWhenOrderingByDataElementDesc()
-      throws ForbiddenException, NotFoundException {
-    EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("dataElement", SortDirection.DESC).build();
+        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.ASC).build();
     Event event = getEvent("kWjSezkXHVp");
 
     updateDataValues(event, "GieVkTxp4HH", "20", "25");
@@ -198,10 +174,35 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByFieldAsc()
+  void shouldSortChangeLogsWhenOrderingByDataItemDesc()
+      throws ForbiddenException, NotFoundException {
+    EventChangeLogOperationParams params =
+        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.DESC).build();
+    Event event = getEvent("kWjSezkXHVp");
+
+    updateDataValues(event, "GieVkTxp4HH", "20", "25");
+    updateDataValues(event, "GieVkTxp4HG", "20");
+
+    List<EventChangeLog> changeLogs =
+        eventChangeLogService
+            .getEventChangeLog(UID.of("kWjSezkXHVp"), params, defaultPageParams)
+            .getItems();
+
+    assertAll(
+        () -> assertFieldCreate("scheduledAt", "2022-04-26 06:00:34.323", changeLogs.get(0)),
+        () -> assertFieldCreate("occurredAt", "2022-04-22 06:00:38.343", changeLogs.get(1)),
+        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(2)),
+        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(3)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(4)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(5)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(6)));
+  }
+
+  @Test
+  void shouldSortChangeLogsWhenOrderingByDataItemAscAndChangesOnlyToEventFields()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("field", SortDirection.ASC).build();
+        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.ASC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();
@@ -232,10 +233,10 @@ class OrderAndFilterEventChangeLogTest extends TrackerTest {
   }
 
   @Test
-  void shouldSortChangeLogsWhenOrderingByFieldDesc()
+  void shouldSortChangeLogsWhenOrderingByDataItemDescAndChangesOnlyToEventFields()
       throws ForbiddenException, NotFoundException, IOException {
     EventChangeLogOperationParams params =
-        EventChangeLogOperationParams.builder().orderBy("field", SortDirection.DESC).build();
+        EventChangeLogOperationParams.builder().orderBy("dataItem", SortDirection.DESC).build();
     UID event = UID.of("QRYjLTiJTrA");
 
     LocalDateTime currentTime = LocalDateTime.now();


### PR DESCRIPTION
When it comes to sorting event change logs, we need to treat data elements and event fields as a single entity, filtering stays the same.
Sort data elements by form name instead of UID, as that's how the UI shows them.
Still need to take care of translations, I'll do that in a separate ticket.