### PR TITLE
ci: remove boolean type from var definition [skip ci]

### DIFF
--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -122,7 +122,7 @@ pipeline {
                     oldImageTag = env.DOCKER_IMAGE_TAG.replace("-rc", "")
 
                     // If version contains more than 2 dots... It's a hotfix.
-                    boolean isHotfix = oldImageTag.length() - oldImageTag.replace(".", "").length() > 2
+                    isHotfix = oldImageTag.length() - oldImageTag.replace(".", "").length() > 2
 
                     if (!isHotfix) {
                         oldImageTag = "$oldImageTag.0"


### PR DESCRIPTION
Using a type like `boolean` in the variable definition scopes it to a stage, like `def` would, but we need `isHotfix` in multiple stages.

Could not find any documentation confirming this (Jenkins is using a flavoured version of Groovy), but I confirmed it with this [test pipeline job](https://ci.dhis2.org/job/dhis2-core-stable/view/tags/job/test-stable-pipeline). 

[Build #1](https://ci.dhis2.org/job/dhis2-core-stable/view/tags/job/test-stable-pipeline/1) shows the issue with the `boolean` type in the declaration and [build #2](https://ci.dhis2.org/job/dhis2-core-stable/view/tags/job/test-stable-pipeline/2) confirms that removing the type fixes it.