### PR TITLE
feat: Add defaults to optionSetItem [DHIS2-18643]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OptionSetItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OptionSetItem.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.analytics.Aggregation.AGGREGATED;
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -70,5 +71,18 @@ public class OptionSetItem implements Serializable {
 
   public void setAggregation(Aggregation aggregation) {
     this.aggregation = aggregation;
+  }
+
+  /**
+   * Returns the current {@link Aggregation} or default.
+   *
+   * @return the respective {@link Aggregation} object.
+   */
+  public Aggregation getAggregationOrDefault() {
+    if (aggregation == null) {
+      return AGGREGATED;
+    }
+
+    return aggregation;
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -436,4 +436,51 @@ class VisualizationControllerTest extends H2ControllerIntegrationTestBase {
     assertEquals(
         "[\"BFhv3jQZ8Cw\"]", itemsNode.get("optionSetItem").get("options").value().toString());
   }
+
+  @Test
+  void testPostWithoutOptionSetItemAndLoadDefaults() {
+    // Given
+    DataElement dataElement = createDataElement('A');
+    manager.save(dataElement);
+
+    String dataElementUid = dataElement.getUid();
+    String jsonBody =
+        """
+{
+    "type": "PIE",
+    "columns": [
+        {
+            "dimension": "dx",
+            "items": [
+                {
+                    "id": "${dataElement}",
+                    "name": "Data Element - OptionSet",
+                    "dimensionItemType": "DATA_ELEMENT"
+                }
+            ]
+        }
+    ],
+    "name": "OptionSetItem - Test"
+}
+"""
+            .replace("${dataElement}", dataElementUid);
+
+    // When
+    String uid = assertStatus(CREATED, POST("/visualizations/", jsonBody));
+
+    // Then
+    String getParams = "?fields=columns[:all,items[:all,optionSetItem[options,aggregation]]";
+    JsonObject response = GET("/visualizations/" + uid + getParams).content();
+
+    JsonNode columnNode = response.get("columns").node().element(0);
+    JsonNode itemsNode = columnNode.get("items").elementOrNull(0);
+
+    assertEquals("DATA_X", columnNode.get("dimensionType").value());
+    assertTrue((boolean) columnNode.get("dataDimension").value());
+    assertEquals("DATA_ELEMENT", itemsNode.get("dimensionItemType").value());
+    assertEquals("SUM", itemsNode.get("aggregationType").value());
+    assertEquals(dataElementUid, itemsNode.get("dimensionItem").value());
+    assertEquals("AGGREGATED", itemsNode.get("optionSetItem").get("aggregation").value());
+    assertEquals("[]", itemsNode.get("optionSetItem").get("options").value().toString());
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -483,4 +483,57 @@ class VisualizationControllerTest extends H2ControllerIntegrationTestBase {
     assertEquals("AGGREGATED", itemsNode.get("optionSetItem").get("aggregation").value());
     assertEquals("[]", itemsNode.get("optionSetItem").get("options").value().toString());
   }
+
+  @Test
+  void testPostOptionSetItemWithNoAggregation() {
+    // Given
+    DataElement dataElement = createDataElement('A');
+    manager.save(dataElement);
+
+    String dataElementUid = dataElement.getUid();
+    String jsonBody =
+        """
+{
+    "type": "PIE",
+    "columns": [
+        {
+            "dimension": "dx",
+            "items": [
+                {
+                    "id": "${dataElement}",
+                    "name": "Data Element - OptionSet",
+                    "dimensionItemType": "DATA_ELEMENT",
+                    "optionSetItem": {
+                        "options": [
+                            "BFhv3jQZ8Cw"
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "name": "OptionSetItem - Test"
+}
+"""
+            .replace("${dataElement}", dataElementUid);
+
+    // When
+    String uid = assertStatus(CREATED, POST("/visualizations/", jsonBody));
+
+    // Then
+    String getParams = "?fields=columns[:all,items[:all,optionSetItem[options,aggregation]]";
+    JsonObject response = GET("/visualizations/" + uid + getParams).content();
+
+    JsonNode columnNode = response.get("columns").node().element(0);
+    JsonNode itemsNode = columnNode.get("items").elementOrNull(0);
+
+    assertEquals("DATA_X", columnNode.get("dimensionType").value());
+    assertTrue((boolean) columnNode.get("dataDimension").value());
+    assertEquals("DATA_ELEMENT", itemsNode.get("dimensionItemType").value());
+    assertEquals("SUM", itemsNode.get("aggregationType").value());
+    assertEquals(dataElementUid, itemsNode.get("dimensionItem").value());
+    assertEquals("AGGREGATED", itemsNode.get("optionSetItem").get("aggregation").value());
+    assertEquals(
+        "[\"BFhv3jQZ8Cw\"]", itemsNode.get("optionSetItem").get("options").value().toString());
+  }
 }


### PR DESCRIPTION
We need to return a default “optionSetItem” object to keep the new option set item object backward compatible with existing Visualization and allow clients to distinguish between elements that contain an option set from elements that do not.

To achieve it we have to return something like the snippet below:
```
columns: [{
	dimension: 'dx',
	items: [{
		name: "Data element with option set",
		optionSetItem: { // Always return below by default, if optionSetItem or aggregation is not set
			aggregation: "AGGREGATED",
		},
	}],
}]
```
