### PR TITLE
chore: Make dependabot upgrade rule-engine library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,12 +52,6 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
-      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
-        versions:
-          - ">= 1.0"
-      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
-        versions:
-          - ">= 2.0"
       - dependency-name: "org.slf4j:slf4j-api" # will update in https://dhis2.atlassian.net/browse/DHIS2-16504
         versions:
           - ">= 2.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -132,12 +132,6 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
-      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
-        versions:
-          - ">= 1.0"
-      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
-        versions:
-          - ">= 2.0"
       - dependency-name: "org.flywaydb:flyway-core" # It requires Postgres version to be >= 11
         versions:
           - "> 9.22.3"

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -428,16 +428,6 @@
         <groupId>org.hisp.dhis.rules</groupId>
         <artifactId>rule-engine-jvm</artifactId>
         <version>${dhis2-rule-engine.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!-- Spring -->


### PR DESCRIPTION
Rule-engine doesn't have circular dependency anymore and it can be managed by dependabot as any other dependency