### PR TITLE
fix: Always add default order as last order param in tracker exporters [DHIS2-18659]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -279,7 +279,7 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
       orderJoiner.add(
           order.getField() + " " + (order.getDirection().isAscending() ? "asc" : "desc"));
     }
-    return " order by " + orderJoiner;
+    return " order by " + orderJoiner + ", " + DEFAULT_ORDER;
   }
 
   @Getter

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -1612,7 +1612,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     }
 
     if (!orderFields.isEmpty()) {
-      return "order by " + StringUtils.join(orderFields, ',') + " ";
+      return "order by " + StringUtils.join(orderFields, ',') + ", " + DEFAULT_ORDER + " ";
     } else {
       return "order by " + DEFAULT_ORDER + " ";
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -264,10 +265,13 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
   private List<Order> orderBy(
       RelationshipQueryParams queryParams, CriteriaBuilder builder, Root<Relationship> root) {
+    List<Order> defaultOrder = orderBy(List.of(DEFAULT_ORDER), builder, root);
     if (!queryParams.getOrder().isEmpty()) {
-      return orderBy(queryParams.getOrder(), builder, root);
+      return Stream.concat(
+              orderBy(queryParams.getOrder(), builder, root).stream(), defaultOrder.stream())
+          .toList();
     } else {
-      return orderBy(List.of(DEFAULT_ORDER), builder, root);
+      return defaultOrder;
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -1007,10 +1007,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     if (!orderFields.isEmpty()) {
-      return "ORDER BY " + StringUtils.join(orderFields, ',') + SPACE;
+      return "ORDER BY " + StringUtils.join(orderFields, ',') + ", " + DEFAULT_ORDER + SPACE;
     }
 
-    return "ORDER BY " + DEFAULT_ORDER + " ";
+    return "ORDER BY " + DEFAULT_ORDER + SPACE;
   }
 
   /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -208,6 +208,32 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderTrackedEntitiesByInactiveAndByDefaultOrder()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    List<String> expected =
+        Stream.of(
+                get(TrackedEntity.class, "QesgJkTyTCk"),
+                get(TrackedEntity.class, "dUE514NMOlo"),
+                get(TrackedEntity.class, "mHWCacsGYYn"))
+            .sorted(Comparator.comparing(TrackedEntity::getId).reversed()) // reversed = desc
+            .map(TrackedEntity::getUid)
+            .toList();
+
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(orgUnit)
+            .orgUnitMode(SELECTED)
+            .trackedEntities(UID.of("mHWCacsGYYn", "QesgJkTyTCk", "dUE514NMOlo"))
+            .trackedEntityType(trackedEntityType)
+            .orderBy("inactive", SortDirection.ASC)
+            .build();
+
+    List<String> trackedEntities = getTrackedEntities(params);
+
+    assertEquals(expected, trackedEntities);
+  }
+
+  @Test
   void shouldOrderTrackedEntitiesByPrimaryKeyDescByDefault()
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntity QS6w44flWAf = get(TrackedEntity.class, "QS6w44flWAf");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -569,6 +569,12 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @Test
   void shouldOrderEnrollmentsByStatusAndByDefaultOrder()
       throws ForbiddenException, BadRequestException {
+    List<String> expected =
+        Stream.of(get(Enrollment.class, "HDWTYSYkICe"), get(Enrollment.class, "GYWSSZunTLk"))
+            .sorted(Comparator.comparing(Enrollment::getId).reversed()) // reversed = desc
+            .map(Enrollment::getUid)
+            .toList();
+
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
             .orgUnits(get(OrganisationUnit.class, "DiszpKrYNg8"))
@@ -577,16 +583,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .orderBy("status", SortDirection.DESC)
             .build();
 
-    Page<Enrollment> firstPage =
-        enrollmentService.getEnrollments(operationParams, new PageParams(1, 3, false));
+    List<String> actual = getEnrollments(operationParams);
 
-    assertAll(
-        "first page",
-        () -> assertPage(1, 3, firstPage),
-        () -> assertEquals(List.of("GYWSSZunTLk", "HDWTYSYkICe"), uids(firstPage.getItems())));
-
-    assertIsEmpty(
-        enrollmentService.getEnrollments(operationParams, new PageParams(2, 3, false)).getItems());
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -702,6 +701,15 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Test
   void shouldOrderEventsByStatusAndByDefaultOrder() throws ForbiddenException, BadRequestException {
+    List<String> expected =
+        Stream.of(
+                get(Event.class, "ck7DzdxqLqA"),
+                get(Event.class, "kWjSezkXHVp"),
+                get(Event.class, "OTmjvJDn0Fu"))
+            .sorted(Comparator.comparing(Event::getId).reversed()) // reversed = desc
+            .map(Event::getUid)
+            .toList();
+
     EventOperationParams operationParams =
         eventParamsBuilder
             .orgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"))
@@ -709,14 +717,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .orderBy("status", SortDirection.DESC)
             .build();
 
-    Page<Event> firstPage = eventService.getEvents(operationParams, new PageParams(1, 3, false));
+    List<String> actual = getEvents(operationParams);
 
-    assertAll(
-        "first page",
-        () -> assertPage(1, 3, firstPage),
-        () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), uids(firstPage)));
-
-    assertIsEmpty(getEvents(operationParams, new PageParams(2, 3, false)));
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -1314,6 +1317,29 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     List<String> events = getEvents(eventParamsBuilder.build());
     assertEquals(List.of(firstEvent, secondEvent), events);
+  }
+
+  @Test
+  void shouldOrderRelationshipsByCreatedAtClientAndByDefaultOrder()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    Relationship oLT07jKRu9e = get(Relationship.class, "fHn74P5T3r1");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+    List<String> expected =
+        Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+            .sorted(Comparator.comparing(Relationship::getId).reversed()) // reversed = desc
+            .map(Relationship::getUid)
+            .toList();
+
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder()
+            .type(TrackerType.TRACKED_ENTITY)
+            .identifier(UID.of("dUE514NMOlo"))
+            .orderBy("createdAtClient", SortDirection.DESC)
+            .build();
+
+    List<String> relationships = getRelationships(params);
+
+    assertEquals(expected, relationships);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -567,6 +567,29 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEnrollmentsByStatusAndByDefaultOrder()
+      throws ForbiddenException, BadRequestException {
+    EnrollmentOperationParams operationParams =
+        EnrollmentOperationParams.builder()
+            .orgUnits(get(OrganisationUnit.class, "DiszpKrYNg8"))
+            .orgUnitMode(SELECTED)
+            .enrollments(UID.of("HDWTYSYkICe", "GYWSSZunTLk"))
+            .orderBy("status", SortDirection.DESC)
+            .build();
+
+    Page<Enrollment> firstPage =
+        enrollmentService.getEnrollments(operationParams, new PageParams(1, 3, false));
+
+    assertAll(
+        "first page",
+        () -> assertPage(1, 3, firstPage),
+        () -> assertEquals(List.of("GYWSSZunTLk", "HDWTYSYkICe"), uids(firstPage.getItems())));
+
+    assertIsEmpty(
+        enrollmentService.getEnrollments(operationParams, new PageParams(2, 3, false)).getItems());
+  }
+
+  @Test
   void shouldReturnPaginatedEnrollmentsGivenNonDefaultPageSize()
       throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams operationParams =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -678,6 +678,25 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEventsByStatusAndByDefaultOrder() throws ForbiddenException, BadRequestException {
+    EventOperationParams operationParams =
+        eventParamsBuilder
+            .orgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"))
+            .events(UID.of("ck7DzdxqLqA", "kWjSezkXHVp", "OTmjvJDn0Fu"))
+            .orderBy("status", SortDirection.DESC)
+            .build();
+
+    Page<Event> firstPage = eventService.getEvents(operationParams, new PageParams(1, 3, false));
+
+    assertAll(
+        "first page",
+        () -> assertPage(1, 3, firstPage),
+        () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), uids(firstPage)));
+
+    assertIsEmpty(getEvents(operationParams, new PageParams(2, 3, false)));
+  }
+
+  @Test
   void shouldReturnPaginatedEventsWithNotesGivenNonDefaultPageSize()
       throws ForbiddenException, BadRequestException {
     EventOperationParams operationParams =

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -1309,6 +1309,22 @@
       "to": {
         "event": "pTzf9KYMk72"
       }
+    },
+    {
+      "relationship": "fHn74P5T3r1",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "createdAtClient": "2018-11-01T13:24:37.118",
+      "bidirectional": false,
+      "deleted": false,
+      "from": {
+        "trackedEntity": "dUE514NMOlo"
+      },
+      "to": {
+        "event": "D9PbzJY8bJM"
+      }
     }
   ],
   "username": "system-process"


### PR DESCRIPTION
Always add default order as a last order parameter to have a consistent order between results.