### PR TITLE
fix: [DHIS2-18690] Re-add TESchemaDescriptor to avoid in-memory query planner (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -167,6 +167,7 @@ import org.hisp.dhis.schema.descriptors.TrackedEntityAttributeValueSchemaDescrip
 import org.hisp.dhis.schema.descriptors.TrackedEntityDataElementDimensionSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.TrackedEntityFilterSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.TrackedEntityProgramIndicatorDimensionSchemaDescriptor;
+import org.hisp.dhis.schema.descriptors.TrackedEntitySchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.TrackedEntityTypeAttributeSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.TrackedEntityTypeSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.UserAccessSchemaDescriptor;
@@ -281,6 +282,7 @@ public class DefaultSchemaService implements SchemaService {
     register(new SqlViewSchemaDescriptor());
     register(new TrackedEntityAttributeSchemaDescriptor());
     register(new TrackedEntityAttributeValueSchemaDescriptor());
+    register(new TrackedEntitySchemaDescriptor());
     register(new TrackedEntityFilterSchemaDescriptor());
     register(new TrackedEntityTypeSchemaDescriptor());
     register(new TrackedEntityTypeAttributeSchemaDescriptor());

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntitySchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntitySchemaDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.schema.descriptors;
+
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaDescriptor;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+public class TrackedEntitySchemaDescriptor implements SchemaDescriptor {
+
+  public static final String SINGULAR = "trackedEntityInstance";
+
+  public static final String PLURAL = "trackedEntityInstances";
+
+  public static final String API_ENDPOINT = "/" + PLURAL;
+
+  @Override
+  public Schema getSchema() {
+    Schema schema = new Schema(TrackedEntity.class, SINGULAR, PLURAL);
+    schema.setRelativeApiEndpoint(API_ENDPOINT);
+
+    return schema;
+  }
+}


### PR DESCRIPTION
Calle had complaned a simple enrollment api caused an OutOfMemory heap space error.  On investigating, the culprit was the removal of `TrackedEntityInstanceSchemaDescriptor` removal. This meant the SchemaService would identify TrackedEntity as a "non persisted" entity and cause the queryPlanner in DefaultQueryService to use npQuery (non-persisted in-memory query) instead. 

This meant, whenever enrollment was done, as part of `prepareCaches` it loaded all the TEs  (8 million in Calle's case) into the memory and did an in-memory filtering for the single TEI it was interested in. Thereby causing the OutOfMemory issue.

This PR simply re-introduces the SchemaDescriptor back as TrackedEntitySchemaDescriptor. This is rightfully removed in v42 and not required there. However the old API still exists in v41 and relied on the existence of the SchemaDescriptor. Instead of changing any other logics, re-introduced it back which fixes the issue. 