### PR TITLE
fix: broken linked account feature

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -850,4 +850,16 @@ public interface UserService {
    * @return matching {@link User}s
    */
   List<User> getUsersWithOrgUnit(@Nonnull UserOrgUnitProperty orgUnitProperty, @Nonnull UID uid);
+
+  /**
+   * Sets the active account for the next login session.
+   *
+   * <p>This method updates the last login timestamp of the target account 'activeUsername', to one
+   * hour in the future. This future timestamp ensures the account appears first when sorting linked
+   * accounts by last login date, and hence the top of the list will be the 'active'.
+   *
+   * @param actingUser the acting/current user
+   * @param activeUsername the username of the user to set as active
+   */
+  void setActiveLinkedAccounts(@Nonnull String actingUser, @Nonnull String activeUsername);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -218,7 +218,11 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   CurrentUserGroupInfo getCurrentUserGroupInfo(String userUid);
 
   /**
-   * Get active linked user accounts for the given user
+   * Sets the active account for the next login session.
+   *
+   * <p>This method updates the last login timestamp of the target account 'activeUsername', to one
+   * hour in the future. This future timestamp ensures the account appears first when sorting linked
+   * accounts by last login date, and hence the top of the list will be the 'active'.
    *
    * @param actingUser the acting/current user
    * @param activeUsername the username of the user to set as active

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.user.UserStore;
+import org.hisp.dhis.user.UserService;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
@@ -56,8 +56,8 @@ import org.springframework.stereotype.Component;
 public class DhisOidcLogoutSuccessHandler implements LogoutSuccessHandler {
 
   private final DhisConfigurationProvider config;
-  private final UserStore userStore;
   private final DhisOidcProviderRepository dhisOidcProviderRepository;
+  private final UserService userService;
 
   private SimpleUrlLogoutSuccessHandler handler;
 
@@ -116,7 +116,7 @@ public class DhisOidcLogoutSuccessHandler implements LogoutSuccessHandler {
       // switch parameter present: switch accounts and then redirect to re-login URL
       String currentUsername = request.getParameter("current");
       if (!isNullOrEmpty(currentUsername)) {
-        userStore.setActiveLinkedAccounts(currentUsername, usernameToSwitchTo);
+        userService.setActiveLinkedAccounts(currentUsername, usernameToSwitchTo);
       }
       this.handler.setDefaultTargetUrl(config.getProperty(LINKED_ACCOUNTS_RELOGIN_URL));
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1500,4 +1500,10 @@ public class DefaultUserService implements UserService {
   public User getUserByVerifiedEmail(String email) {
     return userStore.getUserByVerifiedEmail(email);
   }
+
+  @Transactional
+  @Override
+  public void setActiveLinkedAccounts(@Nonnull String actingUser, @Nonnull String activeUsername) {
+    userStore.setActiveLinkedAccounts(actingUser, activeUsername);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.query.QueryUtils;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccountExpiryInfo;
 import org.hisp.dhis.user.UserGroup;
@@ -635,7 +636,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
               ? Date.from(oneHourInTheFuture)
               : Date.from(oneHourAgo));
 
-      update(user);
+      update(user, new SystemUser());
     }
   }
 


### PR DESCRIPTION
### Problem:
Users could not switch between linked account users.
### Cause:
When the log out handler `(DhisOidcLogoutSuccessHandler)`, was called and tried to set the user we want to switch to with the method `setActiveLinkedAccounts()`, nothing happened because the there was no transaction involved, because it called the UserStore directly, instead of going through the service layer.
So when it tried to persist the updated `lastLogin` field, nothing happened.

### Solution:
Add the `setActiveLinkedAccounts() `method to the UserService and annotate it with @Transactional and make the log out handler call the new method.

### Automatic tests:
Automatic tests not available, because it needs a full setup with an external IDP and tests with E2E.

### Manual test:
1. Enable a OIDC provider. (See documentation for setting up with Google for example).
2. Enable linked account. `linked_accounts.enabled = on` and `linked_accounts.relogin_url = http://localhost:8080` in dhis.conf
3. Create two users that has the same OIDC mapping.
4. Log in as user A.
5. Try to log out and switch to user B, with URL like this: `http://localhost:8080/dhis-web-commons-security/logout.action?switch=userb&current=usera` 
6. Observe next time you log in (with OIDC) you now get logged in as user B.