### PR TITLE
fix: remove F_MAP_EXTERNAL_LAYER_ADD authorities

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
@@ -74,7 +74,6 @@ public enum Authorities {
   F_DATAVALUE_ADD,
   F_IMPERSONATE_USER,
   F_SYSTEM_SETTING,
-  F_MAP_EXTERNAL_LAYER_ADD,
   F_PREVIOUS_IMPERSONATOR_AUTHORITY;
 
   public static Set<String> getAllAuthorities() {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -443,7 +443,6 @@ F_ROUTE_PUBLIC_ADD=Add/Update Public Route
 F_ROUTE_PRIVATE_ADD=Add/Update Private Route
 F_ROUTE_PUBLIC_DELETE=Delete Route
 F_IMPERSONATE_USER=Impersonate user
-F_MAP_EXTERNAL_LAYER_ADD=Add external map layer
 #-- Common ---------------------------------------------------------------------#
 
 offline=Offline


### PR DESCRIPTION
Reverts the original PR, because the new authority was not needed. 