### PR TITLE
fix: mandatory attributes cannot have empty value [DHIS2-18365]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.preheat.PreheatMode;
 import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.RecordingJobProgress;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
@@ -80,7 +81,7 @@ public class DefaultMetadataImportService implements MetadataImportService {
   @Transactional
   public ImportReport importMetadata(
       @Nonnull MetadataImportParams params, @Nonnull MetadataObjects objects) {
-    return importMetadata(params, objects, JobProgress.noop());
+    return importMetadata(params, objects, RecordingJobProgress.transitory());
   }
 
   @Override

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.attribute.Attribute;
@@ -1244,6 +1245,53 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
     JsonObject programs =
         GET("/programs?filter=sharing.users:lt:2", programId).content().as(JsonObject.class);
     assertEquals(1, programs.get("programs").as(JsonArray.class).size());
+  }
+
+  @Test
+  void testPostObject_MandatoryAttributeNoValue() {
+    String attr =
+        "{'name':'USER', 'valueType':'TRUE_ONLY', 'userAttribute':true, 'mandatory':true}";
+    String attrId = assertStatus(HttpStatus.CREATED, POST("/attributes", attr));
+    // language=JSON5
+    String user =
+        """
+        {
+          "username": "testMandatoryAttribute",
+          "password": "-hu@_ka9$P",
+          "firstName": "testMandatoryAttribute",
+          "surname": "tester",
+          "userRoles":[{ "id": "yrB6vc5Ip3r" }],
+          "attributeValues": [{ "attribute": { "id": "%s" }, "value": "" } ]
+        }
+        """;
+    assertErrorMandatoryAttributeRequired(attrId, POST("/users", user.formatted(attrId)));
+  }
+
+  @Test
+  void testPostObject_MandatoryAttributeNoAttribute() {
+    String attr =
+        "{'name':'USER', 'valueType':'TRUE_ONLY', 'userAttribute':true, 'mandatory':true}";
+    String attrId = assertStatus(HttpStatus.CREATED, POST("/attributes", attr));
+    String user =
+        """
+        {
+          "username": "testMandatoryAttribute",
+          "password": "-hu@_ka9$P",
+          "firstName": "testMandatoryAttribute",
+          "surname": "tester",
+          "userRoles":[{ "id": "yrB6vc5Ip3r" }]
+        }
+        """;
+    assertErrorMandatoryAttributeRequired(attrId, POST("/users", user));
+  }
+
+  private void assertErrorMandatoryAttributeRequired(String attrId, HttpResponse response) {
+    JsonError msg = response.content(HttpStatus.CONFLICT).as(JsonError.class);
+    JsonList<JsonErrorReport> errorReports = msg.getTypeReport().getErrorReports();
+    assertEquals(1, errorReports.size());
+    JsonErrorReport error = errorReports.get(0);
+    assertEquals(ErrorCode.E4011, error.getErrorCode());
+    assertEquals(List.of(attrId), error.getErrorProperties());
   }
 
   private void assertUserGroupHasOnlyUser(String groupId, String userId) {


### PR DESCRIPTION
### Summary
The main issue was that an empty string value was considered as being present.

Secondary issue was that the attribute value parsing in 2.42 did not accept any other JSON values than a JSON string.
While this is strictly correct the app apparently does use JSON boolean so the parsing was adjusted to handle other JSON types.

For better visibility in case of errors the `JobProgress` tracking for synchronous metadata imports was changed to use `RecordingJobProgress.transitory` which behaves like a persistent tracking except that it discards completed nodes in the progress tree.

### Manual Testing
See Jira description

### Automatic Testing
2 new test scenarios where added testing that adding a user either with an empty value for the mandatory attribute or entirely without the attribute results in a CONFLICT response. 