### PR TITLE
fix: [DHIS2-18459] Re-use obtained maxTeLimit (2.41)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -471,7 +471,7 @@ public class TrackedEntityQueryParams {
 
   /** Indicates whether this parameters specifies a max TE limit. */
   public boolean hasMaxTeLimit() {
-    return this.maxTeLimit > 0;
+    return maxTeLimit > 0;
   }
 
   /** Indicates whether this parameters is of the given organisation unit mode. */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -469,6 +469,11 @@ public class TrackedEntityQueryParams {
     return trackedEntityType != null;
   }
 
+  /** Indicates whether this parameters specifies a max TE limit. */
+  public boolean hasMaxTeLimit() {
+    return this.maxTeLimit > 0;
+  }
+
   /** Indicates whether this parameters is of the given organisation unit mode. */
   public boolean isOrganisationUnitMode(OrganisationUnitSelectionMode mode) {
     return orgUnitMode != null && orgUnitMode.equals(mode);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -681,7 +681,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
       params.setMaxTeLimit(maxTeiLimit);
       checkIfMaxTeiLimitIsReached(params);
-
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -679,16 +679,17 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         }
       }
 
-      checkIfMaxTeiLimitIsReached(params, maxTeiLimit);
       params.setMaxTeLimit(maxTeiLimit);
+      checkIfMaxTeiLimitIsReached(params);
+
     }
   }
 
-  private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {
-    if (maxTeiLimit > 0) {
+  private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params) {
+    if (params.getMaxTeLimit() > 0) {
       int teCount = trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(params);
 
-      if (teCount > maxTeiLimit) {
+      if (teCount > params.getMaxTeLimit()) {
         throw new IllegalQueryException("maxteicountreached");
       }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -685,7 +685,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params) {
-    if (params.getMaxTeLimit() > 0) {
+    if (params.hasMaxTeLimit()) {
       int teCount = trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(params);
 
       if (teCount > params.getMaxTeLimit()) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -414,7 +414,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
         .append(getFromSubQuery(params, true, true))
         .append(getQueryRelatedTables(params))
         .append(getQueryGroupBy(params))
-        .append(params.getMaxTeLimit() > 0 ? getLimitClause(params.getMaxTeLimit() + 1) : "")
+        .append(params.hasMaxTeLimit() ? getLimitClause(params.getMaxTeLimit() + 1) : "")
         .append(" ) tecount")
         .toString();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -407,8 +407,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * @return a count SQL query
    */
   private String getCountQueryWithMaxTeiLimit(TrackedEntityQueryParams params) {
-    boolean hasMaxTeiCountToReturn =
-        params.hasProgram() && params.getProgram().hasMaxTeiCountToReturn();
     return new StringBuilder()
         .append(getQueryCountSelect(params))
         .append(getQuerySelect(params))
@@ -417,8 +415,8 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
         .append(getQueryRelatedTables(params))
         .append(getQueryGroupBy(params))
         .append(
-            hasMaxTeiCountToReturn
-                ? getLimitClause(params.getProgram().getMaxTeiCountToReturn() + 1)
+            params.getMaxTeLimit() > 0
+                ? getLimitClause(params.getMaxTeLimit() + 1)
                 : "")
         .append(" ) tecount")
         .toString();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -414,10 +414,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
         .append(getFromSubQuery(params, true, true))
         .append(getQueryRelatedTables(params))
         .append(getQueryGroupBy(params))
-        .append(
-            params.getMaxTeLimit() > 0
-                ? getLimitClause(params.getMaxTeLimit() + 1)
-                : "")
+        .append(params.getMaxTeLimit() > 0 ? getLimitClause(params.getMaxTeLimit() + 1) : "")
         .append(" ) tecount")
         .toString();
   }


### PR DESCRIPTION
Fixing another fix https://github.com/dhis2/dhis2-core/pull/19240 (which does fix the nullPointer issue, but does not consider a small functional gap)

The mentioned PR does not consider if the maxTeLimit is obtained from TrackedEntityType. And proceeds to fetch it from Program again. (Ignores the maxTeLimit could also have been obtained from the TET)

Since the obtained maxTeLimit is injected into the Params, it makes sense to simply re-use that. There already exists a unit test case to check the NPE from the previous PR.