### PR TITLE
fix: user query parameter must include username [DHIS2-18748]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyControllerTest.java
@@ -38,7 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonUser;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +56,25 @@ import org.springframework.transaction.annotation.Transactional;
 class AbstractFullReadOnlyControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private DataElementService dataElementService;
+
+  @Test
+  void testGetObjectList_QueryUsers() {
+    // this just simulates the normal setup with a system super-user
+    User user = switchToNewUser("system", "ALL");
+    // make sure "system" does not occur in any other property that might be searched by query=
+    user.setName("x");
+    user.setFirstName("y");
+    user.setSurname("z");
+    user.setCode("xyz");
+    userService.updateUser(user);
+
+    JsonList<JsonUser> users =
+        GET("/users?fields=id,name,username&query=system")
+            .content()
+            .getList("users", JsonUser.class);
+    assertEquals(1, users.size());
+    assertEquals("system", users.get(0).getUsername());
+  }
 
   @Test
   void testGetObjectListCsv() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -81,6 +81,7 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.ReflectionUtils;
 import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserSettingsService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -242,7 +243,7 @@ public abstract class AbstractFullReadOnlyController<
   @Nonnull
   protected List<Criterion> getAdditionalFilters(P params) throws ConflictException {
     List<Criterion> filters = new ArrayList<>();
-    if (params.getQuery() != null && !params.getQuery().isEmpty())
+    if (params.getQuery() != null && !params.getQuery().isEmpty() && getEntityClass() != User.class)
       filters.add(Restrictions.query(getSchema(), params.getQuery()));
     List<UID> matches = getPreQueryMatches(params);
     // Note: null = no special filters, empty = no matches for special filters

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -217,7 +217,8 @@ public class UserController
 
     @JsonIgnore
     boolean isUsingAnySpecialFilters() {
-      return phoneNumber != null
+      return getQuery() != null
+          || phoneNumber != null
           || canManage
           || authSubset
           || lastLogin != null


### PR DESCRIPTION
### Summary
When using the `query` parameter with `User` this should not run the standard implementation. 
Therefore `query` needs to be considered a "special filter" and excluded for users.

This got overlooked when reworking the special filters in #19046 since the `query` parameter basically has a name clash.

### Manual Testing 
Using it to find `system` user by `username` once with other special filters and once without

* `/api/users?userOrgUnits=true&includeChildren=true&query=system`
* `/api/users?query=system`
* check both URLs result in a list containing the system user (in SL this is the only match)

### Automatic Testing
Added a controller test scenario that searches with `query=system` to match on the `username`.