### PR TITLE
feat: adds sortable schema property [DHIS2-18749]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -213,6 +213,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
+  @Sortable(whenPersisted = false)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Translatable(propertyName = "name", key = "NAME")
@@ -282,7 +283,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
 
   @Gist(included = Include.FALSE)
   @Override
-  @Sortable(false)
+  @Sortable(value = false)
   @JsonProperty
   @JacksonXmlElementWrapper(localName = "translations", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "translation", namespace = DxfNamespaces.DXF_2_0)
@@ -362,7 +363,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
-  @Sortable(false)
+  @Sortable(value = false)
   @Gist(included = Include.FALSE)
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @JacksonXmlProperty(localName = "access", namespace = DxfNamespaces.DXF_2_0)
@@ -394,7 +395,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
-  @Sortable(false)
+  @Sortable(value = false)
   @Gist(included = Include.FALSE)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -49,6 +49,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.Immutable;
@@ -83,22 +85,22 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @JacksonXmlRootElement(localName = "identifiableObject", namespace = DxfNamespaces.DXF_2_0)
 public class BaseIdentifiableObject extends BaseLinkableObject implements IdentifiableObject {
   /** The database internal identifier for this Object. */
-  protected long id;
+  @Setter protected long id;
 
   /** The unique identifier for this object. */
-  @AuditAttribute protected String uid;
+  @Setter @AuditAttribute protected String uid;
 
   /** The unique code for this object. */
-  @AuditAttribute protected String code;
+  @Setter @AuditAttribute protected String code;
 
   /** The name of this object. Required and unique. */
-  protected String name;
+  @Setter protected String name;
 
   /** The date this object was created. */
-  protected Date created;
+  @Setter protected Date created;
 
   /** The date this object was last updated. */
-  protected Date lastUpdated;
+  @Setter protected Date lastUpdated;
 
   /** Set of the dynamic attributes values that belong to this data element. */
   @AuditAttribute private AttributeValues attributeValues = AttributeValues.empty();
@@ -110,7 +112,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
    * Cache for object translations, where the cache key is a combination of locale and translation
    * property, and value is the translated value.
    */
-  private Map<String, String> translationCache = new ConcurrentHashMap<>();
+  private final Map<String, String> translationCache = new ConcurrentHashMap<>();
 
   /** User who created this object. This field is immutable and must not be updated. */
   @Immutable protected User createdBy;
@@ -119,13 +121,13 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   protected transient Access access;
 
   /** Users who have marked this object as a favorite. */
-  protected Set<String> favorites = new HashSet<>();
+  @Setter protected Set<String> favorites = new HashSet<>();
 
   /** Last user updated this object. */
-  protected User lastUpdatedBy;
+  @Setter protected User lastUpdatedBy;
 
   /** Object sharing (JSONB). */
-  protected Sharing sharing = new Sharing();
+  @Setter protected Sharing sharing = new Sharing();
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -162,7 +164,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
    * name.
    */
   @Override
-  public int compareTo(IdentifiableObject object) {
+  public int compareTo(@Nonnull IdentifiableObject object) {
     if (this.getDisplayName() == null) {
       return object.getDisplayName() == null ? 0 : 1;
     }
@@ -182,10 +184,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     return id;
   }
 
-  public void setId(long id) {
-    this.id = id;
-  }
-
   @Override
   @JsonProperty(value = "id")
   @JacksonXmlProperty(localName = "id", isAttribute = true)
@@ -194,10 +192,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   @PropertyRange(min = 11, max = 11)
   public String getUid() {
     return uid;
-  }
-
-  public void setUid(String uid) {
-    this.uid = uid;
   }
 
   @Override
@@ -209,10 +203,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     return code;
   }
 
-  public void setCode(String code) {
-    this.code = code;
-  }
-
   @Override
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
@@ -220,10 +210,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   @PropertyRange(min = 1)
   public String getName() {
     return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
   }
 
   @Override
@@ -243,10 +229,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     return created;
   }
 
-  public void setCreated(Date created) {
-    this.created = created;
-  }
-
   @Override
   @OpenApi.Property(UserPropertyTransformer.UserDto.class)
   @JsonProperty
@@ -258,10 +240,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     return lastUpdatedBy;
   }
 
-  public void setLastUpdatedBy(User lastUpdatedBy) {
-    this.lastUpdatedBy = lastUpdatedBy;
-  }
-
   @Override
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
@@ -269,10 +247,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   @Property(value = PropertyType.DATE, required = Value.FALSE)
   public Date getLastUpdated() {
     return lastUpdated;
-  }
-
-  public void setLastUpdated(Date lastUpdated) {
-    this.lastUpdated = lastUpdated;
   }
 
   public record AttributeValue(@JsonProperty Attribute attribute, @JsonProperty String value) {}
@@ -308,6 +282,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
 
   @Gist(included = Include.FALSE)
   @Override
+  @Sortable(false)
   @JsonProperty
   @JacksonXmlElementWrapper(localName = "translations", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "translation", namespace = DxfNamespaces.DXF_2_0)
@@ -387,8 +362,9 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
+  @Sortable(false)
   @Gist(included = Include.FALSE)
-  @JsonProperty
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @JacksonXmlProperty(localName = "access", namespace = DxfNamespaces.DXF_2_0)
   public Access getAccess() {
     return access;
@@ -407,10 +383,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     return favorites;
   }
 
-  public void setFavorites(Set<String> favorites) {
-    this.favorites = favorites;
-  }
-
   @Override
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
@@ -422,6 +394,7 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   @Override
+  @Sortable(false)
   @Gist(included = Include.FALSE)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
@@ -431,10 +404,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     }
 
     return sharing;
-  }
-
-  public void setSharing(Sharing sharing) {
-    this.sharing = sharing;
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseLinkableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseLinkableObject.java
@@ -45,7 +45,7 @@ public class BaseLinkableObject implements LinkableObject {
   private transient String href;
 
   @Override
-  @Sortable(false)
+  @Sortable(value = false)
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @JacksonXmlProperty(isAttribute = true)
   @Property(PropertyType.URL)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseNameableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseNameableObject.java
@@ -166,6 +166,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
   // -------------------------------------------------------------------------
 
   @Override
+  @Sortable
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
   @PropertyRange(min = 1)
@@ -178,6 +179,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
   }
 
   @Override
+  @Sortable(whenPersisted = false)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Translatable(propertyName = "shortName", key = "SHORT_NAME")
@@ -186,6 +188,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
   }
 
   @Override
+  @Sortable
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @PropertyRange(min = 1)
@@ -198,6 +201,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
   }
 
   @Override
+  @Sortable(value = false)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Translatable(propertyName = "description", key = "DESCRIPTION")
@@ -206,6 +210,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
   }
 
   @JsonProperty
+  @Sortable(whenPersisted = false)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Translatable(propertyName = "formName", key = "FORM_NAME")
   public String getDisplayFormName() {
@@ -217,6 +222,7 @@ public class BaseNameableObject extends BaseIdentifiableObject implements Nameab
     return formName != null && !formName.isEmpty() ? getFormName() : getDisplayName();
   }
 
+  @Sortable
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getFormName() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Sortable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Sortable.java
@@ -35,5 +35,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Sortable {
+
   boolean value() default true;
+
+  boolean whenPersisted() default true;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Sortable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Sortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,13 @@
  */
 package org.hisp.dhis.common;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.annotation.Property;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@JacksonXmlRootElement(localName = "linkableObject", namespace = DxfNamespaces.DXF_2_0)
-public class BaseLinkableObject implements LinkableObject {
-  /**
-   * As part of the serializing process, this field can be set to indicate a link to this
-   * identifiable object (will be used on the web layer for navigating the REST API)
-   */
-  private transient String href;
-
-  @Override
-  @Sortable(false)
-  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-  @JacksonXmlProperty(isAttribute = true)
-  @Property(PropertyType.URL)
-  public String getHref() {
-    return href;
-  }
-
-  @Override
-  public void setHref(String href) {
-    this.href = href;
-  }
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Sortable {
+  boolean value() default true;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -38,10 +38,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.NameableObject;
+import org.hisp.dhis.common.Sortable;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.springframework.core.Ordered;
 
@@ -54,56 +57,56 @@ public class Property implements Ordered, Klass {
   private Class<?> klass;
 
   /** Normalized type of this property */
-  private PropertyType propertyType;
+  @Setter private PropertyType propertyType;
 
   /** If this property is a collection, this is the class of the items inside the collection. */
-  private Class<?> itemKlass;
+  @Setter private Class<?> itemKlass;
 
   /**
    * If this property is a collection, this is the normalized type of the items inside the
    * collection.
    */
-  private PropertyType itemPropertyType;
+  @Setter private PropertyType itemPropertyType;
 
   /** Direct link to getter for this property. */
-  private Method getterMethod;
+  @Getter @Setter private Method getterMethod;
 
   /** Direct link to setter for this property. */
-  private Method setterMethod;
+  @Getter @Setter private Method setterMethod;
 
   /**
    * Name for this property, if this class is a collection, it is the name of the items -inside- the
    * collection and not the collection wrapper itself.
    */
-  private String name;
+  @Setter private String name;
 
   /** Name for actual field, used to persistence operations and getting setter/getter. */
-  private String fieldName;
+  @Setter private String fieldName;
 
   /**
    * Is this property persisted somewhere. This property will be used to create criteria queries on
    * demand (default: false)
    */
-  private boolean persisted;
+  @Setter private boolean persisted;
 
   /** Name of collection wrapper. */
-  private String collectionName;
+  @Setter private String collectionName;
 
   /** If this Property is a collection, should it be wrapped with collectionName? */
-  private Boolean collectionWrapping;
+  @Setter private Boolean collectionWrapping;
 
   /**
    * Description if provided, will be fetched from @Description annotation.
    *
    * @see org.hisp.dhis.common.annotation.Description
    */
-  private String description;
+  @Setter private String description;
 
   /** Namespace used for this property. */
-  private String namespace;
+  @Setter private String namespace;
 
   /** Usually only used for XML. Is this property considered an attribute. */
-  private boolean attribute;
+  @Setter private boolean attribute;
 
   /**
    * This property is true if the type pointed to does not export any properties itself, it is then
@@ -111,120 +114,121 @@ public class Property implements Ordered, Klass {
    * type of the collection, e.g. List<String> would set simple to be true, but List<DataElement>
    * would set it to false.
    */
-  private boolean simple;
+  @Setter private boolean simple;
 
   /**
    * This property is true if the type of this property is a sub-class of Collection.
    *
    * @see java.util.Collection
    */
-  private boolean collection;
+  @Setter private boolean collection;
 
   /**
    * This property is true if collection=true and klass points to a implementation with a stable
    * order (i.e. List).
    */
-  private boolean ordered;
+  @Setter private boolean ordered;
 
   /**
    * If this property is a complex object or a collection, is this property considered the owner of
    * that relationship (important for imports etc).
    */
-  private boolean owner;
+  @Setter private boolean owner;
 
   /**
    * Is this class a sub-class of IdentifiableObject
    *
    * @see org.hisp.dhis.common.IdentifiableObject
    */
-  private boolean identifiableObject;
+  @Setter private boolean identifiableObject;
 
   /**
    * Is this class a sub-class of NameableObject
    *
    * @see org.hisp.dhis.common.NameableObject
    */
-  private boolean nameableObject;
+  @Setter private boolean nameableObject;
 
   /** Does this class implement {@link EmbeddedObject} ? */
-  private boolean embeddedObject;
+  @Setter private boolean embeddedObject;
 
   /** Does this class implement {@link EmbeddedObject} ? */
-  private boolean analyticalObject;
+  @Setter private boolean analyticalObject;
 
   /** Can this property be read. */
-  private boolean readable;
+  @Setter private boolean readable;
 
   /** Can this property be written to. */
-  private boolean writable;
+  @Setter private boolean writable;
 
   /** Are the values for this property required to be unique? */
-  private boolean unique;
+  @Setter private boolean unique;
 
   /** Nullability of this property. */
-  private boolean required;
+  @Setter private boolean required;
 
   /** Maximum length/size/value of this property. */
-  private Integer length;
+  @Setter private Integer length;
 
   /** Minimum size/length of this property. */
-  private Double max;
+  @Setter private Double max;
 
   /** Minimum size/length of this property. */
-  private Double min;
+  @Setter private Double min;
 
   /** Cascading used when doing CRUD operations. */
-  private String cascade;
+  @Setter private String cascade;
 
   /** Is property many-to-many. */
-  private boolean manyToMany;
+  @Setter private boolean manyToMany;
 
   /** Is property one-to-one. */
-  private boolean oneToOne;
+  @Setter private boolean oneToOne;
 
   /** Is property many-to-one. */
-  private boolean manyToOne;
+  @Setter private boolean manyToOne;
 
   /** Is property one-to-many. */
-  private boolean oneToMany;
+  @Setter private boolean oneToMany;
 
   /** The hibernate role of the owning side. */
-  private String owningRole;
+  @Setter private String owningRole;
 
   /** The hibernate role of the inverse side (if many-to-many). */
-  private String inverseRole;
+  @Setter private String inverseRole;
 
   /** If property type is enum, this is the list of valid options. */
-  private List<String> constants;
+  @Setter private List<String> constants;
 
   /** Used by LinkService to link to the Schema describing this type (if reference). */
-  private String href;
+  @Setter private String href;
 
   /** Points to relative Web-API endpoint (if exposed). */
-  private String relativeApiEndpoint;
+  @Setter private String relativeApiEndpoint;
 
   /** Used by LinkService to link to the API endpoint containing this type. */
-  private String apiEndpoint;
+  @Setter private String apiEndpoint;
 
   /** PropertyTransformer to apply to this property before and field filtering is applied. */
-  private Class<? extends PropertyTransformer> propertyTransformer;
+  @Getter @Setter private Class<? extends PropertyTransformer> propertyTransformer;
 
   /** Default value of the Property */
   private Object defaultValue;
 
-  private boolean translatable;
+  @Setter private boolean translatable;
 
-  private String translationKey;
+  @Setter private String translationKey;
 
   /**
    * The translation key use for retrieving I18n translation of this property's name. The key
    * follows snake_case naming convention.
    */
-  private String i18nTranslationKey;
+  @Setter private String i18nTranslationKey;
 
   private GistPreferences gistPreferences = GistPreferences.DEFAULT;
 
   /** All annotations present on this property (either through field or method) */
+  @Getter @Setter
   private Map<Class<? extends Annotation>, Annotation> annotations = new HashMap<>();
 
   public Property() {}
@@ -259,18 +263,10 @@ public class Property implements Ordered, Klass {
     return propertyType;
   }
 
-  public void setPropertyType(PropertyType propertyType) {
-    this.propertyType = propertyType;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Class<?> getItemKlass() {
     return itemKlass;
-  }
-
-  public void setItemKlass(Class<?> itemKlass) {
-    this.itemKlass = itemKlass;
   }
 
   @JsonProperty
@@ -279,34 +275,10 @@ public class Property implements Ordered, Klass {
     return itemPropertyType;
   }
 
-  public void setItemPropertyType(PropertyType itemPropertyType) {
-    this.itemPropertyType = itemPropertyType;
-  }
-
-  public Method getGetterMethod() {
-    return getterMethod;
-  }
-
-  public void setGetterMethod(Method getterMethod) {
-    this.getterMethod = getterMethod;
-  }
-
-  public Method getSetterMethod() {
-    return setterMethod;
-  }
-
-  public void setSetterMethod(Method setterMethod) {
-    this.setterMethod = setterMethod;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getName() {
     return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
   }
 
   @JsonProperty
@@ -315,18 +287,10 @@ public class Property implements Ordered, Klass {
     return fieldName;
   }
 
-  public void setFieldName(String fieldName) {
-    this.fieldName = fieldName;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isPersisted() {
     return persisted;
-  }
-
-  public void setPersisted(boolean persisted) {
-    this.persisted = persisted;
   }
 
   @JsonProperty
@@ -335,18 +299,10 @@ public class Property implements Ordered, Klass {
     return collectionName != null ? collectionName : (isCollection() ? name : null);
   }
 
-  public void setCollectionName(String collectionName) {
-    this.collectionName = collectionName;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Boolean isCollectionWrapping() {
     return collectionWrapping;
-  }
-
-  public void setCollectionWrapping(Boolean collectionWrapping) {
-    this.collectionWrapping = collectionWrapping;
   }
 
   @JsonProperty
@@ -355,18 +311,10 @@ public class Property implements Ordered, Klass {
     return description;
   }
 
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getNamespace() {
     return namespace;
-  }
-
-  public void setNamespace(String namespace) {
-    this.namespace = namespace;
   }
 
   @JsonProperty
@@ -375,18 +323,10 @@ public class Property implements Ordered, Klass {
     return attribute;
   }
 
-  public void setAttribute(boolean attribute) {
-    this.attribute = attribute;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isSimple() {
     return simple;
-  }
-
-  public void setSimple(boolean simple) {
-    this.simple = simple;
   }
 
   @JsonProperty
@@ -395,8 +335,11 @@ public class Property implements Ordered, Klass {
     return collection;
   }
 
-  public void setCollection(boolean collection) {
-    this.collection = collection;
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public boolean isSortable() {
+    Sortable sortable = getterMethod == null ? null : getterMethod.getAnnotation(Sortable.class);
+    return sortable != null ? sortable.value() : !isCollection() && isSimple();
   }
 
   @JsonProperty
@@ -405,18 +348,10 @@ public class Property implements Ordered, Klass {
     return ordered;
   }
 
-  public void setOrdered(boolean ordered) {
-    this.ordered = ordered;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isOwner() {
     return owner;
-  }
-
-  public void setOwner(boolean owner) {
-    this.owner = owner;
   }
 
   @JsonProperty
@@ -425,18 +360,10 @@ public class Property implements Ordered, Klass {
     return identifiableObject;
   }
 
-  public void setIdentifiableObject(boolean identifiableObject) {
-    this.identifiableObject = identifiableObject;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isNameableObject() {
     return nameableObject;
-  }
-
-  public void setNameableObject(boolean nameableObject) {
-    this.nameableObject = nameableObject;
   }
 
   @JsonProperty
@@ -445,18 +372,10 @@ public class Property implements Ordered, Klass {
     return embeddedObject;
   }
 
-  public void setEmbeddedObject(boolean embeddedObject) {
-    this.embeddedObject = embeddedObject;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isAnalyticalObject() {
     return analyticalObject;
-  }
-
-  public void setAnalyticalObject(boolean analyticalObject) {
-    this.analyticalObject = analyticalObject;
   }
 
   @JsonProperty
@@ -465,18 +384,10 @@ public class Property implements Ordered, Klass {
     return readable;
   }
 
-  public void setReadable(boolean readable) {
-    this.readable = readable;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isWritable() {
     return writable;
-  }
-
-  public void setWritable(boolean writable) {
-    this.writable = writable;
   }
 
   @JsonProperty
@@ -485,18 +396,10 @@ public class Property implements Ordered, Klass {
     return unique;
   }
 
-  public void setUnique(boolean unique) {
-    this.unique = unique;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isRequired() {
     return required;
-  }
-
-  public void setRequired(boolean required) {
-    this.required = required;
   }
 
   @JsonProperty
@@ -505,18 +408,10 @@ public class Property implements Ordered, Klass {
     return length;
   }
 
-  public void setLength(Integer length) {
-    this.length = length;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Double getMax() {
     return max;
-  }
-
-  public void setMax(Double max) {
-    this.max = max;
   }
 
   @JsonProperty
@@ -525,18 +420,10 @@ public class Property implements Ordered, Klass {
     return min;
   }
 
-  public void setMin(Double min) {
-    this.min = min;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getCascade() {
     return cascade;
-  }
-
-  public void setCascade(String cascade) {
-    this.cascade = cascade;
   }
 
   @JsonProperty
@@ -545,18 +432,10 @@ public class Property implements Ordered, Klass {
     return manyToMany;
   }
 
-  public void setManyToMany(boolean manyToMany) {
-    this.manyToMany = manyToMany;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isOneToOne() {
     return oneToOne;
-  }
-
-  public void setOneToOne(boolean oneToOne) {
-    this.oneToOne = oneToOne;
   }
 
   @JsonProperty
@@ -565,18 +444,10 @@ public class Property implements Ordered, Klass {
     return manyToOne;
   }
 
-  public void setManyToOne(boolean manyToOne) {
-    this.manyToOne = manyToOne;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isOneToMany() {
     return oneToMany;
-  }
-
-  public void setOneToMany(boolean oneToMany) {
-    this.oneToMany = oneToMany;
   }
 
   @JsonProperty
@@ -585,18 +456,10 @@ public class Property implements Ordered, Klass {
     return owningRole;
   }
 
-  public void setOwningRole(String owningRole) {
-    this.owningRole = owningRole;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getInverseRole() {
     return inverseRole;
-  }
-
-  public void setInverseRole(String inverseRole) {
-    this.inverseRole = inverseRole;
   }
 
   @JsonProperty
@@ -605,18 +468,10 @@ public class Property implements Ordered, Klass {
     return this.translationKey;
   }
 
-  public void setTranslationKey(String translationKey) {
-    this.translationKey = translationKey;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getI18nTranslationKey() {
     return i18nTranslationKey;
-  }
-
-  public void setI18nTranslationKey(String i18nTranslationKey) {
-    this.i18nTranslationKey = i18nTranslationKey;
   }
 
   @JsonProperty
@@ -626,18 +481,10 @@ public class Property implements Ordered, Klass {
     return constants;
   }
 
-  public void setConstants(List<String> constants) {
-    this.constants = constants;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getHref() {
     return href;
-  }
-
-  public void setHref(String href) {
-    this.href = href;
   }
 
   @JsonProperty
@@ -646,32 +493,16 @@ public class Property implements Ordered, Klass {
     return relativeApiEndpoint;
   }
 
-  public void setRelativeApiEndpoint(String relativeApiEndpoint) {
-    this.relativeApiEndpoint = relativeApiEndpoint;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getApiEndpoint() {
     return apiEndpoint;
   }
 
-  public void setApiEndpoint(String apiEndpoint) {
-    this.apiEndpoint = apiEndpoint;
-  }
-
   @JsonProperty("propertyTransformer")
   @JacksonXmlProperty(localName = "propertyTransformer", namespace = DxfNamespaces.DXF_2_0)
   public boolean hasPropertyTransformer() {
     return propertyTransformer != null;
-  }
-
-  public Class<? extends PropertyTransformer> getPropertyTransformer() {
-    return propertyTransformer;
-  }
-
-  public void setPropertyTransformer(Class<? extends PropertyTransformer> propertyTransformer) {
-    this.propertyTransformer = propertyTransformer;
   }
 
   @JsonProperty
@@ -695,10 +526,6 @@ public class Property implements Ordered, Klass {
     return this.translatable;
   }
 
-  public void setTranslatable(boolean translatable) {
-    this.translatable = translatable;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public GistPreferences getGistPreferences() {
@@ -707,14 +534,6 @@ public class Property implements Ordered, Klass {
 
   public void setGistPreferences(GistPreferences gistPreferences) {
     this.gistPreferences = gistPreferences == null ? GistPreferences.DEFAULT : gistPreferences;
-  }
-
-  public Map<Class<? extends Annotation>, Annotation> getAnnotations() {
-    return annotations;
-  }
-
-  public void setAnnotations(Map<Class<? extends Annotation>, Annotation> annotations) {
-    this.annotations = annotations;
   }
 
   @SuppressWarnings("unchecked")

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -339,7 +339,9 @@ public class Property implements Ordered, Klass {
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isSortable() {
     Sortable sortable = getterMethod == null ? null : getterMethod.getAnnotation(Sortable.class);
-    return sortable != null ? sortable.value() : !isCollection() && isSimple();
+    return sortable != null
+        ? sortable.value() && (!sortable.whenPersisted() || isPersisted())
+        : !isCollection() && isSimple() && isPersisted();
   }
 
   @JsonProperty

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonProperty.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonProperty.java
@@ -90,6 +90,10 @@ public interface JsonProperty extends JsonObject {
     return getBoolean("simple").booleanValue();
   }
 
+  default boolean isSortable() {
+    return getBoolean("sortable").booleanValue();
+  }
+
   default boolean isRequired() {
     return getBoolean("required").booleanValue();
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
@@ -27,14 +27,18 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
+import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
@@ -144,5 +148,36 @@ class SchemaControllerTest extends H2ControllerIntegrationTestBase {
     assertTrue(name.isReadable());
     assertFalse(name.isWritable());
     assertFalse(name.isRequired());
+  }
+
+  @Test
+  void testSortableProperties() {
+    JsonSchema de = GET("/schemas/dataElement").content().as(JsonSchema.class);
+    JsonList<JsonProperty> properties = de.getProperties();
+    Set<String> expected =
+        Set.of(
+            "fieldMask",
+            "aggregationType",
+            "code",
+            "domainType",
+            "displayName",
+            "created",
+            "description",
+            "zeroIsSignificant",
+            "displayFormName",
+            "displayShortName",
+            "url",
+            "lastUpdated",
+            "valueType",
+            "formName",
+            "name",
+            "id",
+            "shortName");
+    Set<String> actual =
+        properties.stream()
+            .filter(JsonProperty::isSortable)
+            .map(JsonProperty::getName)
+            .collect(toSet());
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
### Summary
Adds a `sortable` property to schema `Property` that indicates if a property can be used in the `order` parameter.

By default only simple non-collections properties are sortable. Exceptions can be made by annotating the property getter with `@Sortable(true)` or `@Sortable(false)`.

As far as I could tell we do not have any actual validation for the `order` parameter apart from simply ignoring collections and non-simple properties should they be present. Therefore that logic was used as the fall-back if no `@Sortable` annotation is present.

### Cleanup
IDE supported refactoring to 

* use `@Setter` and some `@Getter` instead of explicitly stating the method
* use `final`
* add nullable annotations to overridden method

Manual changes

* mark some computed properties as `access = READ_ONLY` for jackson

### Manual Testing
 check for example `/api/schemas/dataElement` and look at the `properties` array

Properties now have a `sortable` attribute, for example `name` looks like
```JSON
{
      "klass": "java.lang.String",
      "propertyType": "TEXT",
      "name": "name",
      "fieldName": "name",
      "persisted": true,
      "description": "The name of this Object. Required and unique.",
      "attribute": true,
      "simple": true,
      "collection": false,
      "ordered": false,
      "owner": true,
      "identifiableObject": false,
      "nameableObject": false,
      "embeddedObject": false,
      "analyticalObject": false,
      "readable": true,
      "writable": true,
      "unique": true,
      "required": true,
      "length": 230,
      "max": 230.0,
      "min": 1.0,
      "manyToMany": false,
      "oneToOne": false,
      "manyToOne": false,
      "oneToMany": false,
      "translatable": true,
      "translationKey": "NAME",
      "i18nTranslationKey": "name",
      "gistPreferences": {
        "included": "AUTO",
        "transformation": "AUTO"
      },
      "sortable": true,
      "propertyTransformer": false
    }
```