### PR TITLE
test: Centralize creation of org units in test

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -807,6 +807,14 @@ public class OrganisationUnit extends BaseDimensionalItemObject
     return hierarchyLevel;
   }
 
+  /**
+   * Note that the {@code path} is mapped with the "property access" mode. This method is for unit
+   * testing purposes only.
+   */
+  public void updatePath() {
+    setPath(getPath());
+  }
+
   /** Do not set directly. */
   public void setHierarchyLevel(Integer hierarchyLevel) {
     this.hierarchyLevel = hierarchyLevel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.IdScheme.UID;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -142,7 +143,7 @@ class DataQueryServiceDimensionItemKeywordTest {
     lenient().when(i18nManager.getI18n()).thenReturn(i18n);
     lenient().when(i18n.getString("LAST_12_MONTHS")).thenReturn("Last 12 months");
 
-    rootOu = new OrganisationUnit("Sierra Leone");
+    rootOu = createOrganisationUnit('A');
     rootOu.setUid(CodeGenerator.generateUid());
     rootOu.setCode("OU_525");
   }
@@ -164,7 +165,7 @@ class DataQueryServiceDimensionItemKeywordTest {
         .thenReturn(getOrgUnitLevel(2, "level2UID", "District", null));
     when(organisationUnitService.getOrganisationUnitLevelByLevelOrUid("2")).thenReturn(2);
     when(organisationUnitService.getOrganisationUnitsAtLevels(Mockito.anyList(), Mockito.anyList()))
-        .thenReturn(Lists.newArrayList(new OrganisationUnit(), new OrganisationUnit()));
+        .thenReturn(Lists.newArrayList(createOrganisationUnit('A'), createOrganisationUnit('B')));
 
     rb.addOuFilter("LEVEL-2;ImspTQPwCqd");
     rb.addDimension(concatenateUuid(DATA_ELEMENT_1, DATA_ELEMENT_2, DATA_ELEMENT_3));
@@ -199,7 +200,7 @@ class DataQueryServiceDimensionItemKeywordTest {
     when(organisationUnitService.getOrganisationUnitLevelByLevelOrUid("3")).thenReturn(3);
     when(organisationUnitService.getOrganisationUnitLevelByLevelOrUid("2")).thenReturn(2);
     when(organisationUnitService.getOrganisationUnitsAtLevels(Mockito.anyList(), Mockito.anyList()))
-        .thenReturn(Lists.newArrayList(new OrganisationUnit(), new OrganisationUnit()));
+        .thenReturn(Lists.newArrayList(createOrganisationUnit('A'), createOrganisationUnit('B')));
 
     rb.addOuFilter("LEVEL-2;LEVEL-3;ImspTQPwCqd");
     rb.addDimension(concatenateUuid(DATA_ELEMENT_1, DATA_ELEMENT_2, DATA_ELEMENT_3));
@@ -240,9 +241,9 @@ class DataQueryServiceDimensionItemKeywordTest {
     when(idObjectManager.getObject(IndicatorGroup.class, UID, INDICATOR_GROUP_UID))
         .thenReturn(indicatorGroup);
     when(idObjectManager.getObject(OrganisationUnit.class, UID, "goRUwCHPg1M"))
-        .thenReturn(new OrganisationUnit("aaa"));
+        .thenReturn(createOrganisationUnit('A'));
     when(idObjectManager.getObject(OrganisationUnit.class, UID, "fdc6uOvgoji"))
-        .thenReturn(new OrganisationUnit("bbb"));
+        .thenReturn(createOrganisationUnit('B'));
 
     rb.addOuFilter("goRUwCHPg1M;fdc6uOvgoji");
     rb.addDimension("IN_GROUP-" + INDICATOR_GROUP_UID + ";cYeuwXTCPkU;Jtf34kNZhz");
@@ -343,7 +344,8 @@ class DataQueryServiceDimensionItemKeywordTest {
     assertNull(keywords.getKeyword("level2UID").getMetadataItem().getCode());
 
     assertNotNull(keywords.getKeyword(rootOu.getUid()));
-    assertEquals("Sierra Leone", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
+    assertEquals(
+        "OrganisationUnitA", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
     assertEquals(
         rootOu.getCode(), keywords.getKeyword(rootOu.getUid()).getMetadataItem().getCode());
   }
@@ -403,7 +405,8 @@ class DataQueryServiceDimensionItemKeywordTest {
         groupOu.getCode(), keywords.getKeyword(groupOu.getUid()).getMetadataItem().getCode());
 
     assertNotNull(keywords.getKeyword(rootOu.getUid()));
-    assertEquals("Sierra Leone", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
+    assertEquals(
+        "OrganisationUnitA", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
     assertEquals(
         rootOu.getCode(), keywords.getKeyword(rootOu.getUid()).getMetadataItem().getCode());
   }
@@ -632,7 +635,7 @@ class DataQueryServiceDimensionItemKeywordTest {
     when(idObjectManager.getObject(OrganisationUnit.class, UID, this.rootOu.getUid()))
         .thenReturn(rootOu);
     when(organisationUnitService.getOrganisationUnits(Mockito.anyList(), Mockito.anyList()))
-        .thenReturn(Lists.newArrayList(new OrganisationUnit(), new OrganisationUnit()));
+        .thenReturn(Lists.newArrayList(createOrganisationUnit('A'), createOrganisationUnit('B')));
   }
 
   private void assertOrgUnitGroup(String ouGroupUID, DimensionalObject dimension) {
@@ -644,7 +647,8 @@ class DataQueryServiceDimensionItemKeywordTest {
     assertEquals("CODE_001", keywords.getKeyword(ouGroupUID).getMetadataItem().getCode());
 
     assertNotNull(keywords.getKeyword(rootOu.getUid()));
-    assertEquals("Sierra Leone", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
+    assertEquals(
+        "OrganisationUnitA", keywords.getKeyword(rootOu.getUid()).getMetadataItem().getName());
     assertEquals(
         rootOu.getCode(), keywords.getKeyword(rootOu.getUid()).getMetadataItem().getCode());
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
@@ -216,8 +216,8 @@ class DimensionalObjectProviderTest {
 
   @Test
   void testGetOrgUnitDimensionWithNoLevelsNoGroup() {
-    OrganisationUnit level2Ou1 = createOrganisationUnit("Bo");
-    OrganisationUnit level2Ou2 = createOrganisationUnit("Bombali");
+    OrganisationUnit level2Ou1 = createOrganisationUnit('A');
+    OrganisationUnit level2Ou2 = createOrganisationUnit('B');
     OrganisationUnit ou1 = createOrganisationUnit('A');
     OrganisationUnit ou2 = createOrganisationUnit('B');
     List<OrganisationUnit> organisationUnits =
@@ -253,8 +253,8 @@ class DimensionalObjectProviderTest {
   @Test
   void testGetOrgUnitDimensionWithWithLevelAndGroup() {
     OrganisationUnitGroup organisationUnitGroup = createOrganisationUnitGroup('A');
-    OrganisationUnit level2Ou1 = createOrganisationUnit("Bo");
-    OrganisationUnit level2Ou2 = createOrganisationUnit("Bombali");
+    OrganisationUnit level2Ou1 = createOrganisationUnit('A');
+    OrganisationUnit level2Ou2 = createOrganisationUnit('B');
     OrganisationUnit ou1 = createOrganisationUnit('A');
     OrganisationUnit ou2 = createOrganisationUnit('B');
     List<OrganisationUnit> organisationUnits =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
@@ -255,8 +255,8 @@ class DimensionalObjectProviderTest {
     OrganisationUnitGroup organisationUnitGroup = createOrganisationUnitGroup('A');
     OrganisationUnit level2Ou1 = createOrganisationUnit('A');
     OrganisationUnit level2Ou2 = createOrganisationUnit('B');
-    OrganisationUnit ou1 = createOrganisationUnit('A');
-    OrganisationUnit ou2 = createOrganisationUnit('B');
+    OrganisationUnit ou1 = createOrganisationUnit('C');
+    OrganisationUnit ou2 = createOrganisationUnit('D');
     List<OrganisationUnit> organisationUnits =
         new ArrayList<>(asList(level2Ou1, level2Ou2, ou1, ou2));
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.analytics.data.handler;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.lang.String.valueOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
@@ -42,6 +41,7 @@ import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.common.IdScheme.UUID;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.TestBase.createProgram;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -83,12 +83,12 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToName() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
         Data.builder()
-            .organizationUnits(List.of(stubOrgUnit()))
+            .organizationUnits(List.of(organisationUnit))
             .dataElementOperands(List.of(dataElementOperands.get(0), dataElementOperands.get(1)))
             .dimensionalItemObjects(Set.of(period, organisationUnit))
             .build();
@@ -121,7 +121,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToCode() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -158,12 +158,12 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUuid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
         Data.builder()
-            .organizationUnits(List.of(stubOrgUnit()))
+            .organizationUnits(List.of(createOrganisationUnit('A')))
             .dataElementOperands(List.of(dataElementOperands.get(0), dataElementOperands.get(1)))
             .dimensionalItemObjects(Set.of(period, organisationUnit))
             .build();
@@ -192,7 +192,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -226,7 +226,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToName() {
     List<DataElement> dataElements = stubDataElements();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -257,7 +257,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToCode() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -295,7 +295,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUuid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -330,7 +330,7 @@ class SchemeIdResponseMapperTest {
   void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
     DataElement dataElement = stubDataElement();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -365,7 +365,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToName() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -399,7 +399,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToCode() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -433,7 +433,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUuid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -467,7 +467,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUid() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -501,7 +501,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeOverridesOutputIdScheme() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -543,7 +543,7 @@ class SchemeIdResponseMapperTest {
   @Test
   void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdScheme() {
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -587,7 +587,7 @@ class SchemeIdResponseMapperTest {
     DataElement dataElement = stubDataElement();
     Indicator indicator = stubIndicator();
     ProgramIndicator programIndicator = stubProgramIndicator();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
     List<DataElementOperand> dataElementOperands = stubDataElementOperands();
 
@@ -613,13 +613,11 @@ class SchemeIdResponseMapperTest {
 
     Map<String, String> responseMap = schemeIdResponseMapper.getSchemeIdResponseMap(schemeInfo);
 
-    String orgUnitUid = organisationUnit.getUid();
     String periodIsoDate = period.getIsoDate();
     DataElement dataElementA = dataElementOperands.get(0).getDataElement();
     DataElement dataElementB = dataElementOperands.get(1).getDataElement();
     CategoryOptionCombo categoryOptionComboC = dataElementOperands.get(0).getCategoryOptionCombo();
 
-    assertThat(responseMap.get(orgUnitUid), is(equalTo(valueOf(organisationUnit.getId()))));
     assertThat(responseMap.get(periodIsoDate), is(equalTo(period.getName())));
     assertThat(responseMap.get(dataElementA.getUid()), is(equalTo(dataElementA.getCode())));
     assertThat(responseMap.get(dataElementB.getUid()), is(equalTo(dataElementB.getCode())));
@@ -636,7 +634,7 @@ class SchemeIdResponseMapperTest {
     DataElement dataElement = stubDataElement();
     Indicator indicator = stubIndicator();
     ProgramIndicator programIndicator = stubProgramIndicator();
-    OrganisationUnit organisationUnit = stubOrgUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     Period period = stubPeriod();
 
     Data schemeData =
@@ -870,7 +868,8 @@ class SchemeIdResponseMapperTest {
   private Data stubSchemeData(Program program) {
     return Data.builder()
         .programs(List.of(program))
-        .dimensionalItemObjects(Set.of(stubPeriod(), stubOrgUnit(), stubDataElement()))
+        .dimensionalItemObjects(
+            Set.of(stubPeriod(), createOrganisationUnit('A'), stubDataElement()))
         .build();
   }
 
@@ -943,16 +942,5 @@ class SchemeIdResponseMapperTest {
     programIndicatorA.setCode("ProgramIndicatorCodeA");
 
     return programIndicatorA;
-  }
-
-  private OrganisationUnit stubOrgUnit() {
-    OrganisationUnit organisationUnit = new OrganisationUnit();
-    organisationUnit.setName("OrgUnitA");
-    organisationUnit.setShortName("ShortOrgUnitA");
-    organisationUnit.setUid("org1234567A");
-    organisationUnit.setCode("CodeA");
-    organisationUnit.setId(1);
-
-    return organisationUnit;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -528,7 +528,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
 
     assertThat(
         whereClause,
-        containsString("and ax.\"uidlevel0\" in ('ouabcdefghA','ouabcdefghB','ouabcdefghC')"));
+        containsString("and ax.\"uidlevel1\" in ('ouabcdefghA','ouabcdefghB','ouabcdefghC')"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTableTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTableTest.java
@@ -43,17 +43,17 @@ class OrganisationUnitStructureResourceTableTest {
     int maxOrgUnitLevels = 3;
     int currentLevel = 3;
 
-    OrganisationUnit root = createOrganisationUnit("ouR");
+    OrganisationUnit root = createOrganisationUnit('A');
     root.setPath("/p1");
 
-    OrganisationUnit ou1 = createOrganisationUnit("ou1", root);
+    OrganisationUnit ou1 = createOrganisationUnit('B', root);
     ou1.setPath("/p1/p2");
 
-    OrganisationUnit ou2 = createOrganisationUnit("ou2", ou1);
+    OrganisationUnit ou2 = createOrganisationUnit('C', ou1);
     ou2.setHierarchyLevel(currentLevel);
     ou2.setPath("/p1/p2/ou2");
 
-    OrganisationUnit ou3 = createOrganisationUnit("ou3", ou1);
+    OrganisationUnit ou3 = createOrganisationUnit('D', ou1);
     ou3.setHierarchyLevel(currentLevel);
     ou3.setPath("/p1/p2/ou3");
 
@@ -72,10 +72,10 @@ class OrganisationUnitStructureResourceTableTest {
     int maxOrgUnitLevels = 3;
     int currentLevel = 2;
 
-    OrganisationUnit root = createOrganisationUnit("ouR");
+    OrganisationUnit root = createOrganisationUnit('A');
     root.setPath("/p1");
 
-    OrganisationUnit ou1 = createOrganisationUnit("ou1", root);
+    OrganisationUnit ou1 = createOrganisationUnit('B', root);
     ou1.setPath("/p1/p2");
 
     List<OrganisationUnit> organisationUnits = new ArrayList<>();
@@ -92,10 +92,10 @@ class OrganisationUnitStructureResourceTableTest {
     int maxOrgUnitLevels = 2;
     int currentLevel = 3;
 
-    OrganisationUnit root = createOrganisationUnit("ouR");
+    OrganisationUnit root = createOrganisationUnit('A');
     root.setPath("/p1");
 
-    OrganisationUnit ou1 = createOrganisationUnit("ou1", root);
+    OrganisationUnit ou1 = createOrganisationUnit('B', root);
     ou1.setPath("/p1/p2");
     ou1.setUid("uid-123");
 
@@ -120,10 +120,10 @@ class OrganisationUnitStructureResourceTableTest {
     int maxOrgUnitLevels = 2;
     int currentLevel = 3;
 
-    OrganisationUnit root = createOrganisationUnit("ouR");
+    OrganisationUnit root = createOrganisationUnit('A');
     root.setPath("/p1");
 
-    OrganisationUnit ou1 = createOrganisationUnit("ou1");
+    OrganisationUnit ou1 = createOrganisationUnit('B');
     ou1.setPath("/p1/p2");
     ou1.setUid("uid-123");
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
@@ -131,7 +131,7 @@ class CopyServiceTest extends TestBase {
   @Test
   void testCopyProgramFromUidWithValidProgram() throws NotFoundException, ForbiddenException {
 
-    OrganisationUnit orgUnit = createOrganisationUnit("New Org 1");
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
     List<Enrollment> originalEnrollments =
         List.of(createEnrollment(original, createTrackedEntity(orgUnit), orgUnit));
     when(programService.getProgram(VALID_PROGRAM_UID)).thenReturn(original);
@@ -382,7 +382,7 @@ class CopyServiceTest extends TestBase {
         Set.of(createProgramNotificationTemplate("not1", 20, ENROLLMENT, WEB_HOOK)));
     p.setOnlyEnrollOnce(true);
     p.setOpenDaysAfterCoEndDate(20);
-    p.setOrganisationUnits(Set.of(createOrganisationUnit("Org 1")));
+    p.setOrganisationUnits(Set.of(createOrganisationUnit('A')));
     p.setProgramAttributes(createProgramAttributes(p));
     p.setProgramIndicators(createIndicators(p));
     p.setProgramRuleVariables(Set.of(createProgramRuleVariable('v', p)));

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.query.planner.DefaultQueryPlanner;
@@ -96,7 +95,7 @@ class DefaultQueryServiceTest {
 
     List<OrganisationUnit> result = new ArrayList<>();
     for (int i = 0; i < size; i++) {
-      result.add(createOrganisationUnit(RandomStringUtils.randomAlphabetic(1)));
+      result.add(createOrganisationUnit((char) (i + 65)));
     }
     return result;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -95,7 +95,7 @@ class DefaultQueryServiceTest {
 
     List<OrganisationUnit> result = new ArrayList<>();
     for (int i = 0; i < size; i++) {
-      result.add(createOrganisationUnit((char) (i + 65)));
+      result.add(createOrganisationUnit((char) (i + 'A')));
     }
     return result;
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -121,6 +121,7 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest {
   @Mock private BatchHandlerFactory batchHandlerFactory;
 
   @Mock private SystemSettingsProvider settingsProvider;
+
   @Mock private SystemSettings settings;
 
   @Mock private CategoryService categoryService;
@@ -158,7 +159,9 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest {
   @Mock private Environment environment;
 
   @Mock private AclService aclService;
+
   @Mock private UserService userService;
+
   private User user;
 
   private DefaultCompleteDataSetRegistrationExchangeService subject;
@@ -299,7 +302,7 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest {
   void testValidateAssertMissingDataSet() {
     ExportParams params =
         new ExportParams()
-            .setOrganisationUnits(Sets.newHashSet(new OrganisationUnit()))
+            .setOrganisationUnits(Sets.newHashSet(createOrganisationUnit('A')))
             .setPeriods(Sets.newHashSet(new Period()));
 
     assertIllegalQueryEx(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.datavalueset;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -878,7 +879,7 @@ class DataValueSetImportValidatorTest {
       builder.period(p);
     }
     if (ouId != null) {
-      OrganisationUnit ou = new OrganisationUnit();
+      OrganisationUnit ou = createOrganisationUnit('A');
       ou.setUid(ouId);
       // we set the path here just for the tests. This is usually done by the persistence layer
       // but there is no interaction with that in these tests.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.attribute;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,8 +72,7 @@ class GeoJsonAttributesCheckTest {
 
   @BeforeEach
   public void setUpTest() {
-    organisationUnit = new OrganisationUnit();
-    organisationUnit.setName("A");
+    organisationUnit = createOrganisationUnit('A');
     attribute = new Attribute();
     attribute.setUid("geoJson");
     attribute.setName("geoJson");

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.attribute;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -84,8 +85,7 @@ class MetadataAttributeCheckTest {
 
   @BeforeEach
   void setUpTest() {
-    organisationUnit = new OrganisationUnit();
-    organisationUnit.setName("A");
+    organisationUnit = createOrganisationUnit('A');
     attribute = new Attribute();
     attribute.setUid("attributeID");
     attribute.setName("attributeA");
@@ -456,7 +456,7 @@ class MetadataAttributeCheckTest {
     organisationUnit.addAttributeValue(attribute.getUid(), "OU-ID");
 
     // OrganisationUnit exists
-    when(manager.get(OrganisationUnit.class, "OU-ID")).thenReturn(new OrganisationUnit());
+    when(manager.get(OrganisationUnit.class, "OU-ID")).thenReturn(createOrganisationUnit('A'));
 
     List<ObjectReport> objectReportList = new ArrayList<>();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHooksTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHooksTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,20 +68,20 @@ class ObjectBundleHooksTest {
 
   @Test
   void testMatchingClassBoundIsIncluded() {
-    assertHasHooksOfType(new OrganisationUnit(), OrganisationUnitObjectBundleHook.class);
+    assertHasHooksOfType(createOrganisationUnit('A'), OrganisationUnitObjectBundleHook.class);
     assertHasHooksOfType(new User(), UserObjectBundleHook.class);
   }
 
   @Test
   void testNonMatchingClassBoundIsNotIncluded() {
-    assertHasNotHooksOfType(new OrganisationUnit(), UserObjectBundleHook.class);
+    assertHasNotHooksOfType(createOrganisationUnit('A'), UserObjectBundleHook.class);
     assertHasNotHooksOfType(new User(), OrganisationUnitObjectBundleHook.class);
   }
 
   @Test
   void testMatchingInterfaceBoundIsIncluded() {
     assertHasHooksOfType(
-        new OrganisationUnit(),
+        createOrganisationUnit('A'),
         IdentifiableObjectBundleHook.class,
         VersionedObjectObjectBundleHook.class);
     assertHasHooksOfType(
@@ -94,7 +95,7 @@ class ObjectBundleHooksTest {
 
   @Test
   void testNonMatchingInterfaceBoundIsNotIncluded() {
-    assertHasNotHooksOfType(new OrganisationUnit(), AnalyticalObjectObjectBundleHook.class);
+    assertHasNotHooksOfType(createOrganisationUnit('A'), AnalyticalObjectObjectBundleHook.class);
     assertHasNotHooksOfType(new User(), AnalyticalObjectObjectBundleHook.class);
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.TestBase.createProgram;
 import static org.hisp.dhis.test.TestBase.createProgramStage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,7 +46,6 @@ import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -112,7 +112,7 @@ class ProgramObjectBundleHookTest {
   @Test
   void verifyProgramInstanceIsSavedForEventProgram() {
     when(organisationUnitService.getRootOrganisationUnits())
-        .thenReturn(List.of(new OrganisationUnit()));
+        .thenReturn(List.of(createOrganisationUnit('A')));
     ArgumentCaptor<Enrollment> argument = ArgumentCaptor.forClass(Enrollment.class);
 
     programA.setProgramType(ProgramType.WITHOUT_REGISTRATION);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.feedback.ErrorCode.E4066;
 import static org.hisp.dhis.feedback.ErrorCode.E4067;
 import static org.hisp.dhis.feedback.ErrorCode.E4068;
 import static org.hisp.dhis.feedback.ErrorCode.E7500;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertErrorReport;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -50,7 +51,6 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.programstagefilter.DateFilterPeriod;
@@ -136,7 +136,7 @@ class ProgramStageWorkingListObjectBundleHookTest {
             .build();
 
     when(organisationUnitService.getOrganisationUnit(anyString()))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(dataElementService.getDataElement(anyString())).thenReturn(new DataElement());
     when(attributeService.getTrackedEntityAttribute(anyString()))
         .thenReturn(new TrackedEntityAttribute());

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -106,8 +106,8 @@ class PredictionAnalyticsDataFetcherTest extends TestBase {
 
     periods = Sets.newHashSet(periodA, periodB);
 
-    orgUnitA = createOrganisationUnit("A");
-    orgUnitB = createOrganisationUnit("B");
+    orgUnitA = createOrganisationUnit('A');
+    orgUnitB = createOrganisationUnit('B');
 
     orgUnitA.setUid("orgUnitAuid");
     orgUnitB.setUid("orgUnitBuid");

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataConsolidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataConsolidatorTest.java
@@ -231,13 +231,13 @@ class PredictionDataConsolidatorTest extends TestBase {
     // -- C ------ F
     // -- D ------ G
 
-    orgUnitA = createOrganisationUnit("A");
-    orgUnitB = createOrganisationUnit("B");
-    orgUnitC = createOrganisationUnit("C");
-    orgUnitD = createOrganisationUnit("D");
-    orgUnitE = createOrganisationUnit("E", orgUnitB);
-    orgUnitF = createOrganisationUnit("F", orgUnitC);
-    orgUnitG = createOrganisationUnit("G", orgUnitD);
+    orgUnitA = createOrganisationUnit('A');
+    orgUnitB = createOrganisationUnit('B');
+    orgUnitC = createOrganisationUnit('C');
+    orgUnitD = createOrganisationUnit('D');
+    orgUnitE = createOrganisationUnit('E', orgUnitB);
+    orgUnitF = createOrganisationUnit('F', orgUnitC);
+    orgUnitG = createOrganisationUnit('G', orgUnitD);
 
     orgUnitA.setId(20);
     orgUnitB.setId(21);

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -248,13 +248,13 @@ class PredictionDataValueFetcherTest extends TestBase {
     // -- C ------ F
     // -- D ------ G
 
-    orgUnitA = createOrganisationUnit("A");
-    orgUnitB = createOrganisationUnit("B");
-    orgUnitC = createOrganisationUnit("C");
-    orgUnitD = createOrganisationUnit("D");
-    orgUnitE = createOrganisationUnit("E", orgUnitB);
-    orgUnitF = createOrganisationUnit("F", orgUnitC);
-    orgUnitG = createOrganisationUnit("G", orgUnitD);
+    orgUnitA = createOrganisationUnit('A');
+    orgUnitB = createOrganisationUnit('B');
+    orgUnitC = createOrganisationUnit('C');
+    orgUnitD = createOrganisationUnit('D');
+    orgUnitE = createOrganisationUnit('E', orgUnitB);
+    orgUnitF = createOrganisationUnit('F', orgUnitC);
+    orgUnitG = createOrganisationUnit('G', orgUnitD);
 
     orgUnitA.setId(20);
     orgUnitB.setId(21);

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.predictor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -123,7 +123,7 @@ class PredictionWriterTest extends TestBase {
     cocA.setId(++id);
     cocB.setId(++id);
 
-    orgUnitA = createOrganisationUnit("A");
+    orgUnitA = createOrganisationUnit('A');
 
     orgUnitA.setId(++id);
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
@@ -31,6 +31,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -90,7 +91,7 @@ class VisualizationGridServiceTest {
     final String anyOrganisationUnitUid = "ouiRzW5e";
     final User userStub = userStub();
     final List<Integer> orgUnitLevels = asList(1, 2);
-    final List<OrganisationUnit> orgUnits = asList(new OrganisationUnit());
+    final List<OrganisationUnit> orgUnits = asList(createOrganisationUnit('A'));
     final Map<String, Object> valueMap = valueMapStub();
 
     final Visualization visualizationStub = visualizationStub("abc123xy");
@@ -124,7 +125,7 @@ class VisualizationGridServiceTest {
     final Date anyRelativePeriodDate = new Date();
     final String anyOrganisationUnitUid = "ouiRzW5e";
     final User userStub = userStub();
-    final List<OrganisationUnit> orgUnits = asList(new OrganisationUnit());
+    final List<OrganisationUnit> orgUnits = asList(createOrganisationUnit('A'));
     final List<OrganisationUnitGroup> orgUnitGroups = asList(new OrganisationUnitGroup());
     final Map<String, Object> valueMap = valueMapStub();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManagerTest.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.tracker.acl;
 import static org.hisp.dhis.common.AccessLevel.CLOSED;
 import static org.hisp.dhis.common.AccessLevel.OPEN;
 import static org.hisp.dhis.common.AccessLevel.PROTECTED;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
+import static org.hisp.dhis.test.TestBase.createProgram;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,6 +40,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,13 +51,22 @@ class DefaultTrackerAccessManagerTest {
 
   @InjectMocks private DefaultTrackerAccessManager trackerAccessManager;
 
+  private Program program;
+
+  private OrganisationUnit orgUnit;
+
+  private User user;
+
+  @BeforeEach
+  public void before() {
+    program = createProgram('A');
+    orgUnit = createOrganisationUnit('A');
+    user = new User();
+  }
+
   @Test
   void shouldHaveAccessWhenProgramOpenAndSearchAccessAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(OPEN);
-    OrganisationUnit orgUnit = new OrganisationUnit();
-
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
@@ -64,10 +76,7 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldNotHaveAccessWhenProgramOpenAndSearchAccessNotAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(OPEN);
-    OrganisationUnit orgUnit = new OrganisationUnit();
 
     assertFalse(
         trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
@@ -76,9 +85,6 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldHaveAccessWhenProgramNullAndSearchAccessAvailable() {
-    User user = new User();
-    OrganisationUnit orgUnit = new OrganisationUnit();
-
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
@@ -88,9 +94,6 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldNotHaveAccessWhenProgramNullAndSearchAccessNotAvailable() {
-    User user = new User();
-    OrganisationUnit orgUnit = new OrganisationUnit();
-
     assertFalse(
         trackerAccessManager.canAccess(UserDetails.fromUser(user), null, orgUnit),
         "User should not have access to unspecified program");
@@ -98,11 +101,7 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldHaveAccessWhenProgramClosedAndCaptureAccessAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(CLOSED);
-    OrganisationUnit orgUnit = new OrganisationUnit();
-
     user.setOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
@@ -112,10 +111,7 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldNotHaveAccessWhenProgramClosedAndCaptureAccessNotAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(CLOSED);
-    OrganisationUnit orgUnit = new OrganisationUnit();
 
     assertFalse(
         trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
@@ -124,11 +120,7 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldHaveAccessWhenProgramProtectedAndCaptureAccessAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(PROTECTED);
-    OrganisationUnit orgUnit = new OrganisationUnit();
-
     user.setOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
@@ -138,10 +130,7 @@ class DefaultTrackerAccessManagerTest {
 
   @Test
   void shouldNotHaveAccessWhenProgramProtectedAndCaptureAccessNotAvailable() {
-    User user = new User();
-    Program program = new Program();
     program.setAccessLevel(PROTECTED);
-    OrganisationUnit orgUnit = new OrganisationUnit();
 
     assertFalse(
         trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.program.ProgramType.WITHOUT_REGISTRATION;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrgUnitMode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -70,7 +71,7 @@ class OperationsParamsValidatorTest {
 
   private final TrackedEntityType trackedEntityType = new TrackedEntityType();
 
-  private final OrganisationUnit orgUnit = new OrganisationUnit();
+  private final OrganisationUnit orgUnit = createOrganisationUnit('A');
 
   private static final UID PROGRAM_UID = UID.generate();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.tracker.audit.TrackedEntityAuditService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserRole;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -65,13 +64,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class OperationsParamsValidatorTest {
-
-  private static final String PARENT_ORG_UNIT_UID = "parent-org-unit";
-
-  private final OrganisationUnit captureScopeOrgUnit = createOrgUnit("captureScopeOrgUnit", "uid3");
-
-  private final OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-
   private final Program program = new Program("program");
 
   private final TrackedEntity trackedEntity = new TrackedEntity();
@@ -103,12 +95,6 @@ class OperationsParamsValidatorTest {
   @InjectMocks private OperationsParamsValidator paramsValidator;
 
   private final UserDetails user = UserDetails.fromUser(new User());
-
-  @BeforeEach
-  public void setUp() {
-    OrganisationUnit organisationUnit = createOrgUnit("orgUnit", PARENT_ORG_UNIT_UID);
-    organisationUnit.setChildren(Set.of(captureScopeOrgUnit, searchScopeOrgUnit));
-  }
 
   @Test
   void shouldFailWhenOuModeCaptureAndUserHasNoOrgUnitsAssigned() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -371,10 +371,4 @@ class OperationsParamsValidatorTest {
 
     assertEquals(Set.of(orgUnit), orgUnits);
   }
-
-  private OrganisationUnit createOrgUnit(String name, String uid) {
-    OrganisationUnit orgUnit = new OrganisationUnit(name);
-    orgUnit.setUid(uid);
-    return orgUnit;
-  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -105,10 +106,10 @@ class EnrollmentOperationParamsMapperTest {
     User testUser = new User();
     testUser.setUsername("admin");
 
-    orgUnit1 = new OrganisationUnit("orgUnit1");
+    orgUnit1 = createOrganisationUnit('A');
     orgUnit1.setUid(ORG_UNIT_1_UID.getValue());
     when(organisationUnitService.getOrganisationUnit(orgUnit1.getUid())).thenReturn(orgUnit1);
-    orgUnit2 = new OrganisationUnit("orgUnit2");
+    orgUnit2 = createOrganisationUnit('B');
     orgUnit2.setUid(ORG_UNIT_2_UID.getValue());
     orgUnit2.setParent(orgUnit1);
     orgUnit1.setChildren(Set.of(orgUnit2));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.security.Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
@@ -131,9 +132,8 @@ class EventOperationParamsMapperTest {
 
   @BeforeEach
   public void setUp() {
-    OrganisationUnit orgUnit = createOrgUnit("orgUnit");
-    orgUnit.setChildren(
-        Set.of(createOrgUnit("captureScopeChild"), createOrgUnit("searchScopeChild")));
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
+    orgUnit.setChildren(Set.of(createOrganisationUnit('B'), createOrganisationUnit('C')));
 
     User testUser = new User();
     testUser.setUid(CodeGenerator.generateUid());
@@ -142,8 +142,7 @@ class EventOperationParamsMapperTest {
     user = UserDetails.fromUser(testUser);
 
     // By default, set to ACCESSIBLE for tests that don't set an orgUnit. The orgUnitMode needs to
-    // be
-    // set because its validation is in the EventRequestParamsMapper.
+    // be set because its validation is in the EventRequestParamsMapper.
     eventBuilder = eventBuilder.orgUnitMode(ACCESSIBLE).eventParams(EventParams.FALSE);
 
     userMap.put("admin", createUserWithAuthority(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS));
@@ -421,15 +420,15 @@ class EventOperationParamsMapperTest {
     program.setUid(CodeGenerator.generateUid());
     program.setAccessLevel(accessLevel);
 
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit");
-    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit");
+    OrganisationUnit searchScopeOrgUnit = createOrganisationUnit('A');
+    OrganisationUnit searchScopeChildOrgUnit = createOrganisationUnit('B');
     searchScopeOrgUnit.setChildren(Set.of(searchScopeChildOrgUnit));
     searchScopeChildOrgUnit.setParent(searchScopeOrgUnit);
 
     User user = new User();
     user.setUid(CodeGenerator.generateUid());
     user.setUsername("testB");
-    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit")));
+    user.setOrganisationUnits(Set.of(createOrganisationUnit('C')));
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
 
     when(organisationUnitService.getOrganisationUnit(searchScopeChildOrgUnit.getUid()))
@@ -453,15 +452,15 @@ class EventOperationParamsMapperTest {
     program.setUid(CodeGenerator.generateUid());
     program.setAccessLevel(OPEN);
 
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit");
-    OrganisationUnit searchScopeChildOrgUnit = createOrgUnit("searchScopeChildOrgUnit");
+    OrganisationUnit searchScopeOrgUnit = createOrganisationUnit('A');
+    OrganisationUnit searchScopeChildOrgUnit = createOrganisationUnit('B');
     searchScopeOrgUnit.setChildren(Set.of(searchScopeChildOrgUnit));
     searchScopeChildOrgUnit.setParent(searchScopeOrgUnit);
 
     User user = new User();
     user.setUid(CodeGenerator.generateUid());
     user.setUsername("testB");
-    user.setOrganisationUnits(Set.of(createOrgUnit("captureScopeOrgUnit")));
+    user.setOrganisationUnits(Set.of(createOrganisationUnit('C')));
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
     UserRole userRole = new UserRole();
     userRole.setAuthorities(Set.of(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
@@ -481,7 +480,7 @@ class EventOperationParamsMapperTest {
   @EnumSource(value = OrganisationUnitSelectionMode.class)
   void shouldFailWhenRequestedOrgUnitOutsideOfSearchScope(
       OrganisationUnitSelectionMode orgUnitMode) {
-    OrganisationUnit orgUnit = createOrgUnit("name");
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
     EventOperationParams operationParams =
         EventOperationParams.builder().orgUnit(orgUnit).orgUnitMode(orgUnitMode).build();
@@ -543,11 +542,5 @@ class EventOperationParamsMapperTest {
     user.setUserRoles(Set.of(userRole));
 
     return user;
-  }
-
-  private OrganisationUnit createOrgUnit(String name) {
-    OrganisationUnit orgUnit = new OrganisationUnit(name);
-    orgUnit.setUid(CodeGenerator.generateUid());
-    return orgUnit;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/OrganisationUnitMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/OrganisationUnitMapperTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.attributeValues;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +45,7 @@ class OrganisationUnitMapperTest {
 
     OrganisationUnit orgUnit =
         setIdSchemeFields(
-            new OrganisationUnit(),
+            createOrganisationUnit('A'),
             "HpSAvRWtdDR",
             "meet",
             "green",
@@ -60,11 +61,11 @@ class OrganisationUnitMapperTest {
 
   @Test
   void testParentFieldsAreMapped() {
-    OrganisationUnit rootOrgUnit = new OrganisationUnit();
+    OrganisationUnit rootOrgUnit = createOrganisationUnit('A');
     rootOrgUnit.setUid("root");
-    OrganisationUnit level1OrgUnit = new OrganisationUnit();
+    OrganisationUnit level1OrgUnit = createOrganisationUnit('B');
     level1OrgUnit.setUid("level1");
-    OrganisationUnit level2OrgUnit = new OrganisationUnit();
+    OrganisationUnit level2OrgUnit = createOrganisationUnit('C');
     level2OrgUnit.setUid("level2");
 
     level2OrgUnit.setParent(level1OrgUnit);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/TrackedEntityMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/TrackedEntityMapperTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.attributeValues;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,7 +58,7 @@ class TrackedEntityMapperTest {
 
     OrganisationUnit orgUnit =
         setIdSchemeFields(
-            new OrganisationUnit(),
+            createOrganisationUnit('A'),
             "HpSAvRWtdDR",
             "meet",
             "green",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/MessageFormatterTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.imports.validation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -104,7 +105,7 @@ class MessageFormatterTest {
     relationshipType.setUid("WTTYiPQDqh1");
     Program program = new Program("friendship");
     ProgramStage programStage = new ProgramStage("meet", program);
-    OrganisationUnit orgUnit = new OrganisationUnit();
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
     orgUnit.setAttributeValues(attributeValues("HpSAvRWtdDR", "sunshine"));
     DataElement dataElement = new DataElement();
     dataElement.setAttributeValues(attributeValues("m0GpPuMUfFW", "ice"));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/MetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/MetaValidatorTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.validation.validator.enrollment;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1068;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1069;
@@ -36,7 +37,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -84,7 +84,7 @@ class MetaValidatorTest {
   void verifyEnrollmentValidationSuccess() {
     Enrollment enrollment = validEnrollment();
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(preheat.getTrackedEntity(TRACKED_ENTITY_UID)).thenReturn(new TrackedEntity());
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_UID))).thenReturn(new Program());
 
@@ -99,7 +99,7 @@ class MetaValidatorTest {
     when(bundle.findTrackedEntityByUid(TRACKED_ENTITY_UID))
         .thenReturn(Optional.of(new org.hisp.dhis.tracker.imports.domain.TrackedEntity()));
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_UID))).thenReturn(new Program());
 
     validator.validate(reporter, bundle, enrollment);
@@ -122,7 +122,7 @@ class MetaValidatorTest {
   void verifyEnrollmentValidationFailsWhenTrackedEntityIsNotPresentInDbOrPayload() {
     Enrollment enrollment = validEnrollment();
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_UID))).thenReturn(new Program());
 
     validator.validate(reporter, bundle, enrollment);
@@ -134,7 +134,7 @@ class MetaValidatorTest {
   void verifyEnrollmentValidationFailsWhenProgramIsNotPresentInDb() {
     Enrollment enrollment = validEnrollment();
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(preheat.getTrackedEntity(TRACKED_ENTITY_UID)).thenReturn(new TrackedEntity());
 
     validator.validate(reporter, bundle, enrollment);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.validation.validator.event;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertNoErrors;
@@ -1128,7 +1129,7 @@ class DataValuesValidatorTest {
   }
 
   private OrganisationUnit organisationUnit() {
-    OrganisationUnit organisationUnit = new OrganisationUnit();
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
     organisationUnit.setUid(ORGANISATION_UNIT_UID);
     return organisationUnit;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/MetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/MetaValidatorTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.validation.validator.trackedentity;
 
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1005;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1049;
@@ -34,7 +35,6 @@ import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidatio
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
@@ -81,7 +81,7 @@ class MetaValidatorTest {
   void verifyTrackedEntityValidationSuccess() {
     TrackedEntity te = validTe();
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
     when(preheat.getTrackedEntityType(MetadataIdentifier.ofUid(TRACKED_ENTITY_TYPE_UID)))
         .thenReturn(new TrackedEntityType());
 
@@ -105,7 +105,7 @@ class MetaValidatorTest {
   void verifyTrackedEntityValidationFailsWhenTrackedEntityTypeIsNotPresentInDb() {
     TrackedEntity te = validTe();
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID)))
-        .thenReturn(new OrganisationUnit());
+        .thenReturn(createOrganisationUnit('A'));
 
     validator.validate(reporter, bundle, te);
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationResultServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationResultServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.validation;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,7 +83,7 @@ class ValidationResultServiceTest {
               List<OrganisationUnit> units = new ArrayList<>();
               for (String uid : uids) {
                 if (CodeGenerator.isValidUid(uid)) {
-                  OrganisationUnit unit = new OrganisationUnit();
+                  OrganisationUnit unit = createOrganisationUnit('A');
                   unit.setUid(uid);
                   units.add(unit);
                 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -1003,6 +1003,7 @@ public abstract class TestBase {
     unit.setCode("OrganisationUnitCode" + uniqueCharacter);
     unit.setOpeningDate(date);
     unit.setComment("Comment" + uniqueCharacter);
+    unit.updatePath();
     return unit;
   }
 
@@ -1021,7 +1022,7 @@ public abstract class TestBase {
     OrganisationUnit unit = createOrganisationUnit(uniqueCharacter);
     unit.setParent(parent);
     parent.getChildren().add(unit);
-
+    unit.updatePath();
     return unit;
   }
 
@@ -1050,6 +1051,7 @@ public abstract class TestBase {
     OrganisationUnit unit = createOrganisationUnit(name);
     unit.setParent(parent);
     parent.getChildren().add(unit);
+    unit.updatePath();
     return unit;
   }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -1025,6 +1025,8 @@ public abstract class TestBase {
   }
 
   /**
+   * Deprecated, use {@code createOrganisationUnit(char,OrganisationUnit)}.
+   *
    * @param name The name, short name and code of the organisation unit.
    */
   public static OrganisationUnit createOrganisationUnit(String name) {
@@ -1038,15 +1040,15 @@ public abstract class TestBase {
   }
 
   /**
+   * Deprecated, use {@code createOrganisationUnit(char,OrganisationUnit)}.
+   *
    * @param name The name, short name and code of the organisation unit.
    * @param parent The parent.
    */
   public static OrganisationUnit createOrganisationUnit(String name, OrganisationUnit parent) {
     OrganisationUnit unit = createOrganisationUnit(name);
-
     unit.setParent(parent);
     parent.getChildren().add(unit);
-
     return unit;
   }
 
@@ -1056,12 +1058,10 @@ public abstract class TestBase {
   public static OrganisationUnitGroup createOrganisationUnitGroup(char uniqueCharacter) {
     OrganisationUnitGroup group = new OrganisationUnitGroup();
     group.setAutoFields();
-
     group.setUid(BASE_UID + uniqueCharacter);
     group.setName("OrganisationUnitGroup" + uniqueCharacter);
     group.setShortName("OrganisationUnitGroupShort" + uniqueCharacter);
     group.setCode("OrganisationUnitGroupCode" + uniqueCharacter);
-
     return group;
   }
 
@@ -1071,13 +1071,11 @@ public abstract class TestBase {
   public static OrganisationUnitGroupSet createOrganisationUnitGroupSet(char uniqueCharacter) {
     OrganisationUnitGroupSet groupSet = new OrganisationUnitGroupSet();
     groupSet.setAutoFields();
-
     groupSet.setName("OrganisationUnitGroupSet" + uniqueCharacter);
     groupSet.setShortName("OrganisationUnitGroupSet" + uniqueCharacter);
     groupSet.setCode("OrganisationUnitGroupSetCode" + uniqueCharacter);
     groupSet.setDescription("Description" + uniqueCharacter);
     groupSet.setCompulsory(true);
-
     return groupSet;
   }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -303,6 +303,7 @@ public abstract class TestBase {
   // -------------------------------------------------------------------------
   // Convenience methods
   // -------------------------------------------------------------------------
+
   public User getCurrentUser() {
     return userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -996,23 +996,18 @@ public abstract class TestBase {
   public static OrganisationUnit createOrganisationUnit(char uniqueCharacter) {
     OrganisationUnit unit = new OrganisationUnit();
     unit.setAutoFields();
-
     unit.setUid(BASE_OU_UID + uniqueCharacter);
     unit.setName("OrganisationUnit" + uniqueCharacter);
     unit.setShortName("OrganisationUnitShort" + uniqueCharacter);
     unit.setCode("OrganisationUnitCode" + uniqueCharacter);
     unit.setOpeningDate(date);
     unit.setComment("Comment" + uniqueCharacter);
-    //    unit.getSharing().setPublicAccess("--------");
-
     return unit;
   }
 
   public static OrganisationUnit createOrganisationUnit(char uniqueCharacter, Geometry geometry) {
     OrganisationUnit unit = createOrganisationUnit(uniqueCharacter);
-
     unit.setGeometry(geometry);
-
     return unit;
   }
 
@@ -1033,16 +1028,12 @@ public abstract class TestBase {
    * @param name The name, short name and code of the organisation unit.
    */
   public static OrganisationUnit createOrganisationUnit(String name) {
-    OrganisationUnit unit = new OrganisationUnit();
-    unit.setAutoFields();
-
+    OrganisationUnit unit = createOrganisationUnit('Y');
     unit.setUid(CodeGenerator.generateUid());
     unit.setName(name);
     unit.setShortName(name);
     unit.setCode(name);
-    unit.setOpeningDate(date);
     unit.setComment("Comment " + name);
-
     return unit;
   }
 


### PR DESCRIPTION
This PR centralizes instantiation of org units through the `createOrganisationUnit` in `TestBase`. This makes the test more realistic (by setting UID, last updated, path, etc) and makes it easier to change later.