### PR TITLE
chore: simplify TrackedEntityService.getTrackedEntity(UID, ...) logic DHIS2-18541

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -57,16 +57,18 @@ public interface TrackedEntityService {
    * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
    * instead to also get the relationships, enrollments and program attributes.
    */
-  TrackedEntity getTrackedEntity(UID uid)
+  @Nonnull
+  TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
   /**
    * Get the tracked entity matching given {@code UID} under the privileges of the currently
-   * authenticated user. If @param programIdentifier is defined, program attributes for such program
-   * are included, otherwise only TETAs are included. It will include enrollments, relationships,
-   * attributes and ownerships as defined in @param params
+   * authenticated user. If {@code program} is defined, program attributes for such program are
+   * included, otherwise only TETAs are included. It will include enrollments, relationships,
+   * attributes and ownerships as defined in {@code params}.
    */
-  TrackedEntity getTrackedEntity(UID uid, UID programIdentifier, TrackedEntityParams params)
+  @Nonnull
+  TrackedEntity getTrackedEntity(@Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException, BadRequestException;
 
   /** Get all tracked entities matching given params. */

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/utils/Assertions.java
@@ -70,6 +70,24 @@ public final class Assertions {
   }
 
   /**
+   * Asserts that the given collection contains exactly the given items in any order. Collections
+   * will be mapped by {@code map} before passing it to {@link #assertContainsOnly(Collection,
+   * Collection)}.
+   *
+   * @param expected the expected items.
+   * @param actual the actual collection.
+   * @param map map the items of expected and actual collections to the type that will be used for
+   *     comparison
+   */
+  public static <T, R> void assertContainsOnly(
+      Collection<T> expected, Collection<T> actual, Function<T, R> map) {
+    assertContainsOnly(
+        expected.stream().map(map).toList(),
+        actual.stream().map(map).toList(),
+        "assertContainsOnly found mismatch");
+  }
+
+  /**
    * Asserts that the given collection contains exactly the given items in any order.
    *
    * @param <E> the type.

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -143,11 +143,11 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
   private TrackedEntityAttribute teaC;
 
-  private TrackedEntityAttributeValue trackedEntityAttributeValueA;
+  private TrackedEntityAttributeValue tetavA;
 
-  private TrackedEntityAttributeValue trackedEntityAttributeValueB;
+  private TrackedEntityAttributeValue tetavB;
 
-  private TrackedEntityAttributeValue trackedEntityAttributeValueC;
+  private TrackedEntityAttributeValue pteavC;
 
   private TrackedEntityType trackedEntityTypeA;
 
@@ -324,17 +324,13 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
                 new ProgramTrackedEntityAttribute(programB, teaE)));
     manager.update(programB);
 
-    trackedEntityAttributeValueA = new TrackedEntityAttributeValue(teaA, trackedEntityA, "A");
-    trackedEntityAttributeValueB = new TrackedEntityAttributeValue(teaB, trackedEntityA, "B");
-    trackedEntityAttributeValueC = new TrackedEntityAttributeValue(teaC, trackedEntityA, "C");
+    tetavA = new TrackedEntityAttributeValue(teaA, trackedEntityA, "A");
+    tetavB = new TrackedEntityAttributeValue(teaB, trackedEntityA, "B");
+    pteavC = new TrackedEntityAttributeValue(teaC, trackedEntityA, "C");
 
     trackedEntityA = createTrackedEntity(orgUnitA);
     trackedEntityA.setTrackedEntityType(trackedEntityTypeA);
-    trackedEntityA.setTrackedEntityAttributeValues(
-        Set.of(
-            trackedEntityAttributeValueA,
-            trackedEntityAttributeValueB,
-            trackedEntityAttributeValueC));
+    trackedEntityA.setTrackedEntityAttributeValues(Set.of(tetavA, tetavB, pteavC));
     manager.save(trackedEntityA, false);
 
     trackedEntityChildA = createTrackedEntity(orgUnitChildA);
@@ -2015,23 +2011,22 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertContainsOnly(
-        Set.of(
-            trackedEntityAttributeValueA,
-            trackedEntityAttributeValueB,
-            trackedEntityAttributeValueC),
-        trackedEntity.getTrackedEntityAttributeValues());
+        Set.of(tetavA, tetavB, pteavC),
+        trackedEntity.getTrackedEntityAttributeValues(),
+        TrackedEntityAttributeValue::getValue);
   }
 
   @Test
-  void shouldReturnTrackedEntityTypeAttributesWhenSingleTERequestedAndNoProgramSpecified()
+  void shouldReturnTrackedEntityTypeAttributesOnlyWhenSingleTERequestedAndNoProgramSpecified()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
-        Set.of(trackedEntityAttributeValueA, trackedEntityAttributeValueB),
-        trackedEntity.getTrackedEntityAttributeValues());
+        Set.of(tetavA, tetavB),
+        trackedEntity.getTrackedEntityAttributeValues(),
+        TrackedEntityAttributeValue::getValue);
   }
 
   @Test


### PR DESCRIPTION
This change is necessary for https://github.com/dhis2/dhis2-core/pull/19377 and should make changes in behavior easier to see/discuss.

We have two methods for getting a single TE. They were implemented independently with convoluted logic. Let one reuse the other. Separate fetching, ACL, mapping to make the flow easier to follow. Move the TETAV logic in one place. This is the only way we can ensure the behavior is the same across different code paths.

Add an `assertContainsOnly` variant that lets us map both collection before making the actual assertion. This makes the assertion error easier to read.

```java
assertContainsOnly(
    Set.of(tetavA, tetavB),
    trackedEntity.getTrackedEntityAttributeValues(),
    TrackedEntityAttributeValue::getValue);
```

gives you

```
org.opentest4j.AssertionFailedError: Expected [C] NOT to be in [A, B, C] ==> 
Expected :true
Actual   :false
```

instead of a giant output with most fields being equal and or irrelevant.