### PR TITLE
fix: Avoid setting path state in get method [DHIS2-18234]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -783,9 +783,7 @@ public class OrganisationUnit extends BaseDimensionalItemObject
 
     Collections.reverse(pathList);
 
-    this.path = PATH_SEP + StringUtils.join(pathList, PATH_SEP);
-
-    return this.path;
+    return PATH_SEP + StringUtils.join(pathList, PATH_SEP);
   }
 
   /**


### PR DESCRIPTION
The `getPath` method is currently setting the state of the `path` property. Having a get method set state is bad practice. It may also have unintended consequences. Hibernate will manage the state of the `path` property value and there should be no need to additionally set it in the get method. A new method `updatePath` has been added which can be used in tests if necessary.