### PR TITLE
fix: prevent accidental job revert of a RUNNING job [DHIS2-18752]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -514,6 +514,7 @@ public class HibernateJobConfigurationStore
             else schedulingtype end
         where jobstatus = 'RUNNING'
         and uid = :id
+        and now() > jobconfiguration.lastalive + interval '1 minute'
       """;
     return nativeSynchronizedQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
   }


### PR DESCRIPTION
### Summary
The goal of this PR was to increase the chance of preventing to `revert` a job that is actually running.
After considering all kinds of more sophisticated options we arrived at a very simple solution. 

That solution is to reject the request to revert if the job row has been updated (`lastAlive`) during the last minute. Usually a running and alive job would update that column about every 10sec. While this time is cooperative and can be longer when a single tracked step (like a long running DB query) exceeds 10sec it usually is not and thereby prevents accidental revert is most cases. 

### Automatic Testing
I considered how to test it but I don't think the benefit of having a test justifies the effort that would be needed to test this
as there are hard timings and asynchronous execution involved.

### Manual Testing
* run analytics via data administration app (include 1 year)
* stop the server in the middle of the run
* restart the server 
* call `revert` on the job that got created, like
  ```shell
  curl -u "admin:district" -X POST http://localhost:8080/api/jobConfigurations/eI0A7lHhlbq/revert
  ```
* check that the job switched from status `RUNNING` to `DISABLED` with `lastExecutionStatus` being `FAILED`

As described above there is a 1min window (since `lastAlive`) where this action is blocked. Locally one could stop and start fast enough to actually run into the block. Otherwise one could manually update the `lastAlive` in the DB to "now" shortly before triggering the `revert`. 

Also note that if 10min have past since `lastAlive` the job auto-reverts as part of the `HOUSEKEEPING` job execution.