### PR TITLE
fix: Map created date of notes as a timestamp [DHIS2-17864](2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -734,7 +734,8 @@ public class JdbcEventStore implements EventStore {
               Note note = new Note();
               note.setNote(resultSet.getString("psinote_uid"));
               note.setValue(resultSet.getString("psinote_value"));
-              note.setStoredDate(DateUtils.getIso8601NoTz(resultSet.getDate("psinote_storeddate")));
+              note.setStoredDate(
+                  DateUtils.getIso8601NoTz(resultSet.getTimestamp("psinote_storeddate")));
               note.setStoredBy(resultSet.getString("psinote_storedby"));
 
               eventRow.getNotes().add(note);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/NoteRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/NoteRowCallbackHandler.java
@@ -52,7 +52,7 @@ public class NoteRowCallbackHandler extends AbstractMapper<Note> {
     note.setNote(rs.getString("uid"));
     note.setValue(rs.getString("commenttext"));
     note.setStoredBy(rs.getString("creator"));
-    note.setStoredDate(DateUtils.getIso8601NoTz(rs.getDate("created")));
+    note.setStoredDate(DateUtils.getIso8601NoTz(rs.getTimestamp("created")));
 
     return note;
   }


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/19236