### PR TITLE
fix: Map created date of notes as a timestamp [DHIS2-17864](2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -733,7 +733,8 @@ public class JdbcEventStore implements EventStore {
               Note note = new Note();
               note.setNote(resultSet.getString("psinote_uid"));
               note.setValue(resultSet.getString("psinote_value"));
-              note.setStoredDate(DateUtils.getIso8601NoTz(resultSet.getDate("psinote_storeddate")));
+              note.setStoredDate(
+                  DateUtils.getIso8601NoTz(resultSet.getTimestamp("psinote_storeddate")));
               note.setStoredBy(resultSet.getString("psinote_storedby"));
 
               eventRow.getNotes().add(note);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/NoteRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/NoteRowCallbackHandler.java
@@ -52,7 +52,7 @@ public class NoteRowCallbackHandler extends AbstractMapper<Note> {
     note.setNote(rs.getString("uid"));
     note.setValue(rs.getString("commenttext"));
     note.setStoredBy(rs.getString("creator"));
-    note.setStoredDate(DateUtils.getIso8601NoTz(rs.getDate("created")));
+    note.setStoredDate(DateUtils.getIso8601NoTz(rs.getTimestamp("created")));
 
     return note;
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,9 +37,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
@@ -199,6 +205,45 @@ public class Assertions {
     assertTrue(
         hasTimeStamp(DateUtils.parseDate(date)),
         String.format("Supported format is %s but found %s", DATE_WITH_TIMESTAMP_PATTERN, date));
+  }
+
+  public static void assertNotes(
+      List<TrackedEntityComment> expected, List<TrackedEntityComment> actual) {
+    assertContainsOnly(expected, actual);
+    Map<String, TrackedEntityComment> expectedNotes =
+        expected.stream()
+            .collect(Collectors.toMap(TrackedEntityComment::getUid, Function.identity()));
+    Map<String, TrackedEntityComment> actualNotes =
+        actual.stream()
+            .collect(Collectors.toMap(TrackedEntityComment::getUid, Function.identity()));
+    List<Executable> assertions =
+        expectedNotes.entrySet().stream()
+            .map(
+                entry ->
+                    (Executable)
+                        () -> {
+                          TrackedEntityComment expectedNote = entry.getValue();
+                          TrackedEntityComment actualNote = actualNotes.get(entry.getKey());
+                          assertAll(
+                              "note assertions " + expectedNote.getUid(),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getCommentText(),
+                                      actualNote.getCommentText(),
+                                      "noteText"),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getCreator(),
+                                      actualNote.getCreator(),
+                                      "creator"),
+                              () ->
+                                  assertEquals(
+                                      expectedNote.getCreated(),
+                                      actualNote.getCreated(),
+                                      "created"));
+                        })
+            .collect(Collectors.toList());
+    assertAll("note assertions", assertions);
   }
 
   /**


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/19236