### PR TITLE
fix: uses "year" column in rs_periodstructure instead of extracting the year from "startdate" [DHIS2-18738]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -654,7 +654,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         new StringBuilder(
             replaceQualify(
                 """
-                select distinct(extract(year from pes.startdate)) \
+                select distinct(year) \
                 from ${datavalue} dv \
                 inner join analytics_rs_periodstructure pes on dv.periodid=pes.periodid \
                 where pes.startdate is not null \


### PR DESCRIPTION
In the `getDataYears` function, the goal is to retrieve all years for all periods built in the `analytics_rs_periodstructure` table. Currently, the year is determined based on the calendar year of the period's start date. However, this approach has limitations, particularly for Weekly periods, where the calendar year of the start date might not match the designated year of the period. This happens because Weekly periods can span across two calendar years (e.g., starting in late December and ending in early January).

This PR updates the behavior to use the `year` column in the `analytics_rs_periodstructure` table instead of deriving the year from the start date. The year column provides a more reliable and accurate representation of the period's year, resolving inconsistencies and simplifying the logic.