### PR TITLE
fix: uses "year" column in rs_periodstructure instead of extracting the year from "startdate" [DHIS2-18738] [2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -664,7 +664,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         new StringBuilder(
             replace(
                 """
-                select distinct(extract(year from pe.startdate)) \
+                select distinct(year) \
                 from datavalue dv \
                 inner join period pe on dv.periodid=pe.periodid \
                 where pe.startdate is not null \

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -664,7 +664,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         new StringBuilder(
             replace(
                 """
-                select distinct(year) \
+                select distinct(extract(year from pe.enddate)) \
                 from datavalue dv \
                 inner join period pe on dv.periodid=pe.periodid \
                 where pe.startdate is not null \


### PR DESCRIPTION
backport of #19673 