### PR TITLE
fix: FK constraint error when delete Program with MapView

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapViewStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapViewStore.java
@@ -30,10 +30,13 @@ package org.hisp.dhis.mapping;
 import java.util.List;
 import org.hisp.dhis.common.AnalyticalObjectStore;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.hisp.dhis.program.Program;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface MapViewStore extends AnalyticalObjectStore<MapView> {
   List<MapView> getByOrganisationUnitGroupSet(OrganisationUnitGroupSet groupSet);
+
+  List<MapView> findByProgram(Program program);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MappingService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MappingService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.mapping;
 import java.util.List;
 import org.hisp.dhis.common.AnalyticalObjectService;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.hisp.dhis.program.Program;
 
 /**
  * @author Jan Henrik Overland
@@ -90,6 +91,8 @@ public interface MappingService extends AnalyticalObjectService<MapView> {
   List<MapView> getMapViewsByOrganisationUnitGroupSet(OrganisationUnitGroupSet groupSet);
 
   int countMapViewMaps(MapView mapView);
+
+  List<MapView> findByProgram(Program program);
 
   // -------------------------------------------------------------------------
   // ExternalMapLayer

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/DefaultMappingService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/DefaultMappingService.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.RelativePeriods;
+import org.hisp.dhis.program.Program;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -183,6 +184,11 @@ public class DefaultMappingService extends GenericAnalyticalObjectService<MapVie
   @Transactional(readOnly = true)
   public int countMapViewMaps(MapView mapView) {
     return mapStore.countMapViewMaps(mapView);
+  }
+
+  @Override
+  public List<MapView> findByProgram(Program program) {
+    return mapViewStore.findByProgram(program);
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/hibernate/HibernateMapViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/hibernate/HibernateMapViewStore.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.common.hibernate.HibernateAnalyticalObjectStore;
 import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.mapping.MapViewStore;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -45,6 +46,7 @@ import org.springframework.stereotype.Repository;
 @Repository("org.hisp.dhis.mapping.MapViewStore")
 public class HibernateMapViewStore extends HibernateAnalyticalObjectStore<MapView>
     implements MapViewStore {
+
   public HibernateMapViewStore(
       EntityManager entityManager,
       JdbcTemplate jdbcTemplate,
@@ -61,5 +63,13 @@ public class HibernateMapViewStore extends HibernateAnalyticalObjectStore<MapVie
         builder,
         newJpaParameters()
             .addPredicate(root -> builder.equal(root.get("organisationUnitGroupSet"), groupSet)));
+  }
+
+  @Override
+  public List<MapView> findByProgram(Program program) {
+    CriteriaBuilder builder = getCriteriaBuilder();
+    return getList(
+        builder,
+        newJpaParameters().addPredicate(root -> builder.equal(root.get("program"), program)));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
+import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
@@ -147,5 +149,21 @@ class ProgramServiceTest extends PostgresIntegrationTestBase {
     Program p = programService.getProgram(programA.getUid());
     OrganisationUnit ou = organisationUnitService.getOrganisationUnit(organisationUnitA.getUid());
     assertTrue(programService.hasOrgUnit(p, ou));
+  }
+
+  @Test
+  void testDeleteProgramWithMapView() {
+    entityManager.persist(programA);
+    ProgramStage programStageA = createProgramStage('A', programA);
+    entityManager.persist(programStageA);
+    programA.getProgramStages().add(programStageA);
+    MapView mapView = createMapView("Test");
+    mapView.setProgram(programA);
+    mapView.setProgramStage(programStageA);
+    entityManager.persist(mapView);
+
+    assertDoesNotThrow(() -> programService.deleteProgram(programA));
+    assertNull(mapView.getProgram());
+    assertNull(mapView.getProgramStage());
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-18702

### Issue:
- Database throw FK constraint violation when deleting a Program which is referenced by MapView.

### Fix
- Remove the program reference from MapView.
- The MapView table also has ProgramStage foreign key, so it also needed to be removed.
- After deleting the Program, user might see an error when viewing the Map. If that happens, user can delete the Map in the Maps app.

### Test
- Added unit test.
- Manual test steps are described in [DHIS2-18702](https://dhis2.atlassian.net/browse/DHIS2-18702)

[DHIS2-18702]: https://dhis2.atlassian.net/browse/DHIS2-18702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ