### PR TITLE
chore: Use EventService in EnrollmentService [DHIS2-18791]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -45,8 +45,8 @@ public interface EnrollmentService {
   Enrollment getEnrollment(UID uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
-  RelationshipItem getEnrollmentInRelationshipItem(
-      UID uid, EnrollmentParams params, boolean includeDeleted) throws NotFoundException;
+  RelationshipItem getEnrollmentInRelationshipItem(UID uid, boolean includeDeleted)
+      throws NotFoundException;
 
   /** Get all enrollments matching given params. */
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -238,6 +238,7 @@ class DefaultEventService implements EventService {
     return event;
   }
 
+  @Nonnull
   @Override
   public List<Event> getEvents(@Nonnull EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
@@ -245,6 +246,7 @@ class DefaultEventService implements EventService {
     return eventStore.getEvents(queryParams);
   }
 
+  @Nonnull
   @Override
   public Page<Event> getEvents(
       @Nonnull EventOperationParams operationParams, @Nonnull PageParams pageParams)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -71,7 +71,8 @@ public class EventOperationParams {
 
   private UID orgUnit;
 
-  private OrganisationUnitSelectionMode orgUnitMode;
+  @Builder.Default
+  private OrganisationUnitSelectionMode orgUnitMode = OrganisationUnitSelectionMode.ACCESSIBLE;
 
   private AssignedUserSelectionMode assignedUserMode;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -71,7 +71,6 @@ import org.hisp.dhis.tracker.audit.TrackedEntityAuditService;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventService;
@@ -543,9 +542,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     } else if (item.getEnrollment() != null) {
       result =
           enrollmentService.getEnrollmentInRelationshipItem(
-              UID.of(item.getEnrollment()),
-              EnrollmentParams.TRUE.withIncludeRelationships(false),
-              includeDeleted);
+              UID.of(item.getEnrollment()), includeDeleted);
     } else if (item.getEvent() != null) {
       result =
           eventService.getEventInRelationshipItem(


### PR DESCRIPTION
Use `https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java#L242` to get the events from the enrollment instead of getting them through the Hibernate proxy.

Getting the events we can safely catch the `BadRequestException` as we are building `EventOperationParams`.
We can also catch `ForbiddenException`. This is less intuitive but this exception is thrown only in the process of mapping the `EventOperationParams` to `EventQueryParams` and we are not using any of the parameters that could thrown this exception.

**Other changes**
- Assign `ACCESSIBLE` as default value to `orgUnitMode` in `EventOperationParams`.
- Remove `EnrollmentParams` from `getEnrollmentInRelationshipItem` signature. The shape of the enrollment to get for a relationship is always the same and it should be hardcoded in the method itself. We are also changing `EnrollmentParams` here to not retrieve the events as they are never part of the enrollment in the relationship https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java#L72-L88