### PR TITLE
fix: don't use getAllPrincipals

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1076,8 +1076,8 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
-  public void invalidateUserSessions(String username) {
-    User user = getUserByUsername(username);
+  public void invalidateUserSessions(String userUid) {
+    User user = getUser(userUid);
     UserDetails userDetails = createUserDetails(user);
     if (userDetails != null) {
       List<SessionInformation> allSessions = sessionRegistry.getAllSessions(userDetails, false);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1076,20 +1076,13 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
-  public void invalidateUserSessions(String userUid) {
-    UserDetails principal = getPrincipalFromSessionRegistry(userUid);
-    if (principal != null) {
-      List<SessionInformation> allSessions = sessionRegistry.getAllSessions(principal, false);
+  public void invalidateUserSessions(String username) {
+    User user = getUserByUsername(username);
+    UserDetails userDetails = createUserDetails(user);
+    if (userDetails != null) {
+      List<SessionInformation> allSessions = sessionRegistry.getAllSessions(userDetails, false);
       allSessions.forEach(SessionInformation::expireNow);
     }
-  }
-
-  private UserDetails getPrincipalFromSessionRegistry(String userUid) {
-    return sessionRegistry.getAllPrincipals().stream()
-        .map(UserDetails.class::cast)
-        .filter(principal -> userUid.equals(principal.getUid()))
-        .findFirst()
-        .orElse(null);
   }
 
   @Override


### PR DESCRIPTION
## Problem

The session registry getAllPrincipals() is not compatible with the Redis backed session store, since it does not store session by principal.

### Fix
Create the principal from the user instead of iterating through the list obtained via the session store.

#### JIRA: [DHIS2-18460](https://dhis2.atlassian.net/browse/DHIS2-18460)

 

[DHIS2-18460]: https://dhis2.atlassian.net/browse/DHIS2-18460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ