### PR TITLE
feat: Handle Indicators and Expressions [DHIS-18321]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionStore.java
@@ -34,5 +34,13 @@ import org.hisp.dhis.common.GenericStore;
  */
 public interface ExpressionStore extends GenericStore<Expression> {
 
+  /**
+   * Update all expressions whose expression property contains the 'find' value. When updating, it
+   * replaces all occurrences of 'find' with 'replace'.
+   *
+   * @param find text to search for
+   * @param replace text used to replace 'find'
+   * @return number of entities updated
+   */
   int updateExpressionContaining(String find, String replace);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionStore.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression;
+
+import org.hisp.dhis.common.GenericStore;
+
+/**
+ * @author david mackessy
+ */
+public interface ExpressionStore extends GenericStore<Expression> {
+
+  int updateExpressionContaining(String find, String replace);
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorStore.java
@@ -47,4 +47,15 @@ public interface IndicatorStore extends IdentifiableObjectStore<Indicator> {
   List<Indicator> getIndicatorsWithNumeratorContaining(String search);
 
   List<Indicator> getIndicatorsWithDenominatorContaining(String search);
+
+  /**
+   * Updates any indicator that has the 'find' param in either its numerator or denominator. The
+   * update involves updating numerator and denominator, replacing all occurrences of 'find' with
+   * 'replace'.
+   *
+   * @param find text to search for
+   * @param replace text used to replace
+   * @return number of rows updated
+   */
+  int updateNumeratorDenominatorContaining(String find, String replace);
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/CategoryOptionComboMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/CategoryOptionComboMergeService.java
@@ -119,7 +119,8 @@ public class CategoryOptionComboMergeService implements MergeService {
             metadataMergeHandler::handlePredictors,
             metadataMergeHandler::handleDataElementOperands,
             metadataMergeHandler::handleMinMaxDataElements,
-            metadataMergeHandler::handleSmsCodes);
+            metadataMergeHandler::handleSmsCodes,
+            metadataMergeHandler::handleIndicators);
 
     dataMergeHandlers =
         List.of(

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/CategoryOptionComboMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/CategoryOptionComboMergeService.java
@@ -120,7 +120,8 @@ public class CategoryOptionComboMergeService implements MergeService {
             metadataMergeHandler::handleDataElementOperands,
             metadataMergeHandler::handleMinMaxDataElements,
             metadataMergeHandler::handleSmsCodes,
-            metadataMergeHandler::handleIndicators);
+            metadataMergeHandler::handleIndicators,
+            metadataMergeHandler::handleExpressions);
 
     dataMergeHandlers =
         List.of(

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/MetadataCategoryOptionComboMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/MetadataCategoryOptionComboMergeHandler.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.datadimensionitem.DataDimensionItemStore;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementOperandStore;
+import org.hisp.dhis.indicator.IndicatorStore;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementStore;
 import org.hisp.dhis.predictor.Predictor;
@@ -66,6 +67,7 @@ public class MetadataCategoryOptionComboMergeHandler {
   private final MinMaxDataElementStore minMaxDataElementStore;
   private final PredictorStore predictorStore;
   private final SMSCommandStore smsCommandStore;
+  private final IndicatorStore indicatorStore;
 
   /**
    * Remove sources from {@link CategoryOption} and add target to {@link CategoryOption}
@@ -176,5 +178,22 @@ public class MetadataCategoryOptionComboMergeHandler {
             UID.of(sources.stream().map(BaseIdentifiableObject::getUid).toList()));
 
     smsCodes.forEach(smsCode -> smsCode.setOptionId(target));
+  }
+
+  /**
+   * Set target to {@link SMSCode}
+   *
+   * @param sources to be removed
+   * @param target to add
+   */
+  public void handleIndicators(List<CategoryOptionCombo> sources, CategoryOptionCombo target) {
+    log.info("Merging source indicators");
+    int totalUpdates = 0;
+    for (CategoryOptionCombo source : sources) {
+      totalUpdates +=
+          indicatorStore.updateNumeratorDenominatorContaining(source.getUid(), target.getUid());
+    }
+
+    log.info("{} indicators updated", totalUpdates);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/MetadataCategoryOptionComboMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/optioncombo/MetadataCategoryOptionComboMergeHandler.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.datadimensionitem.DataDimensionItemStore;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementOperandStore;
+import org.hisp.dhis.expression.ExpressionStore;
 import org.hisp.dhis.indicator.IndicatorStore;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementStore;
@@ -68,6 +69,7 @@ public class MetadataCategoryOptionComboMergeHandler {
   private final PredictorStore predictorStore;
   private final SMSCommandStore smsCommandStore;
   private final IndicatorStore indicatorStore;
+  private final ExpressionStore expressionStore;
 
   /**
    * Remove sources from {@link CategoryOption} and add target to {@link CategoryOption}
@@ -181,10 +183,11 @@ public class MetadataCategoryOptionComboMergeHandler {
   }
 
   /**
-   * Set target to {@link SMSCode}
+   * Update each Indicator numerator and denominator values, replacing any source ref with the
+   * target ref.
    *
-   * @param sources to be removed
-   * @param target to add
+   * @param sources to be replaced
+   * @param target to replace source refs
    */
   public void handleIndicators(List<CategoryOptionCombo> sources, CategoryOptionCombo target) {
     log.info("Merging source indicators");
@@ -195,5 +198,21 @@ public class MetadataCategoryOptionComboMergeHandler {
     }
 
     log.info("{} indicators updated", totalUpdates);
+  }
+
+  /**
+   * Update each Expression expression value, replacing any source ref with the target ref.
+   *
+   * @param sources to be replaced
+   * @param target to replace source refs
+   */
+  public void handleExpressions(List<CategoryOptionCombo> sources, CategoryOptionCombo target) {
+    log.info("Merging source expressions");
+    int totalUpdates = 0;
+    for (CategoryOptionCombo source : sources) {
+      totalUpdates += expressionStore.updateExpressionContaining(source.getUid(), target.getUid());
+    }
+
+    log.info("{} expressions updated", totalUpdates);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/HibernateExpressionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/HibernateExpressionStore.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression;
+
+import jakarta.persistence.EntityManager;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author david mackessy
+ */
+@Repository
+public class HibernateExpressionStore extends HibernateGenericStore<Expression>
+    implements org.hisp.dhis.expression.ExpressionStore {
+
+  public HibernateExpressionStore(
+      EntityManager entityManager, JdbcTemplate jdbcTemplate, ApplicationEventPublisher publisher) {
+    super(entityManager, jdbcTemplate, publisher, Expression.class, false);
+  }
+
+  @Override
+  public int updateExpressionContaining(String find, String replace) {
+    String sql =
+        """
+        update expression
+        set expression = replace(expression, '%s', '%s')
+        where expression like '%s';
+        """
+            .formatted(find, replace, "%" + find + "%");
+    return jdbcTemplate.update(sql);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/hibernate/HibernateIndicatorStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/hibernate/HibernateIndicatorStore.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorStore;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.SqlUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/hibernate/HibernateIndicatorStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/hibernate/HibernateIndicatorStore.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorStore;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.util.SqlUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -99,5 +100,19 @@ public class HibernateIndicatorStore extends HibernateIdentifiableObjectStore<In
     return getQuery("FROM Indicator i where i.denominator like :search", Indicator.class)
         .setParameter("search", "%" + search + "%")
         .getResultList();
+  }
+
+  @Override
+  public int updateNumeratorDenominatorContaining(String find, String replace) {
+    String sql =
+        """
+        update indicator
+        set numerator = replace(numerator, '%s', '%s'),
+            denominator = replace(denominator, '%s', '%s')
+        where numerator like '%s'
+          or denominator like '%s';
+        """
+            .formatted(find, replace, find, replace, "%" + find + "%", "%" + find + "%");
+    return jdbcTemplate.update(sql);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryOptionComboMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryOptionComboMergeTest.java
@@ -74,6 +74,7 @@ class CategoryOptionComboMergeTest extends ApiTest {
   private RestApiActions dataValueSetActions;
   private RestApiActions indicatorActions;
   private RestApiActions indicatorTypeActions;
+  private RestApiActions validationRuleActions;
   private UserActions userActions;
   private LoginActions loginActions;
   private String sourceUid1;
@@ -96,6 +97,7 @@ class CategoryOptionComboMergeTest extends ApiTest {
     visualizationActions = new RestApiActions("visualizations");
     indicatorActions = new RestApiActions("indicators");
     indicatorTypeActions = new RestApiActions("indicatorTypes");
+    validationRuleActions = new RestApiActions("validationRules");
     loginActions.loginAsSuperUser();
 
     // add user with required merge auth
@@ -609,6 +611,53 @@ class CategoryOptionComboMergeTest extends ApiTest {
     checkIndicatorValues(5, indicator5, "randomUID1", "randomUID2", "randomUID3", "randomUID4");
   }
 
+  @Test
+  @DisplayName(
+      "Expressions with COC source refs in their expression are updated with target COC ref")
+  void expressionTest() {
+    // given
+    maintenanceApiActions
+        .post("categoryOptionComboUpdate", new QueryParamsBuilder().build())
+        .validateStatus(204);
+
+    // get cat opt combo uids for sources and target, after generating
+    sourceUid1 = getCocWithOptions("1A", "2A");
+    sourceUid2 = getCocWithOptions("1B", "2B");
+    targetUid = getCocWithOptions("3A", "4B");
+
+    // indicators with mix of source COC in numerator, denominator
+    String validationRule1 =
+        setupExpressionInValidationRule("1", sourceUid1, "leftSide2", "rightSide1", "rightSide2");
+    String validationRule2 =
+        setupExpressionInValidationRule("2", "leftSide1", "leftSide2", "rightSide1", sourceUid2);
+    String validationRule3 =
+        setupExpressionInValidationRule("3", sourceUid1, sourceUid1, sourceUid2, "rightSide2");
+    String validationRule4 =
+        setupExpressionInValidationRule("4", targetUid, "leftSide2", "rightSide1", "rightSide2");
+    String validationRule5 =
+        setupExpressionInValidationRule("5", "leftSide1", "leftSide2", "rightSide1", "rightSide2");
+
+    // when
+    ValidatableResponse response =
+        categoryOptionComboApiActions.post("merge", getMergeBody("DISCARD")).validate();
+
+    // then
+    response
+        .statusCode(200)
+        .body("httpStatus", equalTo("OK"))
+        .body("response.mergeReport.message", equalTo("CategoryOptionCombo merge complete"))
+        .body("response.mergeReport.mergeErrors", empty())
+        .body("response.mergeReport.mergeType", equalTo("CategoryOptionCombo"))
+        .body("response.mergeReport.sourcesDeleted", hasItems(sourceUid1, sourceUid2));
+
+    // and source COC refs have been replaced with target COC refs
+    checkExpressionValues(1, validationRule1, targetUid, "leftSide2", "rightSide1", "rightSide2");
+    checkExpressionValues(2, validationRule2, "leftSide1", "leftSide2", "rightSide1", targetUid);
+    checkExpressionValues(3, validationRule3, targetUid, targetUid, targetUid, "rightSide2");
+    checkExpressionValues(4, validationRule4, targetUid, "leftSide2", "rightSide1", "rightSide2");
+    checkExpressionValues(5, validationRule5, "leftSide1", "leftSide2", "rightSide1", "rightSide2");
+  }
+
   private void checkIndicatorValues(
       int name, String indicator, String num1, String num2, String denom1, String denom2) {
     indicatorActions
@@ -618,6 +667,26 @@ class CategoryOptionComboMergeTest extends ApiTest {
         .body("numerator", equalTo("#{%s.RanDOmUID01}.%s".formatted(num1, num2)))
         .body("denominator", equalTo("#{h0xKKjijTdI.%s}.%s".formatted(denom1, denom2)))
         .body("name", equalTo("test indicator %d".formatted(name)));
+  }
+
+  private void checkExpressionValues(
+      int name,
+      String rule,
+      String leftSide1,
+      String leftSide2,
+      String rightSide1,
+      String rightSide2) {
+    validationRuleActions
+        .get("/" + rule)
+        .validate()
+        .statusCode(200)
+        .body(
+            "leftSide.expression",
+            equalTo("#{%s.RandomUid01}+#{RandomUid02.%s}".formatted(leftSide1, leftSide2)))
+        .body(
+            "rightSide.expression",
+            equalTo("#{%s.RandomUid03}+#{RandomUid04.%s}".formatted(rightSide1, rightSide2)))
+        .body("name", equalTo("test val rule %d".formatted(name)));
   }
 
   private void setupMetadata() {
@@ -685,6 +754,30 @@ class CategoryOptionComboMergeTest extends ApiTest {
             }
             """
                 .formatted(name, name, num1, num2, denom1, denom2, indType))
+        .validateStatus(201)
+        .extractUid();
+  }
+
+  private String setupExpressionInValidationRule(
+      String name, String leftSide1, String leftSide2, String rightSide1, String rightSide2) {
+    return validationRuleActions
+        .post(
+            """
+            {
+                 "name": "test val rule %s",
+                 "leftSide": {
+                     "expression": "#{%s.RandomUid01}+#{RandomUid02.%s}",
+                     "description": "expression 1"
+                 },
+                 "rightSide": {
+                     "expression": "#{%s.RandomUid03}+#{RandomUid04.%s}",
+                     "description": "expression 2"
+                 },
+                 "operator": "less_than_or_equal_to",
+                 "periodType": "Monthly"
+             }
+            """
+                .formatted(name, leftSide1, leftSide2, rightSide1, rightSide2))
         .validateStatus(201)
         .extractUid();
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryOptionComboMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryOptionComboMergeTest.java
@@ -72,6 +72,8 @@ class CategoryOptionComboMergeTest extends ApiTest {
   private RestApiActions visualizationActions;
   private RestApiActions maintenanceApiActions;
   private RestApiActions dataValueSetActions;
+  private RestApiActions indicatorActions;
+  private RestApiActions indicatorTypeActions;
   private UserActions userActions;
   private LoginActions loginActions;
   private String sourceUid1;
@@ -92,6 +94,8 @@ class CategoryOptionComboMergeTest extends ApiTest {
     maintenanceApiActions = new RestApiActions("maintenance");
     dataValueSetActions = new RestApiActions("dataValueSets");
     visualizationActions = new RestApiActions("visualizations");
+    indicatorActions = new RestApiActions("indicators");
+    indicatorTypeActions = new RestApiActions("indicatorTypes");
     loginActions.loginAsSuperUser();
 
     // add user with required merge auth
@@ -560,6 +564,62 @@ class CategoryOptionComboMergeTest extends ApiTest {
         .body("message", containsString("minmaxdataelement_unique_key"));
   }
 
+  @Test
+  @DisplayName(
+      "Indicators with COC source refs in their numerator or denominator are updated with target COC ref")
+  void indicatorsNumeratorDenominatorTest() {
+    // given
+    maintenanceApiActions
+        .post("categoryOptionComboUpdate", new QueryParamsBuilder().build())
+        .validateStatus(204);
+
+    // get cat opt combo uids for sources and target, after generating
+    sourceUid1 = getCocWithOptions("1A", "2A");
+    sourceUid2 = getCocWithOptions("1B", "2B");
+    targetUid = getCocWithOptions("3A", "4B");
+
+    // indicators with mix of source COC in numerator, denominator
+    String indicatorType = setupIndicatorType("1");
+    String indicator1 = setupIndicator("1", indicatorType, sourceUid1, "num2", "denom1", "denom2");
+    String indicator2 = setupIndicator("2", indicatorType, "num1", "num2", sourceUid2, sourceUid2);
+    String indicator3 =
+        setupIndicator("3", indicatorType, sourceUid1, sourceUid2, sourceUid1, sourceUid2);
+    String indicator4 = setupIndicator("4", indicatorType, targetUid, "num2", targetUid, "denom2");
+    String indicator5 =
+        setupIndicator("5", indicatorType, "randomUID1", "randomUID2", "randomUID3", "randomUID4");
+
+    // when
+    ValidatableResponse response =
+        categoryOptionComboApiActions.post("merge", getMergeBody("DISCARD")).validate();
+
+    // then
+    response
+        .statusCode(200)
+        .body("httpStatus", equalTo("OK"))
+        .body("response.mergeReport.message", equalTo("CategoryOptionCombo merge complete"))
+        .body("response.mergeReport.mergeErrors", empty())
+        .body("response.mergeReport.mergeType", equalTo("CategoryOptionCombo"))
+        .body("response.mergeReport.sourcesDeleted", hasItems(sourceUid1, sourceUid2));
+
+    // and source COC refs have been replaced
+    checkIndicatorValues(1, indicator1, targetUid, "num2", "denom1", "denom2");
+    checkIndicatorValues(2, indicator2, "num1", "num2", targetUid, targetUid);
+    checkIndicatorValues(3, indicator3, targetUid, targetUid, targetUid, targetUid);
+    checkIndicatorValues(4, indicator4, targetUid, "num2", targetUid, "denom2");
+    checkIndicatorValues(5, indicator5, "randomUID1", "randomUID2", "randomUID3", "randomUID4");
+  }
+
+  private void checkIndicatorValues(
+      int name, String indicator, String num1, String num2, String denom1, String denom2) {
+    indicatorActions
+        .get("/" + indicator)
+        .validate()
+        .statusCode(200)
+        .body("numerator", equalTo("#{%s.RanDOmUID01}.%s".formatted(num1, num2)))
+        .body("denominator", equalTo("#{h0xKKjijTdI.%s}.%s".formatted(denom1, denom2)))
+        .body("name", equalTo("test indicator %d".formatted(name)));
+  }
+
   private void setupMetadata() {
     metadataActions.importMetadata(metadata()).validateStatus(200);
   }
@@ -604,6 +664,42 @@ class CategoryOptionComboMergeTest extends ApiTest {
              }
              """
                 .formatted(name, name))
+        .validateStatus(201)
+        .extractUid();
+  }
+
+  private String setupIndicator(
+      String name, String indType, String num1, String num2, String denom1, String denom2) {
+    return indicatorActions
+        .post(
+            """
+            {
+                "name": "test indicator %s",
+                "shortName": "test short %s",
+                "dimensionItemType": "INDICATOR",
+                "numerator": "#{%s.RanDOmUID01}.%s",
+                "denominator": "#{h0xKKjijTdI.%s}.%s",
+                "indicatorType": {
+                    "id": "%s"
+                }
+            }
+            """
+                .formatted(name, name, num1, num2, denom1, denom2, indType))
+        .validateStatus(201)
+        .extractUid();
+  }
+
+  private String setupIndicatorType(String name) {
+    return indicatorTypeActions
+        .post(
+            """
+            {
+               "name": "test indicator %s",
+               "factor": 12,
+               "number": true
+            }
+            """
+                .formatted(name))
         .validateStatus(201)
         .extractUid();
   }


### PR DESCRIPTION
# Summary
The requirements for the category option combo merge keep coming in :)
These 2 new scenarios are places in the DB where COC refs can be held within plain string values, which explains why they were originally missed (domain knowledge).

This PR includes handling the refs for these types and their properties:
- `Indicator`
  - `numerator` (plain string)
  - `denominator` (plain string)
- `Expression`
  - `expression` (plain string)

The merge executes an sql update using the postgres function `replace` which replaces all occurrences of a string with another string.

# Testing
## Automated
E2E tests added for each scenario.