### PR TITLE
fix: IN filter now works with org units data elements [DHIS2-18845]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
@@ -46,19 +46,19 @@ import lombok.Data;
 public class InQueryFilter extends QueryFilter {
   private final String field;
 
-  private final boolean isText;
+  private final boolean shouldQuote;
 
   /**
    * Construct a InQueryFilter using field name and the original {@link QueryFilter}
    *
    * @param field the field on which to construct the InQueryFilter
    * @param encodedFilter The original encodedFilter in {@link QueryFilter}
-   * @param isText whether this filter contains text or numeric values
+   * @param shouldQuote whether this filter contains text or numeric values
    */
-  public InQueryFilter(String field, String encodedFilter, boolean isText) {
+  public InQueryFilter(String field, String encodedFilter, boolean shouldQuote) {
     super(IN, encodedFilter);
     this.field = field;
-    this.isText = isText;
+    this.shouldQuote = shouldQuote;
   }
 
   /**
@@ -100,7 +100,7 @@ public class InQueryFilter extends QueryFilter {
   }
 
   private String quoteIfNecessary(String item) {
-    return isText ? quote(item) : item;
+    return shouldQuote ? quote(item) : item;
   }
 
   private boolean hasMissingValue(List<String> filterItems) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
@@ -64,11 +64,11 @@ class InQueryFilterTest {
     executeTest(field, "NV", true, "(" + field + " is null and exists((select * from xy))) ");
   }
 
-  private void executeTest(String filterValue, boolean isText, String expected) {
-    executeTest("aField", filterValue, isText, expected);
+  private void executeTest(String filterValue, boolean shouldQuote, String expected) {
+    executeTest("aField", filterValue, shouldQuote, expected);
   }
 
-  private void executeTest(String field, String filterValue, boolean isText, String expected) {
-    assertEquals(new InQueryFilter(field, filterValue, isText).getSqlFilter(), expected);
+  private void executeTest(String field, String filterValue, boolean shouldQuote, String expected) {
+    assertEquals(new InQueryFilter(field, filterValue, shouldQuote).getSqlFilter(), expected);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryService.java
@@ -176,4 +176,15 @@ public interface DataQueryService {
    * @return a list of organisation units.
    */
   List<OrganisationUnit> getUserOrgUnits(DataQueryParams params, String userOrgUnit);
+
+  /**
+   * Based on the given parameters, this method will return a list of {@link OrganisationUnit} UIDs
+   * based on the given items and user organisation units.
+   *
+   * @param items the list of items that might be included into the resulting organisation unit and
+   *     its keywords.
+   * @param userOrgUnits the list of organisation units associated with the current user.
+   * @return a list of {@link OrganisationUnit} UIDs.
+   */
+  List<String> getOrgUnitDimensionUid(List<String> items, List<OrganisationUnit> userOrgUnits);
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -364,6 +364,21 @@ public class DefaultDataQueryService implements DataQueryService {
   }
 
   /**
+   * Based on the given parameters, this method will return a list of {@link OrganisationUnit} UIDs
+   * based on the given items and user organisation units.
+   *
+   * @param items the list of items that might be included into the resulting organisation unit and
+   *     its keywords.
+   * @param userOrgUnits the list of organisation units associated with the current user.
+   * @return a list of {@link OrganisationUnit} UIDs.
+   */
+  @Override
+  public List<String> getOrgUnitDimensionUid(
+      List<String> items, List<OrganisationUnit> userOrgUnits) {
+    return dimensionalObjectProducer.getOrgUnitDimensionUid(items, userOrgUnits);
+  }
+
+  /**
    * Returns a {@link DimensionalObject}.
    *
    * @param dimension the dimension identifier.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
@@ -424,6 +424,24 @@ public class DimensionalObjectProvider {
   }
 
   /**
+   * This method will return a list of {@link OrganisationUnit} UIDs based on the given items and
+   * user organisation units.
+   *
+   * @param items the list of items that might be included into the resulting organisation unit and
+   *     its keywords.
+   * @param userOrgUnits the list of organisation units associated with the current user.
+   * @return a list of {@link OrganisationUnit} UIDs.
+   */
+  public List<String> getOrgUnitDimensionUid(
+      List<String> items, List<OrganisationUnit> userOrgUnits) {
+    return getOrgUnitDimensionItems(
+            items, userOrgUnits, IdScheme.UID, new ArrayList<>(), new ArrayList<>())
+        .stream()
+        .map(DimensionalItemObject::getUid)
+        .toList();
+  }
+
+  /**
    * Based on the given parameters, this method will return a list of {@link DimensionalItemObject}
    * of type {@link OrganisationUnit}. It also adds to the given levels and groups if certain
    * internal rules match.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1244,13 +1244,14 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   }
 
   /**
-   * Creates a SQL statement for a single filter inside a query item.
+   * Creates a SQL statement for a single filter inside a query item. Made public for testing
+   * purposes.
    *
    * @param item the {@link QueryItem}.
    * @param filter the {@link QueryFilter}.
    * @param params the {@link EventQueryParams}.
    */
-  private String toSql(QueryItem item, QueryFilter filter, EventQueryParams params) {
+  public String toSql(QueryItem item, QueryFilter filter, EventQueryParams params) {
     String field =
         item.hasAggregationType()
             ? getSelectSql(filter, item, params)
@@ -1258,7 +1259,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
     if (IN.equals(filter.getOperator())) {
       InQueryFilter inQueryFilter =
-          new InQueryFilter(field, sqlBuilder.escape(filter.getFilter()), item.isText());
+          new InQueryFilter(field, sqlBuilder.escape(filter.getFilter()), !item.isNumeric());
 
       return inQueryFilter.getSqlFilter();
     } else {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.analytics.AnalyticsAggregationType.fromAggregationType;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.common.QueryOperator.EQ;
+import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.common.QueryOperator.NE;
 import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.common.QueryOperator.NIEQ;
@@ -850,6 +851,23 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
     String select = enrollmentSubject.getSelectClause(params);
     // Then
     assertEquals("select enrollment,Yearly ", select);
+  }
+
+  @Test
+  void testItemsInFilterAreQuotedForOrganisationUnit() {
+    // Given
+    QueryItem queryItem = mock(QueryItem.class);
+    QueryFilter queryFilter = new QueryFilter(IN, "A;B;C");
+    EventQueryParams params =
+        new EventQueryParams.Builder().withStartDate(new Date()).withEndDate(new Date()).build();
+    when(queryItem.getItemName()).thenReturn("anyItem");
+    when(queryItem.getValueType()).thenReturn(ValueType.ORGANISATION_UNIT);
+
+    // When
+    String sql = eventSubject.toSql(queryItem, queryFilter, params).trim();
+
+    // Then
+    assertEquals("ax.\"anyItem\" in ('A','B','C')", sql);
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
@@ -997,4 +997,68 @@ public class EventQueryTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(response, 0, List.of("Ngelehun CHC", "1"));
   }
+
+  @Test
+  public void queryWithOrgUnitDataElement() throws JSONException {
+    // Given
+    String dimensionItems =
+        String.join(
+            ";",
+            "DiszpKrYNg8",
+            "g8upMTyEZGZ",
+            "LEVEL-H1KlN4QIauv",
+            "OU_GROUP-nlX2VoouN63",
+            "USER_ORGUNIT;USER_ORGUNIT_CHILDREN",
+            "USER_ORGUNIT_GRANDCHILDREN");
+
+    String dimensionOrgUnitDataElement = "Ge7Eo3FNnbl.rypjN8CV02V:IN:" + dimensionItems;
+    String dimensionOrgUnit = "ou:USER_ORGUNIT";
+
+    String dimension = dimensionOrgUnitDataElement + "," + dimensionOrgUnit;
+
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=" + dimension)
+            .add("headers=ouname,Ge7Eo3FNnbl.rypjN8CV02V")
+            .add("totalPages=false")
+            .add("displayProperty=NAME")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("includeMetadataDetails=true")
+            .add("outputType=EVENT");
+
+    // When
+    ApiResponse response = analyticsEventActions.query().get("MoUd5BTQ3lY", params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(2)))
+        .body("rows", hasSize(equalTo(0)))
+        .body("height", equalTo(0))
+        .body("width", equalTo(0))
+        .body("headerWidth", equalTo(2));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"Ge7Eo3FNnbl\":{\"uid\":\"Ge7Eo3FNnbl\",\"name\":\"XX MAL RDT - Case Registration\"},\"Ge7Eo3FNnbl.rypjN8CV02V\":{\"uid\":\"rypjN8CV02V\",\"aggregationType\":\"SUM\",\"valueType\":\"TEXT\",\"name\":\"XX MAL RDT TRK - Village of Residence\",\"style\":{\"icon\":\"nullapi\\/icons\\/star_medium_positive\\/icon.svg\"},\"dimensionItemType\":\"DATA_ELEMENT\",\"totalAggregationType\":\"SUM\"},\"MoUd5BTQ3lY\":{\"uid\":\"MoUd5BTQ3lY\",\"name\":\"XX MAL RDT - Case Registration\"},\"USER_ORGUNIT_CHILDREN\":{\"organisationUnits\":[\"at6UHUQatSo\",\"TEQlaapDQoK\",\"PMa2VCrupOd\",\"qhqAxPSTUXp\",\"kJq2mPyFEHo\",\"jmIPBj66vD6\",\"Vth0fbpFcsO\",\"jUb8gELQApl\",\"fdc6uOvgoji\",\"eIQbndfxQMb\",\"O6uvpzGd5pu\",\"lc3eMKXaEfw\",\"bL4ooGhyHRQ\"]},\"rypjN8CV02V\":{\"uid\":\"rypjN8CV02V\",\"aggregationType\":\"SUM\",\"valueType\":\"TEXT\",\"name\":\"XX MAL RDT TRK - Village of Residence\",\"style\":{\"icon\":\"nullapi\\/icons\\/star_medium_positive\\/icon.svg\"},\"dimensionItemType\":\"DATA_ELEMENT\",\"totalAggregationType\":\"SUM\"},\"LAST_12_MONTHS\":{\"name\":\"Last 12 months\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"Ge7Eo3FNnbl.rypjN8CV02V\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "Ge7Eo3FNnbl.rypjN8CV02V",
+        "XX MAL RDT TRK - Village of Residence",
+        "ORGANISATION_UNIT",
+        "org.hisp.dhis.organisationunit.OrganisationUnit",
+        false,
+        true);
+
+    // no rows to assert
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
@@ -1008,7 +1008,8 @@ public class EventQueryTest extends AnalyticsApiTest {
             "g8upMTyEZGZ",
             "LEVEL-H1KlN4QIauv",
             "OU_GROUP-nlX2VoouN63",
-            "USER_ORGUNIT;USER_ORGUNIT_CHILDREN",
+            "USER_ORGUNIT",
+            "USER_ORGUNIT_CHILDREN",
             "USER_ORGUNIT_GRANDCHILDREN");
 
     String dimensionOrgUnitDataElement = "Ge7Eo3FNnbl.rypjN8CV02V:IN:" + dimensionItems;

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -238,7 +238,7 @@
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
     <restrict-imports-enforcer.version>2.6.0</restrict-imports-enforcer.version>
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
-    <dependency-check-maven.version>12.0.0</dependency-check-maven.version>
+    <dependency-check-maven.version>12.0.1</dependency-check-maven.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <spotless.version>2.44.2</spotless.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -247,7 +247,7 @@
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.11.0</gson.version>
     <semver4j.version>3.1.0</semver4j.version>
-    <opentelemetry.version>2.11.0</opentelemetry.version>
+    <opentelemetry.version>2.12.0</opentelemetry.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This pull request will fix a small bug with IN query operator, making it properly quotes values when needed (it was only quoting `TEXT` value types before).
Moreover, it will properly support Data Elements of type ORG_UNIT, by replacing the filter values with org unit UIDs when needed 