### PR TITLE
fix: set maxPasswordLength in password tests

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -191,6 +191,7 @@ class AccountControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void testValidatePasswordGet_PasswordNotValid() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertMessage(
         "response",
         "error",
@@ -209,6 +210,7 @@ class AccountControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void testValidatePasswordPost_PasswordNotValid() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertMessage(
         "response",
         "error",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -136,6 +136,7 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testChangePassword_WrongNew() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertEquals(
         "Password must have at least 8, and at most 72 characters",
         PUT("/me/changePassword", "{'oldPassword':'district','newPassword':'secret'}")
@@ -203,6 +204,7 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testValidatePasswordText_TooShort() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     JsonPasswordValidation result =
         POST("/me/validatePassword", ContentType("text/plain"), Body("secret"))
             .content()
@@ -214,6 +216,7 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testValidatePasswordText_TooLong() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     JsonPasswordValidation result =
         POST(
                 "/me/validatePassword",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -351,7 +351,7 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
   void selfRegInvalidPassword(String input, String expectedError) {
     disableRecaptcha();
     enableSelfRegistration();
-
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertWebMessage(
         "Bad Request",
         400,
@@ -527,7 +527,7 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
   @DisplayName("Invite registration error when invalid password data")
   void inviteRegInvalidPassword(String password, String expectedError) {
     disableRecaptcha();
-
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertWebMessage(
         "Bad Request",
         400,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -663,6 +663,7 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testReplicateUser_PasswordNotValid() {
+    POST("/systemSettings/maxPasswordLength", "72").content(HttpStatus.OK);
     assertWebMessage(
         "Conflict",
         409,


### PR DESCRIPTION
## Problem
Tests that are testing the password length rule fails, because some test change the length.

### Cause
Tests are modifying the password length rule, and the variable is not reset to the default. Test order is random, and the problem can manifest, when new tests are added.

### Fix
Reset password length config to the default.
