### PR TITLE
feat: Filter events by existing data element [DHIS2-15954]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -128,7 +128,12 @@ class DefaultEventService implements EventService {
           "this must be a bug in how the EventOperationParams are built");
     }
     if (events.getItems().isEmpty()) {
-      throw new NotFoundException(Event.class, eventUid);
+      throw new NotFoundException(
+          "Event "
+              + eventUid.getValue()
+              + " with data element "
+              + dataElementUid.getValue()
+              + " could not be found.");
     }
     Event event = events.getItems().get(0);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -142,7 +142,7 @@ public class EventOperationParams {
 
   private Set<UID> enrollments;
 
-  private EventParams eventParams;
+  @Builder.Default private EventParams eventParams = EventParams.FALSE;
 
   @Builder.Default
   private TrackerIdSchemeParams idSchemeParams = TrackerIdSchemeParams.builder().build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -414,7 +414,6 @@ class EventQueryParams {
   /** Order by the given data element {@code de} in given sort {@code direction}. */
   public EventQueryParams orderBy(DataElement de, SortDirection direction) {
     this.order.add(new Order(de, direction));
-    this.dataElements.putIfAbsent(de, new ArrayList<>());
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -894,7 +894,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
             .append(", coc_agg.attributevalues as ")
             .append(COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_ATTRIBUTE_VALUES)
             .append(", coc_agg.co_values AS co_values, coc_agg.co_count AS option_size, ")
-            .append(addOrderFieldsToSelectClause(params.getOrder()));
+            .append(getOrderFieldsForSelectClause(params.getOrder()));
 
     return selectBuilder
         .append(
@@ -920,7 +920,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         .toString();
   }
 
-  private String addOrderFieldsToSelectClause(List<Order> orders) {
+  private String getOrderFieldsForSelectClause(List<Order> orders) {
     StringBuilder selectBuilder = new StringBuilder();
 
     for (Order order : orders) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -1444,6 +1444,11 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
             }
           }
         }
+      } else {
+        eventDataValuesWhereSql.append(hlp.whereAnd());
+        eventDataValuesWhereSql.append(" (ev.eventdatavalues ?? '");
+        eventDataValuesWhereSql.append(item.getKey().getUid());
+        eventDataValuesWhereSql.append("')");
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -894,7 +894,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
             .append(", coc_agg.attributevalues as ")
             .append(COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_ATTRIBUTE_VALUES)
             .append(", coc_agg.co_values AS co_values, coc_agg.co_count AS option_size, ")
-            .append(addOrderFieldsToSelectClause(params));
+            .append(addOrderFieldsToSelectClause(params.getOrder()));
 
     return selectBuilder
         .append(
@@ -920,10 +920,10 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         .toString();
   }
 
-  private String addOrderFieldsToSelectClause(EventQueryParams params) {
+  private String addOrderFieldsToSelectClause(List<Order> orders) {
     StringBuilder selectBuilder = new StringBuilder();
 
-    for (Order order : params.getOrder()) {
+    for (Order order : orders) {
       if (order.getField() instanceof TrackedEntityAttribute tea) {
         selectBuilder
             .append(quote(tea.getUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventQueryParamsTest.java
@@ -70,13 +70,13 @@ class EventQueryParamsTest extends TestBase {
   }
 
   @Test
-  void shouldAddDataElementToOrderAndDataElementsWhenOrderingByDataElement() {
+  void shouldAddDataElementToOrderButNotToDataElementsWhenOrderingByDataElement() {
     EventQueryParams params = new EventQueryParams();
 
     params.orderBy(de1, SortDirection.ASC);
 
     assertEquals(List.of(new Order(de1, SortDirection.ASC)), params.getOrder());
-    assertEquals(Map.of(de1, List.of()), params.getDataElements());
+    assertTrue(params.getDataElements().isEmpty());
     assertFalse(params.hasDataElementFilter());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -588,6 +589,25 @@ class EventExporterTest extends TrackerTest {
     List<String> events = getEvents(params);
 
     assertContainsOnly(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
+  void shouldFilterByEventsWithGivenDataValuesWhenFilterContainsDataElementUIDsOnly()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .eventParams(EventParams.FALSE)
+            .dataElementFilters(
+                Map.of(
+                    UID.of("GieVkTxp4HH"),
+                    new ArrayList<>(),
+                    UID.of("GieVkTxp4HG"),
+                    new ArrayList<>()))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("kWjSezkXHVp"), events);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -596,7 +596,6 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
-            .eventParams(EventParams.FALSE)
             .dataElementFilters(
                 Map.of(
                     UID.of("GieVkTxp4HH"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -534,7 +534,6 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     event.getEventDataValues().add(dataValue(de, file.getUid()));
     manager.update(event);
 
-    // this.switchContextToUser(user);
     switchContextToUser(user);
 
     GET("/tracker/events/{eventUid}/dataValues/{dataElementUid}/file", event.getUid(), de.getUid())
@@ -566,6 +565,25 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     Event event = event(enrollment(trackedEntity()));
     DataElement de = dataElement(ValueType.FILE_RESOURCE);
 
+    switchContextToUser(user);
+
+    assertEquals(
+        "Event " + event.getUid() + " with data element " + de.getUid() + " could not be found.",
+        GET(
+                "/tracker/events/{eventUid}/dataValues/{dataElementUid}/file",
+                event.getUid(),
+                de.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getDataValuesFileByDataElementIfNoDataValueNull() {
+    Event event = event(enrollment(trackedEntity()));
+    DataElement de = dataElement(ValueType.IMAGE);
+
+    event.getEventDataValues().add(dataValue(de, null));
+    manager.flush();
     switchContextToUser(user);
 
     assertEquals(


### PR DESCRIPTION
### Part 1
Requesting events with a filter like `filter={DE_UID}` doesn't work as expected, events are returned regardless of the DEs they contain. This PR aims to fix this issue.

The DEs are stored in a map that uses the UID as the key and a `List<QueryFilter>` as the value. In this case, the value list is always empty. The issue is that this map is also used when sorting. Even though the DEs are present in the order list, we are still using the DE map to add fields to the select clause.

I am changing this in favor of the same approach we use when sorting TEAs, using the order list to add any DE to the select statement.

### Next
This fix will allow users to filter for events containing a value in a given DE.
The next PR will enable filtering for events not containing a value in a given DE.

