### PR TITLE
fix: PI functions and program to handle Doris/CH double type

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Zpvc.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Zpvc.java
@@ -56,6 +56,7 @@ public class D2Zpvc extends ProgramExpressionItem {
       sql += "case when " + visitor.visitAllowingNulls(c) + " >= 0 then 1 else 0 end + ";
     }
 
-    return TextUtils.removeLast(sql, "+").trim() + ") as double precision),0)";
+    return TextUtils.removeLast(sql, "+").trim()
+        + ") as %s),0)".formatted(visitor.getSqlBuilder().dataTypeDouble());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
@@ -52,6 +52,7 @@ public class vValueCount extends ProgramDoubleVariable {
       sql += "case when " + SqlUtils.quote(uid) + " is not null then 1 else 0 end + ";
     }
 
-    return TextUtils.removeLast(sql, "+").trim() + ") as double precision),0)";
+    return TextUtils.removeLast(sql, "+").trim()
+        + ") as %s),0)".formatted(visitor.getSqlBuilder().dataTypeDouble());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
@@ -52,6 +52,7 @@ public class vZeroPosValueCount extends ProgramDoubleVariable {
       sql += "case when " + SqlUtils.quote(uid) + " >= 0 then 1 else 0 end + ";
     }
 
-    return TextUtils.removeLast(sql, "+").trim() + ") as double precision),0)";
+    return TextUtils.removeLast(sql, "+").trim()
+        + ") as %s),0)".formatted(visitor.getSqlBuilder().dataTypeDouble());
   }
 }


### PR DESCRIPTION
# PR Description

Make sure that when casting to `double` in a Program Indicator function, the correct db-specific syntax is used.