### PR TITLE
fix: Return all requested fields in relationships and prevent cycles [DHIS2-18791]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -167,7 +167,14 @@ class DefaultEnrollmentService implements EnrollmentService {
   public RelationshipItem getEnrollmentInRelationshipItem(@Nonnull UID uid) {
     Enrollment enrollment;
     try {
-      enrollment = getEnrollment(uid);
+      enrollment =
+          getEnrollment(
+              uid,
+              EnrollmentParams.TRUE
+                  .withIncludeRelationships(false)
+                  .withEnrollmentEventsParams(
+                      EnrollmentEventsParams.TRUE.withEventParams(EventParams.FALSE)),
+              false);
     } catch (NotFoundException | ForbiddenException e) {
       // enrollments are not shown in relationships if the user has no access to them
       return null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -112,6 +112,7 @@ class DefaultEnrollmentService implements EnrollmentService {
     return enrollments.getItems().get(0);
   }
 
+  // TODO(DHIS2-18883) Pass EnrollmentParams as a parameter
   @Nonnull
   @Override
   public List<Enrollment> getEnrollments(@Nonnull Set<UID> uids) throws ForbiddenException {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -256,11 +256,14 @@ class DefaultEventService implements EventService {
   }
 
   @Override
-  public RelationshipItem getEventInRelationshipItem(
-      @Nonnull UID uid, @Nonnull EventParams eventParams) {
+  public RelationshipItem getEventInRelationshipItem(@Nonnull UID uid) {
     Event event;
     try {
-      event = getEvent(uid, TrackerIdSchemeParams.builder().build(), eventParams);
+      event =
+          getEvent(
+              uid,
+              TrackerIdSchemeParams.builder().build(),
+              EventParams.TRUE.withIncludeRelationships(false));
     } catch (NotFoundException | ForbiddenException e) {
       // events are not shown in relationships if the user has no access to them
       return null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -255,6 +255,7 @@ class DefaultEventService implements EventService {
     return eventStore.getEvents(queryParams, pageParams);
   }
 
+  // TODO(DHIS2-18883) Pass EventParams as a parameter
   @Override
   public RelationshipItem getEventInRelationshipItem(@Nonnull UID uid) {
     Event event;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -92,8 +92,7 @@ public interface EventService {
   Page<Event> getEvents(@Nonnull EventOperationParams params, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException;
 
-  RelationshipItem getEventInRelationshipItem(UID uid, EventParams eventParams)
-      throws NotFoundException;
+  RelationshipItem getEventInRelationshipItem(UID uid) throws NotFoundException;
 
   /**
    * Fields the {@link #getEvents(EventOperationParams)} and {@link #getEvents(EventOperationParams,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -487,6 +487,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
    * @return the TE object if found and accessible by the current user or null otherwise
    * @throws NotFoundException if uid does not exist
    */
+  // TODO(DHIS2-18883) Pass TrackedEntityParams as a parameter
   private RelationshipItem getTrackedEntityInRelationshipItem(String uid) throws NotFoundException {
     RelationshipItem relationshipItem = new RelationshipItem();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -68,7 +68,6 @@ import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggregate;
 import org.hisp.dhis.user.UserDetails;
@@ -474,9 +473,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     } else if (item.getEnrollment() != null) {
       result = enrollmentService.getEnrollmentInRelationshipItem(UID.of(item.getEnrollment()));
     } else if (item.getEvent() != null) {
-      result =
-          eventService.getEventInRelationshipItem(
-              UID.of(item.getEvent()), EventParams.TRUE.withIncludeRelationships(false));
+      result = eventService.getEventInRelationshipItem(UID.of(item.getEvent()));
     }
 
     return result;

--- a/dhis-2/dhis-test-web-api/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/tracker/event_and_enrollment.json
@@ -1169,6 +1169,19 @@
       "to": {
         "enrollment": "nxP7UnKhomJ"
       }
+    },
+    {
+      "relationship": "rSXvGDlJRBT",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "xLmPUYJX8Ks"
+      },
+      "from": {
+        "trackedEntity": "guVNoAerxWo"
+      },
+      "to": {
+        "enrollment": "nxP7UnKhomJ"
+      }
     }
   ],
   "username": "system-process"


### PR DESCRIPTION
When retrieving an enrollment for a relationship item the events were always excluded.
This PR changes the fields that need to be retrieved for enrollment inside a relationship and ensures that the enrollment and the underneath events are not showing their relationships to avoid any possible cycle.