### PR TITLE
Fix Enrollment aggregate CTE with Query Item filter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
@@ -128,8 +128,8 @@ public class CteContext {
    * Adds a CTE definition to the context that represents a filter for a specific query item. The
    * name of the CTE is computed based on the query item.
    *
-   * @param item The query item
-   * @param cteDefinition The CTE definition (the SQL query)
+   * @param item the query item
+   * @param cteDefinition the CTE definition (the SQL query)
    */
   public void addCteFilter(QueryItem item, String cteDefinition) {
     addCteFilter(computeKey(item), item, cteDefinition);
@@ -138,8 +138,8 @@ public class CteContext {
   /**
    * Adds a CTE definition to the context that represents a filter for a specific query item.
    *
-   * @param key The key of the CTE definition
-   * @param item The query item
+   * @param key the key of the CTE definition
+   * @param item the query item
    * @param cteDefinition The CTE definition (the SQL query)
    */
   public void addCteFilter(String key, QueryItem item, String cteDefinition) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
@@ -124,8 +124,25 @@ public class CteContext {
         new CteDefinition(programIndicator.getUid(), cteDefinition, functionRequiresCoalesce));
   }
 
-  public void addCteFilter(QueryItem item, String ctedefinition) {
-    String key = computeKey(item);
+  /**
+   * Adds a CTE definition to the context that represents a filter for a specific query item. The
+   * name of the CTE is computed based on the query item.
+   *
+   * @param item The query item
+   * @param cteDefinition The CTE definition (the SQL query)
+   */
+  public void addCteFilter(QueryItem item, String cteDefinition) {
+    addCteFilter(computeKey(item), item, cteDefinition);
+  }
+
+  /**
+   * Adds a CTE definition to the context that represents a filter for a specific query item.
+   *
+   * @param key The key of the CTE definition
+   * @param item The query item
+   * @param cteDefinition The CTE definition (the SQL query)
+   */
+  public void addCteFilter(String key, QueryItem item, String cteDefinition) {
     if (!cteDefinitions.containsKey(key)) {
       ProgramStage programStage = item.getProgramStage();
       cteDefinitions.put(
@@ -133,7 +150,7 @@ public class CteContext {
           new CteDefinition(
               item.getItemId(),
               programStage == null ? null : programStage.getUid(),
-              ctedefinition,
+              cteDefinition,
               true));
     }
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1477,6 +1477,24 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   }
 
   /**
+   * Transforms the query item filters into an "and" separated SQL string. For instance, if the
+   * query item has filters with values "a" and "b" and the operator is "eq", the resulting SQL
+   * string will be "column = 'a' and column = 'b'". If the query item has no filters, an empty
+   * string is returned.
+   *
+   * @param item the {@link QueryItem}.
+   * @param columnName the column name.
+   * @return the SQL string.
+   */
+  protected String extractFiltersAsSql(QueryItem item, String columnName) {
+    return item.getFilters().stream()
+        .map(
+            f ->
+                "%s %s %s".formatted(columnName, f.getOperator().getValue(), getSqlFilter(f, item)))
+        .collect(Collectors.joining(" and "));
+  }
+
+  /**
    * Returns a select SQL clause for the given query.
    *
    * @param params the {@link EventQueryParams}.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/EventQueryParamsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/EventQueryParamsUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.common.QueryItem;
+
+@UtilityClass
+public class EventQueryParamsUtils {
+
+  /**
+   * Get all program indicators from event query params.
+   *
+   * @param params event query params
+   * @return list of program indicators
+   */
+  public static List<QueryItem> getProgramIndicators(EventQueryParams params) {
+    return params.getItems().stream().filter(QueryItem::isProgramIndicator).toList();
+  }
+
+  /**
+   * Remove program stage items from EventQueryParams. This method creates a copy of the
+   * EventQueryParams instance and filters out QueryItems with hasProgramStage == true.
+   *
+   * @param params event query params
+   * @return list of program stage items
+   */
+  public static EventQueryParams withoutProgramStageItems(EventQueryParams params) {
+    // Create a copy of the EventQueryParams instance
+    EventQueryParams.Builder builder = new EventQueryParams.Builder(params);
+
+    // Filter out QueryItems with hasProgramStage == true
+    List<QueryItem> filteredItems =
+        params.getItems().stream().filter(item -> !item.hasProgramStage()).toList();
+
+    // Clear the current items and itemFilters in the builder
+    builder.removeItems(); // Clears the items
+
+    for (QueryItem item : filteredItems) {
+      builder.addItem(item);
+    }
+
+    return builder.build();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/EventQueryParamsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/EventQueryParamsUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.common.QueryItem;
+import org.junit.jupiter.api.Test;
+
+class EventQueryParamsUtilsTest {
+  @Test
+  void testWithoutProgramStageItems() {
+    // Create mock QueryItems
+    QueryItem item1 = mock(QueryItem.class);
+    QueryItem item2 = mock(QueryItem.class);
+    QueryItem item3 = mock(QueryItem.class);
+
+    // Set behavior for hasProgramStage()
+    when(item1.hasProgramStage()).thenReturn(false); // This item should be retained
+    when(item2.hasProgramStage()).thenReturn(true); // This item should be removed
+    when(item3.hasProgramStage()).thenReturn(false); // This item should be retained
+
+    // Create an EventQueryParams instance with these items
+    EventQueryParams originalParams =
+        new EventQueryParams.Builder().addItem(item1).addItem(item2).addItem(item3).build();
+
+    // Apply the method under test
+    EventQueryParams resultParams = EventQueryParamsUtils.withoutProgramStageItems(originalParams);
+
+    // Assert the resulting params contain only the filtered items
+    List<QueryItem> resultItems = resultParams.getItems();
+    assertEquals(2, resultItems.size());
+    assertTrue(resultItems.contains(item1));
+    assertTrue(resultItems.contains(item3));
+    assertFalse(resultItems.contains(item2));
+  }
+}


### PR DESCRIPTION
## Summary  
This PR addresses an issue with Enrollment Aggregated SQL queries that utilize Common Table Expressions (CTEs) in the context of filtering. The existing query structure was not compatible with Apache Doris  when filters were applied, such as `pTo4uMt3xur.oZg33kd9taw:IN:Female`.

![Screenshot of Issue](https://github.com/user-attachments/assets/96d477c7-5f2c-45ca-9cc7-38df7f5513ec)

## Changes  
- Refactored the `enrollment_aggr_base` CTE to move the subquery into a separate dedicated CTE, ensuring compatibility with the Doris database.
- Introduced a new CTE, `latest_event`, to handle the subquery logic independently, which is then referenced by `enrollment_aggr_base`.

```sql
WITH latest_event AS (
	SELECT 
		enrollment,
		`oZg33kd9taw`
	FROM (
		SELECT
			enrollment,
			`oZg33kd9taw`,
			ROW_NUMBER() OVER (
				PARTITION BY enrollment 
				ORDER BY occurreddate DESC, created DESC
			) AS rn
		FROM analytics_event_VBqh0ynB2wv
		WHERE 
			eventstatus != 'SCHEDULE'
			AND ps = 'pTo4uMt3xur'
			AND `oZg33kd9taw` IS NOT NULL
	) ranked
	WHERE rn = 1 AND `oZg33kd9taw` IN ('Female')
),
enrollment_aggr_base AS (
	SELECT
		ax.enrollment,
		ax.uidlevel1,
		ax.enrollmentdate
	FROM analytics_enrollment_vbqh0ynb2wv ax
	INNER JOIN latest_event le 
		ON ax.enrollment = le.enrollment
	WHERE
		ax.enrollmentdate >= '2023-05-29'
		AND ax.enrollmentdate < '2023-08-30'
		AND ax.uidlevel1 = 'ImspTQPwCqd'
),
```
