### PR TITLE
chore:Move relationship handling into RelationshipService [DHIS2-18883]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -152,14 +152,6 @@
       <artifactId>dhis-support-hibernate</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 
@@ -46,8 +45,6 @@ public interface EnrollmentService {
   @Nonnull
   Enrollment getEnrollment(UID uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
-
-  RelationshipItem getEnrollmentInRelationshipItem(UID uid) throws NotFoundException;
 
   /** Get all enrollments matching given params. */
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -227,8 +227,8 @@ class DefaultEventService implements EventService {
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     List<Event> events = eventStore.getEvents(queryParams);
-    for (Event event : events) {
-      if (operationParams.getEventParams().isIncludeRelationships()) {
+    if (operationParams.getEventParams().isIncludeRelationships()) {
+      for (Event event : events) {
         event.setRelationshipItems(
             relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
       }
@@ -243,8 +243,8 @@ class DefaultEventService implements EventService {
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     Page<Event> events = eventStore.getEvents(queryParams, pageParams);
-    for (Event event : events.getItems()) {
-      if (operationParams.getEventParams().isIncludeRelationships()) {
+    if (operationParams.getEventParams().isIncludeRelationships()) {
+      for (Event event : events.getItems()) {
         event.setRelationshipItems(
             relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -218,11 +218,6 @@ class DefaultEventService implements EventService {
     }
     event.setEventDataValues(dataValues);
 
-    if (eventParams.isIncludeRelationships()) {
-      event.setRelationshipItems(
-          relationshipService.getRelationshipItems(TrackerType.EVENT, eventUid));
-    }
-
     return event;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -51,16 +51,15 @@ import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,6 +83,8 @@ class DefaultEventService implements EventService {
   private final FileResourceService fileResourceService;
 
   private final EventOperationParamsMapper paramsMapper;
+
+  private final RelationshipService relationshipService;
 
   @Override
   public FileResourceStream getFileResource(@Nonnull UID event, @Nonnull UID dataElement)
@@ -161,25 +162,15 @@ class DefaultEventService implements EventService {
 
   @Override
   public Event getEvent(@Nonnull UID event) throws ForbiddenException, NotFoundException {
-    return getEvent(
-        event, TrackerIdSchemeParams.builder().build(), EventParams.FALSE, getCurrentUserDetails());
+    return getEvent(event, TrackerIdSchemeParams.builder().build(), EventParams.FALSE);
   }
 
   @Override
   public Event getEvent(
-      @Nonnull UID event,
+      @Nonnull UID eventUid,
       @Nonnull TrackerIdSchemeParams idSchemeParams,
       @Nonnull EventParams eventParams)
       throws ForbiddenException, NotFoundException {
-    return getEvent(event, idSchemeParams, eventParams, getCurrentUserDetails());
-  }
-
-  private Event getEvent(
-      @Nonnull UID eventUid,
-      @Nonnull TrackerIdSchemeParams idSchemeParams,
-      @Nonnull EventParams eventParams,
-      @Nonnull UserDetails user)
-      throws NotFoundException, ForbiddenException {
     Page<Event> events;
     try {
       EventOperationParams operationParams =
@@ -228,16 +219,8 @@ class DefaultEventService implements EventService {
     event.setEventDataValues(dataValues);
 
     if (eventParams.isIncludeRelationships()) {
-      Set<RelationshipItem> relationshipItems = new HashSet<>();
-      for (RelationshipItem relationshipItem : event.getRelationshipItems()) {
-        Relationship daoRelationship = relationshipItem.getRelationship();
-        if (trackerAccessManager.canRead(user, daoRelationship).isEmpty()
-            && (!daoRelationship.isDeleted())) {
-          relationshipItems.add(relationshipItem);
-        }
-      }
-
-      event.setRelationshipItems(relationshipItems);
+      event.setRelationshipItems(
+          relationshipService.getRelationshipItems(TrackerType.EVENT, eventUid));
     }
 
     return event;
@@ -248,7 +231,14 @@ class DefaultEventService implements EventService {
   public List<Event> getEvents(@Nonnull EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
-    return eventStore.getEvents(queryParams);
+    List<Event> events = eventStore.getEvents(queryParams);
+    for (Event event : events) {
+      if (operationParams.getEventParams().isIncludeRelationships()) {
+        event.setRelationshipItems(
+            relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
+      }
+    }
+    return events;
   }
 
   @Nonnull
@@ -257,27 +247,14 @@ class DefaultEventService implements EventService {
       @Nonnull EventOperationParams operationParams, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
-    return eventStore.getEvents(queryParams, pageParams);
-  }
-
-  // TODO(DHIS2-18883) Pass EventParams as a parameter
-  @Override
-  public RelationshipItem getEventInRelationshipItem(@Nonnull UID uid) {
-    Event event;
-    try {
-      event =
-          getEvent(
-              uid,
-              TrackerIdSchemeParams.builder().build(),
-              EventParams.TRUE.withIncludeRelationships(false));
-    } catch (NotFoundException | ForbiddenException e) {
-      // events are not shown in relationships if the user has no access to them
-      return null;
+    Page<Event> events = eventStore.getEvents(queryParams, pageParams);
+    for (Event event : events.getItems()) {
+      if (operationParams.getEventParams().isIncludeRelationships()) {
+        event.setRelationshipItems(
+            relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
+      }
     }
-
-    RelationshipItem relationshipItem = new RelationshipItem();
-    relationshipItem.setEvent(event);
-    return relationshipItem;
+    return events;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.export.FileResourceStream;
@@ -91,8 +90,6 @@ public interface EventService {
   @Nonnull
   Page<Event> getEvents(@Nonnull EventOperationParams params, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException;
-
-  RelationshipItem getEventInRelationshipItem(UID uid) throws NotFoundException;
 
   /**
    * Fields the {@link #getEvents(EventOperationParams)} and {@link #getEvents(EventOperationParams,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -74,12 +74,12 @@ public class DefaultRelationshipService implements RelationshipService {
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
         };
     return relationshipItems.stream()
+        .filter(ri -> !ri.getRelationship().isDeleted())
         .filter(
             ri ->
                 trackerAccessManager
                     .canRead(CurrentUserUtil.getCurrentUserDetails(), ri.getRelationship())
                     .isEmpty())
-        .filter(ri -> !ri.getRelationship().isDeleted())
         .map(RELATIONSHIP_ITEM_MAPPER::map)
         .collect(Collectors.toSet());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export.relationship;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.UID;
@@ -42,11 +43,13 @@ import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
+import org.mapstruct.factory.Mappers;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,10 +57,32 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DefaultRelationshipService implements RelationshipService {
-
+  private static final RelationshipItemMapper RELATIONSHIP_ITEM_MAPPER =
+      Mappers.getMapper(RelationshipItemMapper.class);
   private final TrackerAccessManager trackerAccessManager;
   private final RelationshipStore relationshipStore;
   private final RelationshipOperationParamsMapper mapper;
+
+  // TODO(DHIS2-18883) Pass fields params as a parameter
+  @Override
+  public Set<RelationshipItem> getRelationshipItems(TrackerType trackerType, UID uid) {
+    List<RelationshipItem> relationshipItems =
+        switch (trackerType) {
+          case TRACKED_ENTITY -> relationshipStore.getRelationshipItemsByTrackedEntity(uid);
+          case ENROLLMENT -> relationshipStore.getRelationshipItemsByEnrollment(uid);
+          case EVENT -> relationshipStore.getRelationshipItemsByEvent(uid);
+          case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
+        };
+    return relationshipItems.stream()
+        .filter(
+            ri ->
+                trackerAccessManager
+                    .canRead(CurrentUserUtil.getCurrentUserDetails(), ri.getRelationship())
+                    .isEmpty())
+        .filter(ri -> !ri.getRelationship().isDeleted())
+        .map(RELATIONSHIP_ITEM_MAPPER::map)
+        .collect(Collectors.toSet());
+  }
 
   @Override
   public List<Relationship> getRelationships(@Nonnull RelationshipOperationParams params)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -197,6 +197,43 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeyList).list();
   }
 
+  @Override
+  public List<RelationshipItem> getRelationshipItemsByTrackedEntity(UID trackedEntity) {
+    @Language("hql")
+    String hql =
+        """
+                from RelationshipItem ri
+                where ri.trackedEntity.uid = :trackedEntity
+                """;
+    return getQuery(hql, RelationshipItem.class)
+        .setParameter(TRACKED_ENTITY, trackedEntity.getValue())
+        .list();
+  }
+
+  @Override
+  public List<RelationshipItem> getRelationshipItemsByEnrollment(UID enrollment) {
+    @Language("hql")
+    String hql =
+        """
+                from RelationshipItem ri
+                where ri.enrollment.uid = :enrollment
+                """;
+    return getQuery(hql, RelationshipItem.class)
+        .setParameter(ENROLLMENT, enrollment.getValue())
+        .list();
+  }
+
+  @Override
+  public List<RelationshipItem> getRelationshipItemsByEvent(UID event) {
+    @Language("hql")
+    String hql =
+        """
+                from RelationshipItem ri
+                where ri.event.uid = :event
+                """;
+    return getQuery(hql, RelationshipItem.class).setParameter(EVENT, event.getValue()).list();
+  }
+
   /**
    * Query to extract relationships with the order by clause and pagination if required
    *

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -206,7 +206,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
                 where ri.trackedEntity.uid = :trackedEntity
                 """;
     return getQuery(hql, RelationshipItem.class)
-        .setParameter(TRACKED_ENTITY, trackedEntity.getValue())
+        .setParameter("trackedEntity", trackedEntity.getValue())
         .list();
   }
 
@@ -219,7 +219,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
                 where ri.enrollment.uid = :enrollment
                 """;
     return getQuery(hql, RelationshipItem.class)
-        .setParameter(ENROLLMENT, enrollment.getValue())
+        .setParameter("enrollment", enrollment.getValue())
         .list();
   }
 
@@ -231,7 +231,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
                 from RelationshipItem ri
                 where ri.event.uid = :event
                 """;
-    return getQuery(hql, RelationshipItem.class).setParameter(EVENT, event.getValue()).list();
+    return getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()).list();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipItemMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipItemMapper.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.export;
+package org.hisp.dhis.tracker.export.relationship;
 
 import java.util.List;
 import java.util.Set;
@@ -53,10 +53,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
-// TODO(DHIS2-18883) move this into the relationship service/store
-// double-check that we only map whats needed!
-// We need to ensure we map everything the
-// org.hisp.dhis.webapi.controller.tracker.export.relationship.RelationshipItemMapper needs
 @Mapper(
     uses = {ProgramStageMapper.class, RelationshipTypeMapper.class, TrackedEntityTypeMapper.class})
 public interface RelationshipItemMapper {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.export.PageParams;
 
 public interface RelationshipService {
 
-  /** Get all relationships matching given params. */
+  /** Get all relationship items matching given params. */
   Set<RelationshipItem> getRelationshipItems(TrackerType trackerType, UID uid);
 
   /** Get all relationships matching given params. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -35,10 +35,15 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 
 public interface RelationshipService {
+
+  /** Get all relationships matching given params. */
+  Set<RelationshipItem> getRelationshipItems(TrackerType trackerType, UID uid);
 
   /** Get all relationships matching given params. */
   List<Relationship> getRelationships(RelationshipOperationParams params)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipStore.java
@@ -35,12 +35,19 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 
 public interface RelationshipStore extends IdentifiableObjectStore<Relationship> {
   String ID = RelationshipStore.class.getName();
+
+  List<RelationshipItem> getRelationshipItemsByTrackedEntity(UID trackedEntity);
+
+  List<RelationshipItem> getRelationshipItemsByEnrollment(UID enrollment);
+
+  List<RelationshipItem> getRelationshipItemsByEvent(UID event);
 
   Optional<TrackedEntity> findTrackedEntity(UID trackedEntity);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.collection.CollectionUtils;
@@ -51,9 +50,6 @@ import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.relationship.RelationshipItem;
-import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -61,6 +57,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeStore;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.audit.TrackedEntityAuditService;
 import org.hisp.dhis.tracker.export.FileResourceStream;
@@ -68,7 +65,7 @@ import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggregate;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
@@ -85,8 +82,6 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   private final TrackedEntityTypeStore trackedEntityTypeStore;
 
-  private final AclService aclService;
-
   private final TrackedEntityAuditService trackedEntityAuditService;
 
   private final TrackerAccessManager trackerAccessManager;
@@ -97,7 +92,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   private final EnrollmentService enrollmentService;
 
-  private final EventService eventService;
+  private final RelationshipService relationshipService;
 
   private final FileResourceService fileResourceService;
 
@@ -273,7 +268,11 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       List<Enrollment> enrollments = enrollmentService.getEnrollments(enrollmentOperationParams);
       trackedEntity.setEnrollments(new HashSet<>(enrollments));
     }
-    setRelationshipItems(trackedEntity, trackedEntity, params, false);
+    if (params.isIncludeRelationships()) {
+      trackedEntity.setRelationshipItems(
+          relationshipService.getRelationshipItems(
+              TrackerType.TRACKED_ENTITY, UID.of(trackedEntity)));
+    }
     if (params.isIncludeProgramOwners()) {
       trackedEntity.setProgramOwners(getTrackedEntityProgramOwners(trackedEntity, program));
     }
@@ -358,8 +357,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       List<TrackedEntityIdentifiers> ids,
       TrackedEntityOperationParams operationParams,
       TrackedEntityQueryParams queryParams,
-      UserDetails user)
-      throws NotFoundException {
+      UserDetails user) {
 
     List<TrackedEntity> trackedEntities =
         this.trackedEntityAggregate.find(
@@ -367,10 +365,13 @@ class DefaultTrackedEntityService implements TrackedEntityService {
             operationParams.getTrackedEntityParams(),
             queryParams,
             queryParams.getOrgUnitMode());
-    setRelationshipItems(
-        trackedEntities,
-        operationParams.getTrackedEntityParams(),
-        operationParams.isIncludeDeleted());
+    for (TrackedEntity trackedEntity : trackedEntities) {
+      if (operationParams.getTrackedEntityParams().isIncludeRelationships()) {
+        trackedEntity.setRelationshipItems(
+            relationshipService.getRelationshipItems(
+                TrackerType.TRACKED_ENTITY, UID.of(trackedEntity)));
+      }
+    }
     for (TrackedEntity trackedEntity : trackedEntities) {
       if (operationParams.getTrackedEntityParams().isIncludeProgramOwners()) {
         trackedEntity.setProgramOwners(
@@ -381,130 +382,6 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
     trackedEntityAuditService.addTrackedEntityAudit(SEARCH, user.getUsername(), trackedEntities);
     return trackedEntities;
-  }
-
-  /**
-   * We need to return the full models for relationship items (i.e. trackedEntity, enrollment and
-   * event) in our API. The aggregate stores currently do not support that, so we need to fetch the
-   * entities individually.
-   */
-  private void setRelationshipItems(
-      List<TrackedEntity> trackedEntities, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException {
-    for (TrackedEntity trackedEntity : trackedEntities) {
-      setRelationshipItems(trackedEntity, trackedEntity, params, includeDeleted);
-    }
-  }
-
-  private void setRelationshipItems(
-      TrackedEntity targetTrackedEntity,
-      TrackedEntity sourceTrackedEntity,
-      TrackedEntityParams params,
-      boolean includeDeleted)
-      throws NotFoundException {
-    if (params.isIncludeRelationships()) {
-      targetTrackedEntity.setRelationshipItems(
-          getRelationshipItems(sourceTrackedEntity, includeDeleted));
-    }
-  }
-
-  private Set<RelationshipItem> getRelationshipItems(
-      TrackedEntity trackedEntity, boolean includeDeleted) throws NotFoundException {
-    Set<RelationshipItem> result = new HashSet<>();
-
-    for (RelationshipItem item : trackedEntity.getRelationshipItems()) {
-      RelationshipItem relationshipItem =
-          getRelationshipItem(item, trackedEntity, trackedEntity, includeDeleted);
-      if (relationshipItem != null) {
-        result.add(relationshipItem);
-      }
-    }
-
-    return result;
-  }
-
-  private RelationshipItem getRelationshipItem(
-      RelationshipItem item,
-      BaseIdentifiableObject itemOwner,
-      TrackedEntity trackedEntity,
-      boolean includeDeleted)
-      throws NotFoundException {
-    Relationship rel = item.getRelationship();
-
-    // We cannot use trackerAccessManager.canRead(getCurrentUserDetails(), rel).isEmpty() as at
-    // least the TE items are not hibernate proxies as they come from the aggregate store. At least
-    // check relationship type access.
-    if (!aclService.canDataRead(getCurrentUserDetails(), rel.getRelationshipType())
-        || (!includeDeleted && rel.isDeleted())) {
-      return null;
-    }
-
-    RelationshipItem from = getRelationshipItem(trackedEntity, rel.getFrom());
-    RelationshipItem to = getRelationshipItem(trackedEntity, rel.getTo());
-    if (from == null || to == null) {
-      return null;
-    }
-    from.setRelationship(rel);
-    rel.setFrom(from);
-    to.setRelationship(rel);
-    rel.setTo(to);
-
-    if (rel.getFrom().getTrackedEntity() != null
-        && itemOwner.getUid().equals(rel.getFrom().getTrackedEntity().getUid())) {
-      return from;
-    }
-
-    return to;
-  }
-
-  private RelationshipItem getRelationshipItem(TrackedEntity trackedEntity, RelationshipItem item)
-      throws NotFoundException {
-    // relationships of relationship items are not mapped to JSON so there is no need to fetch them
-    RelationshipItem result = new RelationshipItem();
-
-    if (item.getTrackedEntity() != null) {
-      if (trackedEntity.getUid().equals(item.getTrackedEntity().getUid())) {
-        // only fetch the TE if we do not already have access to it. meaning the TE owns the item
-        // this is just mapping the TE
-        result.setTrackedEntity(trackedEntity);
-      } else {
-        result = getTrackedEntityInRelationshipItem(item.getTrackedEntity().getUid());
-      }
-    } else if (item.getEnrollment() != null) {
-      result = enrollmentService.getEnrollmentInRelationshipItem(UID.of(item.getEnrollment()));
-    } else if (item.getEvent() != null) {
-      result = eventService.getEventInRelationshipItem(UID.of(item.getEvent()));
-    }
-
-    return result;
-  }
-
-  /**
-   * Gets a tracked entity that's part of a relationship item. This method is meant to be used when
-   * fetching relationship items only, because it won't throw an exception if the TE is not
-   * accessible.
-   *
-   * @return the TE object if found and accessible by the current user or null otherwise
-   * @throws NotFoundException if uid does not exist
-   */
-  // TODO(DHIS2-18883) Pass TrackedEntityParams as a parameter
-  private RelationshipItem getTrackedEntityInRelationshipItem(String uid) throws NotFoundException {
-    RelationshipItem relationshipItem = new RelationshipItem();
-
-    TrackedEntity trackedEntity = trackedEntityStore.getByUid(uid);
-    if (trackedEntity == null) {
-      throw new NotFoundException(TrackedEntity.class, uid);
-    }
-
-    UserDetails user = getCurrentUserDetails();
-    if (!trackerAccessManager.canRead(user, trackedEntity).isEmpty()) {
-      return null;
-    }
-
-    trackedEntityAuditService.addTrackedEntityAudit(SEARCH, user.getUsername(), trackedEntity);
-
-    relationshipItem.setTrackedEntity(trackedEntity);
-    return relationshipItem;
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/simple_metadata.json
@@ -1075,6 +1075,7 @@
         }
       ],
       "autoGenerateEvent": true,
+      "enableUserAssignment": true,
       "code": "multi-stage",
       "created": "2022-04-22T05:57:48.383",
       "displayGenerateEventBox": true,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -234,6 +234,9 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     relationshipTypeA.getSharing().setOwner(user);
     manager.save(relationshipTypeA, false);
 
+    enrollmentA = createEnrollment(programA, trackedEntityA, orgUnitA);
+    manager.save(enrollmentA, false);
+
     relationshipA = new Relationship();
     relationshipA.setUid(CodeGenerator.generateUid());
     relationshipA.setRelationshipType(relationshipTypeA);
@@ -249,13 +252,11 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     relationshipA.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(relationshipA));
     manager.save(relationshipA, false);
 
-    enrollmentA = createEnrollment(programA, trackedEntityA, orgUnitA);
-    manager.save(enrollmentA, false);
     eventA = createEvent(programStageA, enrollmentA, orgUnitA);
     eventA.setOccurredDate(incidentDate);
     manager.save(eventA);
     enrollmentA.setEvents(Set.of(eventA));
-    enrollmentA.setRelationshipItems(Set.of(from, to));
+    enrollmentA.setRelationshipItems(Set.of(to));
     manager.update(enrollmentA);
 
     enrollmentB = createEnrollment(programB, trackedEntityB, orgUnitB);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -39,16 +39,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.hisp.dhis.common.UidObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.Relationship;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.util.DateUtils;
 
 public class JsonAssertions {
@@ -61,6 +61,23 @@ public class JsonAssertions {
         () -> assertEquals(expected.getFirstName(), actual.getFirstName(), "firstName"),
         () -> assertEquals(expected.getSurname(), actual.getSurname(), "surname"),
         () -> assertEquals(expected.getDisplayName(), actual.getDisplayName(), "displayName"));
+  }
+
+  public static void assertProgramOwners(
+      List<Enrollment> enrollments, JsonList<JsonProgramOwner> programOwners) {
+    for (Enrollment enrollment : enrollments) {
+      JsonProgramOwner programOwner =
+          programOwners.stream()
+              .filter(po -> po.getProgram().equals(enrollment.getProgram().getIdentifier()))
+              .findFirst()
+              .get();
+      assertAll(
+          () -> assertEquals(enrollment.getOrgUnit().getIdentifier(), programOwner.getOrgUnit()),
+          () ->
+              assertEquals(
+                  enrollment.getTrackedEntity().getValue(), programOwner.getTrackedEntity()),
+          () -> assertEquals(enrollment.getProgram().getIdentifier(), programOwner.getProgram()));
+    }
   }
 
   public static JsonRelationship assertFirstRelationship(
@@ -81,13 +98,13 @@ public class JsonAssertions {
 
   public static void assertRelationship(Relationship expected, JsonRelationship actual) {
     assertFalse(actual.isEmpty(), "relationship should not be empty");
-    assertEquals(expected.getUid(), actual.getRelationship(), "relationship UID");
+    assertEquals(expected.getUid().getValue(), actual.getRelationship(), "relationship UID");
     assertEquals(
-        DateUtils.toIso8601NoTz(expected.getCreatedAtClient()),
+        DateUtils.toIso8601NoTz(DateUtils.fromInstant(expected.getCreatedAtClient())),
         actual.getCreatedAtClient(),
         "createdAtClient date");
     assertEquals(
-        expected.getRelationshipType().getUid(),
+        expected.getRelationshipType().getIdentifier(),
         actual.getRelationshipType(),
         "relationshipType UID");
   }
@@ -102,54 +119,53 @@ public class JsonAssertions {
       Event expected, JsonRelationshipItem actual) {
     JsonRelationshipItem.JsonEvent jsonEvent = actual.getEvent();
     assertFalse(jsonEvent.isEmpty(), "event should not be empty");
-    assertEquals(expected.getUid(), jsonEvent.getEvent(), "event UID");
+    assertEquals(expected.getUid().getValue(), jsonEvent.getEvent(), "event UID");
 
     assertEquals(expected.getStatus().toString(), jsonEvent.getStatus(), "event status");
     assertEquals(
-        expected.getProgramStage().getUid(), jsonEvent.getProgramStage(), "event programStage UID");
+        expected.getProgramStage().getIdentifier(),
+        jsonEvent.getProgramStage(),
+        "event programStage UID");
     assertEquals(
-        expected.getEnrollment().getUid(), jsonEvent.getEnrollment(), "event enrollment UID");
+        expected.getEnrollment().getValue(), jsonEvent.getEnrollment(), "event enrollment UID");
     assertFalse(
         jsonEvent.has("relationships"), "relationships is not returned within relationship items");
-    assertEquals(expected.getEnrollment().getFollowup(), jsonEvent.getFollowUp(), "followUp");
-    assertEquals(expected.getEnrollment().getFollowup(), jsonEvent.getLegacyFollowUp(), "followup");
   }
 
   public static void assertTrackedEntityWithinRelationshipItem(
       TrackedEntity expected, JsonRelationshipItem actual) {
     JsonRelationshipItem.JsonTrackedEntity jsonTe = actual.getTrackedEntity();
     assertFalse(jsonTe.isEmpty(), "trackedEntity should not be empty");
-    assertEquals(expected.getUid(), jsonTe.getTrackedEntity(), "trackedEntity UID");
+    assertEquals(expected.getUid().getValue(), jsonTe.getTrackedEntity(), "trackedEntity UID");
     assertEquals(
-        expected.getTrackedEntityType().getUid(),
+        expected.getTrackedEntityType().getIdentifier(),
         jsonTe.getTrackedEntityType(),
         "trackedEntityType UID");
-    assertEquals(expected.getOrganisationUnit().getUid(), jsonTe.getOrgUnit(), "orgUnit UID");
+    assertEquals(expected.getOrgUnit().getIdentifier(), jsonTe.getOrgUnit(), "orgUnit UID");
     assertFalse(jsonTe.getAttributes().isEmpty(), "attributes should be empty");
     assertFalse(
         jsonTe.has("relationships"), "relationships is not returned within relationship items");
   }
 
-  public static void assertHasOnlyUid(UidObject expected, String member, JsonObject json) {
+  public static void assertHasOnlyUid(UID expected, String member, JsonObject json) {
     JsonObject j = json.getObject(member);
     assertFalse(j.isEmpty(), member + " should not be empty");
     assertHasOnlyMembers(j, member);
-    assertEquals(expected.getUid(), j.getString(member).string(), member + " UID");
+    assertEquals(expected.getValue(), j.getString(member).string(), member + " UID");
   }
 
   public static void assertEnrollmentWithinRelationship(
       Enrollment expected, JsonRelationshipItem actual) {
     JsonRelationshipItem.JsonEnrollment jsonEnrollment = actual.getEnrollment();
     assertFalse(jsonEnrollment.isEmpty(), "enrollment should not be empty");
-    assertEquals(expected.getUid(), jsonEnrollment.getEnrollment(), "enrollment UID");
+    assertEquals(expected.getUid().getValue(), jsonEnrollment.getEnrollment(), "enrollment UID");
     assertEquals(
-        expected.getTrackedEntity().getUid(),
+        expected.getTrackedEntity().getValue(),
         jsonEnrollment.getTrackedEntity(),
         "trackedEntity UID");
-    assertEquals(expected.getProgram().getUid(), jsonEnrollment.getProgram(), "program UID");
-    assertEquals(expected.getFollowup(), jsonEnrollment.getFollowUp(), "followUp");
-    assertEquals(
-        expected.getOrganisationUnit().getUid(), jsonEnrollment.getOrgUnit(), "orgUnit UID");
+    assertEquals(expected.getProgram().getIdentifier(), jsonEnrollment.getProgram(), "program UID");
+    assertEquals(expected.isFollowUp(), jsonEnrollment.getFollowUp(), "followUp");
+    assertEquals(expected.getOrgUnit().getIdentifier(), jsonEnrollment.getOrgUnit(), "orgUnit UID");
     assertFalse(jsonEnrollment.getArray("events").isEmpty(), "events should be empty");
     assertFalse(
         jsonEnrollment.has("relationships"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContains;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEnrollmentWithinRelationship;
@@ -34,12 +35,13 @@ import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEvent
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyUid;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertNoRelationships;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertProgramOwners;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertTrackedEntityWithinRelationshipItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +50,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
@@ -57,22 +60,28 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationR
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.Relationship;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.tracker.JsonDataValue;
 import org.hisp.dhis.webapi.controller.tracker.JsonNote;
+import org.hisp.dhis.webapi.controller.tracker.JsonProgramOwner;
 import org.hisp.dhis.webapi.controller.tracker.JsonRelationship;
+import org.hisp.dhis.webapi.controller.tracker.JsonRelationshipItem;
+import org.hisp.dhis.webapi.controller.tracker.JsonUser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,6 +111,9 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   private Relationship relationship2;
   private TrackedEntity relationship2From;
   private Enrollment relationship2To;
+  private Relationship deletedTEToEnrollmentRelationship;
+  private Relationship deletedTEToEventRelationship;
+  private TrackerObjects trackerObjects;
 
   protected ObjectBundle setUpMetadata(String path) throws IOException {
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
@@ -129,28 +141,35 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     injectSecurityContextUser(importUser);
 
     TrackerImportParams params = TrackerImportParams.builder().build();
-    assertNoErrors(
-        trackerImportService.importTracker(params, fromJson("tracker/event_and_enrollment.json")));
+    trackerObjects = fromJson("tracker/event_and_enrollment.json");
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
 
     manager.flush();
     manager.clear();
 
-    relationship1 = get(Relationship.class, "oLT07jKRu9e");
-    relationship1From = relationship1.getFrom().getTrackedEntity();
+    relationship1 = getRelationship(UID.of("oLT07jKRu9e"));
+    relationship1From = getTrackedEntity(relationship1.getFrom().getTrackedEntity());
     assertNotNull(relationship1From, "test expects 'from' to be a tracked entity");
-    relationship1To = relationship1.getTo().getEvent();
-    assertNotNull(relationship1To, "test expects 'to' to be an event");
+    relationship1To = getEvent(relationship1.getTo().getEvent());
+    assertNotNull(relationship1To.getUid(), "test expects 'to' to be an event");
 
-    relationship2 = get(Relationship.class, "p53a6314631");
-    relationship2From = relationship2.getFrom().getTrackedEntity();
+    relationship2 = getRelationship(UID.of("p53a6314631"));
+    relationship2From = getTrackedEntity(relationship2.getFrom().getTrackedEntity());
     assertNotNull(relationship2From, "test expects 'from' to be a tracked entity");
-    relationship2To = relationship2.getTo().getEnrollment();
+    relationship2To = getEnrollment(relationship2.getTo().getEnrollment());
     assertNotNull(relationship2To, "test expects 'to' to be an enrollment");
-    // for some reason we get a LazyInit exception in an assertion when running all tests if we
-    // don't eagerly fetch like we do here
-    relationship2From.getUid();
-    relationship2To.getUid();
-    relationship2.getRelationshipType().getUid();
+
+    deletedTEToEnrollmentRelationship = getRelationship(UID.of("rSXvGDlJRBT"));
+
+    deletedTEToEventRelationship = getRelationship(UID.of("rq1MGCJ8hlq"));
+
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder()
+                .relationships(
+                    List.of(deletedTEToEventRelationship, deletedTEToEnrollmentRelationship))
+                .build()));
   }
 
   @BeforeEach
@@ -168,8 +187,9 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     assertHasOnlyMembers(
         jsonRelationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
     assertRelationship(relationship1, jsonRelationship);
-    assertHasOnlyUid(relationship1From, "trackedEntity", jsonRelationship.getObject("from"));
-    assertHasOnlyUid(relationship1To, "event", jsonRelationship.getObject("to"));
+    assertHasOnlyUid(
+        relationship1From.getUid(), "trackedEntity", jsonRelationship.getObject("from"));
+    assertHasOnlyUid(relationship1To.getUid(), "event", jsonRelationship.getObject("to"));
   }
 
   @Test
@@ -192,10 +212,13 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             .as(JsonRelationship.class);
 
     assertHasOnlyMembers(jsonRelationship, "relationship", "to");
-    assertEquals(relationship1.getUid(), jsonRelationship.getRelationship(), "relationship UID");
+    assertEquals(
+        relationship1.getUid().getValue(), jsonRelationship.getRelationship(), "relationship UID");
     assertHasOnlyMembers(jsonRelationship.getObject("to"), "event");
     assertEquals(
-        relationship1To.getUid(), jsonRelationship.getTo().getEvent().getEvent(), "event UID");
+        relationship1To.getUid().getValue(),
+        jsonRelationship.getTo().getEvent().getEvent(),
+        "event UID");
   }
 
   @Test
@@ -231,12 +254,12 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     JsonRelationship jsonRelationship =
         assertContains(
             jsonRelationships,
-            rel -> relationship1.getUid().equals(rel.getRelationship()),
+            rel -> relationship1.getUid().getValue().equals(rel.getRelationship()),
             "expected to find relationship " + relationship1.getUid());
 
     assertRelationship(relationship1, jsonRelationship);
-    assertHasOnlyUid(relationship1From, "trackedEntity", jsonRelationship.getFrom());
-    assertHasOnlyUid(relationship1To, "event", jsonRelationship.getTo());
+    assertHasOnlyUid(relationship1From.getUid(), "trackedEntity", jsonRelationship.getFrom());
+    assertHasOnlyUid(relationship1To.getUid(), "event", jsonRelationship.getTo());
   }
 
   @Test
@@ -249,7 +272,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     JsonRelationship jsonRelationship =
         assertContains(
             jsonRelationships,
-            rel -> relationship1.getUid().equals(rel.getRelationship()),
+            rel -> relationship1.getUid().getValue().equals(rel.getRelationship()),
             "expected to find relationship " + relationship1.getUid());
 
     assertRelationship(relationship1, jsonRelationship);
@@ -269,60 +292,44 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     JsonRelationship jsonRelationship =
         assertContains(
             jsonRelationships,
-            rel -> relationship1.getUid().equals(rel.getRelationship()),
+            rel -> relationship1.getUid().getValue().equals(rel.getRelationship()),
             "expected to find relationship " + relationship1.getUid());
 
     assertHasOnlyMembers(jsonRelationship, "relationship", "to");
     assertHasOnlyMembers(jsonRelationship.getTo(), "event");
     assertEquals(
-        relationship1To.getUid(), jsonRelationship.getTo().getEvent().getEvent(), "event UID");
+        relationship1To.getUid().getValue(),
+        jsonRelationship.getTo().getEvent().getEvent(),
+        "event UID");
   }
 
-  // TODO(DHIS2-18883) migrate these tests
-  //  @Test
-  //  void getRelationshipsByEventWithAssignedUser() {
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?event={uid}&fields=from[event[assignedUser]]",
-  // from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonUser user = relationships.get(0).getFrom().getEvent().getAssignedUser();
-  //    assertEquals(owner.getUid(), user.getUid());
-  //    assertEquals(owner.getUsername(), user.getUsername());
-  //  }
-  //  @Test
-  //  void getRelationshipsByEventWithDataValues() {
-  //    TrackedEntity to = trackedEntity();
-  //    Event from = event(enrollment(to));
-  //    from.setEventDataValues(Set.of(new EventDataValue(dataElement.getUid(), "12")));
-  //    Relationship relationship = relationship(from, to);
-  //    RelationshipType type = relationship.getRelationshipType();
-  //
-  //    RelationshipConstraint toConstraint = new RelationshipConstraint();
-  //
-  //    TrackerDataView trackerDataView = new TrackerDataView();
-  //    trackerDataView.setDataElements(new LinkedHashSet<>(Set.of(dataElement.getUid())));
-  //
-  //    toConstraint.setTrackerDataView(trackerDataView);
-  //
-  //    type.setFromConstraint(toConstraint);
-  //
-  //    manager.update(type);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET(
-  //
-  // "/tracker/relationships?event={uid}&fields=from[event[dataValues[dataElement,value]]]",
-  //                from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonDataValue dataValue = relationships.get(0).getFrom().getEvent().getDataValues().get(0);
-  //    assertEquals(dataElement.getUid(), dataValue.getDataElement());
-  //    assertEquals("12", dataValue.getValue());
-  //  }
+  @Test
+  void getRelationshipsByEventWithAssignedUser() {
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?event={uid}&fields=*", "QRYjLTiJTrA")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonUser user = relationships.get(0).getTo().getEvent().getAssignedUser();
+    assertEquals("lPaILkLkgOM", user.getUid());
+    assertEquals("testuser", user.getUsername());
+  }
+
+  @Test
+  void getRelationshipsByEventWithDataValues() {
+    JsonList<JsonRelationship> relationships =
+        GET(
+                "/tracker/relationships?event={uid}&fields=to[event[dataValues[dataElement,value]]]",
+                relationship1To.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonList<JsonDataValue> dataValues = relationships.get(0).getTo().getEvent().getDataValues();
+    dataValues.forEach(
+        dv -> {
+          assertHasOnlyMembers(dv, "dataElement", "value");
+        });
+  }
 
   @Test
   void getRelationshipsByEventWithNotes() {
@@ -336,7 +343,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     JsonRelationship jsonRelationship =
         assertContains(
             jsonRelationships,
-            rel -> relationship1.getUid().equals(rel.getRelationship()),
+            rel -> relationship1.getUid().getValue().equals(rel.getRelationship()),
             "expected to find relationship " + relationship1.getUid());
 
     JsonList<JsonNote> notes = jsonRelationship.getTo().getEvent().getNotes();
@@ -348,8 +355,6 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
   @Test
   void getRelationshipsByEventNotFound() {
-    assertNull(manager.get(Event.class, "Hq3Kc6HK4OZ"), "test expects event not to exist");
-
     assertStartsWith(
         "Event with id Hq3Kc6HK4OZ",
         GET("/tracker/relationships?event=Hq3Kc6HK4OZ").error(HttpStatus.NOT_FOUND).getMessage());
@@ -364,8 +369,8 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
     JsonRelationship jsonRelationship = assertFirstRelationship(relationship2, jsonRelationships);
     assertHasOnlyMembers(jsonRelationship, "relationship", "relationshipType", "from", "to");
-    assertHasOnlyUid(relationship2From, "trackedEntity", jsonRelationship.getFrom());
-    assertHasOnlyUid(relationship2To, "enrollment", jsonRelationship.getTo());
+    assertHasOnlyUid(relationship2From.getUid(), "trackedEntity", jsonRelationship.getFrom());
+    assertHasOnlyUid(relationship2To.getUid(), "enrollment", jsonRelationship.getTo());
   }
 
   @Test
@@ -380,28 +385,24 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     assertEnrollmentWithinRelationship(relationship2To, jsonRelationship.getTo());
   }
 
-  // TODO(DHIS2-18883) migrate these tests
-  //  @Test
-  //  void getRelationshipsByEnrollmentWithEvents() {
-  //    Enrollment from = enrollment(trackedEntity());
-  //    Event to = event(from);
-  //    relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET(
-  //
-  // "/tracker/relationships?enrollment={uid}&fields=from[enrollment[events[enrollment,event]]]",
-  //                from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonRelationshipItem.JsonEvent event =
-  //        relationships.get(0).getFrom().getEnrollment().getEvents().get(0);
-  //    assertEquals(from.getUid(), event.getEnrollment());
-  //    assertEquals(to.getUid(), event.getEvent());
-  //  }
-  //
+  @Test
+  void getRelationshipsByEnrollmentWithEvents() {
+    JsonList<JsonRelationship> relationships =
+        GET(
+                "/tracker/relationships?enrollment={uid}&fields=to[enrollment[events[enrollment,event]]]",
+                relationship2To.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonRelationshipItem.JsonEvent event =
+        relationships.get(0).getTo().getEnrollment().getEvents().get(0);
+    assertEquals(relationship2To.getUid().getValue(), event.getEnrollment());
+    assertEquals(
+        getEventsByEnrollment(UID.of(event.getEnrollment())).get(0).getEvent().getValue(),
+        event.getEvent());
+    assertHasOnlyMembers(event, "enrollment", "event");
+  }
+
   //  @Test
   //  void getRelationshipsByEnrollmentWithAttributes() {
   //    TrackedEntity to = trackedEntity();
@@ -437,30 +438,30 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   //    assertEquals("12", attribute.getValue());
   //  }
   //
-  //  @Test
-  //  void getRelationshipsByEnrollmentWithNotes() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    from.setNotes(List.of(note("oqXG28h988k", "my notes", owner.getUid())));
-  //    relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?enrollment={uid}&fields=from[enrollment[notes]]",
-  // from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonNote note = relationships.get(0).getFrom().getEnrollment().getNotes().get(0);
-  //    assertEquals("oqXG28h988k", note.getNote());
-  //    assertEquals("my notes", note.getValue());
-  //    assertEquals(owner.getUid(), note.getStoredBy());
-  //  }
+  @Test
+  void getRelationshipsByEnrollmentWithNotes() {
+    JsonList<JsonRelationship> jsonRelationships =
+        GET(
+                "/tracker/relationships?enrollment={uid}&fields=relationship,to[enrollment[notes]]",
+                relationship2To.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonRelationship jsonRelationship =
+        assertContains(
+            jsonRelationships,
+            rel -> relationship2.getUid().getValue().equals(rel.getRelationship()),
+            "expected to find relationship " + relationship2.getUid());
+
+    JsonList<JsonNote> notes = jsonRelationship.getTo().getEnrollment().getNotes();
+    notes.forEach(
+        note -> {
+          assertHasOnlyMembers(note, "note", "value", "storedAt", "storedBy", "createdBy");
+        });
+  }
 
   @Test
   void getRelationshipsByEnrollmentNotFound() {
-    assertNull(manager.get(Enrollment.class, "Hq3Kc6HK4OZ"), "test expects event not to exist");
-
     assertStartsWith(
         "Enrollment with id Hq3Kc6HK4OZ",
         GET("/tracker/relationships?enrollment=Hq3Kc6HK4OZ")
@@ -478,152 +479,96 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     JsonRelationship jsonRelationship =
         assertContains(
             jsonRelationships,
-            rel -> relationship1.getUid().equals(rel.getRelationship()),
+            rel -> relationship1.getUid().getValue().equals(rel.getRelationship()),
             "expected to find relationship " + relationship1.getUid());
 
     assertRelationship(relationship1, jsonRelationship);
     assertHasOnlyMembers(
         jsonRelationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
-    assertHasOnlyUid(relationship1From, "trackedEntity", jsonRelationship.getFrom());
-    assertHasOnlyUid(relationship1To, "event", jsonRelationship.getTo());
+    assertHasOnlyUid(relationship1From.getUid(), "trackedEntity", jsonRelationship.getFrom());
+    assertHasOnlyUid(relationship1To.getUid(), "event", jsonRelationship.getTo());
   }
 
-  //
-  //  @Test
-  //  void shouldNotGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    assertNoRelationships(
-  //        GET("/tracker/relationships?trackedEntity={te}", to.getUid()).content(HttpStatus.OK));
-  //  }
-  //
-  //  @Test
-  //  void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    assertNoRelationships(
-  //        GET("/tracker/relationships?enrollment={en}", from.getUid()).content(HttpStatus.OK));
-  //  }
-  //
-  //  @Test
-  //  void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Event from = event(enrollment(to));
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    assertNoRelationships(
-  //        GET("/tracker/relationships?event={ev}", from.getUid()).content(HttpStatus.OK));
-  //  }
-  //
-  //  @Test
-  //  void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?trackedEntity={te}&includeDeleted=true", to.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    assertFirstRelationship(r, relationships);
-  //  }
-  //
-  //  @Test
-  //  void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Event from = event(enrollment(to));
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?event={ev}&includeDeleted=true", from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    assertFirstRelationship(r, relationships);
-  //  }
-  //
-  //  @Test
-  //  void shouldGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    Relationship r = relationship(from, to);
-  //
-  //    r.setDeleted(true);
-  //    manager.update(r);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?enrollment={en}&includeDeleted=true", from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    assertFirstRelationship(r, relationships);
-  //  }
-  //
-  //  @Test
-  //  void getRelationshipsByDeprecatedTei() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    Relationship r = relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?tei=" + to.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonObject relationship = assertFirstRelationship(r, relationships);
-  //    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
-  //    assertHasOnlyUid(from.getUid(), "enrollment", relationship.getObject("from"));
-  //    assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
-  //  }
-  //
-  //  @Test
-  //  void getRelationshipsByTrackedEntityWithEnrollments() {
-  //    TrackedEntity to = trackedEntity();
-  //    Enrollment from = enrollment(to);
-  //    relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET(
-  //
-  // "/tracker/relationships?trackedEntity={trackedEntity}&fields=to[trackedEntity[enrollments[enrollment,trackedEntity]]",
-  //                to.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonRelationshipItem.JsonEnrollment enrollment =
-  //        relationships.get(0).getTo().getTrackedEntity().getEnrollments().get(0);
-  //    assertEquals(from.getUid(), enrollment.getEnrollment());
-  //    assertEquals(to.getUid(), enrollment.getTrackedEntity());
-  //  }
-  //
+  @Test
+  void shouldNotGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    assertNoRelationships(
+        GET("/tracker/relationships?trackedEntity={te}", "guVNoAerxWo").content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldNotRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?trackedEntity={te}&includeDeleted=true", "guVNoAerxWo")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEnrollmentRelationship, jsonRelationships);
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    assertNoRelationships(
+        GET("/tracker/relationships?enrollment={en}", "ipBifypAQTo").content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?enrollment={en}&includeDeleted=true", "ipBifypAQTo")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEnrollmentRelationship, jsonRelationships);
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    assertNoRelationships(
+        GET("/tracker/relationships?event={ev}", "LCSfHnurnNB").content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?event={ev}&includeDeleted=true", "LCSfHnurnNB")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEventRelationship, jsonRelationships);
+  }
+
+  @Test
+  void getRelationshipsByDeprecatedTei() {
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?tei={te}", relationship1From.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonObject relationship = relationships.get(0);
+    assertHasOnlyMembers(
+        relationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
+    assertHasOnlyUid(relationship1From.getUid(), "trackedEntity", relationship.getObject("from"));
+    assertHasOnlyUid(relationship1To.getUid(), "event", relationship.getObject("to"));
+  }
+
+  @Test
+  void getRelationshipsByTrackedEntityWithEnrollments() {
+    JsonList<JsonRelationship> relationships =
+        GET(
+                "/tracker/relationships?trackedEntity={trackedEntity}&fields=from[trackedEntity[enrollments[enrollment,trackedEntity]]",
+                relationship1From.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonList<JsonRelationshipItem.JsonEnrollment> enrollments =
+        relationships.get(0).getFrom().getTrackedEntity().getEnrollments();
+    List<Enrollment> enrollmentsByTrackedEntity =
+        getEnrollmentsByTrackedEntity(UID.of(enrollments.get(0).getTrackedEntity()));
+
+    assertEquals(relationship1From.getUid().getValue(), enrollments.get(0).getTrackedEntity());
+    assertContainsOnly(
+        enrollmentsByTrackedEntity.stream().map(e -> e.getEnrollment().getValue()).toList(),
+        enrollments.stream().map(JsonRelationshipItem.JsonEnrollment::getEnrollment).toList());
+    assertHasOnlyMembers(enrollments.get(0), "trackedEntity", "enrollment");
+  }
+
   //  @Test
   //  void getRelationshipsByTrackedEntityAndEnrollmentWithAttributesIsEmpty() {
   //    // Tracked entity attribute values are owned by the tracked entity and only mapped onto the
@@ -677,65 +622,23 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   //    assertContainsAll(List.of("12"), teAttributes, JsonAttribute::getValue);
   //  }
   //
-  //  @Test
-  //  void getRelationshipsByTrackedEntityWithProgramOwners() {
-  //    TrackedEntity to = trackedEntity(orgUnit);
-  //    Enrollment from = enrollment(to);
-  //    to.setProgramOwners(Set.of(new TrackedEntityProgramOwner(to, from.getProgram(), orgUnit)));
-  //    relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET(
-  //
-  // "/tracker/relationships?trackedEntity={trackedEntity}&fields=to[trackedEntity[programOwners]",
-  //                to.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonProgramOwner jsonProgramOwner =
-  //        relationships.get(0).getTo().getTrackedEntity().getProgramOwners().get(0);
-  //    assertEquals(orgUnit.getUid(), jsonProgramOwner.getOrgUnit());
-  //    assertEquals(to.getUid(), jsonProgramOwner.getTrackedEntity());
-  //    assertEquals(from.getProgram().getUid(), jsonProgramOwner.getProgram());
-  //  }
-  //
-  //  @Test
-  //  void getRelationshipsByTrackedEntityRelationshipTeToTe() {
-  //    TrackedEntity from = trackedEntity();
-  //    TrackedEntity to = trackedEntity();
-  //    Relationship r = relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?trackedEntity={trackedEntity}", from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonObject relationship = assertFirstRelationship(r, relationships);
-  //    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
-  //    assertHasOnlyUid(from.getUid(), "trackedEntity", relationship.getObject("from"));
-  //    assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
-  //  }
-  //
-  //  @Test
-  //  void shouldRetrieveRelationshipWhenUserHasAccessToRelationship() {
-  //    TrackedEntity from = trackedEntity();
-  //    TrackedEntity to = trackedEntity();
-  //    Relationship r = relationship(from, to);
-  //    switchContextToUser(user);
-  //
-  //    JsonList<JsonRelationship> relationships =
-  //        GET("/tracker/relationships?trackedEntity={trackedEntity}", from.getUid())
-  //            .content(HttpStatus.OK)
-  //            .getList("relationships", JsonRelationship.class);
-  //
-  //    JsonObject relationship = assertFirstRelationship(r, relationships);
-  //    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
-  //    assertHasOnlyUid(from.getUid(), "trackedEntity", relationship.getObject("from"));
-  //    assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
-  //  }
-  //
+
+  @Test
+  void getRelationshipsByTrackedEntityWithProgramOwners() {
+    JsonList<JsonRelationship> relationships =
+        GET(
+                "/tracker/relationships?trackedEntity={trackedEntity}&fields=from[trackedEntity[programOwners]",
+                relationship1From.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    JsonList<JsonProgramOwner> jsonProgramOwners =
+        relationships.get(0).getFrom().getTrackedEntity().getProgramOwners();
+
+    assertProgramOwners(
+        getEnrollmentsByTrackedEntity(relationship1From.getUid()), jsonProgramOwners);
+  }
+
   //  @Test
   //  void getRelationshipsByTrackedEntityRelationshipsNoAccessToRelationshipType() {
   //    TrackedEntity from = trackedEntity();
@@ -775,35 +678,66 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   //  @Test
   //  void
   //
-  // shouldReturnForbiddenWhenGetRelationshipsByTrackedEntityWithNotAccessibleTrackedEntityType() {
-  //    TrackedEntityType type = trackedEntityTypeNotAccessible();
-  //    TrackedEntity from = trackedEntity(type);
-  //    TrackedEntity to = trackedEntity(type);
-  //    relationship(from, to);
-  //    switchContextToUser(user);
+  //   shouldReturnForbiddenWhenGetRelationshipsByTrackedEntityWithNotAccessibleTrackedEntityType()
+  // {
+  //      TrackedEntityType type = trackedEntityTypeNotAccessible();
+  //      TrackedEntity from = trackedEntity(type);
+  //      TrackedEntity to = trackedEntity(type);
+  //      relationship(from, to);
+  //      switchContextToUser(user);
   //
-  //    assertEquals(
-  //        HttpStatus.FORBIDDEN,
-  //        GET("/tracker/relationships?trackedEntity={trackedEntity}", from.getUid()).status());
-  //  }
-  //
-  //  @Test
-  //  void getRelationshipsByTrackedEntityNotFound() {
-  //    assertStartsWith(
-  //        "TrackedEntity with id Hq3Kc6HK4OZ",
-  //        GET("/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ")
-  //            .error(HttpStatus.NOT_FOUND)
-  //            .getMessage());
-  //  }
+  //      assertEquals(
+  //          HttpStatus.FORBIDDEN,
+  //          GET("/tracker/relationships?trackedEntity={trackedEntity}", from.getUid()).status());
+  //    }
 
-  private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
-    T t = manager.get(type, uid);
-    assertNotNull(
-        t,
-        () ->
-            String.format(
-                "'%s' with uid '%s' should have been created", type.getSimpleName(), uid));
-    return t;
+  @Test
+  void getRelationshipsByTrackedEntityNotFound() {
+    assertStartsWith(
+        "TrackedEntity with id Hq3Kc6HK4OZ",
+        GET("/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ")
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  private TrackedEntity getTrackedEntity(UID trackedEntity) {
+    return trackerObjects.getTrackedEntities().stream()
+        .filter(te -> te.getTrackedEntity().equals(trackedEntity))
+        .findFirst()
+        .get();
+  }
+
+  private Enrollment getEnrollment(UID enrollment) {
+    return trackerObjects.getEnrollments().stream()
+        .filter(en -> en.getEnrollment().equals(enrollment))
+        .findFirst()
+        .get();
+  }
+
+  private List<Enrollment> getEnrollmentsByTrackedEntity(UID trackedEntity) {
+    return trackerObjects.getEnrollments().stream()
+        .filter(en -> en.getTrackedEntity().equals(trackedEntity))
+        .toList();
+  }
+
+  private Event getEvent(UID event) {
+    return trackerObjects.getEvents().stream()
+        .filter(ev -> ev.getEvent().equals(event))
+        .findFirst()
+        .get();
+  }
+
+  private List<Event> getEventsByEnrollment(UID enrollment) {
+    return trackerObjects.getEvents().stream()
+        .filter(ev -> ev.getEnrollment().equals(enrollment))
+        .toList();
+  }
+
+  private Relationship getRelationship(UID relationship) {
+    return trackerObjects.getRelationships().stream()
+        .filter(r -> r.getRelationship().equals(relationship))
+        .findFirst()
+        .get();
   }
 
   public static void assertNoErrors(ImportReport report) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -496,7 +496,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   }
 
   @Test
-  void shouldNotRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+  void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
     JsonList<JsonRelationship> jsonRelationships =
         GET("/tracker/relationships?trackedEntity={te}&includeDeleted=true", "guVNoAerxWo")
             .content(HttpStatus.OK)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContainsAll;
-import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
@@ -1319,5 +1318,29 @@ trackedEntity,trackedEntityType,createdAt,createdAtClient,updatedAt,updatedAtCli
     report.forEachErrorReport(err -> errors.add(err.toString()));
     assertFalse(
         report.hasErrorReports(), String.format("Expected no errors, instead got: %s%n", errors));
+  }
+
+  public static JsonRelationship assertFirstRelationship(
+      Relationship expected, JsonList<JsonRelationship> actual) {
+    assertFalse(actual.isEmpty(), "relationships should not be empty");
+    assertTrue(
+        actual.size() >= 0,
+        String.format("element %d does not exist in %d relationships elements", 0, actual.size()));
+    JsonRelationship jsonRelationship = actual.get(0);
+    assertRelationship(expected, jsonRelationship);
+    return jsonRelationship;
+  }
+
+  public static void assertRelationship(Relationship expected, JsonRelationship actual) {
+    assertFalse(actual.isEmpty(), "relationship should not be empty");
+    assertEquals(expected.getUid(), actual.getRelationship(), "relationship UID");
+    assertEquals(
+        DateUtils.toIso8601NoTz(expected.getCreatedAtClient()),
+        actual.getCreatedAtClient(),
+        "createdAtClient date");
+    assertEquals(
+        expected.getRelationshipType().getUid(),
+        actual.getRelationshipType(),
+        "relationshipType UID");
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/tracker/event_and_enrollment.json
@@ -750,7 +750,11 @@
           },
           "value": "1.5"
         }
-      ]
+      ],
+      "assignedUser": {
+        "uid": "lPaILkLkgOM",
+        "username": "testuser"
+      }
     },
     {
       "event": "kWjSezkXHVp",
@@ -1181,6 +1185,19 @@
       },
       "to": {
         "enrollment": "ipBifypAQTo"
+      }
+    },
+    {
+      "relationship": "rq1MGCJ8hlq",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "from": {
+        "trackedEntity": "H8732208127"
+      },
+      "to": {
+        "event": "LCSfHnurnNB"
       }
     }
   ],


### PR DESCRIPTION
Move relationship handling into `RelationshipService` (Remove all `getRelationshiItems` methods from entity service and centralize them in `RelationshipService`).
Now, all entity services depend on `RelationshipService` to retrieve relationships, and `RelationshipService` itself does not depend on any other entity service.

***Test***
In `TrackedEntitiesExportControllerTest` we are now using `TrackerObjects` to make assertions instead of Hibernate Objects. This way we do not have any issues with the session and we can never experience `LazyLoadInitialization` issues (and we also removed unnecessary DB calls to retrieve Hibernate Objects).

***Next steps***
- Continue to migrate and fix commented tests in `RelationshipsExportControllerTest`.
- Remove `RelationshipStore` interface.
- Pass field params to `RelationshipService` in order to only retrieve from the DB what is needed.
- Check how we should deal with `deleted` entities in `RelationshipService`.
- Check if `trackerDataView` is working.

***Open Questions***
- When `assignedUser` is defined in the payload and the `programStage` has `enableUserAssignment=false` a warning is returned and the `assignedUser` is not persisted. Is this the expected behavior?