### PR TITLE
[WAIT] fix: Issue with missing headers when using Doris analytics database

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
@@ -73,6 +73,16 @@ public class GridHeader implements Serializable {
 
   private String displayColumn;
 
+  /**
+   * Indicates whether this GridHeader is virtual.
+   *
+   * <p>A virtual GridHeader does not correspond to any column in the underlying SQL result set.
+   * Instead, it is used to represent a placeholder or derived value in the grid. Virtual headers
+   * should always be assigned a default or empty value in the grid, and they do not increment the
+   * SQL result set index.
+   */
+  private boolean virtual = false;
+
   @With private transient RepeatableStageParams repeatableStageParams;
 
   // -------------------------------------------------------------------------
@@ -138,6 +148,17 @@ public class GridHeader implements Serializable {
     this.type = valueType.getJavaClass().getName();
     this.hidden = hidden;
     this.meta = meta;
+  }
+
+  public GridHeader(
+      String name,
+      String column,
+      ValueType valueType,
+      boolean hidden,
+      boolean meta,
+      boolean virtual) {
+    this(name, column, valueType, hidden, meta);
+    this.virtual = virtual;
   }
 
   /**
@@ -336,6 +357,11 @@ public class GridHeader implements Serializable {
     }
 
     return repeatableStageParams.getIndex();
+  }
+
+  @JsonProperty
+  public boolean isVirtual() {
+    return virtual;
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1001,7 +1001,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       Grid grid, GridHeader header, int index, SqlRowSet sqlRowSet, EventQueryParams params) {
     // Virtual headers do not contain data
     if (header.isVirtual()) {
-      grid.addValue(header.isNumeric() ? 0L : EMPTY);
+      grid.addValue(EMPTY);
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -999,6 +999,12 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    */
   protected void addGridValue(
       Grid grid, GridHeader header, int index, SqlRowSet sqlRowSet, EventQueryParams params) {
+    // Virtual headers do not contain data
+    if (header.isVirtual()) {
+      grid.addValue(header.isNumeric() ? 0L : EMPTY);
+      return;
+    }
+
     if (Double.class.getName().equals(header.getType()) && !header.hasLegendSet()) {
       Object value = sqlRowSet.getObject(index);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryService.java
@@ -189,11 +189,30 @@ public class EnrollmentQueryService {
         .addHeader(
             new GridHeader(LAST_UPDATED.getItem(), LAST_UPDATED.getName(), DATETIME, false, true));
 
-    if (sqlBuilder.supportsGeospatialData()) {
-      grid.addHeader(new GridHeader(GEOMETRY.getItem(), GEOMETRY.getName(), TEXT, false, true))
-          .addHeader(new GridHeader(LONGITUDE.getItem(), LONGITUDE.getName(), NUMBER, false, true))
-          .addHeader(new GridHeader(LATITUDE.getItem(), LATITUDE.getName(), NUMBER, false, true));
-    }
+    grid.addHeader(
+            new GridHeader(
+                GEOMETRY.getItem(),
+                GEOMETRY.getName(),
+                TEXT,
+                false,
+                true,
+                !sqlBuilder.supportsGeospatialData()))
+        .addHeader(
+            new GridHeader(
+                LONGITUDE.getItem(),
+                LONGITUDE.getName(),
+                NUMBER,
+                false,
+                true,
+                !sqlBuilder.supportsGeospatialData()))
+        .addHeader(
+            new GridHeader(
+                LATITUDE.getItem(),
+                LATITUDE.getName(),
+                NUMBER,
+                false,
+                true,
+                !sqlBuilder.supportsGeospatialData()));
 
     grid.addHeader(
             new GridHeader(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -220,13 +220,27 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
       // The amount of headers must not match to amount of columns due the additional ones
       // describing the repeating of repeatable stage.
       int columnOffset = 0;
+      // Start index for SqlRowSet columns. Starts at 1 (NOT 0, per ResultSet conventions).
+      int sqlIndex = 1;
 
       for (int i = 0; i < grid.getHeaders().size(); ++i) {
-        addGridValue(grid, grid.getHeaders().get(i), i + 1 + columnOffset, rowSet, params);
+        GridHeader header = grid.getHeaders().get(i);
 
-        if (params.isRowContext()) {
-          addValueOriginInfo(grid, rowSet, grid.getHeaders().get(i).getName());
-          columnOffset += getRowSetOriginItems(rowSet, grid.getHeaders().get(i).getName());
+        if (header.isVirtual()) {
+          // Add an empty value for virtual headers and skip incrementing the SQL index.
+          addGridValue(grid, header, -1, rowSet, params);
+        } else {
+          // Process the non-virtual GridHeader and increment SQL index accordingly.
+          addGridValue(grid, header, sqlIndex + columnOffset, rowSet, params);
+
+          // Increment the offset for row context (when applicable)
+          if (params.isRowContext()) {
+            addValueOriginInfo(grid, rowSet, header.getName());
+            columnOffset += getRowSetOriginItems(rowSet, header.getName());
+          }
+
+          // Increment SQL index only for non-virtual headers
+          sqlIndex++;
         }
       }
     }


### PR DESCRIPTION
## Summary  
This PR resolves an issue with non-aggregated analytics SQL queries in Doris/Clickhouse, specifically concerning their inability to process Postgis-related columns like latitude and longitude.

## Changes  
- Introduced the concept of a "virtual grid header" to address the mismatch.
  - A virtual `GridHeader` serves as a placeholder without corresponding to any column in the SQL result set.
  - It ensures the preservation of the original `GridHeaders` by providing default (empty) values in the grid when no underlying data is available.