### PR TITLE
Make `concat` function in Doris to work like Postgres

### DIFF
--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/AbstractSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/AbstractSqlBuilder.java
@@ -303,4 +303,17 @@ public abstract class AbstractSqlBuilder implements SqlBuilder {
   protected <T> String toCommaSeparated(Collection<T> collection, Function<T, String> mapper) {
     return collection.stream().map(mapper).collect(Collectors.joining(","));
   }
+
+  /**
+   * Checks if the given input is quoted.
+   *
+   * @param input the input string.
+   * @return true if the input is quoted, false otherwise.
+   */
+  protected static boolean isQuoted(String input) {
+    return input != null
+        && input.length() >= 2
+        && input.startsWith(SINGLE_QUOTE)
+        && input.endsWith(SINGLE_QUOTE);
+  }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -225,23 +225,6 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
         + ")";
   }
 
-  // Helper Method: Ensures `TRIM(NULLIF(...))` regardless of incoming column formatting
-  private String wrapTrimAndNullIfProperly(String column) {
-    // If the column is a literal, return it as-is
-    if (isQuoted(column)) {
-      return column;
-    }
-
-    // If the column already contains TRIM, insert NULLIF inside TRIM
-    if (column.startsWith("trim(")) {
-      String innerValue = column.substring(5, column.length() - 1);
-      return "trim(nullif('', " + innerValue + "))";
-    }
-
-    // For other cases, apply both TRIM and NULLIF normally
-    return "trim(nullif('', " + column + "))";
-  }
-
   @Override
   public String differenceInSeconds(String columnA, String columnB) {
     return String.format("(unix_timestamp(%s) - unix_timestamp(%s))", columnA, columnB);
@@ -496,6 +479,28 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
             "password", password,
             "connection_url", connectionUrl,
             "driver_filename", driverFilename));
+  }
+
+  /**
+   * Ensures `TRIM(NULLIF(...))` regardless of incoming column formatting
+   *
+   * @param column the column to be wrapped
+   * @return the wrapped column
+   */
+  private String wrapTrimAndNullIfProperly(String column) {
+    // If the column is a literal, return it as-is
+    if (isQuoted(column)) {
+      return column;
+    }
+
+    // If the column already contains TRIM, insert NULLIF inside TRIM
+    if (column.startsWith("trim(")) {
+      String innerValue = column.substring(5, column.length() - 1);
+      return "trim(nullif('', " + innerValue + "))";
+    }
+
+    // For other cases, apply both TRIM and NULLIF
+    return "trim(nullif('', " + column + "))";
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -220,7 +220,7 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
   public String concat(String... columns) {
     return "concat("
         + Arrays.stream(columns)
-            .map(this::wrapTrimAndNullIfProperly) // Adjust wrapping logic
+            .map(this::wrapTrimNullIf) // Adjust wrapping logic
             .collect(Collectors.joining(", "))
         + ")";
   }
@@ -487,7 +487,7 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
    * @param column the column to be wrapped
    * @return the wrapped column
    */
-  private String wrapTrimAndNullIfProperly(String column) {
+  private String wrapTrimNullIf(String column) {
     // If the column is a literal, return it as-is
     if (isQuoted(column)) {
       return column;


### PR DESCRIPTION
## PR Description

This PR resolves compatibility issues with the `concat` function in Apache Doris, which differs from PostgreSQL in handling `NULL` values. In Doris (and MySQL), if any argument in `CONCAT()` is `NULL`, the entire result is `NULL`. 

To address this, dynamic column expressions are now wrapped with `TRIM(NULLIF(...))`, ensuring identical behavior across both databases.