### PR TITLE
chore: Add equals tests for Category, CategoryOption and CategoryOptionCombo

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryComboTest.java
@@ -27,9 +27,16 @@
  */
 package org.hisp.dhis.category;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link CategoryCombo}.
@@ -55,5 +62,39 @@ class CategoryComboTest {
     CategoryCombo category = new CategoryCombo();
     category.setName(CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME + "x");
     Assertions.assertFalse(category.isDefault());
+  }
+
+  @ParameterizedTest
+  @MethodSource("categoryComboEqualsParams")
+  @DisplayName("Category Combo equals check has expected result")
+  void categoryComboEqualsTest(String name, String uid, String code, boolean expectedResult) {
+    CategoryCombo ccParams = new CategoryCombo();
+    ccParams.setName(name);
+    ccParams.setUid(uid);
+    ccParams.setCode(code);
+
+    assertEquals(
+        expectedResult,
+        getCategoryOption().equals(ccParams),
+        "Category Combo equals check has expected result");
+  }
+
+  private static Stream<Arguments> categoryComboEqualsParams() {
+    boolean isEqual = true;
+    boolean isNotEqual = false;
+
+    return Stream.of(
+        Arguments.of("name", "uid", "code", isEqual),
+        Arguments.of("name diff", "uid", "code", isNotEqual),
+        Arguments.of("name", "uid diff", "code", isNotEqual),
+        Arguments.of("name", "uid", "code diff", isNotEqual));
+  }
+
+  private CategoryCombo getCategoryOption() {
+    CategoryCombo cc = new CategoryCombo();
+    cc.setName("name");
+    cc.setUid("uid");
+    cc.setCode("code");
+    return cc;
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryOptionComboTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.hisp.dhis.common.DateRange;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
@@ -41,7 +43,11 @@ import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link CategoryOptionCombo}.
@@ -251,5 +257,84 @@ class CategoryOptionComboTest {
     assertNull(optionComboA.getEarliestEndDate());
     assertEquals(jan4, optionComboB.getEarliestEndDate());
     assertEquals(jan4, optionComboC.getEarliestEndDate());
+  }
+
+  @ParameterizedTest
+  @MethodSource("categoryOptionComboEqualsParams")
+  @DisplayName("CategoryOptionCombo equals check has expected result")
+  void categoryOptionComboEqualsTest(
+      CategoryCombo categoryCombo, Set<CategoryOption> categoryOptions, boolean expectedResult) {
+    CategoryOptionCombo cocParams = new CategoryOptionCombo();
+    cocParams.setCategoryCombo(categoryCombo);
+    cocParams.setCategoryOptions(categoryOptions);
+
+    assertEquals(
+        expectedResult,
+        getCategoryOptionCombo().equals(cocParams),
+        "CategoryOptionCombo equals check has expected result");
+  }
+
+  private static Stream<Arguments> categoryOptionComboEqualsParams() {
+    boolean isEqual = true;
+    boolean isNotEqual = false;
+
+    CategoryCombo sameCatCombo = new CategoryCombo();
+    sameCatCombo.setName("name");
+    sameCatCombo.setUid("uid");
+    sameCatCombo.setCode("code");
+
+    CategoryCombo diffCatCombo = new CategoryCombo();
+    diffCatCombo.setName("name diff");
+    diffCatCombo.setUid("uid");
+    diffCatCombo.setCode("code");
+
+    CategoryOption sameCatOption = new CategoryOption();
+    sameCatOption.setName("name");
+    sameCatOption.setUid("uid");
+    sameCatOption.setCode("code");
+    sameCatOption.setShortName("shortName");
+    sameCatOption.setDescription("description");
+    sameCatOption.setQueryMods(null);
+
+    CategoryOption diffCatOption = new CategoryOption();
+    diffCatOption.setName("name");
+    diffCatOption.setUid("uid diff");
+    diffCatOption.setCode("code");
+    diffCatOption.setShortName("shortName");
+    diffCatOption.setDescription("description");
+    diffCatOption.setQueryMods(null);
+
+    return Stream.of(
+        Arguments.of(sameCatCombo, Set.of(sameCatOption), isEqual),
+        Arguments.of(diffCatCombo, Set.of(sameCatOption), isNotEqual),
+        Arguments.of(sameCatCombo, Set.of(diffCatOption), isNotEqual),
+        Arguments.of(diffCatCombo, Set.of(diffCatOption), isNotEqual));
+  }
+
+  private CategoryOptionCombo getCategoryOptionCombo() {
+    CategoryOptionCombo coc = new CategoryOptionCombo();
+    coc.setName("name");
+    coc.setUid("uid");
+    coc.setCode("code");
+    coc.setShortName("shortName");
+    coc.setDescription("description");
+
+    CategoryOption co = new CategoryOption();
+    co.setName("name");
+    co.setUid("uid");
+    co.setCode("code");
+    co.setShortName("shortName");
+    co.setDescription("description");
+    co.setQueryMods(null);
+
+    CategoryCombo cc = new CategoryCombo();
+    cc.setName("name");
+    cc.setUid("uid");
+    cc.setCode("code");
+
+    coc.setCategoryCombo(cc);
+    coc.addCategoryOption(co);
+
+    return coc;
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/category/CategoryTest.java
@@ -27,9 +27,16 @@
  */
 package org.hisp.dhis.category;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link Category}.
@@ -55,5 +62,51 @@ class CategoryTest {
     Category category = new Category();
     category.setName(Category.DEFAULT_NAME + "x");
     Assertions.assertFalse(category.isDefault());
+  }
+
+  @ParameterizedTest
+  @MethodSource("categoryEqualsParams")
+  @DisplayName("Category equals check has expected result")
+  void categoryEqualsTest(
+      String name,
+      String uid,
+      String code,
+      String shortName,
+      String description,
+      boolean expectedResult) {
+    Category coParams = new Category();
+    coParams.setName(name);
+    coParams.setUid(uid);
+    coParams.setCode(code);
+    coParams.setShortName(shortName);
+    coParams.setDescription(description);
+
+    assertEquals(
+        expectedResult,
+        getCategory().equals(coParams),
+        "Category equals check has expected result");
+  }
+
+  private static Stream<Arguments> categoryEqualsParams() {
+    boolean isEqual = true;
+    boolean isNotEqual = false;
+
+    return Stream.of(
+        Arguments.of("name", "uid", "code", "shortName", "description", isEqual),
+        Arguments.of("name", "uid", "code", "shortName", "description diff", isNotEqual),
+        Arguments.of("name", "uid", "code", "shortName diff", "description", isNotEqual),
+        Arguments.of("name", "uid", "code diff", "shortName", "description", isNotEqual),
+        Arguments.of("name", "uid diff", "code", "shortName", "description", isNotEqual),
+        Arguments.of("name diff", "uid", "code", "shortName", "description", isNotEqual));
+  }
+
+  private Category getCategory() {
+    Category co = new Category();
+    co.setName("name");
+    co.setUid("uid");
+    co.setCode("code");
+    co.setShortName("shortName");
+    co.setDescription("description");
+    return co;
   }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -3083,6 +3083,17 @@ public abstract class TestBase {
     return user;
   }
 
+  /**
+   * This test setup allows easy creation of more realistic {@link CategoryOptionCombo}s. It creates
+   * multiple {@link CategoryOptionCombo}s that mirror how they are created in live code, (creating
+   * {@link Category}s, {@link CategoryOption}s, {@link CategoryCombo}s and then invoking the
+   * generation of {@link CategoryOptionCombo}s through the service). {@link CategoryOptionCombo}s
+   * are always system-generated and never created in isolation, like most other resources. When
+   * system-generated, they always have a {@link CategoryCombo} and {@link CategoryOption}s.
+   *
+   * @param identifier unique identifier to create different objects
+   * @return record of created category types
+   */
   protected static TestCategoryMetadata setupCategoryMetadata(String identifier) {
     // 4 category options
     CategoryOption co1 =


### PR DESCRIPTION
Add `equals` tests for:
  - `Category` ( `equals` criteria)
    - `BaseIdentifiableObject`
      - `uid`
      - `code`
      - `name`
    - `BaseNameableObject`
      - `shortName`
      - `description`
  - `CategoryCombo` ( `equals` criteria)
    - `BaseIdentifiableObject`
      - `uid`
      - `code`
      - `name`
  - `CategoryOptionCombo` ( `equals` criteria)
    - `categoryCombo`
    - `categoryOptions`

