### PR TITLE
fix: SQL condition for program indicator with program stage boundaries (2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -133,12 +133,14 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
     format.applyPattern(Period.DEFAULT_DATE_FORMAT);
 
     String sql = EMPTY;
+    boolean firstIteration = true;
     for (String programStage : map.keySet()) {
       Set<AnalyticsPeriodBoundary> boundaries = map.get(programStage);
 
       String eventTableName = "analytics_event_" + programIndicator.getProgram().getUid();
       sql +=
-          " exists(select 1 from "
+          (firstIteration ? "" : " and ")
+              + " exists(select 1 from "
               + eventTableName
               + " where "
               + eventTableName
@@ -159,6 +161,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
       }
 
       sql += " limit 1)";
+      firstIteration = false;
     }
 
     return sql;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -144,7 +144,10 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
               + eventTableName
               + ".pi = "
               + ANALYTICS_TBL_ALIAS
-              + ".pi and executiondate is not null ";
+              + ".pi and executiondate is not null "
+              + "and ps = '"
+              + programStage
+              + "'";
 
       for (AnalyticsPeriodBoundary boundary : boundaries) {
         sql +=


### PR DESCRIPTION
JIRA Issue: ???

Note: The primary goal of this fix was to include the program stage condition. However, during testing, we also discovered that the generated SQL was invalid when boundaries contained multiple program stages, as the 'AND' operator was missing.