### PR TITLE
fix: Add format Datetime method for Doris [DHIS2-16705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -116,6 +116,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -175,6 +176,8 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   private final DhisConfigurationProvider config;
 
   private final OrganisationUnitResolver organisationUnitResolver;
+
+  private final AnalyticsSqlBuilder analyticsSqlBuilder;
 
   /**
    * Returns a SQL paging clause.
@@ -1050,6 +1053,8 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       } catch (Exception e) {
         grid.addValue(json);
       }
+    } else if (header.getValueType() == ValueType.DATETIME) {
+      grid.addValue(analyticsSqlBuilder.renderTimestamp(sqlRowSet.getString(index)));
     } else {
       grid.addValue(StringUtils.trimToNull(sqlRowSet.getString(index)));
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -101,6 +101,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -152,6 +153,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
       SystemSettingsService settingsService,
       DhisConfigurationProvider config,
       SqlBuilder sqlBuilder,
+      AnalyticsSqlBuilder analyticsSqlBuilder,
       OrganisationUnitResolver organisationUnitResolver) {
     super(
         jdbcTemplate,
@@ -161,7 +163,8 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
         sqlBuilder,
         settingsService,
         config,
-        organisationUnitResolver);
+        organisationUnitResolver,
+        analyticsSqlBuilder);
     this.timeFieldSqlRenderer = timeFieldSqlRenderer;
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -82,6 +82,7 @@ import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -121,6 +122,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
       SystemSettingsService settingsService,
       DhisConfigurationProvider config,
       SqlBuilder sqlBuilder,
+      AnalyticsSqlBuilder analyticsSqlBuilder,
       OrganisationUnitResolver organisationUnitResolver) {
     super(
         jdbcTemplate,
@@ -130,7 +132,8 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
         sqlBuilder,
         settingsService,
         config,
-        organisationUnitResolver);
+        organisationUnitResolver,
+        analyticsSqlBuilder);
     this.timeFieldSqlRenderer = timeFieldSqlRenderer;
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.data.programindicator.DefaultProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
@@ -81,6 +82,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
 
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
+  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+
   @Mock private SystemSettingsService systemSettingsService;
 
   @Mock private OrganisationUnitResolver organisationUnitResolver;
@@ -114,6 +117,7 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
             systemSettingsService,
             config,
             sqlBuilder,
+            analyticsSqlBuilder,
             organisationUnitResolver);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -82,7 +82,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
 
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
-  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+  @Spy
+  private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
 
   @Mock private SystemSettingsService systemSettingsService;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -115,7 +115,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
-  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+  @Spy
+  private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
 
   @Mock private SystemSettingsService systemSettingsService;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -114,6 +115,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
+  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+
   @Mock private SystemSettingsService systemSettingsService;
 
   @Mock private OrganisationUnitResolver organisationUnitResolver;
@@ -154,6 +157,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             systemSettingsService,
             config,
             sqlBuilder,
+            analyticsSqlBuilder,
             organisationUnitResolver);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -96,6 +97,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -123,6 +125,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Mock private SystemSettingsService systemSettingsService;
   @Mock private DhisConfigurationProvider config;
+  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
 
   private static final String DEFAULT_COLUMNS_WITH_REGISTRATION =
       "event,ps,occurreddate,storedby,"
@@ -149,6 +152,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             systemSettingsService,
             config,
             sqlBuilder,
+            analyticsSqlBuilder,
             organisationUnitResolver);
 
     when(jdbcTemplate.queryForRowSet(anyString())).thenReturn(this.rowSet);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -125,7 +125,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Mock private SystemSettingsService systemSettingsService;
   @Mock private DhisConfigurationProvider config;
-  @Spy private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+
+  @Spy
+  private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
 
   private static final String DEFAULT_COLUMNS_WITH_REGISTRATION =
       "event,ps,occurreddate,storedby,"

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/AnalyticsSqlBuilder.java
@@ -27,15 +27,31 @@
  */
 package org.hisp.dhis.db.sql;
 
+import java.time.format.DateTimeFormatter;
+
 /**
  * Interface for resolving specific SQL queries for analytics, that requires custom logic that can't
  * be resolved by the default <code>SqlBuilder</code> implementations.
  */
 public interface AnalyticsSqlBuilder {
+
+  DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
   /**
    * Returns the correct SQL based on the underlying database for fetching the event data values.
    *
    * @return a SQL snippet.
    */
   String getEventDataValues();
+
+  /**
+   * Renders a timestamp string to a format that is compatible with the underlying database. The
+   * returned timestamp format is expected to be in the format "yyyy-MM-dd HH:mm:ss.SSS". In case
+   * the last three digits are zeros, the rendered timestamp is truncated to "yyyy-MM-dd
+   * HH:mm:ss.S".
+   *
+   * @param timestampAsString the timestamp as a string.
+   * @return the timestamp as a string in the correct format.
+   */
+  String renderTimestamp(String timestampAsString);
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickhouseAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickhouseAnalyticsSqlBuilder.java
@@ -32,4 +32,9 @@ public class ClickhouseAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
   public String getEventDataValues() {
     return "ev.eventdatavalues";
   }
+
+  @Override
+  public String renderTimestamp(String timestampAsString) {
+    return timestampAsString;
+  }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
@@ -27,9 +27,23 @@
  */
 package org.hisp.dhis.db.sql;
 
+import java.time.LocalDateTime;
+import org.apache.commons.lang3.StringUtils;
+
 public class DorisAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
   @Override
   public String getEventDataValues() {
     return "ev.eventdatavalues";
+  }
+
+  @Override
+  public String renderTimestamp(String timestampAsString) {
+    if (StringUtils.isEmpty(timestampAsString)) return null;
+    LocalDateTime dateTime = LocalDateTime.parse(timestampAsString);
+    String formattedDate = dateTime.format(TIMESTAMP_FORMATTER);
+    if (formattedDate.endsWith("000")) {
+      formattedDate = formattedDate.substring(0, formattedDate.length() - 2);
+    }
+    return formattedDate;
   }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
@@ -41,9 +41,22 @@ public class DorisAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
     if (StringUtils.isBlank(timestampAsString)) return null;
     LocalDateTime dateTime = LocalDateTime.parse(timestampAsString);
     String formattedDate = dateTime.format(TIMESTAMP_FORMATTER);
-    if (formattedDate.endsWith("000")) {
-      formattedDate = formattedDate.substring(0, formattedDate.length() - 2);
+
+    // Find the position of the decimal point
+    int decimalPoint = formattedDate.lastIndexOf('.');
+    if (decimalPoint != -1) {
+      // Remove trailing zeros after decimal point
+      String millisPart = formattedDate.substring(decimalPoint + 1);
+      millisPart = millisPart.replaceAll("0+$", ""); // Remove all trailing zeros
+
+      // If all digits were zeros, use "0" instead of empty string
+      if (millisPart.isEmpty()) {
+        millisPart = "0";
+      }
+
+      formattedDate = formattedDate.substring(0, decimalPoint + 1) + millisPart;
     }
+
     return formattedDate;
   }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilder.java
@@ -38,7 +38,7 @@ public class DorisAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
 
   @Override
   public String renderTimestamp(String timestampAsString) {
-    if (StringUtils.isEmpty(timestampAsString)) return null;
+    if (StringUtils.isBlank(timestampAsString)) return null;
     LocalDateTime dateTime = LocalDateTime.parse(timestampAsString);
     String formattedDate = dateTime.format(TIMESTAMP_FORMATTER);
     if (formattedDate.endsWith("000")) {

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlAnalyticsSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlAnalyticsSqlBuilder.java
@@ -64,4 +64,9 @@ public class PostgreSqlAnalyticsSqlBuilder implements AnalyticsSqlBuilder {
         group by l2.uid)::jsonb
         """;
   }
+
+  @Override
+  public String renderTimestamp(String timestampAsString) {
+    return timestampAsString;
+  }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.format.DateTimeParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DorisAnalyticsSqlBuilderTest {
+
+  private DorisAnalyticsSqlBuilder sqlBuilder;
+
+  @BeforeEach
+  void setUp() {
+    sqlBuilder = new DorisAnalyticsSqlBuilder();
+  }
+
+  @Test
+  void renderTimestamp_validTimestamp_shouldFormatCorrectly() {
+    String input = "2023-10-20T15:30:45";
+    String expected = "2023-10-20 15:30:45.0";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
+
+  @Test
+  void renderTimestamp_timestampWithZeroMillis_shouldTrimTrailingZeros() {
+    String input = "2023-10-20T15:30:45";
+    String result = sqlBuilder.renderTimestamp(input);
+    assertFalse(result.endsWith("000"));
+    assertTrue(result.endsWith(".0"));
+  }
+
+  @Test
+  void renderTimestamp_timestampWithNonZeroMillis_shouldKeepMillis() {
+    String input = "2023-10-20T15:30:45.123";
+    String expected = "2023-10-20 15:30:45.123";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
+
+  /** Tests that null input returns null output */
+  @Test
+  void renderTimestamp_nullInput_shouldReturnNull() {
+    assertNull(sqlBuilder.renderTimestamp(null));
+  }
+
+  /** Tests that empty string input returns null output */
+  @Test
+  void renderTimestamp_emptyString_shouldReturnNull() {
+    assertNull(sqlBuilder.renderTimestamp(""));
+  }
+
+  /** Tests that blank string input returns null output */
+  @Test
+  void renderTimestamp_blankString_shouldReturnNull() {
+    assertNull(sqlBuilder.renderTimestamp("   "));
+  }
+
+  /** Tests that invalid timestamp format throws appropriate exception */
+  @Test
+  void renderTimestamp_invalidFormat_shouldThrowException() {
+    String invalidInput = "2023-13-45 25:65:99"; // Invalid date/time values
+    assertThrows(DateTimeParseException.class, () -> sqlBuilder.renderTimestamp(invalidInput));
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisAnalyticsSqlBuilderTest.java
@@ -88,4 +88,32 @@ class DorisAnalyticsSqlBuilderTest {
     String invalidInput = "2023-13-45 25:65:99"; // Invalid date/time values
     assertThrows(DateTimeParseException.class, () -> sqlBuilder.renderTimestamp(invalidInput));
   }
+
+  @Test
+  void renderTimestamp_allZeroMillis_shouldTrimToSingleZero() {
+    String input = "2023-10-20T15:30:45.000";
+    String expected = "2023-10-20 15:30:45.0";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
+
+  @Test
+  void renderTimestamp_twoTrailingZeros_shouldTrimBothZeros() {
+    String input = "2023-10-20T15:30:45.400";
+    String expected = "2023-10-20 15:30:45.4";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
+
+  @Test
+  void renderTimestamp_oneTrailingZero_shouldTrimZero() {
+    String input = "2023-10-20T15:30:45.420";
+    String expected = "2023-10-20 15:30:45.42";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
+
+  @Test
+  void renderTimestamp_noTrailingZeros_shouldNotTrim() {
+    String input = "2023-10-20T15:30:45.123";
+    String expected = "2023-10-20 15:30:45.123";
+    assertEquals(expected, sqlBuilder.renderTimestamp(input));
+  }
 }


### PR DESCRIPTION
## Summary  
This PR addresses inconsistencies in datetime rendering between MySql/Apache Doris and Postgres JDBC drivers, ensuring uniform output across analytics databases.

## Changes  
- Standardized the conversion and rendering of `datetime` columns when fetched via the JDBC driver.
- Aligned the format for datetime representation with `2021-11-13 00:00:00.000` across different databases.

