### PR TITLE
feat: move 2FA settings from system settings to configuration

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -217,8 +217,8 @@ public enum ErrorCode {
   E3043(
       "User does not have a verified email, please verify your email before you try to enable 2FA"),
   E3044("TOTP 2FA is not enabled"),
-  E3045("Email based 2FA is not enabled in the system settings"),
-  E3046("TOTP 2FA is not enabled in the system settings"),
+  E3045("Email based 2FA is not enabled"),
+  E3046("TOTP 2FA is not enabled"),
   E3047("User is not in TOTP 2FA enrollment mode"),
   E3048("User does not have email 2FA enabled"),
   E3049("Sending 2FA code with email failed"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -722,14 +722,6 @@ public non-sealed interface SystemSettings extends Settings {
     return asString("globalShellAppName", "global-app-shell");
   }
 
-  default boolean getEmail2FAEnabled() {
-    return asBoolean("email2FAEnabled", false);
-  }
-
-  default boolean getTOTP2FAEnabled() {
-    return asBoolean("totp2FAEnabled", true);
-  }
-
   /**
    * @return true if email verification is enforced for all users.
    */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
@@ -42,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.email.EmailResponse;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -79,6 +81,7 @@ public class TwoFactorAuthService {
   private final MessageSender emailMessageSender;
   private final UserSettingsService userSettingsService;
   private final I18nManager i18nManager;
+  private final DhisConfigurationProvider configurationProvider;
 
   /**
    * Enroll user in time-based one-time password (TOTP) 2FA authentication.
@@ -94,7 +97,7 @@ public class TwoFactorAuthService {
     if (user.isTwoFactorEnabled()) {
       throw new ConflictException(ErrorCode.E3022);
     }
-    if (!settingsProvider.getCurrentSettings().getTOTP2FAEnabled()) {
+    if (!configurationProvider.isEnabled(ConfigurationKey.TOTP_2FA_ENABLED)) {
       throw new ConflictException(ErrorCode.E3046);
     }
     String totpSeed = Base32.encode(generateSecureRandomBytes(20));
@@ -117,7 +120,7 @@ public class TwoFactorAuthService {
     if (user.isTwoFactorEnabled()) {
       throw new ConflictException(ErrorCode.E3022);
     }
-    if (!settingsProvider.getCurrentSettings().getEmail2FAEnabled()) {
+    if (!configurationProvider.isEnabled(ConfigurationKey.EMAIL_2FA_ENABLED)) {
       throw new ConflictException(ErrorCode.E3045);
     }
     if (!userService.isEmailVerified(user)) {
@@ -304,7 +307,7 @@ public class TwoFactorAuthService {
 
   @NonTransactional
   public @Nonnull byte[] generateQRCode(@Nonnull User currentUser) throws ConflictException {
-    if (!settingsProvider.getCurrentSettings().getTOTP2FAEnabled()) {
+    if (!configurationProvider.isEnabled(ConfigurationKey.TOTP_2FA_ENABLED)) {
       throw new ConflictException(ErrorCode.E3046);
     }
     if (!TwoFactorType.ENROLLING_TOTP.equals(currentUser.getTwoFactorType())) {

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -93,7 +93,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(146, keys.size());
+    assertEquals(144, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -694,7 +694,13 @@ public enum ConfigurationKey {
    * The maximum number of possible category combination. This is computed by multiplying the number
    * of options in each category in a category combo with each other.
    */
-  METADATA_CATEGORIES_MAX_COMBINATIONS("metadata.categories.max_combinations", "500", false);
+  METADATA_CATEGORIES_MAX_COMBINATIONS("metadata.categories.max_combinations", "500", false),
+
+  /** Enable email-based 2FA authentication. (default: false) */
+  EMAIL_2FA_ENABLED("login.security.email_2fa.enabled", Constants.OFF, false),
+
+  /** Enable TOTP-based 2FA authentication. (default: true) */
+  TOTP_2FA_ENABLED("login.security.totp_2fa.enabled", Constants.ON, false);
 
   private final String key;
 

--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -20,3 +20,6 @@ audit.logger=off
 
 # Analytics configuration
 analytics.table.unlogged = on
+
+login.security.totp_2fa.enabled = on
+login.security.email_2fa.enabled = on

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -144,7 +144,6 @@ public class LoginTest {
       enrollAndLoginEmail2FA(username, password);
     } finally {
       // Reset system settings
-      setSystemProperty("email2FAEnabled", "false");
       setSystemProperty("keyEmailHostName", "");
       setSystemProperty("keyEmailPort", "25");
       setSystemProperty("keyEmailUsername", null);
@@ -471,7 +470,6 @@ public class LoginTest {
   // --------------------------------------------------------------------------------------------
 
   private static void configureEmail2FASettings(String cookie) {
-    setSystemPropertyWithCookie("email2FAEnabled", "true", cookie);
     setSystemPropertyWithCookie("keyEmailHostName", SMTP_HOSTNAME, cookie);
     setSystemPropertyWithCookie("keyEmailPort", String.valueOf(smtpPort), cookie);
     setSystemPropertyWithCookie("keyEmailUsername", "nils", cookie);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TwoFactorControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TwoFactorControllerTest.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.external.conf.ConfigurationKey.EMAIL_2FA_ENABLED;
+import static org.hisp.dhis.external.conf.ConfigurationKey.TOTP_2FA_ENABLED;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,6 +54,7 @@ import java.util.Base64;
 import java.util.List;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -59,7 +62,6 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessage;
 import org.hisp.dhis.security.twofa.TwoFactorAuthService;
 import org.hisp.dhis.security.twofa.TwoFactorType;
-import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.SystemUser;
@@ -84,22 +86,21 @@ import org.springframework.transaction.annotation.Transactional;
 class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private TwoFactorAuthService twoFactorAuthService;
-  @Autowired private SystemSettingsService systemSettingsService;
   @Autowired private MessageSender emailMessageSender;
+  @Autowired private DhisConfigurationProvider config;
 
   @AfterEach
   void tearDown() {
     emailMessageSender.clearMessages();
-    systemSettingsService.put("email2FAEnabled", "false");
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "off");
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "on");
   }
 
   @Test
   void testEnrollTOTP2FA()
       throws ChecksumException, NotFoundException, DecodingException, IOException, FormatException {
-    User user = makeUser("X", List.of("TEST"));
-    user.setEmail("valid.x@email.com");
-    userService.addUser(user);
-    switchToNewUser(user);
+
+    User user = createUserAndInjectSecurityContext(false);
 
     assertStatus(HttpStatus.OK, POST("/2fa/enrollTOTP2FA"));
     User enrolledUser = userService.getUserByUsername(user.getUsername());
@@ -118,6 +119,8 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
     String code = new Totp(base32Secret).now();
     assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    User enabledUser = userService.getUserByUsername(user.getUsername());
+    assertSame(TwoFactorType.TOTP_ENABLED, enabledUser.getTwoFactorType());
   }
 
   private String decodeBase64QRAndExtractBase32Secret(String base64QRCode)
@@ -156,14 +159,13 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testEnrollEmail2FA() {
-    assertStatus(HttpStatus.OK, POST("/systemSettings/email2FAEnabled?value=true"));
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "on");
 
-    User user = makeUser("X", List.of("TEST"));
+    User user = createUserAndInjectSecurityContext(false);
     String emailAddress = "valid.x@email.com";
     user.setEmail(emailAddress);
     user.setVerifiedEmail(emailAddress);
-    userService.addUser(user);
-    switchToNewUser(user);
+    userService.encodeAndSetPassword(user, "Test123###...");
 
     assertStatus(HttpStatus.OK, POST("/2fa/enrollEmail2FA"));
     User enrolledUser = userService.getUserByUsername(user.getUsername());
@@ -178,6 +180,8 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
     // Extract the 6-digit code from the email
     String code = email.substring(email.indexOf("code:\n") + 6, email.indexOf("code:\n") + 12);
     assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    User enabledUser = userService.getUserByUsername(user.getUsername());
+    assertSame(TwoFactorType.EMAIL_ENABLED, enabledUser.getTwoFactorType());
   }
 
   @Test
@@ -190,18 +194,20 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
     String code = new Totp(user.getSecret()).now();
     assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    User enabledUser = userService.getUserByUsername(user.getUsername());
+    assertSame(TwoFactorType.TOTP_ENABLED, enabledUser.getTwoFactorType());
   }
 
   @Test
   void testEnableEmail2FA() throws ConflictException {
-    assertStatus(HttpStatus.OK, POST("/systemSettings/email2FAEnabled?value=true"));
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "on");
 
-    User user = makeUser("X", List.of("TEST"));
+    User user = createUserAndInjectSecurityContext(false);
     user.setEmail("valid.x@email.com");
     user.setVerifiedEmail("valid.x@email.com");
-    userService.addUser(user);
+    userService.encodeAndSetPassword(user, "Test123###...");
+
     twoFactorAuthService.enrollEmail2FA(user.getUsername());
-    switchToNewUser(user);
 
     User enrolledUser = userService.getUserByUsername(user.getUsername());
     String secret = enrolledUser.getSecret();
@@ -213,15 +219,14 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
     String code = codeAndTTL[0];
     assertStatus(HttpStatus.OK, POST("/2fa/enabled", "{'code':'" + code + "'}"));
+    User enabledUser = userService.getUserByUsername(user.getUsername());
+    assertSame(TwoFactorType.EMAIL_ENABLED, enabledUser.getTwoFactorType());
   }
 
   @Test
   void testEnableTOTP2FAWrongCode() throws ConflictException {
-    User user = makeUser("X", List.of("TEST"));
-    user.setEmail("valid.x@email.com");
-    userService.addUser(user);
+    User user = createUserAndInjectSecurityContext(false);
     twoFactorAuthService.enrollTOTP2FA(user.getUsername());
-    switchToNewUser(user);
 
     assertEquals(
         "Invalid 2FA code",
@@ -255,24 +260,22 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testDisableTOTP2FA() throws ConflictException {
-    User newUser = makeUser("Y", List.of("TEST"));
-    newUser.setEmail("valid.y@email.com");
-    userService.addUser(newUser);
-    twoFactorAuthService.enrollTOTP2FA(newUser.getUsername());
+    User user = createUserAndInjectSecurityContext(false);
+    twoFactorAuthService.enrollTOTP2FA(user.getUsername());
 
-    User user = userService.getUserByUsername(newUser.getUsername());
+    user = userService.getUserByUsername(user.getUsername());
     user.setTwoFactorType(user.getTwoFactorType().getEnabledType());
     userService.updateUser(user, new SystemUser());
 
-    switchToNewUser(newUser);
+    switchToNewUser(user);
 
-    String code = new Totp(newUser.getSecret()).now();
+    String code = new Totp(user.getSecret()).now();
     assertStatus(HttpStatus.OK, POST("/2fa/disable", "{'code':'" + code + "'}"));
   }
 
   @Test
   void testDisableEmail2FA() throws ConflictException {
-    assertStatus(HttpStatus.OK, POST("/systemSettings/email2FAEnabled?value=true"));
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "on");
 
     User newUser = makeUser("Y", List.of("TEST"));
     newUser.setEmail("valid.y@email.com");
@@ -306,11 +309,9 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testDisable2FATooManyTimes() throws ConflictException {
-    User user = makeUser("X", List.of("TEST"));
-    user.setEmail("valid.x@email.com");
+    User user = createUserAndInjectSecurityContext(false);
     userService.addUser(user);
     twoFactorAuthService.enrollTOTP2FA(user.getUsername());
-    switchToNewUser(user);
 
     String code = new Totp(user.getSecret()).now();
     assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
@@ -331,5 +332,121 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
         "ERROR",
         "Too many failed disable attempts. Please try again later",
         POST("/2fa/disable", "{'code':'333333'}").content(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void testEnrollTOTP2FAWhenDisabled() {
+    // Given TOTP 2FA is disabled in config
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "off");
+
+    User user = createUserAndInjectSecurityContext(false);
+
+    // When trying to enroll
+    assertWebMessage(
+        "Conflict",
+        409,
+        "ERROR",
+        "TOTP 2FA is not enabled",
+        POST("/2fa/enrollTOTP2FA").content(HttpStatus.CONFLICT));
+
+    // Then user should not be enrolled
+    User updatedUser = userService.getUserByUsername(user.getUsername());
+    assertEquals(TwoFactorType.NOT_ENABLED, updatedUser.getTwoFactorType());
+  }
+
+  @Test
+  void testEnrollEmail2FAWhenDisabled() {
+    // Given Email 2FA is disabled in config
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "off");
+
+    User user = createUserAndInjectSecurityContext(false);
+    user.setEmail("valid.x@email.com");
+    user.setVerifiedEmail("valid.x@email.com");
+    userService.encodeAndSetPassword(user, "Test123###...");
+
+    // When trying to enroll
+    assertWebMessage(
+        "Conflict",
+        409,
+        "ERROR",
+        "Email based 2FA is not enabled",
+        POST("/2fa/enrollEmail2FA").content(HttpStatus.CONFLICT));
+
+    // Then user should not be enrolled
+    User updatedUser = userService.getUserByUsername(user.getUsername());
+    assertNull(updatedUser.getSecret());
+    assertEquals(TwoFactorType.NOT_ENABLED, updatedUser.getTwoFactorType());
+  }
+
+  @Test
+  void testLoginWithTOTP2FAWhenDisabled() {
+    // Given user has TOTP 2FA enabled
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "on");
+
+    User user = createUserAndInjectSecurityContext(false);
+    userService.encodeAndSetPassword(user, "Test123###...");
+
+    assertStatus(HttpStatus.OK, POST("/2fa/enrollTOTP2FA"));
+    String code = new Totp(user.getSecret()).now();
+    assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    assertEquals(TwoFactorType.TOTP_ENABLED, user.getTwoFactorType());
+
+    // When TOTP 2FA is disabled in config
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "off");
+
+    // Then user should be able to log in without 2FA code
+    assertStatus(
+        HttpStatus.OK,
+        POST(
+            "/auth/login", "{'username':'" + user.getUsername() + "','password':'Test123###...'}"));
+  }
+
+  @Test
+  void testLoginWithEmail2FAWhenDisabled() {
+    // Given user has Email 2FA enabled
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "on");
+
+    User user = createUserAndInjectSecurityContext(false);
+    user.setEmail("valid.x@email.com");
+    user.setVerifiedEmail("valid.x@email.com");
+    userService.encodeAndSetPassword(user, "Test123###...");
+
+    assertStatus(HttpStatus.OK, POST("/2fa/enrollEmail2FA"));
+    User enrolledUser = userService.getUserByUsername(user.getUsername());
+    String code = enrolledUser.getSecret().split("\\|")[0];
+    assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    assertEquals(TwoFactorType.EMAIL_ENABLED, user.getTwoFactorType());
+
+    // When Email 2FA is disabled in config
+    config.getProperties().put(EMAIL_2FA_ENABLED.getKey(), "off");
+
+    // Then user should be able to log in without 2FA code
+    assertStatus(
+        HttpStatus.OK,
+        POST(
+            "/auth/login", "{'username':'" + user.getUsername() + "','password':'Test123###...'}"));
+  }
+
+  @Test
+  void testDisable2FAWhenTypeDisabled() {
+    // Given user has TOTP 2FA enabled
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "on");
+
+    User user = createUserAndInjectSecurityContext(false);
+
+    assertStatus(HttpStatus.OK, POST("/2fa/enrollTOTP2FA"));
+    String code = new Totp(user.getSecret()).now();
+    assertStatus(HttpStatus.OK, POST("/2fa/enable", "{'code':'" + code + "'}"));
+    assertEquals(TwoFactorType.TOTP_ENABLED, user.getTwoFactorType());
+
+    // When TOTP 2FA is disabled in config
+    config.getProperties().put(TOTP_2FA_ENABLED.getKey(), "off");
+
+    // Then user should still be able to disable their 2FA
+    assertStatus(HttpStatus.OK, POST("/2fa/disable", "{'code':'" + code + "'}"));
+
+    User updatedUser = userService.getUserByUsername(user.getUsername());
+    assertNull(updatedUser.getSecret());
+    assertEquals(TwoFactorType.NOT_ENABLED, updatedUser.getTwoFactorType());
   }
 }


### PR DESCRIPTION
## Summary
* Move 2FA settings (`email2FAEnabled` & `totp2FAEnabled)` from system settings into system configuration.
* Make it possible to disable the user's 2FA, even if the 2FA type they enrolled in is disabled.
* If the 2FA type the user was enrolled in is disabled in the configuration, the user will not be prompted for 2FA when logging in.

## Automatic tests
See: TwoFactorControllerTest

## Manual testing steps:
#### Disable enrolled TOTP 2FA if setting is disabled & Observe user is not prompted for 2FA on login:
1. Edit dhis.conf, add `login.security.totp_2fa.enabled = true` and `login.security.email_2fa.enabled = false`
2. Enroll a user in TOTP 2FA
3. Edit dhis.conf, add `login.security.totp_2fa.enabled = false`
4. Restart the server
5. Observe you are not prompted for 2FA on login
6. Disable the user's 2FA
7. Observe it is disabled

#### Disable enrolled EMAIL 2FA if setting is disabled & Observe user is not prompted for 2FA on login:
1. Start (in step 1) with: `login.security.totp_2fa.enabled = false` and `login.security.email_2fa.enabled = true`
2. In step 3, do: `login.security.email_2fa.enabled = false`