### PR TITLE
fix: NPE in notifier test (race condition)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -194,14 +194,14 @@ class NotifierTest {
         .forEach(
             i -> {
               for (Notification notification :
-                  getNotifications(METADATA_IMPORT).get(jobConfig.getUid())) {
+                  notifier.getNotificationsByJobId(METADATA_IMPORT, jobConfig.getUid())) {
                 // Iterate over notifications when new notification are added
                 assertNotNull(notification.getUid());
               }
             });
     awaitTermination(e);
     awaitIdle();
-    assertEquals(101, getNotifications(METADATA_IMPORT).get(jobConfig.getUid()).size());
+    assertEquals(101, notifier.getNotificationsByJobId(METADATA_IMPORT, jobConfig.getUid()).size());
   }
 
   public void awaitTermination(ExecutorService threadPool) {


### PR DESCRIPTION
`getNotificationsByJobType` only contains values for jobs that have data. In this test there was a race condition where the map could be empty when trying to read it. Instead the test now uses `getNotificationsByJobId` which always gives a non-null result.