### PR TITLE
fix: (2.40)Schedule notification in capture app while using system variable

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/DefaultTrackerSideEffectConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/DefaultTrackerSideEffectConverterService.java
@@ -140,7 +140,7 @@ public class DefaultTrackerSideEffectConverterService implements TrackerSideEffe
 
     return TrackerScheduleMessageSideEffect.builder()
         .notification(ruleActionScheduleMessage.notification())
-        .data(ruleActionScheduleMessage.data())
+        .data(ruleEffect.data())
         .build();
   }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-18517

PR fix scheduling of notifications using capture app when date at which notification needs to be sent is provided through system variable for example `V{current_date}`