### PR TITLE
feat: Add integrity check for datasets with same name or shortname

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -21,6 +21,7 @@ checks:
   - datasets/datasets_empty.yaml
   - datasets/datasets_not_assigned_to_org_units.yaml
   - datasets/datasets_custom_data_entry_forms_empty.yaml
+  - datasets/datasets_same_name.yaml
   - orgunits/compulsory_orgunit_groups.yaml
   - orgunits/orgunit_open_date_gt_closed_date.yaml
   - orgunits/orgunits_multiple_spaces.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/datasets/datasets_same_name.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/datasets/datasets_same_name.yaml
@@ -1,0 +1,61 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: datasets_same_name
+description: Datasets with the same name or short name
+section: Data sets
+section_order: 4
+summary_sql: >-
+  select count(*) as value,
+  100*count(*) / NULLIF( (select count(*) from dataset),0) as percent
+  from (
+  SELECT a.uid,a.name,'NAME' as comment from dataset a
+  INNER JOIN (
+  SELECT name, COUNT(uid) from dataset group by name HAVING count(uid) > 1 ) as name_duplicates
+    ON a.name = name_duplicates.name
+  UNION
+    SELECT b.uid,b.shortname as name,'SHORTNAME' as comment from dataset b
+    INNER JOIN (
+    SELECT shortname, COUNT(uid) from dataset group by shortname HAVING count(uid) > 1 ) as shortname_duplicates
+        ON b.shortname = shortname_duplicates.shortname) as duplicates
+details_sql: >-
+  SELECT a.uid,a.name,'NAME' as comment from dataset a
+  INNER JOIN (
+  SELECT name, COUNT(uid) from dataset group by name HAVING count(uid) > 1 ) as name_duplicates
+    ON a.name = name_duplicates.name
+  UNION
+    SELECT b.uid,b.shortname as name,'SHORTNAME' as comment from dataset b
+    INNER JOIN (
+    SELECT shortname, COUNT(uid) from dataset group by shortname HAVING count(uid) > 1 ) as shortname_duplicates
+        ON b.shortname = shortname_duplicates.shortname
+severity: WARNING
+introduction: >
+  While datasets are not required to have unique names, it is generally a good idea to avoid having datasets 
+  with the same name or short name. This can lead to confusion and make it difficult to distinguish between datasets.
+details_id_type: dataSets
+recommendation: >
+    Consider renaming datasets with the same name or short name to make it easier to distinguish between them.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -57,7 +57,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(87, checks.size());
+    assertEquals(88, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2075,6 +2075,7 @@ data_integrity.data_elements_aggregate_no_groups.name=Aggregate data elements no
 data_integrity.data_elements_aggregate_with_different_period_types.name=Aggregate data elements which belong to data sets with different period types.
 data_integrity.data_elements_without_datasets.name=Aggregate data elements not assigned to any data sets
 data_integrity.datasets_empty.name=Data sets with no data elements
+data_integrity.datasets_same_name.name=Data sets with the same name or short name
 data_integrity.datasets_custom_data_entry_forms_empty.name=Datasets which have custom data entry forms which are empty.
 data_integrity.datasets_not_assigned_to_org_units.name=Data sets not assigned to any organisation units
 data_integrity.data_elements_excess_groupset_membership.name=Data elements which belong to multiple groups in a group set.

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 class DataIntegrityDatasetsSameNameControllerTest extends AbstractDataIntegrityIntegrationTest {
 
-  private static final String check = "datasets_same_name";
+  private static final String CHECK_NAME = "datasets_same_name";
 
   @Test
   void testDatasetsSameName() {
@@ -66,11 +66,11 @@ class DataIntegrityDatasetsSameNameControllerTest extends AbstractDataIntegrityI
                     + "'}}"));
 
     assertHasDataIntegrityIssues(
-        "dataSets", check, 100, Set.of(datasetA, datasetB), Set.of("Test"), Set.of("NAME"), true);
+        "dataSets", CHECK_NAME, 100, Set.of(datasetA, datasetB), Set.of("Test"), Set.of("NAME"), true);
   }
 
   @Test
   void testEmptyDataSetsRuns() {
-    assertHasNoDataIntegrityIssues("dataSets", check, false);
+    assertHasNoDataIntegrityIssues("dataSets", CHECK_NAME, false);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+
+import java.util.Set;
+import org.hisp.dhis.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for aggregate datasets which have the same name or short name {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/datasets/datasets_same_name.yaml
+ * }
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityDatasetsSameNameControllerTest extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String check = "datasets_same_name";
+
+  private static final String dataSetUID = "CowXAwmulDG";
+
+  @Test
+  void testDatasetsSameName() {
+
+    String defaultCatCombo = getDefaultCatCombo();
+    String datasetA =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/dataSets",
+                "{ 'name': 'Test', 'shortName': 'Test', 'periodType' : 'Monthly', 'categoryCombo' : {'id': '"
+                    + defaultCatCombo
+                    + "'}}"));
+    String datasetB =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/dataSets",
+                "{ 'name': 'Test', 'shortName': 'Test2', 'periodType' : 'Monthly', 'categoryCombo' : {'id': '"
+                    + defaultCatCombo
+                    + "'}}"));
+
+    assertHasDataIntegrityIssues(
+        "dataSets", check, 100, Set.of(datasetA, datasetB), Set.of("Test"), Set.of("NAME"), true);
+  }
+
+  @Test
+  void testEmptyDataSetsRuns() {
+    assertHasNoDataIntegrityIssues("dataSets", check, false);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
@@ -66,7 +66,13 @@ class DataIntegrityDatasetsSameNameControllerTest extends AbstractDataIntegrityI
                     + "'}}"));
 
     assertHasDataIntegrityIssues(
-        "dataSets", CHECK_NAME, 100, Set.of(datasetA, datasetB), Set.of("Test"), Set.of("NAME"), true);
+        "dataSets",
+        CHECK_NAME,
+        100,
+        Set.of(datasetA, datasetB),
+        Set.of("Test"),
+        Set.of("NAME"),
+        true);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDatasetsSameNameControllerTest.java
@@ -44,8 +44,6 @@ class DataIntegrityDatasetsSameNameControllerTest extends AbstractDataIntegrityI
 
   private static final String check = "datasets_same_name";
 
-  private static final String dataSetUID = "CowXAwmulDG";
-
   @Test
   void testDatasetsSameName() {
 


### PR DESCRIPTION
Adds an integrity check for datasets with the same name or short name. The shortname was made unique and not null [here](https://github.com/dhis2/dhis2-core/commit/ecf7d9990ec39aaeded74cd287633022c7769493) in 2023, but otherwise has been both nullable and non-unique since around 2013. I could not find a corresponding flyway migration script to enforce the uniqueness constraint @jbee , but maybe its there? Anyway, we could have situations where both the name and/or shortname are non-unique. The current thinking is that we should not change the name to being unique for the time being, but at least warn people that this may not be best practice. 