### PR TITLE
fix: make totp url ascii only

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/TwoFactoryAuthenticationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/TwoFactoryAuthenticationUtils.java
@@ -101,16 +101,13 @@ public class TwoFactoryAuthenticationUtils {
    */
   public static String generateQrContent(String appName, User user, Consumer<ErrorCode> errorCode) {
     String secret = user.getSecret();
-
     if (Strings.isNullOrEmpty(secret)) {
       errorCode.accept(E3028);
     }
 
     secret = removeApprovalPrefix(secret);
 
-    String app = (APP_NAME_PREFIX + StringUtils.stripToEmpty(appName)).replace(" ", "%20");
-
-    return generateTOTP2FAURL(app, secret, user.getUsername());
+    return generateTOTP2FAURL(appName, secret, user.getUsername());
   }
 
   /**
@@ -129,7 +126,7 @@ public class TwoFactoryAuthenticationUtils {
     normalizedAppname = normalizedAppname.replaceAll("[^\\p{ASCII}]", "X");
     // truncate to 10 characters
     normalizedAppname = normalizedAppname.substring(0, Math.min(normalizedAppname.length(), 10));
-    String app = ("DHIS2_" + normalizedAppname).replace(" ", "%20");
+    String app = ("DHIS2_" + normalizedAppname).replace(" ", "");
     return String.format("otpauth://totp/%s:%s?secret=%s&issuer=%s", app, username, secret, app);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/TwoFactoryAuthenticationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/TwoFactoryAuthenticationUtils.java
@@ -60,8 +60,6 @@ public class TwoFactoryAuthenticationUtils {
     throw new IllegalStateException("Utility class");
   }
 
-  private static final String APP_NAME_PREFIX = "DHIS 2 ";
-
   /**
    * Generate QR code in PNG format based on given qrContent.
    *

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -111,12 +111,13 @@ public class TwoFactorController {
 
     defaultUserService.generateTwoFactorOtpSecretForApproval(currentUser);
 
-    String appName = systemSettingManager.getStringSetting(SettingKey.APPLICATION_TITLE);
-
     List<ErrorCode> errorCodes = new ArrayList<>();
 
     String qrContent =
-        TwoFactoryAuthenticationUtils.generateQrContent(appName, currentUser, errorCodes::add);
+        TwoFactoryAuthenticationUtils.generateQrContent(
+            systemSettingManager.getStringSetting(SettingKey.APPLICATION_TITLE),
+            currentUser,
+            errorCodes::add);
 
     if (!errorCodes.isEmpty()) {
       throw new WebMessageException(conflict(errorCodes.get(0).getMessage(), errorCodes.get(0)));

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -178,7 +178,7 @@
     <google-api-client.version>2.7.2</google-api-client.version>
     <lombok.version>1.18.36</lombok.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
-    <joda-time.version>2.13.0</joda-time.version>
+    <joda-time.version>2.13.1</joda-time.version>
     <cron-utils.version>9.2.1</cron-utils.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-beanutils.version>1.10.0</commons-beanutils.version>


### PR DESCRIPTION
## Problem
Use of non ASCII characters in the TOTP URI fails.
This makes in impossible to use 2FA with instances that has non ASCII characters in the application title. 

### Cause
The QR code encoder does not support non ASCII characters. 

### Fix
Remove non ASCII characters from the URI.