### PR TITLE
fix: match setting enum names with UPPER_CASE as fallback [DHIS2-18962]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/LazySettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/LazySettings.java
@@ -180,7 +180,15 @@ final class LazySettings implements SystemSettings, UserSettings {
   public <E extends Enum<?>> E asEnum(@Nonnull String key, @Nonnull E defaultValue) {
     Serializable value = orDefault(key, defaultValue);
     if (value != null && value.getClass() == defaultValue.getClass()) return (E) value;
-    return (E) asParseValue(key, defaultValue, raw -> Enum.valueOf(defaultValue.getClass(), raw));
+    return (E) asParseValue(key, defaultValue, raw -> parseEnum(defaultValue.getClass(), raw));
+  }
+
+  private static <E extends Enum<E>> E parseEnum(Class<E> type, String value) {
+    try {
+      return Enum.valueOf(type, value);
+    } catch (IllegalArgumentException ex) {
+      return Enum.valueOf(type, value.toUpperCase());
+    }
   }
 
   @Nonnull
@@ -284,7 +292,7 @@ final class LazySettings implements SystemSettings, UserSettings {
       if (defaultValue instanceof Date) return parseDate(value) != null;
       if (defaultValue instanceof Locale) return LocaleUtils.toLocale(value) != null;
       if (defaultValue instanceof Enum<?>)
-        return Enum.valueOf(((Enum<?>) defaultValue).getDeclaringClass(), value) != null;
+        return parseEnum(((Enum<?>) defaultValue).getDeclaringClass(), value) != null;
       return true;
     } catch (Exception ex) {
       return false;


### PR DESCRIPTION
### Summary
When validating and parsing setting values for properties that use an `enum` first it tries the exact case input. If that fails it tries the UPPER_CASE of the input. This allow input that is case insensitive as long as it has the right letters. Note that this will not turn _camelCase_ or _snake-case_ into _UPPER_CASE_ with the `_` magically appearing. 

### Manual Testing
Note that this must be tested manually as part of working full circle is also that the app can handle the value as it is defined in the enum as that will become the new value even if the parsing allows to input the name in a different case.

* login and goto user settings
* change the _Property to display in analysis modules_ between _Name_ and _Short name_
* confirm the change is applied successful
