### PR TITLE
chore: notifications generate UIDs from timestamps [DHIS2-18885]

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/CodeGeneratorTest.java
@@ -83,4 +83,17 @@ class CodeGeneratorTest {
         CodeGenerator.SECURE_RANDOM_TOKEN_MIN_SIZE,
         (CodeGenerator.getRandomSecureToken()).length());
   }
+
+  @Test
+  void testGenerateUid_Timestamp() {
+    // all numbers are just randomly selected
+    // the main point is that they always generate the same UID
+    // and that very similar numbers generate very different UIDs
+    long time = 33249832492304L;
+    assertEquals("D1dL1bY3aA0", CodeGenerator.generateUid(time));
+    assertEquals("eG9bO6eHB0a", CodeGenerator.generateUid(time + 1));
+    assertEquals("D7dL1bY3aC0", CodeGenerator.generateUid(time + 2));
+    assertEquals("eA9bO6eHB2a", CodeGenerator.generateUid(time + 3));
+    assertEquals("oE9bO8kLK2y", CodeGenerator.generateUid(time - 3933));
+  }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/DefaultNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/DefaultNotifier.java
@@ -32,7 +32,6 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Date;
 import java.util.Deque;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -126,9 +125,9 @@ public class DefaultNotifier implements Notifier {
           Notification n = e.getValue();
           // make sure notifications are at least 1ms apart
           // also, make sure the time is actually reflecting the insert order
-          if (n.getTime().getTime() <= lastTime) n.setTime(new Date(lastTime + 1));
+          if (n.getTimestamp() <= lastTime) n.setTimestamp(lastTime + 1);
           asyncPushToStore(e.getKey(), n);
-          lastTime = n.getTime().getTime();
+          lastTime = n.getTimestamp();
         } else {
           // when there hasn't been any notifications lately
           // the poll times out; it is a good time to run some cleanup
@@ -207,9 +206,9 @@ public class DefaultNotifier implements Notifier {
       JsonValue data) {
     if (id == null || level.isOff()) return this;
 
-    Date now = new Date(clock.getAsLong());
     Notification n =
-        new Notification(level, id.getJobType(), now, message, completed, dataType, data);
+        new Notification(
+            level, id.getJobType(), clock.getAsLong(), message, completed, dataType, data);
 
     try {
       if (!pushToStore.offer(Map.entry(UID.of(id.getUid()), n), 50, TimeUnit.MILLISECONDS))

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
@@ -28,11 +28,11 @@
 package org.hisp.dhis.system.notification;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.Date;
 import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.hisp.dhis.common.CodeGenerator;
@@ -48,104 +48,78 @@ import org.hisp.dhis.scheduling.JobType;
 @ToString(onlyExplicitlyIncluded = true)
 @JacksonXmlRootElement(localName = "notification", namespace = DxfNamespaces.DXF_2_0)
 public class Notification implements Comparable<Notification> {
-  @EqualsAndHashCode.Include private String uid;
 
   @ToString.Include private NotificationLevel level;
-
   @ToString.Include private JobType category;
-
-  @Nonnull @ToString.Include private Date time;
-
+  @ToString.Include @Getter private long timestamp;
   @ToString.Include private String message;
-
   private boolean completed;
-
   private NotificationDataType dataType;
-
   private JsonValue data;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
   public Notification() {
-    this.uid = CodeGenerator.generateUid();
-    this.time = new Date();
+    this.timestamp = System.currentTimeMillis();
   }
 
   public Notification(
       NotificationLevel level,
       JobType category,
-      @Nonnull Date time,
+      long timestamp,
       String message,
       boolean completed,
       NotificationDataType dataType,
       JsonValue data) {
-    this.uid = CodeGenerator.generateUid();
     this.level = level;
     this.category = category;
-    this.time = time;
+    this.timestamp = timestamp;
     this.message = message;
     this.completed = completed;
     this.dataType = dataType;
     this.data = data;
   }
 
-  // -------------------------------------------------------------------------
-  // Get and set
-  // -------------------------------------------------------------------------
-
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public NotificationLevel getLevel() {
     return level;
   }
 
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   public String getId() {
-    return uid;
+    return CodeGenerator.generateUid(timestamp);
   }
 
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   public String getUid() {
-    return uid;
+    return getId();
   }
 
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public JobType getCategory() {
     return category;
   }
 
   @Nonnull
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Date getTime() {
-    return time;
+    return new Date(timestamp);
   }
 
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getMessage() {
     return message;
   }
 
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isCompleted() {
     return completed;
   }
 
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public NotificationDataType getDataType() {
     return dataType;
   }
 
   @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public JsonValue getData() {
     return data;
   }
@@ -165,7 +139,7 @@ public class Notification implements Comparable<Notification> {
       return category.compareTo(other.category);
     }
     // flip this/other => newest first
-    int result = other.time.compareTo(time);
+    int result = Long.compare(other.timestamp, timestamp);
 
     if (result != 0) return result;
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifierStore.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifierStore.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.system.notification;
 
 import static java.lang.System.currentTimeMillis;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -184,14 +183,12 @@ public class RedisNotifierStore implements NotifierStore {
       JsonString level = src.getString("level");
       dest.setLevel(
           level.isUndefined() ? NotificationLevel.INFO : level.parsed(NotificationLevel::valueOf));
-      String id = src.getString("id").string();
-      dest.setUid(id);
       dest.setCompleted(src.getBoolean("completed").booleanValue(false));
       JsonValue time = src.get("time");
-      dest.setTime(
+      dest.setTimestamp(
           time.isNumber()
-              ? new Date(time.as(JsonNumber.class).longValue())
-              : DateUtils.parseDate(time.as(JsonString.class).string()));
+              ? time.as(JsonNumber.class).longValue()
+              : DateUtils.parseDate(time.as(JsonString.class).string()).getTime());
       dest.setMessage(src.getString("message").string());
       dest.setDataType(src.getString("dataType").parsed(NotificationDataType::valueOf));
       JsonValue data = src.get("data");
@@ -211,9 +208,7 @@ public class RedisNotifierStore implements NotifierStore {
     private String toJson(Notification n) {
       return Json.object(
               obj -> {
-                obj.addString("id", n.getId())
-                    .addNumber("time", n.getTime().getTime())
-                    .addString("message", n.getMessage());
+                obj.addNumber("time", n.getTimestamp()).addString("message", n.getMessage());
                 if (n.getLevel() != NotificationLevel.INFO)
                   obj.addString("level", n.getLevel().name());
                 if (n.isCompleted()) obj.addBoolean("completed", true);

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationTest.java
@@ -77,7 +77,7 @@ class NotificationTest {
   private Notification createNotificationWithTime(Date now) {
     Notification notification = new Notification();
     notification.setCategory(JobType.ACCOUNT_EXPIRY_ALERT);
-    notification.setTime(now);
+    notification.setTimestamp(now.getTime());
     return notification;
   }
 }


### PR DESCRIPTION
The UID in a `Notification` has no functional relevance. It cannot be used anywhere in the API to select or filter or do anything with. It simply is a unique string given to each notification but there never was a use case for it as far as I can tell.

However, the UID is shown in the app so removing it entirely seems tricky. Therefore this PR generates the UID on the fly from the timestamp of the notification using an algorithm that results in the same UID for the same timestamp and which generates vastly different UIDs for very similar timestamps.

This means, most messages in Redis will now only consist of a `time` and the `message` itself, for example:
```json
{"time":1738772120198,"message":"Run data set validation"}
```
The same message in the API looks like this (and in old version would be stored like this)
```json
  {
    "level": "INFO",
    "category": "DATAVALUE_IMPORT",
    "message": "Run data set validation",
    "completed": false,
    "id": "C0dO3jG8oQ4",
    "time": "2025-02-05T17:15:20.198",
    "uid": "C0dO3jG8oQ4"
  }
```
As a reminder: not storing the some of the other fields was optimized in another PR but it works like this:
* `level` is not stored when `INFO` (and most messages are)
* `category` does not need storing at all as it can be inferred for all messages from the requested "bucket"
* `completed` is only stored when `true` (literally only 1 message in a list uses it)
* `time` is stored as timestamp, not date string
* `id` + `uid` are now generated from the `time` (new in this PR)