### PR TITLE
Dhis2 9507: Begin timeliness calculation at correct time

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -249,7 +249,9 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
         "concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id ";
     String diffInSeconds = sqlBuilder.differenceInSeconds("cdr.date", "ps.enddate");
     String timelyDateDiff = diffInSeconds + " / (" + SECONDS_PER_DAY + ")";
-    String timelyAlias = "((" + timelyDateDiff + ") <= ds.timelydays) as timely";
+    // Since the end date is reported with a time of 00:00:00, we add 1 day to the timely days
+    // so that the calculations starts at 00:00:00 of the day after the end date.
+    String timelyAlias = "((" + timelyDateDiff + ") <= (ds.timelydays + 1)) as timely";
 
     List<AnalyticsTableColumn> columns = new ArrayList<>();
     columns.addAll(FIXED_COLS);


### PR DESCRIPTION
Both start and end dates of periods in DHIS2 are returned with a time portion of their date as 00:00:00. In order to account for this, we adjust the timely days by one day, so that we effectively start the timeliness calculation at midnight of the day after the period end date. If the period is "Jan 2025", the end date would be reported as "Jan 31 2025 00:00:00". If the timeliness is 0.5, that means that all reports for Jan 31 2025 would be considered timely if they are submitted up until 12:00:00 on Feb 1st.  