### PR TITLE
fix: set hibernate.hbm2ddl.auto to string DHIS2-18961

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -170,7 +170,7 @@ public class HibernateConfig {
           MissingCacheStrategy.CREATE.getExternalRepresentation());
     }
 
-    properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE);
+    properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
     // TODO: this is anti-pattern and should be turn off
     properties.put("hibernate.allow_update_outside_transaction", "true");

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/H2TestConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/H2TestConfig.java
@@ -84,7 +84,7 @@ public class H2TestConfig {
     factory.setMappingResources(loadResources());
     Properties jpaProperties = getAdditionalProperties(dhisConfig);
     // let hibernate create the DB schema for H2 tests as no flyway migrations are run
-    jpaProperties.put(AvailableSettings.HBM2DDL_AUTO, Action.UPDATE);
+    jpaProperties.put(AvailableSettings.HBM2DDL_AUTO, Action.UPDATE.getExternalHbm2ddlName());
     factory.setJpaProperties(jpaProperties);
     factory.afterPropertiesSet();
     return factory.getObject();


### PR DESCRIPTION
found this line in the logs during startup

`WARN  org.hibernate.boot.internal.SessionFactoryOptionsBuilder [main] class org.hibernate.tool.schema.Action cannot be cast to class java.lang.String (org.hibernate.tool.schema.Action is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @73a2e526; java.lang.String is in module java.base of loader 'bootstrap') Ignoring`

Not sure why H2 tests and the validation works in postgres tests when using an enum in https://github.com/dhis2/dhis2-core/pull/19856

I now also tested that DHIS2 fails to start outside of tests as I did during tests in https://github.com/dhis2/dhis2-core/pull/19856

by for example setting the column name in the hibernate mapping for enrollment to a wrong name

```
09:04:43.460 [main] ERROR org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean - Failed to initialize JPA EntityManagerFactory: [PersistenceUnit: dhis] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing column [fid] in table [enrollment]
```
