### PR TITLE
feat: expose allowed 2FA types in the configuration endpoint

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dataelement.DataElementGroup;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -479,9 +479,10 @@ public class ConfigurationController {
   @GetMapping("/twoFactorMethods")
   public @ResponseBody Map<String, Boolean> getTwoFactorMethods() {
     return Map.of(
-        "email2faEnabled", Boolean.parseBoolean(config.getProperty(ConfigurationKey.EMAIL_2FA_ENABLED)),
-        "totp2faEnabled", Boolean.parseBoolean(config.getProperty(ConfigurationKey.TOTP_2FA_ENABLED))
-    );
+        "email2faEnabled",
+            Boolean.parseBoolean(config.getProperty(ConfigurationKey.EMAIL_2FA_ENABLED)),
+        "totp2faEnabled",
+            Boolean.parseBoolean(config.getProperty(ConfigurationKey.TOTP_2FA_ENABLED)));
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -33,6 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
@@ -45,6 +46,7 @@ import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -472,6 +474,14 @@ public class ConfigurationController {
   @GetMapping("/appHubUrl")
   public @ResponseBody String getAppHubUrl(Model model, HttpServletRequest request) {
     return appManager.getAppHubUrl();
+  }
+
+  @GetMapping("/twoFactorMethods")
+  public @ResponseBody Map<String, Boolean> getTwoFactorMethods() {
+    return Map.of(
+        "email2faEnabled", Boolean.parseBoolean(config.getProperty(ConfigurationKey.EMAIL_2FA_ENABLED)),
+        "totp2faEnabled", Boolean.parseBoolean(config.getProperty(ConfigurationKey.TOTP_2FA_ENABLED))
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
Expose the allowed/enabled 2FA methods in the ConfigurationController (api/configuration/twoFactorMethods)
Return a JSON object with two boolean fields:
`email2faEnabled`: Whether email-based 2FA is enabled
`totp2faEnabled`: Whether TOTP-based 2FA is enabled