### PR TITLE
feat: make session cookie SameSite attribute configurable

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -693,7 +693,9 @@ public enum ConfigurationKey {
   EMAIL_2FA_ENABLED("login.security.email_2fa.enabled", Constants.OFF, false),
 
   /** Enable TOTP-based 2FA authentication. (default: true) */
-  TOTP_2FA_ENABLED("login.security.totp_2fa.enabled", Constants.ON, false);
+  TOTP_2FA_ENABLED("login.security.totp_2fa.enabled", Constants.ON, false),
+
+  SESSION_COOKIE_SAME_SITE("session.cookie.samesite", "Lax", false);
 
   private final String key;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -88,8 +88,6 @@ import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.session.web.http.CookieHttpSessionIdResolver;
-import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -157,18 +155,6 @@ public class DhisWebApiWebSecurityConfig {
       String requestURI = request.getRequestURI();
       return excludePatterns.stream().noneMatch(pattern -> pattern.equals(requestURI));
     }
-  }
-
-  @Bean
-  public CookieHttpSessionIdResolver httpSessionIdResolver() {
-    CookieHttpSessionIdResolver resolver = new CookieHttpSessionIdResolver();
-    DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
-    cookieSerializer.setCookieName("JSESSIONID");
-    cookieSerializer.setSameSite(dhisConfig.getProperty(ConfigurationKey.SESSION_COOKIE_SAME_SITE));
-    cookieSerializer.setUseSecureCookie(dhisConfig.isEnabled(ConfigurationKey.SERVER_HTTPS));
-    cookieSerializer.setUseHttpOnlyCookie(true);
-    resolver.setCookieSerializer(cookieSerializer);
-    return resolver;
   }
 
   @Bean

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -88,6 +88,8 @@ import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.session.web.http.CookieHttpSessionIdResolver;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -155,6 +157,18 @@ public class DhisWebApiWebSecurityConfig {
       String requestURI = request.getRequestURI();
       return excludePatterns.stream().noneMatch(pattern -> pattern.equals(requestURI));
     }
+  }
+
+  @Bean
+  public CookieHttpSessionIdResolver httpSessionIdResolver() {
+    CookieHttpSessionIdResolver resolver = new CookieHttpSessionIdResolver();
+    DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
+    cookieSerializer.setCookieName("JSESSIONID");
+    cookieSerializer.setSameSite(dhisConfig.getProperty(ConfigurationKey.SESSION_COOKIE_SAME_SITE));
+    cookieSerializer.setUseSecureCookie(dhisConfig.isEnabled(ConfigurationKey.SERVER_HTTPS));
+    cookieSerializer.setUseHttpOnlyCookie(true);
+    resolver.setCookieSerializer(cookieSerializer);
+    return resolver;
   }
 
   @Bean

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
@@ -44,8 +44,6 @@ import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.security.SpringSessionBackedSessionRegistry;
-import org.springframework.session.web.http.CookieHttpSessionIdResolver;
-import org.springframework.session.web.http.DefaultCookieSerializer;
 
 /**
  * Configuration registered if {@link RedisEnabledCondition} matches to true. Redis backed Spring
@@ -76,18 +74,6 @@ public class RedisSpringSessionConfig {
     int sessionTimeout = config.getIntProperty(ConfigurationKey.SYSTEM_SESSION_TIMEOUT);
     repository.setDefaultMaxInactiveInterval(sessionTimeout);
     return repository;
-  }
-
-  @Bean
-  public CookieHttpSessionIdResolver httpSessionIdResolver() {
-    CookieHttpSessionIdResolver resolver = new CookieHttpSessionIdResolver();
-    DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
-    cookieSerializer.setCookieName("JSESSIONID");
-    cookieSerializer.setSameSite("Lax");
-    cookieSerializer.setUseSecureCookie(false);
-    cookieSerializer.setUseHttpOnlyCookie(true);
-    resolver.setCookieSerializer(cookieSerializer);
-    return resolver;
   }
 
   @Bean

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
@@ -44,6 +44,8 @@ import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.security.SpringSessionBackedSessionRegistry;
+import org.springframework.session.web.http.CookieHttpSessionIdResolver;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 
 /**
  * Configuration registered if {@link RedisEnabledCondition} matches to true. Redis backed Spring
@@ -90,5 +92,17 @@ public class RedisSpringSessionConfig {
   @Bean
   public HttpSessionEventPublisher httpSessionEventPublisher() {
     return new HttpSessionEventPublisher();
+  }
+
+  @Bean
+  public CookieHttpSessionIdResolver httpSessionIdResolver() {
+    CookieHttpSessionIdResolver resolver = new CookieHttpSessionIdResolver();
+    DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
+    cookieSerializer.setCookieName("JSESSIONID");
+    cookieSerializer.setUseHttpOnlyCookie(true);
+    cookieSerializer.setSameSite(config.getProperty(ConfigurationKey.SESSION_COOKIE_SAME_SITE));
+    cookieSerializer.setUseSecureCookie(config.isEnabled(ConfigurationKey.SERVER_HTTPS));
+    resolver.setCookieSerializer(cookieSerializer);
+    return resolver;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -57,15 +57,20 @@ import org.springframework.web.servlet.DispatcherServlet;
 public class DhisWebApiWebAppInitializer implements WebApplicationInitializer {
   @Override
   public void onStartup(ServletContext context) {
+    context.getSessionCookieConfig().setName("JSESSIONID");
+    context.getSessionCookieConfig().setHttpOnly(true);
+
     boolean httpsOnly = getConfig().isEnabled(ConfigurationKey.SERVER_HTTPS);
-
-    log.debug(String.format("Configuring cookies, HTTPS only: %b", httpsOnly));
-
+    log.info(String.format("Configuring cookies, HTTPS only: %b", httpsOnly));
     if (httpsOnly) {
       context.getSessionCookieConfig().setSecure(true);
-      context.getSessionCookieConfig().setHttpOnly(true);
-
       log.info("HTTPS only is enabled, cookies configured as secure");
+    }
+
+    String sameSite = getConfig().getProperty(ConfigurationKey.SESSION_COOKIE_SAME_SITE);
+    log.info("SameSite cookie attribute set to: " + sameSite);
+    if (sameSite != null) {
+      context.getSessionCookieConfig().setAttribute("SameSite", sameSite);
     }
 
     context.setSessionTrackingModes(EnumSet.of(SessionTrackingMode.COOKIE));


### PR DESCRIPTION
## Summary
Make the session cookie SameSite attribute configurable, via dhis.conf
Call the variable: `session.cookie.samesite`, possible values are: 'none','strict' and 'lax'
The default value is: 'lax'