### PR TITLE
feat: add 2FA type in authentication error message

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationException.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationException.java
@@ -27,13 +27,21 @@
  */
 package org.hisp.dhis.security.spring2fa;
 
+import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.springframework.security.authentication.BadCredentialsException;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class TwoFactorAuthenticationException extends BadCredentialsException {
-  public TwoFactorAuthenticationException(String msg) {
+  private final TwoFactorType type;
+
+  public TwoFactorAuthenticationException(String msg, TwoFactorType type) {
     super(msg);
+    this.type = type;
+  }
+
+  public TwoFactorType getType() {
+    return type;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -175,17 +175,17 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider {
     if (type == TwoFactorType.EMAIL_ENABLED && StringUtils.isBlank(code)) {
       sendEmail2FACode(userDetails);
       // Inform the caller that the email code has been sent.
-      throw new TwoFactorAuthenticationException(ErrorCode.E3051.getMessage());
+      throw new TwoFactorAuthenticationException(ErrorCode.E3051.getMessage(), type);
     }
 
     // If the code is blank (null, empty, or only whitespace), reject the login.
     if (StringUtils.isBlank(code)) {
-      throw new TwoFactorAuthenticationException(ErrorCode.E3023.getMessage());
+      throw new TwoFactorAuthenticationException(ErrorCode.E3023.getMessage(), type);
     }
 
     // Validate the provided 2FA code.
     if (!isValid2FACode(type, code, userDetails.getSecret())) {
-      throw new TwoFactorAuthenticationException(ErrorCode.E3023.getMessage());
+      throw new TwoFactorAuthenticationException(ErrorCode.E3023.getMessage(), type);
     }
     // If no exception is thrown, the 2FA code is valid.
   }
@@ -194,7 +194,8 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider {
     try {
       twoFactorAuthService.sendEmail2FACode(userDetails.getUsername());
     } catch (ConflictException e) {
-      throw new TwoFactorAuthenticationException(ErrorCode.E3049.getMessage());
+      throw new TwoFactorAuthenticationException(
+          ErrorCode.E3049.getMessage(), TwoFactorType.EMAIL_ENABLED);
     }
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
@@ -48,7 +48,8 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
-    INCORRECT_TWO_FACTOR_CODE("incorrectTwoFactorCode"),
+    INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
+    INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),
     REQUIRES_TWO_FACTOR_ENROLMENT("requiresTwoFactorEnrolment");
 
     private final String keyName;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -161,7 +161,7 @@ public class LoginTest {
     // Test Login doesn't work without 2FA code
     ResponseEntity<LoginResponse> failedLoginResp =
         loginWithUsernameAndPassword(username, password, null);
-    assertLoginStatus(failedLoginResp, STATUS.INCORRECT_TWO_FACTOR_CODE);
+    assertLoginStatus(failedLoginResp, STATUS.INCORRECT_TWO_FACTOR_CODE_TOTP);
 
     // Disable TOTP 2FA
     disable2FAWithTOTP(qrSecretAndCookie);
@@ -181,7 +181,7 @@ public class LoginTest {
     // Test Login doesn't work without 2FA code
     ResponseEntity<LoginResponse> failedLoginResp =
         loginWithUsernameAndPassword(username, password, null);
-    assertLoginStatus(failedLoginResp, STATUS.INCORRECT_TWO_FACTOR_CODE);
+    assertLoginStatus(failedLoginResp, STATUS.INCORRECT_TWO_FACTOR_CODE_EMAIL);
 
     // Disable Email 2FA
     disable2FAWithEmail(cookie);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -128,7 +128,7 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
             .content(HttpStatus.OK)
             .as(JsonLoginResponse.class);
 
-    assertEquals("INCORRECT_TWO_FACTOR_CODE", wrong2FaCodeResponse.getLoginStatus());
+    assertEquals("INCORRECT_TWO_FACTOR_CODE_TOTP", wrong2FaCodeResponse.getLoginStatus());
     Assertions.assertNull(wrong2FaCodeResponse.getRedirectUrl());
 
     Totp totp = new Totp(secret);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationEnrolmentException;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
+import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
@@ -163,7 +164,11 @@ public class AuthenticationController {
       return LoginResponse.builder().loginStatus(STATUS.SUCCESS).redirectUrl(redirectUrl).build();
 
     } catch (TwoFactorAuthenticationException e) {
-      return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE).build();
+      TwoFactorType twoFactorType = e.getType();
+      if (twoFactorType == TwoFactorType.EMAIL_ENABLED) {
+        return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE_EMAIL).build();
+      }
+      return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE_TOTP).build();
     } catch (TwoFactorAuthenticationEnrolmentException e) {
       return LoginResponse.builder().loginStatus(STATUS.REQUIRES_TWO_FACTOR_ENROLMENT).build();
     } catch (CredentialsExpiredException e) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
@@ -50,7 +50,8 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
-    INCORRECT_TWO_FACTOR_CODE("incorrectTwoFactorCode"),
+    INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
+    INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),
     REQUIRES_TWO_FACTOR_ENROLMENT("requiresTwoFactorEnrolment");
 
     private final String keyName;


### PR DESCRIPTION
## Summary
Implement a way to differentiate between TOTP 2FA and Email 2FA.
Currently, when you are logging in, and you are required to enter 2FA, the server will respond with `INCORRECT_TWO_FACTOR_CODE`. To make it possible for the FE to respond to the user if the user needs to check their email or use an authenticator app, we need to have two different response codes, one for each 2FA type.

The new response codes are:
- `INCORRECT_TWO_FACTOR_CODE_EMAIL`
- `INCORRECT_TWO_FACTOR_CODE_TOTP`