### PR TITLE
feat: Support for Options in /dataItems API [DHIS2-18956]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataElementQuery.java
@@ -87,7 +87,10 @@ public class DataElementQuery implements DataItemQuery {
               Pair.of("item_domaintype", "dataelement.domaintype"),
               Pair.of("item_type", "cast ('DATA_ELEMENT' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", "optionset.uid"))
+              Pair.of("optionset_uid", "optionset.uid"),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/DataSetQuery.java
@@ -81,7 +81,10 @@ public class DataSetQuery implements DataItemQuery {
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('REPORTING_RATE' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", CAST_NULL_AS_TEXT))
+              Pair.of("optionset_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
@@ -81,7 +81,10 @@ public class ExpressionDimensionItemQuery implements DataItemQuery {
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('EXPRESSION_DIMENSION_ITEM' as text)"),
               Pair.of("expression", "expressiondimensionitem.expression"),
-              Pair.of("optionset_uid", CAST_NULL_AS_TEXT))
+              Pair.of("optionset_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/IndicatorQuery.java
@@ -83,7 +83,10 @@ public class IndicatorQuery implements DataItemQuery {
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('INDICATOR' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", CAST_NULL_AS_TEXT))
+              Pair.of("optionset_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
@@ -80,7 +80,7 @@ public class ProgramAttributeOptionQuery implements DataItemQuery {
               Pair.of("item_name", "trackedentityattribute.name"),
               Pair.of("item_shortname", "trackedentityattribute.shortname"),
               Pair.of("item_valuetype", "trackedentityattribute.valuetype"),
-              Pair.of("item_code", "trackedentityattribute.code"),
+              Pair.of("item_code", "optionvalue.code"),
               Pair.of("item_sharing", "trackedentityattribute.sharing"),
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('PROGRAM_ATTRIBUTE_OPTION' as text)"),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.dataitem.query;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.hisp.dhis.common.ValueType.NUMBER;
+import static org.hisp.dhis.dataitem.query.QueryableDataItem.PROGRAM_ATTRIBUTE_OPTION;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
@@ -37,16 +37,17 @@ import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiabl
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.optionSetIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.programIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.valueTypeFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
 import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
 import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasNonBlankStringPresence;
-import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasValueTypePresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
@@ -62,42 +63,47 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.stereotype.Component;
 
 /**
- * This component is responsible for providing query capabilities on top of ProgramIndicator
- * objects.
+ * This component is responsible for providing query capabilities on top of {@link
+ * ProgramAttributeOptionDimensionItem} objects.
  *
  * @author maikel arabori
  */
 @Slf4j
 @Component
-public class ProgramIndicatorQuery implements DataItemQuery {
+public class ProgramAttributeOptionQuery implements DataItemQuery {
   private static final String COMMON_COLUMNS =
       List.of(
-              Pair.of("program_name", CAST_NULL_AS_TEXT),
+              Pair.of("program_name", "program.name"),
               Pair.of("program_uid", "program.uid"),
-              Pair.of("program_shortname", CAST_NULL_AS_TEXT),
-              Pair.of("item_uid", "programindicator.uid"),
-              Pair.of("item_name", "programindicator.name"),
-              Pair.of("item_shortname", "programindicator.shortname"),
-              Pair.of("item_valuetype", CAST_NULL_AS_TEXT),
-              Pair.of("item_code", "programindicator.code"),
-              Pair.of("item_sharing", "programindicator.sharing"),
+              Pair.of("program_shortname", "program.shortname"),
+              Pair.of("item_uid", "trackedentityattribute.uid"),
+              Pair.of("item_name", "trackedentityattribute.name"),
+              Pair.of("item_shortname", "trackedentityattribute.shortname"),
+              Pair.of("item_valuetype", "trackedentityattribute.valuetype"),
+              Pair.of("item_code", "trackedentityattribute.code"),
+              Pair.of("item_sharing", "trackedentityattribute.sharing"),
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
-              Pair.of("item_type", "cast ('PROGRAM_INDICATOR' as text)"),
+              Pair.of("item_type", "cast ('PROGRAM_ATTRIBUTE_OPTION' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
+              Pair.of("optionset_uid", "optionset.uid"),
+              Pair.of("optionvalue_uid", "optionvalue.uid"),
+              Pair.of("optionvalue_name", "optionvalue.name"),
+              Pair.of("optionvalue_code", "optionvalue.code"))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));
 
-  private static final String COMMON_UIDS = "program.uid, programindicator.uid";
+  private static final String COMMON_UIDS =
+      "program.uid, trackedentityattribute.uid, optionset.uid, optionvalue.uid, optionvalue.code, optionvalue.name";
 
   private static final String JOINS =
-      "join program on program.programid = programindicator.programid";
+      " join program_attributes on program_attributes.trackedentityattributeid = trackedentityattribute.trackedentityattributeid"
+          + " join program on program_attributes.programid = program.programid"
+          + " join optionset on trackedentityattribute.optionsetid = optionset.optionsetid"
+          + " join optionvalue on optionvalue.optionsetid = optionset.optionsetid";
 
-  private static final String SPACED_FROM_PROGRAM_INDICATOR = " from programindicator ";
+  private static final String SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE =
+      " from trackedentityattribute ";
 
   @Override
   public String getStatement(MapSqlParameterSource paramsMap) {
@@ -106,7 +112,7 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     sql.append("(");
 
     // Creating a temp translated table to be queried.
-    sql.append(SPACED_SELECT + "distinct * from (");
+    sql.append(SPACED_SELECT + "* from (");
 
     if (hasNonBlankStringPresence(paramsMap, LOCALE)) {
       // Selecting translated names.
@@ -117,10 +123,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     }
 
     sql.append(
-        " group by item_name, "
+        " group by program.name, program.shortname, item_name, "
             + COMMON_UIDS
-            + ", item_code, item_sharing, item_shortname,"
-            + " i18n_first_name, i18n_first_shortname, i18n_second_name, i18n_second_shortname");
+            + ", item_valuetype, item_code, item_sharing, item_shortname,"
+            + " i18n_first_name, i18n_first_shortname, i18n_second_name, i18n_second_shortname, i18n_third_name");
 
     // Closing the temp table.
     sql.append(" ) t");
@@ -131,20 +137,30 @@ public class ProgramIndicatorQuery implements DataItemQuery {
 
     // Mandatory filters. They do not respect the root junction filtering.
     sql.append(always(sharingConditions("t.item_sharing", READ_ACCESS, paramsMap)));
+    sql.append(" and");
+    sql.append(ifSet(valueTypeFiltering("t.item_valuetype", paramsMap)));
 
     // Optional filters, based on the current root junction.
     OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder(paramsMap);
-    optionalFilters.append(ifSet(displayNameFiltering("t.i18n_first_name", paramsMap)));
-    optionalFilters.append(ifSet(displayShortNameFiltering("t.i18n_first_shortname", paramsMap)));
-    optionalFilters.append(ifSet(nameFiltering("t.item_name", paramsMap)));
-    optionalFilters.append(ifSet(shortNameFiltering("t.item_shortname", paramsMap)));
+    optionalFilters.append(
+        ifSet(
+            displayNameFiltering(
+                "t.i18n_first_name", "t.i18n_second_name", "t.i18n_third_name", paramsMap)));
+    optionalFilters.append(
+        ifSet(
+            displayShortNameFiltering(
+                "t.i18n_first_shortname", "t.i18n_second_shortname", paramsMap)));
+    optionalFilters.append(ifSet(nameFiltering("t.program_name", "t.item_name", paramsMap)));
+    optionalFilters.append(
+        ifSet(shortNameFiltering("t.program_shortname", "t.item_shortname", paramsMap)));
     optionalFilters.append(ifSet(programIdFiltering("t.program_uid", paramsMap)));
     optionalFilters.append(ifSet(uidFiltering("t.item_uid", paramsMap)));
+    optionalFilters.append(ifSet(optionSetIdFiltering("t.optionset_uid", paramsMap)));
     sql.append(ifAny(optionalFilters.toString()));
 
     String identifiableStatement =
         identifiableTokenFiltering(
-            "t.item_uid", "t.item_code", "t.i18n_first_name", null, paramsMap);
+            "t.item_uid", "t.item_code", "t.i18n_second_name", "t.i18n_first_name", paramsMap);
 
     if (isNotBlank(identifiableStatement)) {
       sql.append(rootJunction(paramsMap));
@@ -154,10 +170,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     sql.append(
         ifSet(
             ordering(
-                "t.i18n_first_name, t.item_uid",
-                "t.item_name, t.item_uid",
-                "t.i18n_first_shortname, t.item_uid",
-                " t.item_shortname, t.item_uid",
+                "t.i18n_first_name, t.i18n_second_name, t.i18n_third_name, t.item_uid",
+                "t.program_name, t.item_name, t.optionvalue_name, t.item_uid",
+                "t.i18n_first_shortname, t.i18n_second_shortname, t.item_uid",
+                "t.program_shortname, t.item_shortname, t.item_uid",
                 paramsMap)));
     sql.append(ifSet(maxLimit(paramsMap)));
     sql.append(")");
@@ -170,30 +186,28 @@ public class ProgramIndicatorQuery implements DataItemQuery {
   }
 
   /**
-   * Very specific case, for Program Indicator objects, needed to handle filter by value type
-   * NUMBER. When the value type filter does not have a NUMBER type, we should not execute this
-   * query.
+   * No rules required.
    *
    * @param paramsMap
-   * @return true if rules are matched.
+   * @return true
    */
   @Override
   public boolean matchQueryRules(MapSqlParameterSource paramsMap) {
-    return hasValueTypePresence(paramsMap, NUMBER);
+    return true;
   }
 
   @Override
   public Class<? extends BaseIdentifiableObject> getRootEntity() {
-    return QueryableDataItem.PROGRAM_INDICATOR.getEntity();
+    return PROGRAM_ATTRIBUTE_OPTION.getEntity();
   }
 
   private String selectRowsContainingTranslatedName() {
     return new StringBuilder()
         .append(SPACED_SELECT + COMMON_COLUMNS)
-        .append(translationNamesColumnsFor("programindicator", false))
-        .append(SPACED_FROM_PROGRAM_INDICATOR)
+        .append(translationNamesColumnsFor("trackedentityattribute", true, true, false))
+        .append(SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE)
         .append(JOINS)
-        .append(translationNamesJoinsOn("programindicator", false))
+        .append(translationNamesJoinsOn("trackedentityattribute", true, true))
         .toString();
   }
 
@@ -201,10 +215,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     return new StringBuilder()
         .append(SPACED_SELECT + COMMON_COLUMNS)
         .append(
-            ", programindicator.name as i18n_first_name, cast (null as text) as i18n_second_name")
+            ", program.name as i18n_first_name, trackedentityattribute.name as i18n_second_name, optionvalue.name as i18n_third_name")
         .append(
-            ", programindicator.shortname as i18n_first_shortname, cast (null as text) as i18n_second_shortname")
-        .append(SPACED_FROM_PROGRAM_INDICATOR)
+            ", program.shortname as i18n_first_shortname, trackedentityattribute.shortname as i18n_second_shortname")
+        .append(SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE)
         .append(JOINS)
         .toString();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeOptionQuery.java
@@ -97,10 +97,12 @@ public class ProgramAttributeOptionQuery implements DataItemQuery {
       "program.uid, trackedentityattribute.uid, optionset.uid, optionvalue.uid, optionvalue.code, optionvalue.name";
 
   private static final String JOINS =
-      " join program_attributes on program_attributes.trackedentityattributeid = trackedentityattribute.trackedentityattributeid"
-          + " join program on program_attributes.programid = program.programid"
-          + " join optionset on trackedentityattribute.optionsetid = optionset.optionsetid"
-          + " join optionvalue on optionvalue.optionsetid = optionset.optionsetid";
+      """
+        join program_attributes on program_attributes.trackedentityattributeid = trackedentityattribute.trackedentityattributeid
+        join program on program_attributes.programid = program.programid
+        join optionset on trackedentityattribute.optionsetid = optionset.optionsetid
+        join optionvalue on optionvalue.optionsetid = optionset.optionsetid
+      """;
 
   private static final String SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE =
       " from trackedentityattribute ";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramAttributeQuery.java
@@ -84,7 +84,10 @@ public class ProgramAttributeQuery implements DataItemQuery {
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('PROGRAM_ATTRIBUTE' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", "optionset.uid"))
+              Pair.of("optionset_uid", "optionset.uid"),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));
@@ -208,7 +211,7 @@ public class ProgramAttributeQuery implements DataItemQuery {
     return new StringBuilder()
         .append(SPACED_SELECT + COMMON_COLUMNS)
         .append(
-            ", program.name as i18n_first_name, trackedentityattribute.name as i18n_second_name")
+            ", program.name as i18n_first_name, trackedentityattribute.name as i18n_second_name, cast (null as text) as i18n_third_name")
         .append(
             ", program.shortname as i18n_first_shortname, trackedentityattribute.shortname as i18n_second_shortname")
         .append(SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
@@ -97,11 +97,13 @@ public class ProgramDataElementOptionQuery implements DataItemQuery {
       "program.uid, dataelement.uid, optionset.uid, optionvalue.uid, optionvalue.code, optionvalue.name";
 
   private static final String JOINS =
-      "   join programstagedataelement on programstagedataelement.dataelementid = dataelement.dataelementid"
-          + " join programstage on programstage.programstageid = programstagedataelement.programstageid"
-          + " join program on programstage.programid = program.programid"
-          + " join optionset on dataelement.optionsetid = optionset.optionsetid"
-          + " join optionvalue on optionvalue.optionsetid = optionset.optionsetid";
+      """
+        join programstagedataelement on programstagedataelement.dataelementid = dataelement.dataelementid
+        join programstage on programstage.programstageid = programstagedataelement.programstageid
+        join program on programstage.programid = program.programid
+        join optionset on dataelement.optionsetid = optionset.optionsetid
+        join optionvalue on optionvalue.optionsetid = optionset.optionsetid
+      """;
 
   private static final String SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE = " from dataelement ";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
@@ -80,7 +80,7 @@ public class ProgramDataElementOptionQuery implements DataItemQuery {
               Pair.of("item_name", "dataelement.name"),
               Pair.of("item_shortname", "dataelement.shortname"),
               Pair.of("item_valuetype", "dataelement.valuetype"),
-              Pair.of("item_code", "dataelement.code"),
+              Pair.of("item_code", "optionvalue.code"),
               Pair.of("item_sharing", "dataelement.sharing"),
               Pair.of("item_domaintype", "dataelement.domaintype"),
               Pair.of("item_type", "cast ('PROGRAM_DATA_ELEMENT_OPTION' as text)"),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramDataElementOptionQuery.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.dataitem.query;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.hisp.dhis.common.ValueType.NUMBER;
+import static org.hisp.dhis.dataitem.query.QueryableDataItem.PROGRAM_DATA_ELEMENT_OPTION;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.always;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.displayShortNameFiltering;
@@ -37,16 +37,17 @@ import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.identifiabl
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifAny;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.ifSet;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.nameFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.optionSetIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.programIdFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.rootJunction;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.shortNameFiltering;
 import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.uidFiltering;
+import static org.hisp.dhis.dataitem.query.shared.FilteringStatement.valueTypeFiltering;
 import static org.hisp.dhis.dataitem.query.shared.LimitStatement.maxLimit;
 import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesColumnsFor;
 import static org.hisp.dhis.dataitem.query.shared.NameTranslationStatement.translationNamesJoinsOn;
 import static org.hisp.dhis.dataitem.query.shared.OrderingStatement.ordering;
 import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasNonBlankStringPresence;
-import static org.hisp.dhis.dataitem.query.shared.ParamPresenceChecker.hasValueTypePresence;
 import static org.hisp.dhis.dataitem.query.shared.QueryParam.LOCALE;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
@@ -62,42 +63,47 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.stereotype.Component;
 
 /**
- * This component is responsible for providing query capabilities on top of ProgramIndicator
- * objects.
+ * This component is responsible for providing query capabilities on top of {@link
+ * ProgramDataElementOptionDimensionItem} objects.
  *
  * @author maikel arabori
  */
 @Slf4j
 @Component
-public class ProgramIndicatorQuery implements DataItemQuery {
+public class ProgramDataElementOptionQuery implements DataItemQuery {
   private static final String COMMON_COLUMNS =
       List.of(
-              Pair.of("program_name", CAST_NULL_AS_TEXT),
+              Pair.of("program_name", "program.name"),
               Pair.of("program_uid", "program.uid"),
-              Pair.of("program_shortname", CAST_NULL_AS_TEXT),
-              Pair.of("item_uid", "programindicator.uid"),
-              Pair.of("item_name", "programindicator.name"),
-              Pair.of("item_shortname", "programindicator.shortname"),
-              Pair.of("item_valuetype", CAST_NULL_AS_TEXT),
-              Pair.of("item_code", "programindicator.code"),
-              Pair.of("item_sharing", "programindicator.sharing"),
-              Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
-              Pair.of("item_type", "cast ('PROGRAM_INDICATOR' as text)"),
+              Pair.of("program_shortname", "program.shortname"),
+              Pair.of("item_uid", "dataelement.uid"),
+              Pair.of("item_name", "dataelement.name"),
+              Pair.of("item_shortname", "dataelement.shortname"),
+              Pair.of("item_valuetype", "dataelement.valuetype"),
+              Pair.of("item_code", "dataelement.code"),
+              Pair.of("item_sharing", "dataelement.sharing"),
+              Pair.of("item_domaintype", "dataelement.domaintype"),
+              Pair.of("item_type", "cast ('PROGRAM_DATA_ELEMENT_OPTION' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
-              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
+              Pair.of("optionset_uid", "optionset.uid"),
+              Pair.of("optionvalue_uid", "optionvalue.uid"),
+              Pair.of("optionvalue_name", "optionvalue.name"),
+              Pair.of("optionvalue_code", "optionvalue.code"))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));
 
-  private static final String COMMON_UIDS = "program.uid, programindicator.uid";
+  private static final String COMMON_UIDS =
+      "program.uid, dataelement.uid, optionset.uid, optionvalue.uid, optionvalue.code, optionvalue.name";
 
   private static final String JOINS =
-      "join program on program.programid = programindicator.programid";
+      "   join programstagedataelement on programstagedataelement.dataelementid = dataelement.dataelementid"
+          + " join programstage on programstage.programstageid = programstagedataelement.programstageid"
+          + " join program on programstage.programid = program.programid"
+          + " join optionset on dataelement.optionsetid = optionset.optionsetid"
+          + " join optionvalue on optionvalue.optionsetid = optionset.optionsetid";
 
-  private static final String SPACED_FROM_PROGRAM_INDICATOR = " from programindicator ";
+  private static final String SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE = " from dataelement ";
 
   @Override
   public String getStatement(MapSqlParameterSource paramsMap) {
@@ -106,7 +112,7 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     sql.append("(");
 
     // Creating a temp translated table to be queried.
-    sql.append(SPACED_SELECT + "distinct * from (");
+    sql.append(SPACED_SELECT + "* from (");
 
     if (hasNonBlankStringPresence(paramsMap, LOCALE)) {
       // Selecting translated names.
@@ -117,10 +123,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     }
 
     sql.append(
-        " group by item_name, "
+        " group by program.name, program.shortname, item_name, item_domaintype, "
             + COMMON_UIDS
-            + ", item_code, item_sharing, item_shortname,"
-            + " i18n_first_name, i18n_first_shortname, i18n_second_name, i18n_second_shortname");
+            + ", item_valuetype, item_code, item_sharing, item_shortname,"
+            + " i18n_first_name, i18n_first_shortname, i18n_second_name, i18n_second_shortname, i18n_third_name");
 
     // Closing the temp table.
     sql.append(" ) t");
@@ -131,20 +137,30 @@ public class ProgramIndicatorQuery implements DataItemQuery {
 
     // Mandatory filters. They do not respect the root junction filtering.
     sql.append(always(sharingConditions("t.item_sharing", READ_ACCESS, paramsMap)));
+    sql.append(" and");
+    sql.append(ifSet(valueTypeFiltering("t.item_valuetype", paramsMap)));
 
     // Optional filters, based on the current root junction.
     OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder(paramsMap);
-    optionalFilters.append(ifSet(displayNameFiltering("t.i18n_first_name", paramsMap)));
-    optionalFilters.append(ifSet(displayShortNameFiltering("t.i18n_first_shortname", paramsMap)));
-    optionalFilters.append(ifSet(nameFiltering("t.item_name", paramsMap)));
-    optionalFilters.append(ifSet(shortNameFiltering("t.item_shortname", paramsMap)));
+    optionalFilters.append(
+        ifSet(
+            displayNameFiltering(
+                "t.i18n_first_name", "t.i18n_second_name", "t.i18n_third_name", paramsMap)));
+    optionalFilters.append(
+        ifSet(
+            displayShortNameFiltering(
+                "t.i18n_first_shortname", "t.i18n_second_shortname", paramsMap)));
+    optionalFilters.append(ifSet(nameFiltering("t.program_name", "t.item_name", paramsMap)));
+    optionalFilters.append(
+        ifSet(shortNameFiltering("t.program_shortname", "t.item_shortname", paramsMap)));
     optionalFilters.append(ifSet(programIdFiltering("t.program_uid", paramsMap)));
     optionalFilters.append(ifSet(uidFiltering("t.item_uid", paramsMap)));
+    optionalFilters.append(ifSet(optionSetIdFiltering("t.optionset_uid", paramsMap)));
     sql.append(ifAny(optionalFilters.toString()));
 
     String identifiableStatement =
         identifiableTokenFiltering(
-            "t.item_uid", "t.item_code", "t.i18n_first_name", null, paramsMap);
+            "t.item_uid", "t.item_code", "t.i18n_second_name", "t.i18n_first_name", paramsMap);
 
     if (isNotBlank(identifiableStatement)) {
       sql.append(rootJunction(paramsMap));
@@ -154,10 +170,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     sql.append(
         ifSet(
             ordering(
-                "t.i18n_first_name, t.item_uid",
-                "t.item_name, t.item_uid",
-                "t.i18n_first_shortname, t.item_uid",
-                " t.item_shortname, t.item_uid",
+                "t.i18n_first_name, t.i18n_second_name, t.i18n_third_name, t.item_uid",
+                "t.program_name, t.item_name, t.optionvalue_name, t.item_uid",
+                "t.i18n_first_shortname, t.i18n_second_shortname, t.item_uid",
+                "t.program_shortname, t.item_shortname, t.item_uid",
                 paramsMap)));
     sql.append(ifSet(maxLimit(paramsMap)));
     sql.append(")");
@@ -170,30 +186,28 @@ public class ProgramIndicatorQuery implements DataItemQuery {
   }
 
   /**
-   * Very specific case, for Program Indicator objects, needed to handle filter by value type
-   * NUMBER. When the value type filter does not have a NUMBER type, we should not execute this
-   * query.
+   * No rules required.
    *
    * @param paramsMap
-   * @return true if rules are matched.
+   * @return true
    */
   @Override
   public boolean matchQueryRules(MapSqlParameterSource paramsMap) {
-    return hasValueTypePresence(paramsMap, NUMBER);
+    return true;
   }
 
   @Override
   public Class<? extends BaseIdentifiableObject> getRootEntity() {
-    return QueryableDataItem.PROGRAM_INDICATOR.getEntity();
+    return PROGRAM_DATA_ELEMENT_OPTION.getEntity();
   }
 
   private String selectRowsContainingTranslatedName() {
     return new StringBuilder()
         .append(SPACED_SELECT + COMMON_COLUMNS)
-        .append(translationNamesColumnsFor("programindicator", false))
-        .append(SPACED_FROM_PROGRAM_INDICATOR)
+        .append(translationNamesColumnsFor("dataelement", true, true, false))
+        .append(SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE)
         .append(JOINS)
-        .append(translationNamesJoinsOn("programindicator", false))
+        .append(translationNamesJoinsOn("dataelement", true, true))
         .toString();
   }
 
@@ -201,10 +215,10 @@ public class ProgramIndicatorQuery implements DataItemQuery {
     return new StringBuilder()
         .append(SPACED_SELECT + COMMON_COLUMNS)
         .append(
-            ", programindicator.name as i18n_first_name, cast (null as text) as i18n_second_name")
+            ", program.name as i18n_first_name, dataelement.name as i18n_second_name, optionvalue.name as i18n_third_name")
         .append(
-            ", programindicator.shortname as i18n_first_shortname, cast (null as text) as i18n_second_shortname")
-        .append(SPACED_FROM_PROGRAM_INDICATOR)
+            ", program.shortname as i18n_first_shortname, dataelement.shortname as i18n_second_shortname")
+        .append(SPACED_FROM_TRACKED_ENTITY_ATTRIBUTE)
         .append(JOINS)
         .toString();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ProgramStageDataElementQuery.java
@@ -84,7 +84,10 @@ public class ProgramStageDataElementQuery implements DataItemQuery {
               Pair.of("item_domaintype", CAST_NULL_AS_TEXT),
               Pair.of("item_type", "cast ('PROGRAM_DATA_ELEMENT' as text)"),
               Pair.of("expression", CAST_NULL_AS_TEXT),
-              Pair.of("optionset_uid", "optionset.uid"))
+              Pair.of("optionset_uid", "optionset.uid"),
+              Pair.of("optionvalue_uid", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_name", CAST_NULL_AS_TEXT),
+              Pair.of("optionvalue_code", CAST_NULL_AS_TEXT))
           .stream()
           .map(pair -> pair.getRight() + " as " + pair.getLeft())
           .collect(joining(", "));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/QueryableDataItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/QueryableDataItem.java
@@ -37,8 +37,10 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
+import org.hisp.dhis.program.ProgramDataElementOptionDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
+import org.hisp.dhis.program.ProgramTrackedEntityAttributeOptionDimensionItem;
 
 /**
  * This Enum holds the allowed data item types to be queried.
@@ -46,25 +48,41 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
  * @author maikel arabori
  */
 public enum QueryableDataItem {
-  INDICATOR(Indicator.class),
-  DATA_ELEMENT(DataElement.class),
-  DATA_SET(DataSet.class),
-  PROGRAM_INDICATOR(ProgramIndicator.class),
-  PROGRAM_DATA_ELEMENT(ProgramDataElementDimensionItem.class),
-  PROGRAM_ATTRIBUTE(ProgramTrackedEntityAttributeDimensionItem.class),
-  EXPRESSION_DIMENSION_ITEM(ExpressionDimensionItem.class);
+  INDICATOR(Indicator.class, true),
+  DATA_ELEMENT(DataElement.class, true),
+  DATA_SET(DataSet.class, true),
+  PROGRAM_INDICATOR(ProgramIndicator.class, true),
+  PROGRAM_DATA_ELEMENT(ProgramDataElementDimensionItem.class, true),
+  PROGRAM_DATA_ELEMENT_OPTION(ProgramDataElementOptionDimensionItem.class, false),
+  PROGRAM_ATTRIBUTE(ProgramTrackedEntityAttributeDimensionItem.class, true),
+  PROGRAM_ATTRIBUTE_OPTION(ProgramTrackedEntityAttributeOptionDimensionItem.class, false),
+  EXPRESSION_DIMENSION_ITEM(ExpressionDimensionItem.class, true);
 
   private Class<? extends BaseIdentifiableObject> entity;
 
-  QueryableDataItem(Class<? extends BaseIdentifiableObject> entity) {
+  private boolean isDefault;
+
+  QueryableDataItem(Class<? extends BaseIdentifiableObject> entity, boolean isDefault) {
     this.entity = entity;
+    this.isDefault = isDefault;
   }
 
   public Class<? extends BaseIdentifiableObject> getEntity() {
     return this.entity;
   }
 
+  public boolean isDefault() {
+    return this.isDefault;
+  }
+
   public static Set<Class<? extends BaseIdentifiableObject>> getEntities() {
     return of(QueryableDataItem.values()).map(QueryableDataItem::getEntity).collect(toSet());
+  }
+
+  public static Set<Class<? extends BaseIdentifiableObject>> getDefaultEntities() {
+    return of(QueryableDataItem.values())
+        .filter(QueryableDataItem::isDefault)
+        .map(QueryableDataItem::getEntity)
+        .collect(toSet());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.dataitem.query;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_ATTRIBUTE_OPTION;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_DATA_ELEMENT_OPTION;
 import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
 import static org.hisp.dhis.common.DimensionItemType.valueOf;
 import static org.hisp.dhis.common.ValueType.fromString;
@@ -107,18 +109,33 @@ class ResultProcessor {
   }
 
   private static String getUid(SqlRowSet rowSet) {
+    String uid = rowSet.getString("item_uid");
+    String itemType = rowSet.getString("item_type");
+
     boolean ignoreProgramUid =
         PROGRAM_INDICATOR.name().equalsIgnoreCase(rowSet.getString("item_type"));
 
     if (isNotBlank(rowSet.getString(PROGRAM_UID)) && !ignoreProgramUid) {
-      return rowSet.getString(PROGRAM_UID) + "." + rowSet.getString("item_uid");
-    } else {
-      return rowSet.getString("item_uid");
+      uid = rowSet.getString(PROGRAM_UID) + "." + uid;
     }
+
+    if (hasOptionUid(itemType)) {
+      uid += "." + rowSet.getString("optionvalue_uid");
+    }
+
+    return uid;
   }
 
   private static String getDisplayShortName(SqlRowSet rowSet) {
-    if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
+    String itemType = rowSet.getString("item_type");
+
+    if (hasOptionUid(itemType)) {
+      return String.format(
+          "%s (%s, %s)",
+          trimToEmpty(rowSet.getString("i18n_third_name")),
+          trimToEmpty(rowSet.getString("i18n_second_name")),
+          trimToEmpty(rowSet.getString("i18n_first_name")));
+    } else if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
       return trimToEmpty(rowSet.getString("i18n_first_shortname"))
           + SPACE
           + trimToEmpty(rowSet.getString("i18n_second_shortname"));
@@ -128,7 +145,15 @@ class ResultProcessor {
   }
 
   private static String getShortName(SqlRowSet rowSet) {
-    if (isNotBlank(rowSet.getString("program_shortname"))) {
+    String itemType = rowSet.getString("item_type");
+
+    if (hasOptionUid(itemType)) {
+      return String.format(
+          "%s (%s, %s)",
+          trimToEmpty(rowSet.getString("optionvalue_name")),
+          trimToEmpty(rowSet.getString("item_shortname")),
+          trimToEmpty(rowSet.getString("program_shortname")));
+    } else if (isNotBlank(rowSet.getString("program_shortname"))) {
       return trimToEmpty(rowSet.getString("program_shortname"))
           + SPACE
           + trimToEmpty(rowSet.getString("item_shortname"));
@@ -138,7 +163,15 @@ class ResultProcessor {
   }
 
   private static String getDisplayName(SqlRowSet rowSet) {
-    if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
+    String itemType = rowSet.getString("item_type");
+
+    if (hasOptionUid(itemType)) {
+      return String.format(
+          "%s (%s, %s)",
+          trimToEmpty(rowSet.getString("i18n_third_name")),
+          trimToEmpty(rowSet.getString("i18n_second_name")),
+          trimToEmpty(rowSet.getString("i18n_first_name")));
+    } else if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
       return trimToEmpty(rowSet.getString("i18n_first_name"))
           + SPACE
           + trimToEmpty(rowSet.getString("i18n_second_name"));
@@ -147,8 +180,21 @@ class ResultProcessor {
     }
   }
 
+  private static boolean hasOptionUid(String itemType) {
+    return PROGRAM_ATTRIBUTE_OPTION.name().equalsIgnoreCase(itemType)
+        || PROGRAM_DATA_ELEMENT_OPTION.name().equalsIgnoreCase(itemType);
+  }
+
   private static String getName(SqlRowSet rowSet) {
-    if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
+    String itemType = rowSet.getString("item_type");
+
+    if (hasOptionUid(itemType)) {
+      return String.format(
+          "%s (%s, %s)",
+          trimToEmpty(rowSet.getString("optionvalue_name")),
+          trimToEmpty(rowSet.getString("item_name")),
+          trimToEmpty(rowSet.getString(PROGRAM_NAME)));
+    } else if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
       return trimToEmpty(rowSet.getString(PROGRAM_NAME))
           + SPACE
           + trimToEmpty(rowSet.getString("item_name"));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/FilteringStatement.java
@@ -220,6 +220,27 @@ public class FilteringStatement {
   }
 
   /**
+   * Returns a SQL string related to 'displayName' "ilike" comparison to be reused as part of data
+   * items 'displayName' filtering. It required two columns so it can compare two different
+   * displayNames. It will always use 'or' condition, which translates to "columnOne ilike
+   * :displayName OR columnTwo ilike :displayName".
+   *
+   * @param columnOne the displayName's first column
+   * @param columnTwo the displayName's second column
+   * @param columnThree the displayName's three column
+   * @param paramsMap
+   * @return the uid SQL comparison
+   */
+  public static String displayNameFiltering(
+      String columnOne, String columnTwo, String columnThree, MapSqlParameterSource paramsMap) {
+    if (hasStringPresence(paramsMap, DISPLAY_NAME)) {
+      return ilikeOrFiltering(columnOne, columnTwo, columnThree, DISPLAY_NAME);
+    }
+
+    return EMPTY;
+  }
+
+  /**
    * Returns a SQL string related to 'displayShortName' "ilike" comparison to be reused as part of
    * data items 'displayShortName' filtering.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/NameTranslationStatement.java
@@ -110,6 +110,33 @@ public class NameTranslationStatement {
   }
 
   /**
+   * This method will join the translations column for the given table. Depending on the program
+   * flag it will also join the program table.
+   *
+   * @param table the table containing the translation columns
+   * @param includeProgram if true, it will also join the program table
+   * @param includeOption if true, it will also join the option table
+   * @return the joins responsible to bring translated names
+   */
+  public static String translationNamesJoinsOn(
+      String table, boolean includeProgram, boolean includeOption) {
+    if (isNotBlank(table)) {
+      StringBuilder joins = new StringBuilder(translationNamesJoinsOn(table, includeProgram));
+
+      if (includeOption) {
+        joins.append(
+            " left join jsonb_to_recordset(optionvalue.translations) as o_displayname(value TEXT, locale TEXT, property TEXT) on o_displayname.locale = :"
+                + LOCALE
+                + " and o_displayname.property = 'NAME'");
+      }
+
+      return joins.toString();
+    }
+
+    return EMPTY;
+  }
+
+  /**
    * This method defines the values for the translatable columns, for the given table.
    *
    * @param table the table containing the translation columns
@@ -132,7 +159,7 @@ public class NameTranslationStatement {
    * @return the columns containing the translated names
    */
   public static String translationNamesColumnsFor(String table, boolean includeProgram) {
-    return translationNamesColumnsFor(table, includeProgram, true);
+    return translationNamesColumnsFor(table, includeProgram, false, true);
   }
 
   /**
@@ -145,7 +172,7 @@ public class NameTranslationStatement {
    * @return the columns containing the translated names
    */
   public static String translationNamesColumnsFor(
-      String table, boolean includeProgram, boolean hasShortName) {
+      String table, boolean includeProgram, boolean includeOption, boolean hasShortName) {
     StringBuilder columns = new StringBuilder();
 
     if (isNotBlank(table)) {
@@ -161,6 +188,17 @@ public class NameTranslationStatement {
             .append(translationNamesColumnsForItem(table, "i18n_first", hasShortName))
             .append(", cast (null as text) as i18n_second_name")
             .append(", cast (null as text) as i18n_second_shortname");
+      }
+
+      if (includeOption) {
+        columns
+            .append(
+                ", (case when o_displayname.value is not null then o_displayname.value else optionvalue.name end) as i18n_third_name")
+            .append(", cast (null as text) as i18n_third_shortname");
+      } else {
+        columns
+            .append(", cast (null as text) as i18n_third_name")
+            .append(", cast (null as text) as i18n_third_shortname");
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
@@ -118,6 +118,32 @@ public class StatementUtil {
   }
 
   /**
+   * Creates a "ilike" SQL statement isolated by parenthesis. It consider two different columns and
+   * uses "or" as junction, ie.: "( columnOne ilike :param or columnTwo ilike :param)"
+   *
+   * @param columnOne
+   * @param columnTwo
+   * @param namedParam
+   * @return the SQL string
+   */
+  public static String ilikeOrFiltering(
+      String columnOne, String columnTwo, String columnThree, String namedParam) {
+    return SPACED_LEFT_PARENTHESIS
+        + columnOne
+        + ILIKE
+        + namedParam
+        + " or "
+        + columnTwo
+        + ILIKE
+        + namedParam
+        + " or "
+        + columnThree
+        + ILIKE
+        + namedParam
+        + SPACED_RIGHT_PARENTHESIS;
+  }
+
+  /**
    * Creates a "equal" SQL statement isolated by parenthesis, ie.: "( column = :param )"
    *
    * @param column

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/StatementUtil.java
@@ -86,14 +86,14 @@ public class StatementUtil {
   }
 
   /**
-   * Creates a "ilike" SQL statement isolated by parenthesis, ie.: "( column ilike :param )"
+   * Creates an "ilike" SQL statement isolated by parenthesis, ie.: "( column ilike :param )"
    *
    * @param column
    * @param namedParam
    * @return the SQL string
    */
   public static String ilikeFiltering(String column, String namedParam) {
-    return SPACED_LEFT_PARENTHESIS + column + ILIKE + namedParam + SPACED_RIGHT_PARENTHESIS;
+    return SPACED_LEFT_PARENTHESIS + ilike(column, namedParam) + SPACED_RIGHT_PARENTHESIS;
   }
 
   /**
@@ -107,13 +107,7 @@ public class StatementUtil {
    */
   public static String ilikeOrFiltering(String columnOne, String columnTwo, String namedParam) {
     return SPACED_LEFT_PARENTHESIS
-        + columnOne
-        + ILIKE
-        + namedParam
-        + " or "
-        + columnTwo
-        + ILIKE
-        + namedParam
+        + String.join(" or ", ilike(columnOne, namedParam), ilike(columnTwo, namedParam))
         + SPACED_RIGHT_PARENTHESIS;
   }
 
@@ -129,18 +123,23 @@ public class StatementUtil {
   public static String ilikeOrFiltering(
       String columnOne, String columnTwo, String columnThree, String namedParam) {
     return SPACED_LEFT_PARENTHESIS
-        + columnOne
-        + ILIKE
-        + namedParam
-        + " or "
-        + columnTwo
-        + ILIKE
-        + namedParam
-        + " or "
-        + columnThree
-        + ILIKE
-        + namedParam
+        + String.join(
+            " or ",
+            ilike(columnOne, namedParam),
+            ilike(columnTwo, namedParam),
+            ilike(columnThree, namedParam))
         + SPACED_RIGHT_PARENTHESIS;
+  }
+
+  /**
+   * Creates an ilike code snippet.
+   *
+   * @param column the column
+   * @param param the param to match
+   * @return ( column ilike :param )
+   */
+  private static String ilike(String column, String param) {
+    return column + ILIKE + param;
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/dataitems/DataItemsAnalyticsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/dataitems/DataItemsAnalyticsTest.java
@@ -27,8 +27,13 @@
  */
 package org.hisp.dhis.analytics.dataitems;
 
+import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import org.hisp.dhis.helpers.extensions.ConfigurationExtension;
@@ -71,6 +76,8 @@ public class DataItemsAnalyticsTest {
     response
         .validate()
         .statusCode(equalTo(200))
+        .body("dataItems.dimensionItemType", not(hasItem("PROGRAM_DATA_ELEMENT_OPTION")))
+        .body("dataItems.dimensionItemType", not(hasItem("PROGRAM_ATTRIBUTE_OPTION")))
         .body("dataItems.dimensionItemType", hasItem("PROGRAM_INDICATOR"))
         .body("dataItems.dimensionItemType", hasItem("DATA_ELEMENT"))
         .body("dataItems.dimensionItemType", not(hasItem("OPTION_SET")));
@@ -128,5 +135,85 @@ public class DataItemsAnalyticsTest {
         .validate()
         .statusCode(equalTo(200))
         .body("dataItems.optionSetId", hasItem("SokRAajDrRz"));
+  }
+
+  @Test
+  void testDataItems_PROGRAM_DATA_ELEMENT_OPTION() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("page=1")
+            .add("paging=false")
+            .add("order=name:asc")
+            .add("filter=dimensionItemType:in:[PROGRAM_DATA_ELEMENT_OPTION]")
+            .add("filter=displayName:ilike:bel");
+
+    // When
+    ApiResponse response = dataItemsActions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(equalTo(200))
+        .body("dataItems", is(not(empty())))
+        .body("dataItems", hasSize(25))
+        .body("dataItems.dimensionItemType", not(hasItem("PROGRAM_ATTRIBUTE_OPTION")))
+        .body("dataItems.dimensionItemType", everyItem(is("PROGRAM_DATA_ELEMENT_OPTION")))
+        .body("dataItems.optionSetId", (allOf(hasItem("ynHtyLDVeJO"), hasItem("eUZ79clX7y1"))));
+  }
+
+  @Test
+  void testDataItems_PROGRAM_ATTRIBUTE_OPTION() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("page=1")
+            .add("paging=false")
+            .add("order=name:asc")
+            .add("filter=dimensionItemType:in:[PROGRAM_ATTRIBUTE_OPTION]")
+            .add("filter=displayName:ilike:bel");
+
+    // When
+    ApiResponse response = dataItemsActions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(equalTo(200))
+        .body("dataItems", is(not(empty())))
+        .body("dataItems", hasSize(3))
+        .body("dataItems.dimensionItemType", not(hasItem("PROGRAM_DATA_ELEMENT_OPTION")))
+        .body("dataItems.dimensionItemType", everyItem(is("PROGRAM_ATTRIBUTE_OPTION")))
+        .body("dataItems.optionSetId", (not(hasItem("eUZ79clX7y1"))))
+        .body("dataItems.optionSetId", (allOf(hasItem("ynHtyLDVeJO"))))
+        .body("dataItems.programId", (allOf(hasItem("qDkgAbB5Jlk"))));
+  }
+
+  @Test
+  void testDataItems_PROGRAM_ATTRIBUTE_OPTION_and_PROGRAM_DATA_ELEMENT_OPTION() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("page=1")
+            .add("paging=false")
+            .add("order=name:asc")
+            .add(
+                "filter=dimensionItemType:in:[PROGRAM_ATTRIBUTE_OPTION,PROGRAM_DATA_ELEMENT_OPTION]")
+            .add("filter=displayName:ilike:bel");
+
+    // When
+    ApiResponse response = dataItemsActions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(equalTo(200))
+        .body("dataItems", is(not(empty())))
+        .body("dataItems", hasSize(28))
+        .body("dataItems.dimensionItemType", hasItem("PROGRAM_DATA_ELEMENT_OPTION"))
+        .body("dataItems.dimensionItemType", hasItem("PROGRAM_ATTRIBUTE_OPTION"))
+        .body("dataItems.optionSetId", (hasItem("eUZ79clX7y1")))
+        .body("dataItems.optionSetId", (hasItem("ynHtyLDVeJO")))
+        .body("dataItems.programId", (hasItem("qDkgAbB5Jlk")));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacade.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacade.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.webapi.controller.dataitem;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.hisp.dhis.dataitem.query.QueryableDataItem.getEntities;
+import static org.hisp.dhis.dataitem.query.QueryableDataItem.getDefaultEntities;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DIMENSION_TYPE_EQUAL;
 import static org.hisp.dhis.webapi.controller.dataitem.Filter.Combination.DIMENSION_TYPE_IN;
 import static org.hisp.dhis.webapi.controller.dataitem.helper.FilteringHelper.extractEntitiesFromInFilter;
@@ -125,7 +125,7 @@ public class DataItemServiceFacade {
       addFilteredTargetEntities(filters, targetedEntities);
     } else {
       // If no filter is set we search for all entities.
-      targetedEntities.addAll(getEntities());
+      targetedEntities.addAll(getDefaultEntities());
     }
 
     return targetedEntities;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hisp.dhis.common.DimensionItemType.INDICATOR;
-import static org.hisp.dhis.dataitem.query.QueryableDataItem.getEntities;
+import static org.hisp.dhis.dataitem.query.QueryableDataItem.getDefaultEntities;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
@@ -191,7 +191,7 @@ class DataItemServiceFacadeTest {
         dataItemServiceFacade.extractTargetEntities(noTargetEntitiesFilters);
 
     // Then
-    assertThat(actualTargetEntities, containsInAnyOrder(getEntities().toArray()));
+    assertThat(actualTargetEntities, containsInAnyOrder(getDefaultEntities().toArray()));
   }
 
   private WebOptions mockWebOptions(final int pageSize, final int pageNumber) {


### PR DESCRIPTION
The endpoint needs to support new objects as part of the support for Option in analytics.

New objects introduced:
PROGRAM_DATA_ELEMENT_OPTION (PDEO)
PROGRAM_ATTRIBUTE_OPTION (PAO)

Those objects will only be returned on /dataItems when "dimensionItemType" and "programDataElementId"/"programAttributeId" filters are specified:

`dimensionItemType:in:[PROGRAM_DATA_ELEMENT_OPTION,PROGRAM_ATTRIBUTE_OPTION]`
`programDataElementId:eq:eBAyeGv0exc.fWIAEtYVEGk`

When these filters are not specified, we don't want PDEO and PAO to be returned in a global search, as there could be many of them.

PDEO and PAO objects will have a property that holds the `id` of the associated program data element or program attribute. Example:
```
{
	"valueType": "TEXT",
	"simplifiedValueType": "TEXT",
	"displayName": "Discharged (Mode of Discharde, Inpatient morbidity and mortality)",
	"name": "Discharged (Mode of Discharde, Inpatient morbidity and mortality)",
	"programDataElementId": "eBAyeGv0exc.fWIAEtYVEGk",
	"id": "eBAyeGv0exc.fWIAEtYVEGk.yeod5tOXpkP",
	"shortName": "Discharged (Mode of Discharde, Inpatient morbidity and mortality)",
	"displayShortName": "Discharged (Mode of Discharde, Inpatient morbidity and mortality)",
	"dimensionItemType": "PROGRAM_DATA_ELEMENT_OPTION"
}
```