### PR TITLE
chore: Propagate includeDeleted through relationships [DHIS2-18883]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -224,7 +224,8 @@ class DefaultEnrollmentService implements EnrollmentService {
     }
     if (params.isIncludeRelationships()) {
       result.setRelationshipItems(
-          relationshipService.getRelationshipItems(TrackerType.ENROLLMENT, UID.of(result)));
+          relationshipService.getRelationshipItems(
+              TrackerType.ENROLLMENT, UID.of(result), includeDeleted));
     }
     if (params.isIncludeAttributes()) {
       result

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -230,7 +230,8 @@ class DefaultEventService implements EventService {
     if (operationParams.getEventParams().isIncludeRelationships()) {
       for (Event event : events) {
         event.setRelationshipItems(
-            relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
+            relationshipService.getRelationshipItems(
+                TrackerType.EVENT, UID.of(event), queryParams.isIncludeDeleted()));
       }
     }
     return events;
@@ -246,7 +247,8 @@ class DefaultEventService implements EventService {
     if (operationParams.getEventParams().isIncludeRelationships()) {
       for (Event event : events.getItems()) {
         event.setRelationshipItems(
-            relationshipService.getRelationshipItems(TrackerType.EVENT, UID.of(event)));
+            relationshipService.getRelationshipItems(
+                TrackerType.EVENT, UID.of(event), queryParams.isIncludeDeleted()));
       }
     }
     return events;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -66,16 +66,18 @@ public class DefaultRelationshipService implements RelationshipService {
 
   // TODO(DHIS2-18883) Pass fields params as a parameter
   @Override
-  public Set<RelationshipItem> getRelationshipItems(TrackerType trackerType, UID uid) {
+  public Set<RelationshipItem> getRelationshipItems(
+      TrackerType trackerType, UID uid, boolean includeDeleted) {
     List<RelationshipItem> relationshipItems =
         switch (trackerType) {
-          case TRACKED_ENTITY -> relationshipStore.getRelationshipItemsByTrackedEntity(uid);
-          case ENROLLMENT -> relationshipStore.getRelationshipItemsByEnrollment(uid);
-          case EVENT -> relationshipStore.getRelationshipItemsByEvent(uid);
+          case TRACKED_ENTITY ->
+              relationshipStore.getRelationshipItemsByTrackedEntity(uid, includeDeleted);
+          case ENROLLMENT ->
+              relationshipStore.getRelationshipItemsByEnrollment(uid, includeDeleted);
+          case EVENT -> relationshipStore.getRelationshipItemsByEvent(uid, includeDeleted);
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
         };
     return relationshipItems.stream()
-        .filter(ri -> !ri.getRelationship().isDeleted())
         .filter(
             ri ->
                 trackerAccessManager

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -191,37 +191,48 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString).list();
   }
 
-  public List<RelationshipItem> getRelationshipItemsByTrackedEntity(UID trackedEntity) {
+  public List<RelationshipItem> getRelationshipItemsByTrackedEntity(
+      UID trackedEntity, boolean includeDeleted) {
     @Language("hql")
     String hql =
         """
                 from RelationshipItem ri
                 where ri.trackedEntity.uid = :trackedEntity
                 """;
+    if (!includeDeleted) {
+      hql += "and ri.relationship.deleted = false";
+    }
     return getQuery(hql, RelationshipItem.class)
         .setParameter("trackedEntity", trackedEntity.getValue())
         .list();
   }
 
-  public List<RelationshipItem> getRelationshipItemsByEnrollment(UID enrollment) {
+  public List<RelationshipItem> getRelationshipItemsByEnrollment(
+      UID enrollment, boolean includeDeleted) {
     @Language("hql")
     String hql =
         """
                 from RelationshipItem ri
                 where ri.enrollment.uid = :enrollment
                 """;
+    if (!includeDeleted) {
+      hql += "and ri.relationship.deleted = false";
+    }
     return getQuery(hql, RelationshipItem.class)
         .setParameter("enrollment", enrollment.getValue())
         .list();
   }
 
-  public List<RelationshipItem> getRelationshipItemsByEvent(UID event) {
+  public List<RelationshipItem> getRelationshipItemsByEvent(UID event, boolean includeDeleted) {
     @Language("hql")
     String hql =
         """
                 from RelationshipItem ri
                 where ri.event.uid = :event
                 """;
+    if (!includeDeleted) {
+      hql += "and ri.relationship.deleted = false";
+    }
     return getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()).list();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -44,7 +44,8 @@ import org.hisp.dhis.tracker.export.PageParams;
 public interface RelationshipService {
 
   /** Get all relationship items matching given params. */
-  Set<RelationshipItem> getRelationshipItems(TrackerType trackerType, UID uid);
+  Set<RelationshipItem> getRelationshipItems(
+      TrackerType trackerType, UID uid, boolean includeDeleted);
 
   /** Get all relationships matching given params. */
   List<Relationship> getRelationships(RelationshipOperationParams params)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -271,7 +271,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     if (params.isIncludeRelationships()) {
       trackedEntity.setRelationshipItems(
           relationshipService.getRelationshipItems(
-              TrackerType.TRACKED_ENTITY, UID.of(trackedEntity)));
+              TrackerType.TRACKED_ENTITY, UID.of(trackedEntity), false));
     }
     if (params.isIncludeProgramOwners()) {
       trackedEntity.setProgramOwners(getTrackedEntityProgramOwners(trackedEntity, program));
@@ -369,7 +369,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       if (operationParams.getTrackedEntityParams().isIncludeRelationships()) {
         trackedEntity.setRelationshipItems(
             relationshipService.getRelationshipItems(
-                TrackerType.TRACKED_ENTITY, UID.of(trackedEntity)));
+                TrackerType.TRACKED_ENTITY, UID.of(trackedEntity), queryParams.isIncludeDeleted()));
       }
     }
     for (TrackedEntity trackedEntity : trackedEntities) {


### PR DESCRIPTION
Propagate `includeDeleted` params from any entity service to `RelationshipService` to include soft-deleted `relationshipItems` when `includeDeleted` is `true`.

***Next steps***
- Fix `isDeleted` check in `OperationsParamsValidator`
- Check if we can remove `isDeleted` check from `RelationshipService`
- Serve multiple and single tracked entities using the same path
- Pass field params to `RelationshipService` in order to only retrieve from the DB what is needed.
- Changing the test input to use the `view` model in relationship tests