### PR TITLE
fix: cannot get TE if there are no tracker programs DHIS2-18991

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
@@ -50,6 +50,10 @@ public class Page<T> {
   private final Integer prevPage;
   private final Integer nextPage;
 
+  public static <T> Page<T> empty() {
+    return new Page<>(List.of(), 0, 0, 0L, null, null);
+  }
+
   /**
    * Create a new page based on an existing one but with given {@code items}. Page related counts
    * will not be changed so make sure the given {@code items} match the previous page size.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -375,10 +375,12 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     for (TrackedEntity trackedEntity : trackedEntities) {
       if (operationParams.getTrackedEntityParams().isIncludeProgramOwners()) {
         trackedEntity.setProgramOwners(
-            getTrackedEntityProgramOwners(trackedEntity, queryParams.getProgram()));
+            getTrackedEntityProgramOwners(
+                trackedEntity, queryParams.getEnrolledInTrackerProgram()));
       }
       trackedEntity.setTrackedEntityAttributeValues(
-          getTrackedEntityAttributeValues(trackedEntity, queryParams.getProgram()));
+          getTrackedEntityAttributeValues(
+              trackedEntity, queryParams.getEnrolledInTrackerProgram()));
     }
     trackedEntityAuditService.addTrackedEntityAudit(SEARCH, user.getUsername(), trackedEntities);
     return trackedEntities;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -148,6 +148,13 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   }
 
   public List<TrackedEntityIdentifiers> getTrackedEntityIds(TrackedEntityQueryParams params) {
+    // A TE which is not enrolled can only be accessed by a user that is able to enroll it into a
+    // tracker program. Return an empty result if there are no tracker programs or the user does
+    // not have access to one.
+    if (!params.hasEnrolledInTrackerProgram() && params.getAccessibleTrackerPrograms().isEmpty()) {
+      return List.of();
+    }
+
     String sql = getQuery(params, null);
     SqlRowSet rowSet = jdbcTemplate.queryForRowSet(sql);
 
@@ -163,6 +170,13 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   public Page<TrackedEntityIdentifiers> getTrackedEntityIds(
       TrackedEntityQueryParams params, PageParams pageParams) {
+    // A TE which is not enrolled can only be accessed by a user that is able to enroll it into a
+    // tracker program. Return an empty result if there are no tracker programs or the user does
+    // not have access to one.
+    if (!params.hasEnrolledInTrackerProgram() && params.getAccessibleTrackerPrograms().isEmpty()) {
+      return Page.empty();
+    }
+
     String sql = getQuery(params, pageParams);
     SqlRowSet rowSet = jdbcTemplate.queryForRowSet(sql);
 
@@ -206,12 +220,26 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
   }
 
-  public Long getTrackedEntityCount(TrackedEntityQueryParams params) {
+  private Long getTrackedEntityCount(TrackedEntityQueryParams params) {
+    // A TE which is not enrolled can only be accessed by a user that is able to enroll it into a
+    // tracker program. Return an empty result if there are no tracker programs or the user does
+    // not have access to one.
+    if (!params.hasEnrolledInTrackerProgram() && params.getAccessibleTrackerPrograms().isEmpty()) {
+      return 0L;
+    }
+
     String sql = getCountQuery(params);
     return jdbcTemplate.queryForObject(sql, Long.class);
   }
 
   public int getTrackedEntityCountWithMaxTrackedEntityLimit(TrackedEntityQueryParams params) {
+    // A TE which is not enrolled can only be accessed by a user that is able to enroll it into a
+    // tracker program. Return an empty result if there are no tracker programs or the user does
+    // not have access to one.
+    if (!params.hasEnrolledInTrackerProgram() && params.getAccessibleTrackerPrograms().isEmpty()) {
+      return 0;
+    }
+
     String sql = getCountQueryWithMaxTrackedEntityLimit(params);
     return jdbcTemplate.queryForObject(sql, Integer.class);
   }
@@ -306,8 +334,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         + getQuerySelect(params)
         + "FROM "
         + getFromSubQuery(params, true, null)
-        + (params.getProgram().getMaxTeiCountToReturn() > 0
-            ? getLimitClause(params.getProgram().getMaxTeiCountToReturn() + 1)
+        + (params.getEnrolledInTrackerProgram().getMaxTeiCountToReturn() > 0
+            ? getLimitClause(params.getEnrolledInTrackerProgram().getMaxTeiCountToReturn() + 1)
             : "")
         + " ) tecount";
   }
@@ -439,10 +467,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     trackedEntity.append(" INNER JOIN program P ");
     trackedEntity.append(" ON P.trackedentitytypeid = TE.trackedentitytypeid ");
 
-    if (!params.hasProgram()) {
+    if (!params.hasEnrolledInTrackerProgram()) {
       trackedEntity
           .append("AND P.programid IN (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getPrograms())))
+          .append(getCommaDelimitedString(getIdentifiers(params.getAccessibleTrackerPrograms())))
           .append(")");
     }
 
@@ -472,7 +500,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
           .append(whereAnd.whereAnd())
           .append("TE.trackedentitytypeid = ")
           .append(params.getTrackedEntityType().getId());
-    } else if (!params.hasProgram()) {
+    } else if (!params.hasEnrolledInTrackerProgram()) {
       trackedEntity
           .append(whereAnd.whereAnd())
           .append("TE.trackedentitytypeid in (")
@@ -594,10 +622,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * @return a SQL INNER JOIN for program owner, or a LEFT JOIN if no program is specified.
    */
   private String getFromSubQueryJoinProgramOwnerConditions(TrackedEntityQueryParams params) {
-    if (params.hasProgram()) {
+    if (params.hasEnrolledInTrackerProgram()) {
       return " INNER JOIN trackedentityprogramowner PO "
           + " ON PO.programid = "
-          + params.getProgram().getId()
+          + params.getEnrolledInTrackerProgram().getId()
           + " AND PO.trackedentityid = TE.trackedentityid "
           + " AND P.programid = PO.programid";
     }
@@ -662,7 +690,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   }
 
   private String getOwnerOrgUnit(TrackedEntityQueryParams params) {
-    if (params.hasProgram()) {
+    if (params.hasEnrolledInTrackerProgram()) {
       return "PO.organisationunitid ";
     }
 
@@ -736,10 +764,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
             ON %1$s.trackedentityid = TE.trackedentityid
             """;
 
-      return !params.hasProgram()
+      return !params.hasEnrolledInTrackerProgram()
           ? join.formatted(ENROLLMENT_ALIAS)
           : join.concat(" AND %1$s.programid = %2$s")
-              .formatted(ENROLLMENT_ALIAS, params.getProgram().getId());
+              .formatted(ENROLLMENT_ALIAS, params.getEnrolledInTrackerProgram().getId());
     }
 
     return "";
@@ -757,7 +785,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       SqlHelper whereAnd, TrackedEntityQueryParams params) {
     StringBuilder program = new StringBuilder();
 
-    if (!params.hasProgram()) {
+    if (!params.hasEnrolledInTrackerProgram()) {
       return "";
     }
 
@@ -774,7 +802,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     program
         .append("WHERE EN.trackedentityid = TE.trackedentityid ")
         .append("AND EN.programid = ")
-        .append(params.getProgram().getId())
+        .append(params.getEnrolledInTrackerProgram().getId())
         .append(SPACE);
 
     if (params.hasEnrollmentStatus()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -114,8 +114,8 @@ class TrackedEntityOperationParamsMapper {
         program, requestedTrackedEntityType, operationParams, orgUnits, params);
 
     params
-        .setProgram(program)
-        .setPrograms(programs)
+        .setEnrolledInTrackerProgram(program)
+        .setAccessibleTrackerPrograms(programs)
         .setProgramStage(programStage)
         .setEnrollmentStatus(operationParams.getEnrollmentStatus())
         .setFollowUp(operationParams.getFollowUp())
@@ -297,8 +297,9 @@ class TrackedEntityOperationParamsMapper {
   private List<UID> getSearchableAttributeIds(TrackedEntityQueryParams params) {
     List<UID> searchableAttributeIds = new ArrayList<>();
 
-    if (params.hasProgram()) {
-      searchableAttributeIds.addAll(UID.of(params.getProgram().getSearchableAttributeIds()));
+    if (params.hasEnrolledInTrackerProgram()) {
+      searchableAttributeIds.addAll(
+          UID.of(params.getEnrolledInTrackerProgram().getSearchableAttributeIds()));
     }
 
     if (params.hasTrackedEntityType()) {
@@ -306,7 +307,7 @@ class TrackedEntityOperationParamsMapper {
           UID.of(params.getTrackedEntityType().getSearchableAttributeIds()));
     }
 
-    if (!params.hasProgram() && !params.hasTrackedEntityType()) {
+    if (!params.hasEnrolledInTrackerProgram() && !params.hasTrackedEntityType()) {
       searchableAttributeIds.addAll(
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(UID::of)
@@ -346,13 +347,13 @@ class TrackedEntityOperationParamsMapper {
       }
     }
 
-    if (params.hasProgram()) {
-      maxTeiLimit = params.getProgram().getMaxTeiCountToReturn();
+    if (params.hasEnrolledInTrackerProgram()) {
+      maxTeiLimit = params.getEnrolledInTrackerProgram().getMaxTeiCountToReturn();
 
       if (!params.hasTrackedEntities() && isProgramMinAttributesViolated(params)) {
         throw new IllegalQueryException(
             "At least "
-                + params.getProgram().getMinAttributesRequiredToSearch()
+                + params.getEnrolledInTrackerProgram().getMinAttributesRequiredToSearch()
                 + " attributes should be mentioned in the search criteria.");
       }
     }
@@ -405,9 +406,11 @@ class TrackedEntityOperationParamsMapper {
       return false;
     }
 
-    return (!params.hasFilters() && params.getProgram().getMinAttributesRequiredToSearch() > 0)
+    return (!params.hasFilters()
+            && params.getEnrolledInTrackerProgram().getMinAttributesRequiredToSearch() > 0)
         || (params.hasFilters()
-            && params.getFilters().size() < params.getProgram().getMinAttributesRequiredToSearch());
+            && params.getFilters().size()
+                < params.getEnrolledInTrackerProgram().getMinAttributesRequiredToSearch());
   }
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -68,11 +68,17 @@ public class TrackedEntityQueryParams {
    */
   private Set<OrganisationUnit> orgUnits = new HashSet<>();
 
-  /** Program for which instances in the response must be enrolled in. */
-  private Program program;
+  /**
+   * Tracker program the tracked entity must be enrolled in. This should not be set when {@link
+   * #accessibleTrackerPrograms} is set. The user must have data read access to this program.
+   */
+  private Program enrolledInTrackerProgram;
 
-  /** Programs to fetch. */
-  private List<Program> programs = List.of();
+  /**
+   * Tracker programs the user has data read access to. This should not be set when {@link
+   * #enrolledInTrackerProgram} is set.
+   */
+  private List<Program> accessibleTrackerPrograms = List.of();
 
   /** Status of a tracked entities enrollment into a given program. */
   private EnrollmentStatus enrollmentStatus;
@@ -172,8 +178,8 @@ public class TrackedEntityQueryParams {
   }
 
   /** Indicates whether these parameters specify a program. */
-  public boolean hasProgram() {
-    return program != null;
+  public boolean hasEnrolledInTrackerProgram() {
+    return enrolledInTrackerProgram != null;
   }
 
   /** Indicates whether these parameters specify an enrollment status. */
@@ -308,21 +314,22 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  public Program getProgram() {
-    return program;
+  public Program getEnrolledInTrackerProgram() {
+    return enrolledInTrackerProgram;
   }
 
-  public TrackedEntityQueryParams setProgram(Program program) {
-    this.program = program;
+  public TrackedEntityQueryParams setEnrolledInTrackerProgram(Program enrolledInTrackerProgram) {
+    this.enrolledInTrackerProgram = enrolledInTrackerProgram;
     return this;
   }
 
-  public List<Program> getPrograms() {
-    return programs;
+  public List<Program> getAccessibleTrackerPrograms() {
+    return accessibleTrackerPrograms;
   }
 
-  public TrackedEntityQueryParams setPrograms(List<Program> programs) {
-    this.programs = programs;
+  public TrackedEntityQueryParams setAccessibleTrackerPrograms(
+      List<Program> accessibleTrackerPrograms) {
+    this.accessibleTrackerPrograms = accessibleTrackerPrograms;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -241,7 +241,7 @@ public class TrackedEntityAggregate {
 
               Stream<String> teUidStream = trackedEntities.keySet().parallelStream();
 
-              if (user.isPresent() && queryParams.hasProgram()) {
+              if (user.isPresent() && queryParams.hasEnrolledInTrackerProgram()) {
                 teUidStream = teUidStream.filter(ownedTeis::containsKey);
               }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityStore.java
@@ -183,9 +183,10 @@ class TrackedEntityStore extends AbstractStore {
 
     String sql;
 
-    if (ctx.getQueryParams().hasProgram()) {
+    if (ctx.getQueryParams().hasEnrolledInTrackerProgram()) {
       sql = getTrackedEntitiesOwnershipSqlForSpecificProgram(skipUserScopeValidation);
-      paramSource.addValue("programUid", ctx.getQueryParams().getProgram().getUid());
+      paramSource.addValue(
+          "programUid", ctx.getQueryParams().getEnrolledInTrackerProgram().getUid());
     } else if (checkForOwnership) {
       sql = getTrackedEntitiesOwnershipSqlForAllPrograms(skipUserScopeValidation);
     } else {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -361,7 +361,7 @@ class TrackedEntityOperationParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(operationParams, user);
 
-    assertEquals(program, params.getProgram());
+    assertEquals(program, params.getEnrolledInTrackerProgram());
   }
 
   @Test


### PR DESCRIPTION
cherry-pick of https://github.com/dhis2/dhis2-core/pull/19918

https://dhis2.atlassian.net/browse/DHIS2-18991 is the same bug as https://dhis2.atlassian.net/browse/DHIS2-17959 except it manifests only in tracker exporter as tracker is not part of metadata sync in 42.

So a user requesting TEs

* with no access to any tracker program
* or on a system without tracker programs

would get a 500 due to invalid SQL.
