### PR TITLE
chore: allow testing sync using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ DHIS2_DB_DUMP_URL=https://databases.dhis2.org/sierra-leone/2.39/dhis2-db-sierra-
 
 using versions we for example publish to https://databases.dhis2.org/
 
+### Sync between DHIS2 instances
+
+You can run multiple DHIS2 instances to test [data and metadata
+synchronization](https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/exchanging-data/metadata-synchronization.html)
+by running
+
+```sh
+docker compose --profile sync up
+```
+
+After that follow this
+[guide](https://github.com/dhis2/wow-backend/blob/master/guides/testing/metadata_sync_testing.md).
+
 ## Build process
 
 This repository contains the source code for the server-side component of DHIS2, which is developed in [Java](https://www.java.com/en/) and built with [Maven](https://maven.apache.org/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,83 @@
 version: "3.8"
 
+x-web-base: &web-base
+  image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
+  volumes:
+    - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
+    - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
+  environment:
+    JAVA_OPTS:
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081 \
+      -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml
+      -Dcom.sun.management.jmxremote \
+      -Dcom.sun.management.jmxremote.port=9010 \
+      -Dcom.sun.management.jmxremote.local.only=false \
+      -Dcom.sun.management.jmxremote.authenticate=false \
+      -Dcom.sun.management.jmxremote.ssl=false"
+
+x-db-base: &db-base
+  image: ghcr.io/baosystems/postgis:12-3.3
+  # uncomment to enable query logging
+  # command:
+  #   ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
+  volumes:
+    - db-dump:/docker-entrypoint-initdb.d/
+  environment:
+    POSTGRES_USER: dhis
+    POSTGRES_DB: dhis
+    POSTGRES_PASSWORD: &postgres_password dhis
+    PGPASSWORD: *postgres_password # needed by psql in healthcheck
+  healthcheck:
+    test:
+      [
+        "CMD-SHELL",
+        'psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command "SELECT ''ok''" > /dev/null',
+      ]
+    start_period: 120s
+    interval: 1s
+    timeout: 3s
+    retries: 5
+  depends_on:
+    db-dump:
+      condition: service_completed_successfully # make sure the DB dump has been downloaded
+
 services:
   web:
-    image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
+    <<: *web-base
     ports:
       - "127.0.0.1:8080:8080" # DHIS2
       - "127.0.0.1:8081:8081" # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
       - "127.0.0.1:9010:9010" # JMX port (for example for VisualVM)
-    volumes:
-      - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
-      - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
-    environment:
-      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081 \
-              -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml
-              -Dcom.sun.management.jmxremote \
-              -Dcom.sun.management.jmxremote.port=9010 \
-              -Dcom.sun.management.jmxremote.local.only=false \
-              -Dcom.sun.management.jmxremote.authenticate=false \
-              -Dcom.sun.management.jmxremote.ssl=false"
     depends_on:
       db:
         condition: service_healthy
 
   db:
-    image: ghcr.io/baosystems/postgis:13-3.4
-    # uncomment to enable query logging
-    # command:
-    #   ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
+    <<: *db-base
     ports:
       - "127.0.0.1:5432:5432"
-    volumes:
-      - db-dump:/docker-entrypoint-initdb.d/
-    environment:
-      POSTGRES_USER: dhis
-      POSTGRES_DB: dhis
-      POSTGRES_PASSWORD: &postgres_password dhis
-      PGPASSWORD: *postgres_password # needed by psql in healthcheck
-    healthcheck:
-      test: [ "CMD-SHELL", "psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command \"SELECT 'ok'\" > /dev/null" ]
-      start_period: 120s
-      interval: 1s
-      timeout: 3s
-      retries: 5
+
+  # Test synchronizing data and metadata between two DHIS2 instances
+  # Run
+  #   docker compose --profile sync up
+  # then follow
+  # https://github.com/dhis2/wow-backend/blob/c190287f8bf6493ed6f93d10bda4e764fcaf9930/guides/testing/metadata_sync_testing.md
+  web-sync:
+    <<: *web-base
+    profiles: [sync]
+    ports:
+      - "127.0.0.1:8082:8080" # DHIS2
+      - "127.0.0.1:8083:8081" # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8083
+      - "127.0.0.1:9012:9010" # JMX port (for example for VisualVM)
     depends_on:
-      db-dump:
-        condition: service_completed_successfully # make sure the DB dump has been downloaded
+      db-sync:
+        condition: service_healthy
+
+  db-sync:
+    <<: *db-base
+    profiles: [sync]
+    ports:
+      - "127.0.0.1:5434:5432"
 
   db-dump:
     image: busybox # busybox wget version does not have --no-clobber, so we need to do the [ -f ] test
@@ -56,4 +89,4 @@ services:
       - db-dump:/opt/dump
 
 volumes:
-  db-dump: { }
+  db-dump: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 x-web-base: &web-base
   image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
   volumes:
-    - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
     - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
   environment:
     JAVA_OPTS:
@@ -44,6 +43,8 @@ x-db-base: &db-base
 services:
   web:
     <<: *web-base
+    volumes:
+      - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
     ports:
       - "127.0.0.1:8080:8080" # DHIS2
       - "127.0.0.1:8081:8081" # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
@@ -60,10 +61,11 @@ services:
   # Test synchronizing data and metadata between two DHIS2 instances
   # Run
   #   docker compose --profile sync up
-  # then follow
-  # https://github.com/dhis2/wow-backend/blob/c190287f8bf6493ed6f93d10bda4e764fcaf9930/guides/testing/metadata_sync_testing.md
+
   web-sync:
     <<: *web-base
+    volumes:
+      - ./docker/dhis-sync.conf:/opt/dhis2/dhis.conf:ro
     profiles: [sync]
     ports:
       - "127.0.0.1:8082:8080" # DHIS2

--- a/docker/dhis-sync.conf
+++ b/docker/dhis-sync.conf
@@ -1,0 +1,7 @@
+connection.dialect = org.hibernate.dialect.PostgreSQLDialect
+connection.driver_class = org.postgresql.Driver
+connection.url = jdbc:postgresql://db-sync/dhis
+connection.username = dhis
+connection.password = dhis
+
+tracker.import.preheat.cache.enabled=off


### PR DESCRIPTION
allowing to test 

https://github.com/dhis2/wow-backend/blob/master/guides/testing/metadata_sync_testing.md

using docker-compose.

We now have a base config for db and web. The base config is then used and adapted for diverging things like ports and volumes.

There is no heredoc syntax we can use to for example inline the `dhis.conf`. There are hacky workarounds. I sticked to creating a separate `dhis-sync.conf` for the `web-sync` container.