### PR TITLE
fix: TransientObjectException on LegendSet during import EventVisualization

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
@@ -70,7 +70,7 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
     handleDataElementDimensions(entityManager, schema, analyticalObject, bundle);
     handleAttributeDimensions(entityManager, schema, analyticalObject, bundle);
     handleProgramIndicatorDimensions(entityManager, schema, analyticalObject, bundle);
-    handleVisualizationLegendSet(schema, analyticalObject, bundle);
+    handleAnalyticalLegendSet(schema, analyticalObject, bundle);
     handleRelativePeriods(schema, analyticalObject);
   }
 
@@ -124,46 +124,44 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
    * @param analyticalObject the analytic object to be processed
    * @param bundle current {@link ObjectBundle}
    */
-  private void handleVisualizationLegendSet(
+  private void handleAnalyticalLegendSet(
       Schema schema, BaseAnalyticalObject analyticalObject, ObjectBundle bundle) {
-    if (!schema.getKlass().isAssignableFrom(Visualization.class)) {
+    if (!BaseAnalyticalObject.class.isAssignableFrom(schema.getKlass())) {
       return;
     }
 
-    Visualization visualization = (Visualization) analyticalObject;
-
-    if (visualization.getLegendDefinitions() == null
-        || visualization.getLegendDefinitions().getLegendSet() == null) {
+    if (analyticalObject.getLegendDefinitions() == null
+        || analyticalObject.getLegendDefinitions().getLegendSet() == null) {
       return;
     }
 
-    String legendSetId = visualization.getLegendDefinitions().getLegendSet().getUid();
+    String legendSetId = analyticalObject.getLegendDefinitions().getLegendSet().getUid();
     LegendSet legendSet =
         bundle.getPreheat().get(bundle.getPreheatIdentifier(), LegendSet.class, legendSetId);
 
     if (legendSet != null) {
-      visualization.getLegendDefinitions().setLegendSet(legendSet);
+      analyticalObject.getLegendDefinitions().setLegendSet(legendSet);
       return;
     }
 
     legendSet = objectManager.get(LegendSet.class, legendSetId);
 
     if (legendSet != null) {
-      visualization.getLegendDefinitions().setLegendSet(legendSet);
+      analyticalObject.getLegendDefinitions().setLegendSet(legendSet);
       bundle.getPreheat().put(bundle.getPreheatIdentifier(), legendSet);
       return;
     }
 
     // Add new LegendSet
     preheatService.connectReferences(
-        visualization.getLegendDefinitions().getLegendSet(),
+        analyticalObject.getLegendDefinitions().getLegendSet(),
         bundle.getPreheat(),
         bundle.getPreheatIdentifier());
-    objectManager.save(visualization.getLegendDefinitions().getLegendSet());
+    objectManager.save(analyticalObject.getLegendDefinitions().getLegendSet());
 
     bundle
         .getPreheat()
-        .put(bundle.getPreheatIdentifier(), visualization.getLegendDefinitions().getLegendSet());
+        .put(bundle.getPreheatIdentifier(), analyticalObject.getLegendDefinitions().getLegendSet());
   }
 
   private void handleDataDimensionItems(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.eventreport.EventReport;
+import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.feedback.TypeReport;
@@ -1122,6 +1123,31 @@ class MetadataImportServiceTest extends PostgresIntegrationTestBase {
                     .getMessage()
                     .equals(
                         "Duplicate reference [XJGLlMAMCcn] (Category) on object Gender [faV8QvLgIwB] (CategoryCombo) for association `category`")));
+  }
+
+  @Test
+  void testImportVisualizationWithExistedLegendSet() throws IOException {
+    Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
+        renderService.fromMetadata(
+            new ClassPathResource("dxf2/favorites/metadata_with_legendSet.json").getInputStream(),
+            RenderFormat.JSON);
+    MetadataImportParams params = createParams(ImportStrategy.CREATE);
+    ImportReport report = importService.importMetadata(params, new MetadataObjects(metadata));
+
+    assertEquals(Status.OK, report.getStatus());
+
+    metadata =
+        renderService.fromMetadata(
+            new ClassPathResource("dxf2/favorites/event_visualizations.json").getInputStream(),
+            RenderFormat.JSON);
+    params = createParams(ImportStrategy.CREATE);
+    report = importService.importMetadata(params, new MetadataObjects(metadata));
+
+    assertEquals(Status.OK, report.getStatus());
+
+    EventVisualization visualization = manager.get(EventVisualization.class, "gyYXi0rXAIc");
+    assertNotNull(visualization.getLegendDefinitions().getLegendSet());
+    assertEquals("CGWUjDCWaMA", visualization.getLegendDefinitions().getLegendSet().getUid());
   }
 
   private MetadataImportParams createParams(ImportStrategy importStrategy) {

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/favorites/event_visualizations.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/favorites/event_visualizations.json
@@ -1,0 +1,651 @@
+{
+  "eventVisualizations": [
+    {
+      "completedOnly": false,
+      "externalAccess": false,
+      "showData": true,
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "dataDimensionItems": [
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement": {
+            "id": "JXWenbITNIR"
+          }
+        },
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement": {
+            "id": "Kvv6LltZuOd"
+          }
+        }
+      ],
+      "filterDimensions": [
+        "ou"
+      ],
+      "series": [
+        {
+          "dimensionItem": "JXWenbITNIR",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Kvv6LltZuOd",
+          "visualizationType": "LINE"
+        }
+      ],
+      "organisationUnitLevels": [],
+      "id": "gyYXi0rXAIc",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "organisationUnitGroups": [],
+      "name": "ChartA",
+      "sortOrder": 0,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "category": "pe",
+      "categoryOptionGroups": [],
+      "dataElementGroups": [],
+      "relativePeriods": {
+        "lastSixMonth": false,
+        "last5Years": false,
+        "thisSixMonth": false,
+        "thisWeek": false,
+        "last4Weeks": false,
+        "last4Quarters": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "thisQuarter": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "thisFinancialYear": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisYear": false,
+        "lastBimonth": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastYear": false,
+        "last2SixMonths": false,
+        "lastFinancialYear": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false
+      },
+      "categoryDimensions": [],
+      "userOrganisationUnit": false,
+      "userGroupAccesses": [],
+      "hideSubtitle": false,
+      "hideTitle": false,
+      "regression": false,
+      "type": "COLUMN",
+      "aggregationType": "SUM",
+      "created": "2016-03-17T01:56:51.847+0000",
+      "periods": [],
+      "hideLegend": false,
+      "itemOrganisationUnitGroups": [],
+      "lastUpdated": "2016-03-17T01:56:51.847+0000",
+      "userOrganisationUnitGrandChildren": false,
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "set": {
+          "id": "CGWUjDCWaMA"
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "showData": true,
+      "filterDimensions": [
+        "ou"
+      ],
+      "dataDimensionItems": [
+        {
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "JrpFZgTcp5m"
+            },
+            "categoryOptionCombo": {
+              "id": "c8yQa2ZIqhL"
+            }
+          },
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND"
+        },
+        {
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND",
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "Dy2uRmhOKbJ"
+            },
+            "categoryOptionCombo": {
+              "id": "c8yQa2ZIqhL"
+            }
+          }
+        }
+      ],
+      "series": [
+        {
+          "dimensionItem": "JrpFZgTcp5m",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Dy2uRmhOKbJ",
+          "visualizationType": "LINE"
+        }
+      ],
+      "completedOnly": false,
+      "externalAccess": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "sortOrder": 0,
+      "relativePeriods": {
+        "lastYear": false,
+        "last2SixMonths": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false,
+        "lastFinancialYear": false,
+        "lastBimonth": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "thisBimonth": false,
+        "last6BiMonths": false,
+        "thisYear": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisFinancialYear": false,
+        "last4Weeks": false,
+        "last5Years": false,
+        "thisWeek": false,
+        "thisSixMonth": false,
+        "last4Quarters": false,
+        "lastSixMonth": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "thisQuarter": false,
+        "monthsLastYear": false
+      },
+      "dataElementGroups": [],
+      "categoryOptionGroups": [],
+      "category": "pe",
+      "organisationUnitLevels": [],
+      "organisationUnitGroups": [],
+      "name": "ChartB",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "id": "qD72aBqsHvt",
+      "regression": false,
+      "type": "COLUMN",
+      "hideTitle": false,
+      "hideSubtitle": false,
+      "aggregationType": "SUM",
+      "userGroupAccesses": [],
+      "categoryDimensions": [],
+      "userOrganisationUnit": false,
+      "itemOrganisationUnitGroups": [],
+      "hideLegend": false,
+      "userOrganisationUnitGrandChildren": false,
+      "lastUpdated": "2016-03-17T01:57:13.118+0000",
+      "periods": [],
+      "created": "2016-03-17T01:57:13.118+0000",
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "aggregationType": "SUM",
+      "hideTitle": false,
+      "hideSubtitle": false,
+      "type": "COLUMN",
+      "regression": false,
+      "userOrganisationUnit": false,
+      "categoryDimensions": [],
+      "userGroupAccesses": [],
+      "lastUpdated": "2016-03-17T01:57:32.354+0000",
+      "userOrganisationUnitGrandChildren": false,
+      "hideLegend": false,
+      "itemOrganisationUnitGroups": [],
+      "created": "2016-03-17T01:57:32.354+0000",
+      "periods": [],
+      "dataDimensionItems": [
+        {
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND",
+          "dataElementOperand": {
+            "categoryOptionCombo": {
+              "id": "O9ZA0CUVVmL"
+            },
+            "dataElement": {
+              "id": "JrpFZgTcp5m"
+            }
+          }
+        },
+        {
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "Dy2uRmhOKbJ"
+            },
+            "categoryOptionCombo": {
+              "id": "O9ZA0CUVVmL"
+            }
+          },
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND"
+        }
+      ],
+      "filterDimensions": [
+        "ou"
+      ],
+      "series": [
+        {
+          "dimensionItem": "JrpFZgTcp5m",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Dy2uRmhOKbJ",
+          "visualizationType": "LINE"
+        }
+      ],
+      "showData": true,
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "externalAccess": false,
+      "completedOnly": false,
+      "category": "pe",
+      "categoryOptionGroups": [],
+      "dataElementGroups": [],
+      "relativePeriods": {
+        "quartersLastYear": false,
+        "thisFinancialYear": false,
+        "last3Months": false,
+        "lastQuarter": false,
+        "quartersThisYear": false,
+        "thisYear": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "thisQuarter": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "monthsThisYear": false,
+        "lastSixMonth": false,
+        "last4Quarters": false,
+        "last5Years": false,
+        "thisWeek": false,
+        "thisSixMonth": false,
+        "last4Weeks": false,
+        "lastFinancialYear": false,
+        "lastMonth": false,
+        "last6Months": false,
+        "last52Weeks": false,
+        "last2SixMonths": false,
+        "lastYear": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastBimonth": false
+      },
+      "sortOrder": 0,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "id": "z3zvnIJYQ4J",
+      "hideEmptyRows": false,
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "organisationUnitGroups": [],
+      "name": "ChartC",
+      "organisationUnitLevels": [],
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ],
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15
+    }
+  ]
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/favorites/metadata_with_legendSet.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/favorites/metadata_with_legendSet.json
@@ -1,0 +1,388 @@
+{
+  "categories": [
+    {
+      "lastUpdated": "2016-03-17T01:53:56.098+0000",
+      "code": "Gender",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [],
+      "id": "XFgfIO1qQmd",
+      "name": "Gender",
+      "shortName": "Gender",
+      "created": "2016-03-17T01:53:56.097+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        },
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "dataDimension": true
+    }
+  ],
+  "organisationUnitGroups": [
+    {
+      "code": "OrgUnitGroupA",
+      "lastUpdated": "2016-03-17T01:52:11.966+0000",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:52:11.957+0000",
+      "name": "OrgUnitGroupA",
+      "id": "K82vX2wgq6j",
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "shortName": "OrgUnitGroupA"
+    }
+  ],
+  "categoryOptions": [
+    {
+      "userGroupAccesses": [],
+      "id": "DRs8ZFxNOpW",
+      "name": "Female",
+      "created": "2016-03-17T01:53:41.459+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "Female",
+      "attributeValues": [],
+      "lastUpdated": "2016-03-17T01:53:41.461+0000",
+      "code": "Female",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "organisationUnits": []
+    },
+    {
+      "code": "Male",
+      "lastUpdated": "2016-03-17T01:53:34.526+0000",
+      "organisationUnits": [],
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "name": "Male",
+      "created": "2016-03-17T01:53:34.525+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "x3Owjhq9G7K",
+      "attributeValues": [],
+      "shortName": "Male"
+    }
+  ],
+  "organisationUnitLevels": [
+    {
+      "level": 1,
+      "name": "Country",
+      "created": "2016-03-17T01:51:45.201+0000",
+      "id": "knxIFcPUBz2",
+      "lastUpdated": "2016-03-17T01:51:45.201+0000"
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        }
+      ],
+      "name": "Female",
+      "created": "2016-03-17T01:54:04.952+0000",
+      "lastUpdated": "2016-03-17T01:54:04.952+0000",
+      "ignoreApproval": false,
+      "id": "c8yQa2ZIqhL"
+    },
+    {
+      "name": "Male",
+      "created": "2016-03-17T01:54:04.954+0000",
+      "lastUpdated": "2016-03-17T01:54:04.954+0000",
+      "ignoreApproval": false,
+      "id": "O9ZA0CUVVmL",
+      "categoryOptions": [
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      }
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "created": "2016-03-16T17:00:00.000+0000",
+      "name": "Person",
+      "description": "Person",
+      "code": "Person",
+      "lastUpdated": "2016-03-16T17:00:00.000+0000",
+      "id": "MCPQUTHX1Ze",
+      "attributeValues": []
+    }
+  ],
+  "categoryCombos": [
+    {
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "lastUpdated": "2016-03-17T01:54:04.956+0000",
+      "code": "Gender",
+      "skipTotal": false,
+      "id": "v7n8H4aj8Cg",
+      "categories": [
+        {
+          "id": "XFgfIO1qQmd"
+        }
+      ],
+      "userGroupAccesses": [],
+      "created": "2016-03-17T01:54:04.875+0000",
+      "name": "Gender",
+      "dataDimensionType": "DISAGGREGATION",
+      "user": {
+        "id": "M5zQapPyTZI"
+      }
+    }
+  ],
+  "dataElements": [
+    {
+      "code": "DataElementCodeA",
+      "zeroIsSignificant": false,
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "aggregationLevels": [],
+      "userGroupAccesses": [],
+      "valueType": "NUMBER",
+      "lastUpdated": "2016-03-17T01:52:56.021+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "created": "2016-03-17T01:52:56.017+0000",
+      "name": "DataElementA",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "JXWenbITNIR",
+      "attributeValues": [],
+      "shortName": "DataElementShortA"
+    },
+    {
+      "lastUpdated": "2016-03-17T01:53:21.549+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "id": "Kvv6LltZuOd",
+      "name": "DataElementB",
+      "created": "2016-03-17T01:53:21.548+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "DataElementShortB",
+      "attributeValues": [],
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "code": "DataElementCodeB",
+      "zeroIsSignificant": false,
+      "aggregationLevels": [],
+      "userGroupAccesses": [],
+      "valueType": "NUMBER"
+    },
+    {
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "DataElementC",
+      "created": "2016-03-17T01:54:39.781+0000",
+      "id": "JrpFZgTcp5m",
+      "attributeValues": [],
+      "shortName": "DataElementShortC",
+      "lastUpdated": "2016-03-17T01:54:39.782+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "valueType": "NUMBER",
+      "userGroupAccesses": [],
+      "code": "DataElementCodeC",
+      "zeroIsSignificant": false,
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels": []
+    },
+    {
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:55:00.723+0000",
+      "name": "DataElementD",
+      "id": "Dy2uRmhOKbJ",
+      "attributeValues": [],
+      "shortName": "DataElementShortD",
+      "lastUpdated": "2016-03-17T01:55:00.724+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "valueType": "NUMBER",
+      "userGroupAccesses": [],
+      "zeroIsSignificant": false,
+      "code": "DataElementCodeD",
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels": []
+    }
+  ],
+  "date": "2016-03-17T01:57:49.262+0000",
+  "dataSets": [
+    {
+      "created": "2016-03-17T01:55:31.495+0000",
+      "name": "DataSetA",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "skipOffline": false,
+      "id": "f1OijtLnf8a",
+      "renderHorizontally": false,
+      "openFuturePeriods": 0,
+      "attributeValues": [],
+      "shortName": "DataSetShortA",
+      "version": 1,
+      "timelyDays": 15,
+      "indicators": [],
+      "notifyCompletingUser": false,
+      "dataElementDecoration": false,
+      "lastUpdated": "2016-03-17T01:55:35.911+0000",
+      "renderAsTabs": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "fieldCombinationRequired": false,
+      "mobile": false,
+      "userGroupAccesses": [],
+      "compulsoryDataElementOperands": [],
+      "periodType": "Monthly",
+      "expiryDays": 0,
+      "noValueRequiresComment": false,
+      "dataElements": [
+        {
+          "id": "JXWenbITNIR"
+        },
+        {
+          "id": "Kvv6LltZuOd"
+        },
+        {
+          "id": "Dy2uRmhOKbJ"
+        },
+        {
+          "id": "JrpFZgTcp5m"
+        }
+      ],
+      "code": "DataSetCodeA",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "validCompleteOnly": false
+    }
+  ],
+  "organisationUnits": [
+    {
+      "path": "/uyHni0GvBpD",
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "lastUpdated": "2016-03-17T01:51:39.609+0000",
+      "shortName": "Country",
+      "attributeValues": [],
+      "openingDate": "2016-03-17",
+      "id": "uyHni0GvBpD",
+      "description": "",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "Country",
+      "created": "2016-03-17T01:51:39.597+0000"
+    }
+  ],
+  "legendSets": [
+    {
+      "attributeValues": [],
+      "createdBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "displayName": "Outbreak",
+      "externalAccess": false,
+      "favorite": false,
+      "favorites": [],
+      "id": "CGWUjDCWaMA",
+      "legends": [
+        {
+          "attributeValues": [],
+          "color": "#CE1256",
+          "displayName": "Outbreak",
+          "endValue": 100000.0,
+          "externalAccess": false,
+          "created": "2022-03-21T14:54:50.379",
+          "lastUpdated": "2022-03-21T14:54:50.379",
+          "favorite": false,
+          "favorites": [],
+          "id": "Vv93Hj1RIhO",
+          "name": "Outbreak",
+          "sharing": {
+            "external": false,
+            "userGroups": {},
+            "users": {}
+          },
+          "startValue": 1.0
+        }
+      ],
+      "name": "Outbreak",
+      "sharing": {
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "public": "r-------",
+        "userGroups": {},
+        "users": {}
+      },
+      "translations": [
+        {
+          "locale": "fr",
+          "property": "NAME",
+          "value": "Flambée"
+        }
+      ],
+      "user": {
+        "id": "M5zQapPyTZI"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17445

### Issue:
- When importing, `EventVisualization.legendDefinitions.legendSet` is not picked up by `AnalyticalObjectImportHandler`. Hence, the  referenced `LegendSet` object is in detached state.

### Fix
- Update `AnalyticalObjectImportHandler` to handle all objects extend `BaseAnalyticObject`

### Test
- Added integration test