### PR TITLE
fix: use error only notifier logging for frequent jobs [DHIS2-17998]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -260,19 +260,20 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
 
   private JobProgress startRecording(@Nonnull JobConfiguration job, @Nonnull Runnable observer) {
     SystemSettings settings = settingsProvider.getCurrentSettings();
-    boolean logInfoOnDebug = isLogInfoOnDebug(job, settings);
+    boolean nonVerboseLogging = isNonVerboseLogging(job, settings);
     NotificationLevel level =
-        !logInfoOnDebug && job.getJobType().isUsingNotifications()
+        job.getJobType().isUsingNotifications() && !nonVerboseLogging
             ? settings.getNotifierLogLevel()
             : NotificationLevel.ERROR;
     JobProgress tracker = new NotifierJobProgress(notifier, job, level);
     RecordingJobProgress progress =
-        new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug, false);
+        new RecordingJobProgress(messages, job, tracker, true, observer, nonVerboseLogging, false);
     recordingsById.put(job.getUid(), progress);
     return progress;
   }
 
-  private static boolean isLogInfoOnDebug(@Nonnull JobConfiguration job, SystemSettings settings) {
+  private static boolean isNonVerboseLogging(
+      @Nonnull JobConfiguration job, SystemSettings settings) {
     return job.getSchedulingType() != SchedulingType.ONCE_ASAP
         && job.getLastExecuted() != null
         && Duration.between(job.getLastExecuted().toInstant(), Instant.now()).getSeconds()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -260,20 +260,23 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
 
   private JobProgress startRecording(@Nonnull JobConfiguration job, @Nonnull Runnable observer) {
     SystemSettings settings = settingsProvider.getCurrentSettings();
+    boolean logInfoOnDebug = isLogInfoOnDebug(job, settings);
     NotificationLevel level =
-        job.getJobType().isUsingNotifications()
+        !logInfoOnDebug && job.getJobType().isUsingNotifications()
             ? settings.getNotifierLogLevel()
             : NotificationLevel.ERROR;
     JobProgress tracker = new NotifierJobProgress(notifier, job, level);
-    boolean logInfoOnDebug =
-        job.getSchedulingType() != SchedulingType.ONCE_ASAP
-            && job.getLastExecuted() != null
-            && Duration.between(job.getLastExecuted().toInstant(), Instant.now()).getSeconds()
-                < settings.getJobsLogDebugBelowSeconds();
     RecordingJobProgress progress =
         new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug, false);
     recordingsById.put(job.getUid(), progress);
     return progress;
+  }
+
+  private static boolean isLogInfoOnDebug(@Nonnull JobConfiguration job, SystemSettings settings) {
+    return job.getSchedulingType() != SchedulingType.ONCE_ASAP
+        && job.getLastExecuted() != null
+        && Duration.between(job.getLastExecuted().toInstant(), Instant.now()).getSeconds()
+            < settings.getJobsLogDebugBelowSeconds();
   }
 
   private void stopRecording(@Nonnull String jobId) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -81,7 +81,7 @@ public class NotifierJobProgress implements JobProgress {
     notifier.notify(
         jobId,
         NotificationLevel.INFO,
-        message,
+        isLoggedInfo() ? message : "",
         false,
         NotificationDataType.PARAMETERS,
         getJobParameterData());
@@ -90,7 +90,7 @@ public class NotifierJobProgress implements JobProgress {
   @Override
   public void completedProcess(String summary, Object... args) {
     // Note: intentionally no log level check - always log last
-    notifier.notify(jobId, format(summary, args), true);
+    notifier.notify(jobId, isLoggedInfo() ? format(summary, args) : "", true);
   }
 
   @Override


### PR DESCRIPTION
### Summary
I noticed that with the changes made to the notifier where all jobs do forward at least the first and the last message (procress start/end) to the notifier jobs that do run frequently (like the housekeeping job) basically spam the log with 1 line per run through the notifier logging.  

To prevent it the notifier log level is set to ERROR if a job should use non-verbose logging. This means for the first and last message where the notification is still always send the message is blanked which also prevents logging.

### Automatic Testing
There is no good way of testing it and I don't think it is worth making a complicated setup to verify.

### Manual Testing
* start the server
* check the logs for not showing a line from the `DefaultNotifier` once every 30 sec