### PR TITLE
fix: Propagate includeDeleted from TEs to Enrollments services [DHIS2-18883]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
@@ -173,27 +173,18 @@ public class OperationsParamsValidator {
    *
    * @return the tracked entity if found and accessible
    * @throws BadRequestException if the tracked entity uid does not exist
-   * @throws ForbiddenException if the user has no data read access to type of the tracked entity
    */
-  public TrackedEntity validateTrackedEntity(UID uid, UserDetails user)
-      throws BadRequestException, ForbiddenException {
+  public TrackedEntity validateTrackedEntity(UID uid, UserDetails user, boolean includeDeleted)
+      throws BadRequestException {
     if (uid == null) {
       return null;
     }
 
-    // TODO(tracker) Are these validations enough? Should we check for ownership too?
     TrackedEntity trackedEntity = manager.get(TrackedEntity.class, uid.getValue());
-    if (trackedEntity == null || trackedEntity.isDeleted()) {
+    if (trackedEntity == null || (trackedEntity.isDeleted() && !includeDeleted)) {
       throw new BadRequestException("Tracked entity is specified but does not exist: " + uid);
     }
     trackedEntityAuditService.addTrackedEntityAudit(READ, user.getUsername(), trackedEntity);
-
-    if (trackedEntity.getTrackedEntityType() != null
-        && !aclService.canDataRead(user, trackedEntity.getTrackedEntityType())) {
-      throw new ForbiddenException(
-          "User is not authorized to read data from type of selected tracked entity: "
-              + trackedEntity.getTrackedEntityType().getUid());
-    }
 
     return trackedEntity;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -199,7 +200,9 @@ class DefaultEnrollmentService implements EnrollmentService {
       trackedEntity.setUid(enrollment.getTrackedEntity().getUid());
       result.setTrackedEntity(trackedEntity);
     }
-    result.setOrganisationUnit(enrollment.getOrganisationUnit());
+    OrganisationUnit organisationUnit = new OrganisationUnit();
+    organisationUnit.setUid(enrollment.getOrganisationUnit().getUid());
+    result.setOrganisationUnit(organisationUnit);
     result.setGeometry(enrollment.getGeometry());
     result.setCreated(enrollment.getCreated());
     result.setCreatedAtClient(enrollment.getCreatedAtClient());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -67,7 +67,8 @@ class EnrollmentOperationParamsMapper {
     TrackedEntityType trackedEntityType =
         paramsValidator.validateTrackedEntityType(operationParams.getTrackedEntityType(), user);
     TrackedEntity trackedEntity =
-        paramsValidator.validateTrackedEntity(operationParams.getTrackedEntity(), user);
+        paramsValidator.validateTrackedEntity(
+            operationParams.getTrackedEntity(), user, operationParams.isIncludeDeleted());
 
     Set<OrganisationUnit> orgUnits =
         paramsValidator.validateOrgUnits(operationParams.getOrgUnits(), user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -89,7 +89,8 @@ class EventOperationParamsMapper {
         validateProgramStage(
             applyIfNotNull(operationParams.getProgramStage(), UID::getValue), user);
     TrackedEntity trackedEntity =
-        paramsValidator.validateTrackedEntity(operationParams.getTrackedEntity(), user);
+        paramsValidator.validateTrackedEntity(
+            operationParams.getTrackedEntity(), user, operationParams.isIncludeDeleted());
     OrganisationUnit orgUnit =
         validateRequestedOrgUnit(applyIfNotNull(operationParams.getOrgUnit(), UID::getValue), user);
     validateOrgUnitMode(operationParams.getOrgUnitMode(), program, user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -58,9 +58,10 @@ class RelationshipOperationParamsMapper {
 
     IdentifiableObject entity =
         switch (params.getType()) {
-          case TRACKED_ENTITY -> getTrackedEntity(params.getIdentifier());
-          case ENROLLMENT -> getEnrollment(params.getIdentifier());
-          case EVENT -> getEvent(params.getIdentifier());
+          case TRACKED_ENTITY ->
+              getTrackedEntity(params.getIdentifier(), params.isIncludeDeleted());
+          case ENROLLMENT -> getEnrollment(params.getIdentifier(), params.isIncludeDeleted());
+          case EVENT -> getEvent(params.getIdentifier(), params.isIncludeDeleted());
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
         };
 
@@ -71,11 +72,12 @@ class RelationshipOperationParamsMapper {
         .build();
   }
 
-  private TrackedEntity getTrackedEntity(UID trackedEntityUid)
+  private TrackedEntity getTrackedEntity(UID trackedEntityUid, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
     TrackedEntity trackedEntity =
         relationshipStore
             .findTrackedEntity(trackedEntityUid)
+            .filter(te -> (includeDeleted || !te.isDeleted()))
             .orElseThrow(() -> new NotFoundException(TrackedEntity.class, trackedEntityUid));
     if (!trackerAccessManager
         .canRead(CurrentUserUtil.getCurrentUserDetails(), trackedEntity)
@@ -85,10 +87,12 @@ class RelationshipOperationParamsMapper {
     return trackedEntity;
   }
 
-  private Enrollment getEnrollment(UID enrollmentUid) throws NotFoundException, ForbiddenException {
+  private Enrollment getEnrollment(UID enrollmentUid, boolean includeDeleted)
+      throws NotFoundException, ForbiddenException {
     Enrollment enrollment =
         relationshipStore
             .findEnrollment(enrollmentUid)
+            .filter(te -> (includeDeleted || !te.isDeleted()))
             .orElseThrow(() -> new NotFoundException(Enrollment.class, enrollmentUid));
     if (!trackerAccessManager
         .canRead(CurrentUserUtil.getCurrentUserDetails(), enrollment, false)
@@ -98,10 +102,12 @@ class RelationshipOperationParamsMapper {
     return enrollment;
   }
 
-  private Event getEvent(UID eventUid) throws NotFoundException, ForbiddenException {
+  private Event getEvent(UID eventUid, boolean includeDeleted)
+      throws NotFoundException, ForbiddenException {
     Event event =
         relationshipStore
             .findEvent(eventUid)
+            .filter(te -> (includeDeleted || !te.isDeleted()))
             .orElseThrow(() -> new NotFoundException(Event.class, eventUid));
     if (!trackerAccessManager
         .canRead(CurrentUserUtil.getCurrentUserDetails(), event, false)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentAggregate.java
@@ -70,6 +70,7 @@ class EnrollmentAggregate {
                 EnrollmentOperationParams.builder()
                     .enrollmentParams(ctx.getParams().getEnrollmentParams())
                     .trackedEntity(UID.of(id.uid()))
+                    .includeDeleted(ctx.getQueryParams().isIncludeDeleted())
                     .build();
             try {
               result.putAll(id.uid(), enrollmentService.getEnrollments(params));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -144,7 +144,8 @@ class EnrollmentOperationParamsMapperTest {
     when(paramsValidator.validateTrackerProgram(PROGRAM_UID, user)).thenReturn(program);
     when(paramsValidator.validateTrackedEntityType(TRACKED_ENTITY_TYPE_UID, user))
         .thenReturn(trackedEntityType);
-    when(paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user)).thenReturn(trackedEntity);
+    when(paramsValidator.validateTrackedEntity(TRACKED_ENTITY_UID, user, false))
+        .thenReturn(trackedEntity);
     when(paramsValidator.validateOrgUnits(Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID), user))
         .thenReturn(Set.of(orgUnit1, orgUnit2));
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -1431,7 +1431,6 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         () -> assertEquals(trackedEntityA.getUid(), enrollment.getTrackedEntity().getUid()),
         () -> assertEquals(trackedEntityA.getUid(), enrollment.getTrackedEntity().getUid()),
         () -> assertEquals(orgUnitA.getUid(), enrollment.getOrganisationUnit().getUid()),
-        () -> assertEquals(orgUnitA.getName(), enrollment.getOrganisationUnit().getName()),
         () -> assertEquals(programA.getUid(), enrollment.getProgram().getUid()),
         () -> assertEquals(EnrollmentStatus.ACTIVE, enrollment.getStatus()),
         () -> assertFalse(enrollment.isDeleted()),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -154,7 +154,7 @@ public class JsonAssertions {
     assertEquals(expected.getValue(), j.getString(member).string(), member + " UID");
   }
 
-  public static void assertEnrollmentWithinRelationship(
+  public static void assertEnrollmentWithinRelationshipItem(
       Enrollment expected, JsonRelationshipItem actual) {
     JsonRelationshipItem.JsonEnrollment jsonEnrollment = actual.getEnrollment();
     assertFalse(jsonEnrollment.isEmpty(), "enrollment should not be empty");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
@@ -52,6 +52,10 @@ public interface JsonEnrollment extends JsonObject {
     return getString("orgUnit").string();
   }
 
+  default Boolean getDeleted() {
+    return getBoolean("deleted").bool();
+  }
+
   default JsonList<JsonEvent> getEvents() {
     return get("events").asList(JsonEvent.class);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -440,12 +440,8 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
   @Test
   void
       shouldGetNotFoundWhenGettingEnrollmentsByTrackedEntityAndTrackedEntityIsDeletedAndIncludeDeletedIsFalse() {
-    assertEquals(
-        BAD_REQUEST,
-        GET(
-                "/tracker/enrollments?trackedEntity={te}&includeDeleted=false",
-                DELETE_TRACKED_ENTITY_UID)
-            .status());
+    GET("/tracker/enrollments?trackedEntity={te}&includeDeleted=false", DELETE_TRACKED_ENTITY_UID)
+        .error(BAD_REQUEST);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -458,9 +458,7 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     manager.flush();
     switchContextToUser(user);
 
-    assertEquals(
-        BAD_REQUEST,
-        GET("/tracker/events?trackedEntity={te}&includeDeleted=false", te.getUid()).status());
+    GET("/tracker/events?trackedEntity={te}&includeDeleted=false", te.getUid()).error(BAD_REQUEST);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.hisp.dhis.http.HttpStatus.FORBIDDEN;
 import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
@@ -569,10 +570,8 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
                 .trackedEntities(List.of(getTrackedEntity(UID.of("guVNoAerxWo"))))
                 .build()));
 
-    assertEquals(
-        NOT_FOUND,
-        GET("/tracker/relationships?trackedEntity={te}&includeDeleted=false", "guVNoAerxWo")
-            .status());
+    GET("/tracker/relationships?trackedEntity={te}&includeDeleted=false", "guVNoAerxWo")
+        .error(NOT_FOUND);
   }
 
   @Test
@@ -618,9 +617,8 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
                 .enrollments(List.of(getEnrollment(UID.of("ipBifypAQTo"))))
                 .build()));
 
-    assertEquals(
-        NOT_FOUND,
-        GET("/tracker/relationships?enrollment={en}&includeDeleted=false", "ipBifypAQTo").status());
+    GET("/tracker/relationships?enrollment={en}&includeDeleted=false", "ipBifypAQTo")
+        .error(NOT_FOUND);
   }
 
   @Test
@@ -661,9 +659,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
             TrackerObjects.builder().events(List.of(getEvent(UID.of("LCSfHnurnNB")))).build()));
 
-    assertEquals(
-        NOT_FOUND,
-        GET("/tracker/relationships?event={ev}&includeDeleted=false", "LCSfHnurnNB").status());
+    GET("/tracker/relationships?event={ev}&includeDeleted=false", "LCSfHnurnNB").error(NOT_FOUND);
   }
 
   @Test
@@ -886,10 +882,8 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
     switchContextToUser(user);
 
-    assertEquals(
-        HttpStatus.FORBIDDEN,
-        GET("/tracker/relationships?trackedEntity={trackedEntity}", relationship1From.getUid())
-            .status());
+    GET("/tracker/relationships?trackedEntity={trackedEntity}", relationship1From.getUid())
+        .error(FORBIDDEN);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -27,11 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContains;
-import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEnrollmentWithinRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEnrollmentWithinRelationshipItem;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEventWithinRelationshipItem;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
@@ -239,7 +240,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   void shouldReturnNotFoundWhenGettingANonExistingRelationshipById() {
     assertEquals(
         "Relationship with id Hq3Kc6HK4OZ could not be found.",
-        GET("/tracker/relationships/Hq3Kc6HK4OZ").error(HttpStatus.NOT_FOUND).getMessage());
+        GET("/tracker/relationships/Hq3Kc6HK4OZ").error(NOT_FOUND).getMessage());
   }
 
   @Test
@@ -320,7 +321,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   @Test
   void shouldGetRelationshipsByEventWithAssignedUser() {
     JsonList<JsonRelationship> relationships =
-        GET("/tracker/relationships?event={uid}&fields=*", "QRYjLTiJTrA")
+        GET("/tracker/relationships?event={uid}&fields=to[event[assignedUser]]", "QRYjLTiJTrA")
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
@@ -371,7 +372,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   void shouldReturnNotFoundWhenGettingRelationshipsByNonExistingEvent() {
     assertStartsWith(
         "Event with id Hq3Kc6HK4OZ",
-        GET("/tracker/relationships?event=Hq3Kc6HK4OZ").error(HttpStatus.NOT_FOUND).getMessage());
+        GET("/tracker/relationships?event=Hq3Kc6HK4OZ").error(NOT_FOUND).getMessage());
   }
 
   @Test
@@ -396,7 +397,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
     JsonRelationship jsonRelationship = assertFirstRelationship(relationship2, jsonRelationships);
     assertTrackedEntityWithinRelationshipItem(relationship2From, jsonRelationship.getFrom());
-    assertEnrollmentWithinRelationship(relationship2To, jsonRelationship.getTo());
+    assertEnrollmentWithinRelationshipItem(relationship2To, jsonRelationship.getTo());
   }
 
   @Test
@@ -502,9 +503,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   void shouldReturnNotFoundWhenGettingRelationshipsByNonExistingEnrollment() {
     assertStartsWith(
         "Enrollment with id Hq3Kc6HK4OZ",
-        GET("/tracker/relationships?enrollment=Hq3Kc6HK4OZ")
-            .error(HttpStatus.NOT_FOUND)
-            .getMessage());
+        GET("/tracker/relationships?enrollment=Hq3Kc6HK4OZ").error(NOT_FOUND).getMessage());
   }
 
   @Test
@@ -543,6 +542,40 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   }
 
   @Test
+  void shouldGetRelationshipsByTrackedEntityWhenTrackedEntityIsDeletedAndIncludeDeletedIsTrue() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder()
+                .trackedEntities(List.of(getTrackedEntity(UID.of("guVNoAerxWo"))))
+                .build()));
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?trackedEntity={te}&fields=*&includeDeleted=true", "guVNoAerxWo")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEnrollmentRelationship, jsonRelationships);
+    assertTrackedEntityWithinRelationshipItem(
+        getTrackedEntity(UID.of("guVNoAerxWo")), jsonRelationships.get(0).getFrom());
+  }
+
+  @Test
+  void
+      shouldReturnNotFoundWhenGettingRelationshipsByTrackedEntityAndTrackedEntityIsDeletedAndIncludeDeletedIsFalse() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder()
+                .trackedEntities(List.of(getTrackedEntity(UID.of("guVNoAerxWo"))))
+                .build()));
+
+    assertEquals(
+        NOT_FOUND,
+        GET("/tracker/relationships?trackedEntity={te}&includeDeleted=false", "guVNoAerxWo")
+            .status());
+  }
+
+  @Test
   void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
     assertNoRelationships(
         GET("/tracker/relationships?enrollment={en}", "ipBifypAQTo").content(HttpStatus.OK));
@@ -558,18 +591,79 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   }
 
   @Test
+  void shouldGetRelationshipsByEnrollmentWhenEnrollmentIsDeletedAndIncludeDeletedIsTrue() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder()
+                .enrollments(List.of(getEnrollment(UID.of("ipBifypAQTo"))))
+                .build()));
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?enrollment={en}&includeDeleted=true&fields=*", "ipBifypAQTo")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEnrollmentRelationship, jsonRelationships);
+    assertEnrollmentWithinRelationshipItem(
+        getEnrollment(UID.of("ipBifypAQTo")), jsonRelationships.get(0).getTo());
+  }
+
+  @Test
+  void
+      shouldGetNotFoundWhenGettingRelationshipsByEnrollmentAndEnrollmentIsDeletedAndIncludeDeletedIsFalse() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder()
+                .enrollments(List.of(getEnrollment(UID.of("ipBifypAQTo"))))
+                .build()));
+
+    assertEquals(
+        NOT_FOUND,
+        GET("/tracker/relationships?enrollment={en}&includeDeleted=false", "ipBifypAQTo").status());
+  }
+
+  @Test
   void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
     assertNoRelationships(
         GET("/tracker/relationships?event={ev}", "LCSfHnurnNB").content(HttpStatus.OK));
   }
 
   @Test
-  void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
+  void shouldGetRelationshipsByEventWhenRelationshipIsDeletedAndIncludeDeletedIsTrue() {
     JsonList<JsonRelationship> jsonRelationships =
         GET("/tracker/relationships?event={ev}&includeDeleted=true", "LCSfHnurnNB")
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
     assertFirstRelationship(deletedTEToEventRelationship, jsonRelationships);
+  }
+
+  @Test
+  void shouldGetRelationshipsByEventWhenEventIsDeletedAndIncludeDeletedIsTrue() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder().events(List.of(getEvent(UID.of("LCSfHnurnNB")))).build()));
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?event={ev}&includeDeleted=true&fields=*", "LCSfHnurnNB")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+    assertFirstRelationship(deletedTEToEventRelationship, jsonRelationships);
+    assertEventWithinRelationshipItem(
+        getEvent(UID.of("LCSfHnurnNB")), jsonRelationships.get(0).getTo());
+  }
+
+  @Test
+  void shouldGetNotFoundWhenGettingRelationshipsByEventAndEventIsDeletedAndIncludeDeletedIsFalse() {
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build(),
+            TrackerObjects.builder().events(List.of(getEvent(UID.of("LCSfHnurnNB")))).build()));
+
+    assertEquals(
+        NOT_FOUND,
+        GET("/tracker/relationships?event={ev}&includeDeleted=false", "LCSfHnurnNB").status());
   }
 
   @Test
@@ -802,9 +896,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   void shouldReturnNotFoundWhenGettingRelationshipsByNonExistingTrackedEntity() {
     assertStartsWith(
         "TrackedEntity with id Hq3Kc6HK4OZ",
-        GET("/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ")
-            .error(HttpStatus.NOT_FOUND)
-            .getMessage());
+        GET("/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ").error(NOT_FOUND).getMessage());
   }
 
   private TrackedEntity getTrackedEntity(UID trackedEntity) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -470,9 +470,8 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
     relationship(from, to);
     this.switchContextToUser(user);
 
-    assertEquals(
-        HttpStatus.FORBIDDEN,
-        GET("/tracker/trackedEntities/{id}?fields=relationships", from.getUid()).status());
+    GET("/tracker/trackedEntities/{id}?fields=relationships", from.getUid())
+        .error(HttpStatus.FORBIDDEN);
   }
 
   @Test


### PR DESCRIPTION
Propagate `includeDeleted` from `TrackedEntityService` to `EnrollmentService` and fix `validateTrackedEntity` method: this was a bug only and it was only present in master. Getting `/tracker/trackedEntities?trackedEntity={te_uid}&includeDeleted=true&fields=* when TE is deleted  return a 500 because it was trying to get enrollments filtering by a soft-deleted `trackedEntity` that was throwing the error [here](https://github.com/dhis2/dhis2-core/blob/68ffdfbcb8bc9ac8013c620be76c045c54ae2b64/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentAggregate.java#L77).

Now the behavior of `validateTrackedEntity` changed and a deleted `trackedEntity` is a valid parameter if the `includeDeleted` parameter is `true`.

Additionally, partial ACL check in `validateTrackedEntity` method was removed as any child entity (eg. event or enrollment) will check the ACL of the parent when checking its own ACL.

Enrollment [`canRead`](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java#L252-L256)
Event [`canRead`](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java#L406-L410) 

The same propagation for `includeDeleted` was added in `RelationshipService`, so a deleted entity is a valid parameter if the `includeDeleted` parameter is `true`.

***Next steps***
- Check if we can remove `isDeleted` check from `RelationshipService`
- Serve multiple and single tracked entities using the same path
- Pass field params to `RelationshipService` in order to only retrieve from the DB what is needed.
- Changing the test input to use the `view` model in relationship tests