### PR TITLE
fix: NullPointerException in Legend.draw()[DHIS2-12003-41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/mapgeneration/Legend.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/mapgeneration/Legend.java
@@ -32,6 +32,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.i18n.I18nFormat;
 
 /**
@@ -65,7 +66,7 @@ public class Legend {
   public void draw(Graphics2D g, I18nFormat format) {
     g.setColor(Color.BLACK);
     g.setFont(PLAIN_FONT);
-    g.drawString(mapLayer.getName(), 0, 15);
+    g.drawString(ObjectUtils.firstNonNull(mapLayer.getName(), mapLayer.getLayer(), ""), 0, 15);
     g.drawString(format.formatPeriod(mapLayer.getPeriod()) + "", 0, 35);
 
     g.translate(0, HEADER_HEIGHT);

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapgeneration/MapUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapgeneration/MapUtilsTest.java
@@ -28,10 +28,17 @@
 package org.hisp.dhis.mapgeneration;
 
 import static org.hisp.dhis.mapgeneration.MapUtils.getWidthHeight;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import org.hisp.dhis.i18n.I18nFormat;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /** Lars Helge Overland */
 class MapUtilsTest {
@@ -57,5 +64,38 @@ class MapUtilsTest {
   @Test
   void testGetWidthHeightIllegalArgument() {
     assertThrows(IllegalArgumentException.class, () -> getWidthHeight(null, null, 0, 0, 0.5));
+  }
+
+  @Test
+  @DisplayName("Should not throw null pointer exception when drawing legend with null name")
+  void testLegendDrawWithNullName() {
+    InternalMapLayer mapLayer = Mockito.mock(InternalMapLayer.class);
+    when(mapLayer.getName()).thenReturn(null);
+    when(mapLayer.getLayer()).thenReturn("layer");
+    when(mapLayer.getIntervalSet()).thenReturn(new IntervalSet());
+
+    BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = (Graphics2D) image.getGraphics();
+
+    Legend legend = new Legend(mapLayer);
+    I18nFormat i18nFormat = new I18nFormat();
+    assertDoesNotThrow(() -> legend.draw(graphics, i18nFormat));
+  }
+
+  @Test
+  @DisplayName(
+      "Should not throw null pointer exception when drawing legend with null layer and name")
+  void testLegendDrawWithNullLayerAndName() {
+    InternalMapLayer mapLayer = Mockito.mock(InternalMapLayer.class);
+    when(mapLayer.getName()).thenReturn(null);
+    when(mapLayer.getLayer()).thenReturn(null);
+    when(mapLayer.getIntervalSet()).thenReturn(new IntervalSet());
+
+    BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = (Graphics2D) image.getGraphics();
+
+    Legend legend = new Legend(mapLayer);
+    I18nFormat i18nFormat = new I18nFormat();
+    assertDoesNotThrow(() -> legend.draw(graphics, i18nFormat));
   }
 }


### PR DESCRIPTION
This PR backports commit 69050430787cce7af18303166239cf67393cd21e.