### PR TITLE
backport: fix: Prevent duplicate descriptions in data integrity checks

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/groups/group_size_category_option_group_sets.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/groups/group_size_category_option_group_sets.yaml
@@ -26,7 +26,7 @@
 #
 ---
 name: category_option_group_sets_scarce
-description: Category option groups should have at least two members.
+description: Category option group sets should have at least two members.
 section: Group size
 section_order: 8
 summary_sql: >-

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -75,6 +75,11 @@ class DataIntegrityYamlReaderTest {
     List<String> codeList = checks.stream().map(DataIntegrityCheck::getCode).sorted().toList();
     assertEquals(codeList.size(), Set.copyOf(codeList).size());
 
+    // Assert that all the descriptions are unique.
+    List<String> nameList =
+        checks.stream().map(DataIntegrityCheck::getDescription).sorted().toList();
+    assertEquals(nameList.size(), Set.copyOf(nameList).size());
+
     // Assert that codes consist of upper case letter and numbers only
     String regEx = "^[A-Z0-9]+$";
     Predicate<String> IS_NOT_CAPS = Pattern.compile(regEx).asPredicate().negate();


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/19911