### PR TITLE
fix: use error only notifier logging for frequent jobs [DHIS2-17998] (2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -84,7 +84,7 @@ public class NotifierJobProgress implements JobProgress {
     notifier.notify(
         jobId,
         NotificationLevel.INFO,
-        message,
+        isLoggedInfo() ? message : "",
         false,
         NotificationDataType.PARAMETERS,
         getJobParameterData());
@@ -93,7 +93,7 @@ public class NotifierJobProgress implements JobProgress {
   @Override
   public void completedProcess(String summary) {
     // Note: intentionally no log level check - always log last
-    notifier.notify(jobId, summary, true);
+    notifier.notify(jobId, isLoggedInfo() ? summary : "", true);
   }
 
   @Override


### PR DESCRIPTION
Manual backport of the changes in #19949 which are relevant in 2.40