### PR TITLE
fix: metadata API filter for objects that have a value for a given attribute [DHIS2-18970]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -69,7 +69,7 @@ public class DefaultJpaQueryParser implements QueryParser {
 
     List<String> mentions = new ArrayList<>();
     for (String filter : filters) {
-      String[] split = filter.split(":");
+      String[] split = rewriteFilter(filter).split(":");
 
       if (split.length < 2) {
         throw new QueryParserException("Invalid filter => " + filter);
@@ -94,6 +94,12 @@ public class DefaultJpaQueryParser implements QueryParser {
       }
     }
     return query;
+  }
+
+  private static String rewriteFilter(String filter) {
+    if (filter.startsWith("attributeValues.attribute.id:eq:"))
+      return filter.substring(filter.lastIndexOf(':') + 1) + ":!null";
+    return filter;
   }
 
   private void handleIdentifiablePath(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
@@ -214,6 +214,9 @@ class GistAttributeControllerTest extends AbstractGistControllerTest {
     String url =
         "/userGroups/gist?fields=id,name&headless=true&filter=attributeValues.attribute.id:eq:{attr}";
     assertEquals(2, GET(url, attrId).content().size());
+    // cross-check with metadata API
+    url = url.replace("/gist", "");
+    assertEquals(2, GET(url, attrId).content().size());
   }
 
   private String postNewUserGroupWithAttributeValue(String name, String attrId, String value) {


### PR DESCRIPTION
### Summary
A filter like `attributeValues.attribute.id:eq:{uid}` (which no longer works in 2.40) is internally rewritten to the equivalent filter `{uid}:!null` (which works). 

### Automatic Testing
Added an assert to an existing test 

### Manual Testing
* try `/api/organisationUnits?fields=name,id,attributeValues&filter=attributeValues.attribute.id:eq:ihn1wb9eho8`
* check the filter has results on SL demo and does not end up with an error