### PR TITLE
fix: Duplicate table aliases in RelationshipTypeJoinGenerator [DHIS-18989] [2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
@@ -82,11 +82,11 @@ public class RelationshipTypeJoinGenerator {
     String sql = "LEFT JOIN ";
     switch (relationshipEntity) {
       case TRACKED_ENTITY_INSTANCE:
-        return sql + "trackedentity tei on tei.trackedentityid = ri2.trackedentityid";
+        return sql + "trackedentity tei2 on tei2.trackedentityid = ri2.trackedentityid";
       case PROGRAM_STAGE_INSTANCE:
-        return sql + "event psi on psi.eventid = ri2.eventid";
+        return sql + "event psi2 on psi2.eventid = ri2.eventid";
       case PROGRAM_INSTANCE:
-        return sql + "enrollment pi on pi.enrollmentid = ri2.enrollmentid";
+        return sql + "enrollment pi2 on pi2.enrollmentid = ri2.enrollmentid";
       default:
         throw new IllegalQueryException(
             new ErrorMessage(ErrorCode.E7227, relationshipEntity.name()));
@@ -138,11 +138,11 @@ public class RelationshipTypeJoinGenerator {
 
     switch (relationshipEntity) {
       case TRACKED_ENTITY_INSTANCE:
-        return sql + "tei.uid = ax.tei ";
+        return sql + "tei2.uid = ax.tei ";
       case PROGRAM_STAGE_INSTANCE:
-        return sql + "psi.uid = ax.psi ";
+        return sql + "psi2.uid = ax.psi ";
       case PROGRAM_INSTANCE:
-        return sql + "pi.uid = ax.pi ";
+        return sql + "pi2.uid = ax.pi ";
       default:
         throw new IllegalQueryException(
             new ErrorMessage(ErrorCode.E7227, relationshipEntity.name()));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -585,10 +585,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN trackedentity tei on tei.trackedentityid = ri2.trackedentityid "
+            + "LEFT JOIN trackedentity tei2 on tei2.trackedentityid = ri2.trackedentityid "
             + "WHERE rty.relationshiptypeid = "
             + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )) as \""
+            + " AND tei2.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  "
             + "from analytics_enrollment_"
@@ -633,10 +633,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN enrollment pi on pi.enrollmentid = ri2.enrollmentid WHERE rty.relationshiptypeid "
+            + "LEFT JOIN enrollment pi2 on pi2.enrollmentid = ri2.enrollmentid WHERE rty.relationshiptypeid "
             + "= "
             + relationshipTypeA.getId()
-            + " AND pi.uid = ax.pi ))"
+            + " AND pi2.uid = ax.pi ))"
             + " as \""
             + programIndicatorA.getUid()
             + "\"  "
@@ -709,10 +709,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN trackedentity tei on tei.trackedentityid = ri2.trackedentityid "
+            + "LEFT JOIN trackedentity tei2 on tei2.trackedentityid = ri2.trackedentityid "
             + "WHERE rty.relationshiptypeid = "
             + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )) as \""
+            + " AND tei2.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  "
             + "from analytics_enrollment_"

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -171,10 +171,10 @@ class ProgramIndicatorSubqueryBuilderTest {
                 + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
                 + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
                 + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-                + "LEFT JOIN trackedentity tei on tei.trackedentityid = ri2.trackedentityid "
+                + "LEFT JOIN trackedentity tei2 on tei2.trackedentityid = ri2.trackedentityid "
                 + "WHERE rty.relationshiptypeid = "
                 + relationshipType.getId()
-                + " AND tei.uid = ax.tei ))"));
+                + " AND tei2.uid = ax.tei ))"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
@@ -64,12 +64,12 @@ class RelationshipTypeJoinGeneratorTest {
           + ".psi in (select psi.uid from event psi LEFT JOIN relationshipitem ri on psi.eventid = ri.eventid ";
 
   private static final String TEI_RELTO_JOIN =
-      "LEFT JOIN trackedentity tei on tei.trackedentityid = ri2.trackedentityid";
+      "LEFT JOIN trackedentity tei2 on tei2.trackedentityid = ri2.trackedentityid";
 
   private static final String PI_RELTO_JOIN =
-      "LEFT JOIN enrollment pi on pi.enrollmentid = ri2.enrollmentid";
+      "LEFT JOIN enrollment pi2 on pi2.enrollmentid = ri2.enrollmentid";
 
-  private static final String PSI_RELTO_JOIN = "LEFT JOIN event psi on psi.eventid = ri2.eventid";
+  private static final String PSI_RELTO_JOIN = "LEFT JOIN event psi2 on psi2.eventid = ri2.eventid";
 
   private final BeanRandomizer rnd = BeanRandomizer.create();
 
@@ -170,8 +170,11 @@ class RelationshipTypeJoinGeneratorTest {
     expected += addWhere(relationshipType);
     expected +=
         (to.equals(TRACKED_ENTITY_INSTANCE)
-            ? " AND tei.uid = ax.tei )"
-            : (to.equals(PROGRAM_INSTANCE) ? " AND pi.uid = ax.pi )" : " AND psi.uid = ax.psi )"));
+            ? " AND tei2.uid = ax.tei )"
+            : (to.equals(PROGRAM_INSTANCE)
+                ? " AND pi2.uid = ax.pi )"
+                : " AND psi2.uid = ax.psi )"));
+    System.out.println(expected);
     assertEquals(expected, RelationshipTypeJoinGenerator.generate(ALIAS, relationshipType, type));
   }
 


### PR DESCRIPTION
Back-port from: https://github.com/dhis2/dhis2-core/commit/e83448455487dc606675aaef4eb17e43011fb213