### PR TITLE
fix: Duplicate table aliases in RelationshipTypeJoinGenerator [DHIS2-18989] [2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
@@ -83,12 +83,12 @@ public class RelationshipTypeJoinGenerator {
     switch (relationshipEntity) {
       case TRACKED_ENTITY_INSTANCE:
         return sql
-            + "trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid";
+            + "trackedentityinstance tei2 on tei2.trackedentityinstanceid = ri2.trackedentityinstanceid";
       case PROGRAM_STAGE_INSTANCE:
         return sql
-            + "programstageinstance psi on psi.programstageinstanceid = ri2.programstageinstanceid";
+            + "programstageinstance psi2 on psi2.programstageinstanceid = ri2.programstageinstanceid";
       case PROGRAM_INSTANCE:
-        return sql + "programinstance pi on pi.programinstanceid = ri2.programinstanceid";
+        return sql + "programinstance pi2 on pi2.programinstanceid = ri2.programinstanceid";
       default:
         throw new IllegalQueryException(
             new ErrorMessage(ErrorCode.E7227, relationshipEntity.name()));
@@ -140,11 +140,11 @@ public class RelationshipTypeJoinGenerator {
 
     switch (relationshipEntity) {
       case TRACKED_ENTITY_INSTANCE:
-        return sql + "tei.uid = ax.tei ";
+        return sql + "tei2.uid = ax.tei ";
       case PROGRAM_STAGE_INSTANCE:
-        return sql + "psi.uid = ax.psi ";
+        return sql + "psi2.uid = ax.psi ";
       case PROGRAM_INSTANCE:
-        return sql + "pi.uid = ax.pi ";
+        return sql + "pi2.uid = ax.pi ";
       default:
         throw new IllegalQueryException(
             new ErrorMessage(ErrorCode.E7227, relationshipEntity.name()));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -550,10 +550,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid "
+            + "LEFT JOIN trackedentityinstance tei2 on tei2.trackedentityinstanceid = ri2.trackedentityinstanceid "
             + "WHERE rty.relationshiptypeid = "
             + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )) as \""
+            + " AND tei2.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  "
             + "from analytics_enrollment_"
@@ -598,10 +598,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN programinstance pi on pi.programinstanceid = ri2.programinstanceid WHERE rty.relationshiptypeid "
+            + "LEFT JOIN programinstance pi2 on pi2.programinstanceid = ri2.programinstanceid WHERE rty.relationshiptypeid "
             + "= "
             + relationshipTypeA.getId()
-            + " AND pi.uid = ax.pi ))"
+            + " AND pi2.uid = ax.pi ))"
             + " as \""
             + programIndicatorA.getUid()
             + "\"  "
@@ -674,10 +674,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
             + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
             + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid "
+            + "LEFT JOIN trackedentityinstance tei2 on tei2.trackedentityinstanceid = ri2.trackedentityinstanceid "
             + "WHERE rty.relationshiptypeid = "
             + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )) as \""
+            + " AND tei2.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  "
             + "from analytics_enrollment_"

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -171,10 +171,10 @@ class ProgramIndicatorSubqueryBuilderTest {
                 + "LEFT JOIN relationship r on r.from_relationshipitemid = ri.relationshipitemid "
                 + "LEFT JOIN relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
                 + "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-                + "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid "
+                + "LEFT JOIN trackedentityinstance tei2 on tei2.trackedentityinstanceid = ri2.trackedentityinstanceid "
                 + "WHERE rty.relationshiptypeid = "
                 + relationshipType.getId()
-                + " AND tei.uid = ax.tei ))"));
+                + " AND tei2.uid = ax.tei ))"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
@@ -64,13 +64,13 @@ class RelationshipTypeJoinGeneratorTest {
           + ".psi in (select psi.uid from programstageinstance psi LEFT JOIN relationshipitem ri on psi.programstageinstanceid = ri.programstageinstanceid ";
 
   private static final String TEI_RELTO_JOIN =
-      "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid";
+      "LEFT JOIN trackedentityinstance tei2 on tei2.trackedentityinstanceid = ri2.trackedentityinstanceid";
 
   private static final String PI_RELTO_JOIN =
-      "LEFT JOIN programinstance pi on pi.programinstanceid = ri2.programinstanceid";
+      "LEFT JOIN programinstance pi2 on pi2.programinstanceid = ri2.programinstanceid";
 
   private static final String PSI_RELTO_JOIN =
-      "LEFT JOIN programstageinstance psi on psi.programstageinstanceid = ri2.programstageinstanceid";
+      "LEFT JOIN programstageinstance psi2 on psi2.programstageinstanceid = ri2.programstageinstanceid";
 
   private final BeanRandomizer rnd = BeanRandomizer.create();
 
@@ -171,8 +171,10 @@ class RelationshipTypeJoinGeneratorTest {
     expected += addWhere(relationshipType);
     expected +=
         (to.equals(TRACKED_ENTITY_INSTANCE)
-            ? " AND tei.uid = ax.tei )"
-            : (to.equals(PROGRAM_INSTANCE) ? " AND pi.uid = ax.pi )" : " AND psi.uid = ax.psi )"));
+            ? " AND tei2.uid = ax.tei )"
+            : (to.equals(PROGRAM_INSTANCE)
+                ? " AND pi2.uid = ax.pi )"
+                : " AND psi2.uid = ax.psi )"));
     assertEquals(expected, RelationshipTypeJoinGenerator.generate(ALIAS, relationshipType, type));
   }
 


### PR DESCRIPTION
Backport from: https://github.com/dhis2/dhis2-core/commit/e83448455487dc606675aaef4eb17e43011fb213