### PR TITLE
chore: remove csp constants for removed tracker endpoints DHIS2-16564

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/utils/CspConstants.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/utils/CspConstants.java
@@ -35,25 +35,20 @@ public class CspConstants {
 
   public static final String SCRIPT_SOURCE_DEFAULT = "script-src 'none'; ";
 
-  public static final Pattern P_1 = Pattern.compile("^.+/events/files$");
+  public static final Pattern P_1 = Pattern.compile("^.+/dataValues/files$");
 
   public static final Pattern P_2 =
-      Pattern.compile("^.+trackedEntityInstance/[a-zA-Z\\d]+/[a-zA-Z\\d]+/image$");
-
-  public static final Pattern P_3 = Pattern.compile("^.+/dataValues/files$");
-
-  public static final Pattern P_4 =
       Pattern.compile(
           "^.+messageConversations/[a-zA-Z\\d]+/[a-zA-Z\\d]+/attachments/[a-zA-Z\\d]+$");
 
-  public static final Pattern P_5 = Pattern.compile("^.+fileResources/[a-zA-Z\\d]+/data$");
+  public static final Pattern P_3 = Pattern.compile("^.+fileResources/[a-zA-Z\\d]+/data$");
 
-  public static final Pattern P_6 = Pattern.compile("^.+audits/files/[a-zA-Z\\d]+$");
+  public static final Pattern P_4 = Pattern.compile("^.+audits/files/[a-zA-Z\\d]+$");
 
-  public static final Pattern P_7 = Pattern.compile("^.+externalFileResources/[a-zA-Z\\d]+$");
+  public static final Pattern P_5 = Pattern.compile("^.+externalFileResources/[a-zA-Z\\d]+$");
 
   public static final List<Pattern> EXTERNAL_STATIC_CONTENT_URL_PATTERNS =
-      List.of(P_1, P_2, P_3, P_4, P_5, P_6, P_7);
+      List.of(P_1, P_2, P_2, P_4, P_5);
 
   public static final Pattern LOGIN_PATTERN = Pattern.compile("^.+/dhis-web-commons/security/.+$");
 }


### PR DESCRIPTION
the old tracker endpoints have been removed https://dhis2.atlassian.net/browse/DHIS2-16564

New tracker endpoints that serve files/images

- `/{event}/dataValues/{dataElement}/file`
- `/{event}/dataValues/{dataElement}/image`
- `/{trackedEntity}/attributes/{attribute}/file`
- `/{trackedEntity}/attributes/{attribute}/image`

get their headers via https://github.com/dhis2/dhis2-core/blob/2097f7e16fd8808f05c80eaa4490d4da00b79feb/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java#L67-L75
