### PR TITLE
fix: Correctly map RelationshipType to avoid Lazy exception

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipTypeMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipTypeMapper.java
@@ -35,7 +35,14 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {DebugMapper.class, AttributeValuesMapper.class})
+@Mapper(
+    uses = {
+      DebugMapper.class,
+      AttributeValuesMapper.class,
+      ProgramMapper.class,
+      TrackedEntityTypeMapper.class,
+      ProgramStageMapper.class
+    })
 public interface RelationshipTypeMapper extends PreheatMapper<RelationshipType> {
   RelationshipTypeMapper INSTANCE = Mappers.getMapper(RelationshipTypeMapper.class);
 


### PR DESCRIPTION
This PR is fixing some mapping problems in tracker importer that were sometimes causing failures when validating relationships.
Hopefully it will also fix Jenkins e2e tests failures.