### PR TITLE
revert: metadata api to support sort iasc (#19865)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -194,22 +194,13 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject> implements Que
   @Nonnull
   private static <T extends IdentifiableObject> List<jakarta.persistence.criteria.Order> getOrders(
       Query query, CriteriaBuilder builder, Root<T> root) {
-    return query.getOrders().stream().map(o -> getOrderPredicate(builder, root, o)).toList();
-  }
-
-  private static <T extends IdentifiableObject>
-      jakarta.persistence.criteria.Order getOrderPredicate(
-          CriteriaBuilder builder, Root<T> root, @Nonnull Order order) {
-
-    if (order.isIgnoreCase()) {
-      return order.isAscending()
-          ? builder.asc(builder.lower(root.get(order.getProperty().getFieldName())))
-          : builder.desc(builder.lower(root.get(order.getProperty().getFieldName())));
-    }
-
-    return order.isAscending()
-        ? builder.asc(root.get(order.getProperty().getFieldName()))
-        : builder.desc(root.get(order.getProperty().getFieldName()));
+    return query.getOrders().stream()
+        .map(
+            o ->
+                o.isAscending()
+                    ? builder.asc(root.get(o.getProperty().getFieldName()))
+                    : builder.desc(root.get(o.getProperty().getFieldName())))
+        .toList();
   }
 
   private void initStoreMap() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -1285,25 +1285,6 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
     assertErrorMandatoryAttributeRequired(attrId, POST("/users", user));
   }
 
-  @Test
-  void testSortIAscending() {
-    POST(
-            "/categories/",
-            "{'name':'Child Health', 'shortName':'CAT1','dataDimensionType':'DISAGGREGATION'}")
-        .content(HttpStatus.CREATED);
-    POST(
-            "/categories/",
-            "{'name':'births attended by', 'shortName':'CAT2','dataDimensionType':'DISAGGREGATION'}")
-        .content(HttpStatus.CREATED);
-
-    JsonList<JsonIdentifiableObject> response =
-        GET("/categories?order=name:iasc")
-            .content()
-            .getList("categories", JsonIdentifiableObject.class);
-    assertEquals("births attended by", response.get(0).getDisplayName());
-    assertEquals("Child Health", response.get(1).getDisplayName());
-  }
-
   private void assertErrorMandatoryAttributeRequired(String attrId, HttpResponse response) {
     JsonError msg = response.content(HttpStatus.CONFLICT).as(JsonError.class);
     JsonList<JsonErrorReport> errorReports = msg.getTypeReport().getErrorReports();


### PR DESCRIPTION
This reverts commit c8aee8e543d15e4b165654c78731a7458a4439ba due to e2e test error


```
test-1   | [ERROR]   RelationshipsTests.shouldNotImportDuplicateRelationships:517 » ConditionTimeout Condition with Lambda expression in org.hisp.dhis.test.e2e.actions.tracker.TrackerImportExportActions was not fulfilled within 21 seconds.
test-1   | [ERROR]   RelationshipsTests.shouldNotImportDuplicateRelationships:517 » ConditionTimeout Condition with Lambda expression in org.hisp.dhis.test.e2e.actions.tracker.TrackerImportExportActions was not fulfilled within 21 seconds.
```