### PR TITLE
fix: avoid nested junctions in OU filters [DHIS2-18041]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restrictions.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restrictions.java
@@ -149,24 +149,14 @@ public final class Restrictions {
     return or(schema, id, code, name);
   }
 
-  public static Disjunction or(Schema schema, Criterion... filters) {
+  private static Disjunction or(Schema schema, Criterion... filters) {
     return or(schema, List.of(filters));
   }
 
-  public static Disjunction or(Schema schema, List<? extends Criterion> filters) {
+  private static Disjunction or(Schema schema, List<? extends Criterion> filters) {
     Disjunction or = new Disjunction(schema);
     or.add(filters);
     return or;
-  }
-
-  public static Conjunction and(Schema schema, Criterion... filters) {
-    return and(schema, List.of(filters));
-  }
-
-  public static Conjunction and(Schema schema, List<? extends Criterion> filters) {
-    Conjunction and = new Conjunction(schema);
-    and.add(filters);
-    return and;
   }
 
   private Restrictions() {}


### PR DESCRIPTION
### Summary
I found that the query engine does not really support using AND or OR junctions other than the root level.
When processing a nested junction the criterion in the junction would be removed to split them into DB and in-memory.
This meant that when using a junction the first query (fetch) is (likely) correct but the second use (count) is not as by then it has dropped the criterion from the junction so that it becomes a `true` filter. 

The workaround for the OU special filters is to use filters that do not need junctions.