### PR TITLE
chore: add query parameter orgUnit to /tracker/ownership/transfer in favor of ou DHIS2-19037

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
@@ -135,11 +135,41 @@ class TrackerOwnershipControllerTest extends PostgresControllerIntegrationTestBa
         "OK",
         "Ownership transferred",
         PUT(
+                "/tracker/ownership/transfer?trackedEntity={te}&program={prog}&orgUnit={orgUnit}",
+                teUid,
+                pId,
+                orgUnitBUid)
+            .content(HttpStatus.OK));
+  }
+
+  @Test
+  void
+      shouldUpdateTrackerProgramOwnerAndBeAccessibleFromTransferredOrgUnitUsingDeprecatedParameter() {
+    assertWebMessage(
+        "OK",
+        200,
+        "OK",
+        "Ownership transferred",
+        PUT(
                 "/tracker/ownership/transfer?trackedEntity={te}&program={prog}&ou={ou}",
                 teUid,
                 pId,
                 orgUnitBUid)
             .content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldFailToTransferIfGivenDeprecatedAndNewOrgUnitParameter() {
+    assertStartsWith(
+        "Only one parameter of 'ou'",
+        PUT(
+                "/tracker/ownership/transfer?trackedEntity={te}&program={prog}&ou={ou}&orgUnit={orgUnit}",
+                teUid,
+                pId,
+                orgUnitBUid,
+                orgUnitBUid)
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
@@ -547,7 +547,7 @@ public class RequestParamsValidator {
   }
 
   /**
-   * Validates that no org unit is present if the ou mode is ACCESSIBLE or CAPTURE. If it is, an
+   * Validates that no org unit is present if the orgUnitMode is ACCESSIBLE or CAPTURE. If it is, an
    * exception will be thrown. If the org unit mode is not defined, SELECTED will be used by default
    * if an org unit is present. Otherwise, ACCESSIBLE will be the default.
    *

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.ownership;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateMandatoryDeprecatedUidParameter;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.common.DhisApiVersion;
@@ -87,13 +88,17 @@ public class TrackerOwnershipController {
   @PutMapping(value = "/transfer", produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public WebMessage updateTrackerProgramOwner(
-      @RequestParam UID trackedEntity, @RequestParam String program, @RequestParam String ou)
+      @RequestParam UID trackedEntity,
+      @RequestParam UID program,
+      @RequestParam(required = false) UID ou,
+      @RequestParam(required = false) UID orgUnit)
       throws BadRequestException, ForbiddenException, NotFoundException {
+    UID orgUnitUid = validateMandatoryDeprecatedUidParameter("ou", ou, "orgUnit", orgUnit);
+
     trackerOwnershipAccessManager.transferOwnership(
-        trackedEntityService.getTrackedEntity(
-            trackedEntity, UID.of(program), TrackedEntityParams.FALSE),
-        programService.getProgram(program),
-        organisationUnitService.getOrganisationUnit(ou));
+        trackedEntityService.getTrackedEntity(trackedEntity, program, TrackedEntityParams.FALSE),
+        programService.getProgram(program.getValue()),
+        organisationUnitService.getOrganisationUnit(orgUnitUid.getValue()));
     return ok("Ownership transferred");
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -105,12 +105,12 @@ public class TrackerOwnershipController {
   @PostMapping(value = "/override", produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public WebMessage grantTemporaryAccess(
-      @RequestParam UID trackedEntity, @RequestParam String reason, @RequestParam String program)
+      @RequestParam UID trackedEntity, @RequestParam String reason, @RequestParam UID program)
       throws BadRequestException, ForbiddenException, NotFoundException {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
         trackedEntityService.getTrackedEntity(trackedEntity),
-        programService.getProgram(program),
+        programService.getProgram(program.getValue()),
         currentUser,
         reason);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -90,7 +90,11 @@ public class TrackerOwnershipController {
   public WebMessage updateTrackerProgramOwner(
       @RequestParam UID trackedEntity,
       @RequestParam UID program,
-      @RequestParam(required = false) UID ou,
+      @Deprecated(
+              since = "2.41",
+              forRemoval = true) // TODO(tracker) remove `ou` parameter in favor of `orgUnit` in v43
+          @RequestParam(required = false)
+          UID ou,
       @RequestParam(required = false) UID orgUnit)
       throws BadRequestException, ForbiddenException, NotFoundException {
     UID orgUnitUid = validateMandatoryDeprecatedUidParameter("ou", ou, "orgUnit", orgUnit);


### PR DESCRIPTION
We renamed `ouMode` to `orgUnitMode` and all other organisation unit related parameters in `/tracker` endpoints are either called `orgUnit` if they only accept one like in `/tracker/events` or `orgUnits` if they accept multiple.

* use `UID` type so parameters are validated