### PR TITLE
test: see if sync gives us an error message

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -514,7 +514,9 @@ public class RelationshipsTests extends TrackerApiTest {
             .addArray("relationships", relationship1, relationship2)
             .build();
 
-    TrackerApiResponse response = trackerImportExportActions.postAndGetJobReport(payload);
+    TrackerApiResponse response =
+        trackerImportExportActions.postAndGetJobReport(
+            payload, new QueryParamsBuilder().add("async=false"));
 
     response.validateSuccessfulImport().validate().body("stats.created", equalTo(expectedCount));
 


### PR DESCRIPTION
Jenkins tests fail due to a timeout

```
test-1   | [ERROR]   RelationshipsTests.shouldNotImportDuplicateRelationships:517 » ConditionTimeout Condition with Lambda expression in org.hisp.dhis.test.e2e.actions.tracker.TrackerImportExportActions was not fulfilled within 21 seconds.
test-1   | [ERROR]   RelationshipsTests.shouldNotImportDuplicateRelationships:517 » ConditionTimeout Condition with Lambda expression in org.hisp.dhis.test.e2e.actions.tracker.TrackerImportExportActions was not fulfilled within 21 seconds.
```

We don't have visibility into why. We cannot reproduce it locally.

I switched the tracker import for these two tests to sync. I ran these changes on Jenkins and the tests passed.