### PR TITLE
fix: Fix Relationship e2e test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -491,6 +491,8 @@ public class RelationshipsTests extends TrackerApiTest {
                     .addAll(
                         "filter=fromConstraint.relationshipEntity:eq:TRACKED_ENTITY_INSTANCE",
                         "filter=toConstraint.relationshipEntity:eq:TRACKED_ENTITY_INSTANCE",
+                        "filter=toConstraint.trackedEntityType.id:eq:Q9GufDoplCL",
+                        "filter=fromConstraint.trackedEntityType.id:eq:Q9GufDoplCL",
                         "filter=bidirectional:eq:" + bidirectional,
                         "filter=name:like:TA"))
             .extractString("relationshipTypes.id[0]");


### PR DESCRIPTION
The failing test was a combination of `IdSchemeTest` not cleaning up data properly and [this PR](https://github.com/dhis2/dhis2-core/pull/19865) that somehow changed the order of the tests and was running `IdSchemeTest` before `RelationshipsTest`.

The solution involves developing more effective filters to obtain the required `RelationshipType` necessary for executing the test.