### PR TITLE
ci: upload IM db from stable pipeline if one is missing [skip ci]

### DIFF
--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -204,6 +204,7 @@ pipeline {
                             sh 'git push https://$GITHUB_TOKEN@github.com/$DHIS2_RELEASES_REPO'
 
                             sh "gh pr create --head $releasesBranch --fill-first --reviewer Philip-Larsen-Donnelly,dhis2/devops"
+                            sh "gh pr merge $releasesBranch"
                         }
                     }
                 }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -252,14 +252,31 @@ pipeline {
                             }
 
                             dir('scripts/databases') {
-                                env.DATABASE_ID = sh(
-                                        returnStdout: true,
-                                        script: "./list.sh | jq -r '.[] | select(.name == \"test-dbs\") | .databases[] | select(.name == \"sierra-leone/${version}.sql.gz\") | .slug'"
-                                ).trim()
-                            }
+                                DATABASE_GROUP_NAME = 'test-dbs'
+                                env.DATABASE_ID = im.findDatabaseId(DATABASE_GROUP_NAME, version)
 
-                            sh '[ -n "$DATABASE_ID" ]'
-                            echo "Database: ${env.DATABASE_ID}"
+                                if (!env.DATABASE_ID) {
+                                    echo "Couldn't find database for $version"
+
+                                    try {
+                                        env.DATABASE_ID = im.uploadNewDatabase(DATABASE_GROUP_NAME, version)
+                                    } catch (err) {
+                                        echo "Couldn't download database for ${version}: ${err}"
+
+                                        shortVersion = version.split('\\.').take(2).join('.')
+                                        env.DATABASE_ID = im.findDatabaseId(DATABASE_GROUP_NAME, shortVersion)
+
+                                        if (!env.DATABASE_ID) {
+                                            echo "Couldn't find database for $shortVersion"
+
+                                            env.DATABASE_ID = im.uploadNewDatabase(DATABASE_GROUP_NAME, shortVersion)
+                                        }
+                                    }
+                                }
+
+                                sh '[ -n "$DATABASE_ID" ]'
+                                echo "Database: ${env.DATABASE_ID}"
+                            }
 
                             dir('scripts/instances') {
                                 description = "DHIS 2 stable branch ${env.GIT_BRANCH}"


### PR DESCRIPTION
With this PR the stable pipeline will upload a DB to the IM for the new released version, if one is missing.
The `stable.json` update PR will also be merged directly from the pipeline.

Related to https://github.com/dhis2/jenkins-pipeline-library/pull/24

Tested with the following build - https://ci.dhis2.org/view/dhis2-core/job/dhis2-core-stable/view/tags/job/2.55.5/7/