### PR TITLE
feat: Add email 2FA code sent status to login response

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -175,7 +175,7 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider {
     if (type == TwoFactorType.EMAIL_ENABLED && StringUtils.isBlank(code)) {
       sendEmail2FACode(userDetails);
       // Inform the caller that the email code has been sent.
-      throw new TwoFactorAuthenticationException(ErrorCode.E3051.getMessage(), type);
+      throw new TwoFactorCodeSentException(ErrorCode.E3051.getMessage(), type);
     }
 
     // If the code is blank (null, empty, or only whitespace), reject the login.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorCodeSentException.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorCodeSentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,37 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.security.twofa;
+package org.hisp.dhis.security.spring2fa;
 
-import lombok.Getter;
+import org.hisp.dhis.security.twofa.TwoFactorType;
+import org.springframework.security.authentication.BadCredentialsException;
 
-@Getter
-public enum TwoFactorType {
-  NOT_ENABLED,
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class TwoFactorCodeSentException extends BadCredentialsException {
+  private final TwoFactorType type;
 
-  // Enabled states
-  TOTP_ENABLED,
-  EMAIL_ENABLED,
-
-  // Enrolling states
-  ENROLLING_TOTP, // User is in the process of enrolling in TOTP 2FA
-  ENROLLING_EMAIL; // User is in the process of enrolling in email-based 2FA
-
-  public boolean isEnrolling() {
-    return this == ENROLLING_TOTP || this == ENROLLING_EMAIL;
+  public TwoFactorCodeSentException(String msg, TwoFactorType type) {
+    super(msg);
+    this.type = type;
   }
 
-  public TwoFactorType getEnabledType() {
-    if (this == ENROLLING_TOTP) {
-      return TOTP_ENABLED;
-    } else if (this == ENROLLING_EMAIL) {
-      return EMAIL_ENABLED;
-    } else {
-      return this;
-    }
-  }
-
-  public boolean isEnabled() {
-    return this == TOTP_ENABLED || this == EMAIL_ENABLED;
+  public TwoFactorType getType() {
+    return type;
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
@@ -48,6 +48,7 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
+    EMAIL_TWO_FACTOR_CODE_SENT("emailTwoFactorCodeSent"),
     INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
     INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),
     REQUIRES_TWO_FACTOR_ENROLMENT("requiresTwoFactorEnrolment");

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -181,7 +181,7 @@ public class LoginTest {
     // Test Login doesn't work without 2FA code
     ResponseEntity<LoginResponse> failedLoginResp =
         loginWithUsernameAndPassword(username, password, null);
-    assertLoginStatus(failedLoginResp, STATUS.INCORRECT_TWO_FACTOR_CODE_EMAIL);
+    assertLoginStatus(failedLoginResp, STATUS.EMAIL_TWO_FACTOR_CODE_SENT);
 
     // Disable Email 2FA
     disable2FAWithEmail(cookie);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationEnrolmentException;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
+import org.hisp.dhis.security.spring2fa.TwoFactorCodeSentException;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.setting.SystemSettingsProvider;
@@ -163,6 +164,12 @@ public class AuthenticationController {
 
       return LoginResponse.builder().loginStatus(STATUS.SUCCESS).redirectUrl(redirectUrl).build();
 
+    } catch (TwoFactorCodeSentException e) {
+      TwoFactorType twoFactorType = e.getType();
+      if (twoFactorType == TwoFactorType.EMAIL_ENABLED) {
+        return LoginResponse.builder().loginStatus(STATUS.EMAIL_TWO_FACTOR_CODE_SENT).build();
+      }
+      return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE_TOTP).build();
     } catch (TwoFactorAuthenticationException e) {
       TwoFactorType twoFactorType = e.getType();
       if (twoFactorType == TwoFactorType.EMAIL_ENABLED) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
@@ -50,6 +50,7 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
+    EMAIL_TWO_FACTOR_CODE_SENT("emailTwoFactorCodeSent"),
     INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
     INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),
     REQUIRES_TWO_FACTOR_ENROLMENT("requiresTwoFactorEnrolment");


### PR DESCRIPTION
This PR adds a new login response status 'EMAIL_TWO_FACTOR_CODE_SENT' to 
indicate when a user with email 2FA enabled attempts to log in and the 
verification code has been sent to their email. This improves the authentication 
flow by providing clear feedback about the 2FA email verification state.

The new status allows the client to:
- Distinguish between sent 2FA code and incorrect or empty 2FA code provided
- Confirm to users that a verification code has been sent