### PR TITLE
fix: add test in dhis2-core for DHIS2-19001

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -297,9 +297,9 @@ class ProgramRuleAssignActionTest extends TrackerTest {
         fromJson("tracker/programrule/event_update_datavalue_different_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    ImportReport report = trackerImportService.importTracker(params, trackerObjects);
 
-    assertNoErrors(importReport);
+    assertNoErrors(report);
   }
 
   private TrackerObjects getEvent(UID eventUid, String occurredDate, String value)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -293,7 +293,7 @@ class ProgramRuleAssignActionTest extends TrackerTest {
     assignToCalculatedValueProgramRule();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        fromJson("tracker/programrule/event_update_datavalue_empty_value.json");
+        fromJson("tracker/programrule/event_update_datavalue_different_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -348,6 +348,8 @@ class ProgramRuleAssignActionTest extends TrackerTest {
     programRuleActionService.addProgramRuleAction(programRuleAction);
     programRule.getProgramRuleActions().add(programRuleAction);
     programRuleService.updateProgramRule(programRule);
+
+    assignProgramRule();
   }
 
   private void assignPreviousEventProgramRule() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -345,7 +345,9 @@ class ProgramRuleAssignActionTest extends TrackerTest {
     programRuleAction.setData("1");
     programRuleAction.setContent("#{prv_cal_val}");
 
-    assignProgramRule();
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
   }
 
   private void assignPreviousEventProgramRule() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertHasOnlyWarnings;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1307;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1308;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1310;
@@ -298,7 +299,7 @@ class ProgramRuleAssignActionTest extends TrackerTest {
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
-    assertHasOnlyWarnings(importReport, E1308);
+    assertNoErrors(importReport);
   }
 
   private TrackerObjects getEvent(UID eventUid, String occurredDate, String value)
@@ -348,8 +349,6 @@ class ProgramRuleAssignActionTest extends TrackerTest {
     programRuleActionService.addProgramRuleAction(programRuleAction);
     programRule.getProgramRuleActions().add(programRuleAction);
     programRuleService.updateProgramRule(programRule);
-
-    assignProgramRule();
   }
 
   private void assignPreviousEventProgramRule() {

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -85,7 +85,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.3.7-SNAPSHOT</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.3.7</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.2</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -85,7 +85,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.3.3</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.3.7-SNAPSHOT</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.2</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -85,7 +85,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.3.7-SNAPSHOT</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.3.6</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.2</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -85,7 +85,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.3.6</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.3.7-SNAPSHOT</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.2</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->


### PR DESCRIPTION
The actual fix is incorporated in rule-engine library. But the test is added in dhis2-core to make sure it fixes the problem.
Once [this](https://github.com/dhis2/dhis2-rule-engine/pull/157) is merged then i can bump rule-engine version so this PR points to release version of rule-engine. 