### PR TITLE
fix: handle URL encoded paths in AppOverrideFilter

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.filter;
 import static java.util.regex.Pattern.compile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -84,7 +85,7 @@ public class AppOverrideFilter extends OncePerRequestFilter {
     String pathInfo = request.getPathInfo();
     String contextPath = HttpServletRequestPaths.getContextPath(request);
 
-    Matcher m = APP_PATH_PATTERN.matcher(pathInfo);
+    Matcher m = APP_PATH_PATTERN.matcher(Strings.nullToEmpty(pathInfo));
     if (m.find()) {
       String appName = m.group(1);
       String resourcePath = m.group(2);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -81,17 +81,15 @@ public class AppOverrideFilter extends OncePerRequestFilter {
       @Nonnull HttpServletResponse response,
       @Nonnull FilterChain chain)
       throws IOException, ServletException {
-    String requestPath = request.getServletPath();
+    String pathInfo = request.getPathInfo();
     String contextPath = HttpServletRequestPaths.getContextPath(request);
 
-    String appUrl = request.getRequestURI().substring(request.getContextPath().length());
-
-    Matcher m = APP_PATH_PATTERN.matcher(appUrl);
+    Matcher m = APP_PATH_PATTERN.matcher(pathInfo);
     if (m.find()) {
       String appName = m.group(1);
       String resourcePath = m.group(2);
 
-      log.debug("AppOverrideFilter :: Matched for path " + requestPath);
+      log.debug("AppOverrideFilter :: Matched for path: " + pathInfo);
 
       App app = appManager.getApp(appName, contextPath);
       if (app != null && app.getAppState() != AppStatus.DELETION_IN_PROGRESS) {

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
@@ -105,7 +105,7 @@ public class Main {
     context.addServletContainerInitializer(starter, Collections.emptySet());
     context.setName("/");
     context.setDisplayName("/");
-    context.setPath("kuk");
+    context.setPath("");
     context.setMimeMappings(MimeMappings.lazyCopy(MimeMappings.DEFAULT));
 
     context.setResources(new LoaderHidingResourceRoot(context));

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
@@ -105,7 +105,7 @@ public class Main {
     context.addServletContainerInitializer(starter, Collections.emptySet());
     context.setName("/");
     context.setDisplayName("/");
-    context.setPath("");
+    context.setPath("kuk");
     context.setMimeMappings(MimeMappings.lazyCopy(MimeMappings.DEFAULT));
 
     context.setResources(new LoaderHidingResourceRoot(context));


### PR DESCRIPTION
## Summary
The `AppOverrideFilter` was incorrectly handling paths containing URL encoded characters (like spaces encoded as %20) by extracting the "raw" encoded URL with the `request.getRequestURI()` method. This caused issues with file paths containing spaces, such as font files (e.g. "Open Sans Regular").

The fix simplifies the path handling by using `request.getPathInfo()` which provides the correct decoded path after the servlet mapping part of the URL. This ensures proper handling of paths containing spaces and other URL encoded characters, while also being more maintainable by using the standard Servlet API as intended.

### Manual test:

1. Try to access the URL: `http://localhost:8080/dhis-web-maps/fonts/Open Sans Bold/6144-6399.pbf` (double check on the file system that this path actually exist in the installed/overridden app folder, the .pdf file names can vary) 
2. Make sure you can access it.
3. Install an overridden app version from the "App management" app. We chose to install the map app, since it contains fonts that have spaces in it.
4. Try to access the same URL: `http://localhost:8080/dhis-web-maps/fonts/Open Sans Bold/6144-6399.pbf` (make sure it actually exists on file system first, the .pbf files can vary from map app version)
5. Make sure you also can access it.

**TIP**: The file system path for installed apps looks similar to this: `DHIS2_HOME_FOLDER/files/apps/maps_101.0.1/fonts/Open Sans Bold`