### PR TITLE
DHIS-19010 Append geo suffix to OU Data Element fields

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
@@ -133,7 +133,7 @@ public class DefaultEventCoordinateService implements EventCoordinateService {
     if (ValueType.COORDINATE != valueType && ValueType.ORGANISATION_UNIT != valueType) {
       throwIllegalQueryEx(errorCode, field);
     }
-    // append the "_geom" suffix to the field
+    // Append the "_geom" suffix to the field
     // so that the correct geometry column
     // is selected
     return field + OU_GEOMETRY_COL_SUFFIX;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.hisp.dhis.analytics.table.AbstractEventJdbcTableManager.OU_GEOMETRY_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 
 import java.util.ArrayList;
@@ -132,8 +133,10 @@ public class DefaultEventCoordinateService implements EventCoordinateService {
     if (ValueType.COORDINATE != valueType && ValueType.ORGANISATION_UNIT != valueType) {
       throwIllegalQueryEx(errorCode, field);
     }
-
-    return field;
+    // append the "_geom" suffix to the field
+    // so that the correct geometry column
+    // is selected
+    return field + OU_GEOMETRY_COL_SUFFIX;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -407,12 +407,7 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
    * <p>All possible coordinate fields are collected. The order defines the priority of geometries
    * and is used as a parameters in SQL coalesce function.
    *
-   * @param program the program identifier.
-   * @param coordinateField the coordinate field.
-   * @param fallbackCoordinateField the fallback coordinate field applied if coordinate field in
-   *     result set is null.
-   * @param defaultCoordinateFallback flag for cascade fallback, first not null geometry (coalesce)
-   *     will be applied.
+   * @param request the {@link EventDataQueryRequest}.
    * @return the coordinate column list.
    */
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_ENROLLMENT_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_EVENT_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_TRACKED_ENTITY_GEOMETRY;
+import static org.hisp.dhis.analytics.table.AbstractEventJdbcTableManager.OU_GEOMETRY_COL_SUFFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -513,7 +514,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
         dataQueryService.getCoordinateFields(
             toRequest(prA.getUid(), null, "eventgeometry", false)));
     assertEquals(
-        List.of(deC.getUid() + "_geom"),
+        List.of(deC.getUid() + OU_GEOMETRY_COL_SUFFIX),
         dataQueryService.getCoordinateFields(toRequest(prA.getUid(), deC.getUid(), null, false)));
   }
 
@@ -548,7 +549,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
         dataQueryService.getCoordinateFields(
             toRequest(prA.getUid(), null, OLD_COL_NAME_TRACKED_ENTITY_GEOMETRY, false)));
     assertEquals(
-        List.of(deC.getUid() + "_geom"),
+        List.of(deC.getUid() + OU_GEOMETRY_COL_SUFFIX),
         dataQueryService.getCoordinateFields(toRequest(prA.getUid(), deC.getUid(), null, false)));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -513,7 +513,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
         dataQueryService.getCoordinateFields(
             toRequest(prA.getUid(), null, "eventgeometry", false)));
     assertEquals(
-        List.of(deC.getUid()),
+        List.of(deC.getUid() + "_geom"),
         dataQueryService.getCoordinateFields(toRequest(prA.getUid(), deC.getUid(), null, false)));
   }
 
@@ -548,7 +548,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
         dataQueryService.getCoordinateFields(
             toRequest(prA.getUid(), null, OLD_COL_NAME_TRACKED_ENTITY_GEOMETRY, false)));
     assertEquals(
-        List.of(deC.getUid()),
+        List.of(deC.getUid() + "_geom"),
         dataQueryService.getCoordinateFields(toRequest(prA.getUid(), deC.getUid(), null, false)));
   }
 


### PR DESCRIPTION
## Summary

Fix a [bug](https://dhis2.atlassian.net/browse/DHIS2-19010) that caused an Analytics Event API request to fail if the selected Data Element for the Program is type `OU`.

## Issue

When composing the Select statement for the query against `analytics_event_*` table, the wrong column is selected if the Data Element is of type OU.

```
-- Assuming n1rtSHYf6O6 is a OU DE

select .. from ..

ST_AsGeoJSON(coalesce(ax."n1rtSHYf6O6"),6) as geometry,
```

The column `n1rtSHYf6O6` on the `analytics_event_*` table **is not** a geometry column, therefore the SQL statement fails.

## Resolution

When collecting the coordinate fields (`DefaultEventDataQueryService.getCoordinateFields`), append the `_geom` suffix to the column name, so that it can be correctly passed to the `ST_AsGeoJSON` function.
