### PR TITLE
chore: remove deprecated setting DHIS2-16564

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -676,14 +676,6 @@ public non-sealed interface SystemSettings extends Settings {
   }
 
   /**
-   * @deprecated use {@link #getTrackedEntityMaxLimit()} instead
-   */
-  @Deprecated(forRemoval = true, since = "2.41")
-  default int getTrackedEntityInstanceMaxLimit() {
-    return asInt("KeyTrackedEntityInstanceMaxLimit", 50000);
-  }
-
-  /**
    * @return Max tracked entity records that can be retrieved from database.
    */
   default int getTrackedEntityMaxLimit() {

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -93,7 +93,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(143, keys.size());
+    assertEquals(142, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -91,7 +91,7 @@ public class TrackerOwnershipController {
       @RequestParam UID trackedEntity,
       @RequestParam UID program,
       @Deprecated(
-              since = "2.41",
+              since = "2.42",
               forRemoval = true) // TODO(tracker) remove `ou` parameter in favor of `orgUnit` in v43
           @RequestParam(required = false)
           UID ou,


### PR DESCRIPTION
* remove deprecated setting with TEI in its name
* fix `since` version which I put the wrong one into. I just deprecated the param in master so v42 not v41 https://github.com/dhis2/dhis2-core/pull/19983