### PR TITLE
chore: add OpenAPI spec and ignore totalPages DHIS2-19021

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/HibernatePotentialDuplicateStore.java
@@ -107,6 +107,10 @@ class HibernatePotentialDuplicateStore
 
   public Page<PotentialDuplicate> getPotentialDuplicates(
       PotentialDuplicateCriteria criteria, PageParams pageParams) {
+    if (pageParams.isPageTotal()) {
+      throw new UnsupportedOperationException("pageTotal is not supported");
+    }
+
     TypedQuery<PotentialDuplicate> query = getQuery(criteria);
 
     query.setFirstResult(pageParams.getOffset());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -95,6 +95,9 @@ public class HibernateEventChangeLogStore {
       @Nonnull UID event,
       @Nonnull EventChangeLogOperationParams operationParams,
       @Nonnull PageParams pageParams) {
+    if (pageParams.isPageTotal()) {
+      throw new UnsupportedOperationException("pageTotal is not supported");
+    }
 
     Pair<String, QueryFilter> filter = operationParams.getFilter();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
@@ -93,6 +93,9 @@ public class HibernateTrackedEntityChangeLogStore {
       @Nonnull Set<UID> attributes,
       @Nonnull TrackedEntityChangeLogOperationParams operationParams,
       @Nonnull PageParams pageParams) {
+    if (pageParams.isPageTotal()) {
+      throw new UnsupportedOperationException("pageTotal is not supported");
+    }
 
     String hql =
         """

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
@@ -317,6 +317,34 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
   }
 
   @Test
+  void shouldGetPageWithFields() {
+    JsonPage page =
+        GET(
+                "/potentialDuplicates?trackedEntities={uid}&fields=status",
+                trackedEntityADuplicate.getUid())
+            .content(HttpStatus.OK)
+            .asA(JsonPage.class);
+
+    assertEquals(
+        """
+{"status":"OPEN"}""",
+        page.getList("potentialDuplicates", JsonPotentialDuplicate.class).get(0).toMinimizedJson());
+  }
+
+  @Test
+  void shouldIgnoreTotalPages() {
+    JsonPage page =
+        GET(
+                "/potentialDuplicates?trackedEntities={uid}&totalPages=true",
+                trackedEntityADuplicate.getUid())
+            .content(HttpStatus.OK)
+            .asA(JsonPage.class);
+
+    JsonPager pager = page.getPager();
+    assertHasNoMember(pager, "total", "pageCount");
+  }
+
+  @Test
   void shouldGetLastPage() {
     JsonPage page =
         GET(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
@@ -283,6 +283,29 @@ class TrackedEntitiesChangeLogsControllerTest extends PostgresControllerIntegrat
         () -> assertHasNoMember(pagerObject, "prevPage", "nextPage", "total", "pageCount"));
   }
 
+  @Test
+  void shouldIgnoreTotalPages() {
+    JsonPage page =
+        GET("/tracker/trackedEntities/{id}/changeLogs?totalPages=true", trackedEntity.getUid())
+            .content(HttpStatus.OK)
+            .asA(JsonPage.class);
+
+    JsonPager pager = page.getPager();
+    assertHasNoMember(pager, "total", "pageCount");
+  }
+
+  @Test
+  void shouldAlwaysReturnPages() {
+    JsonPage page =
+        GET("/tracker/trackedEntities/{id}/changeLogs?paging=false", trackedEntity.getUid())
+            .content(HttpStatus.OK)
+            .asA(JsonPage.class);
+
+    JsonPager pager = page.getPager();
+    assertEquals(1, pager.getPage());
+    assertEquals(50, pager.getPageSize());
+  }
+
   private TrackerObjects fromJson(String path) throws IOException {
     return renderService.fromJson(
         new ClassPathResource(path).getInputStream(), TrackerObjects.class);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/message/ProgramMessageRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/message/ProgramMessageRequestParams.java
@@ -58,9 +58,17 @@ public class ProgramMessageRequestParams {
 
   private Date beforeDate;
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
@@ -43,13 +43,34 @@ public class ProgramNotificationTemplateRequestParams implements PageRequestPara
 
   private UID programStage;
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers `prev/nextPage` to determine if there is a previous or a next page instead.
+""")
   private boolean totalPages = false;
 
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/FieldsRequestParam.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/FieldsRequestParam.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.webapi.controller.tracker;
 
 import java.util.List;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -34,6 +34,6 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
  * FieldsRequestParam represents the HTTP request parameter {@code fields}. This allows users to
  * specify the exact fields they want in the JSON response.
  */
-interface FieldsRequestParam {
+public interface FieldsRequestParam {
   List<FieldPath> getFields();
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.deduplication.DeduplicationMergeParams;
@@ -87,15 +86,10 @@ public class DeduplicationController {
 
   private final TrackedEntityService trackedEntityService;
 
-  private static final String DEFAULT_FIELDS_PARAM =
-      "id,created,lastUpdated,original,duplicate,status";
-
   @OpenApi.Response(PotentialDuplicate[].class)
   @GetMapping
   ResponseEntity<Page<ObjectNode>> getPotentialDuplicates(
-      PotentialDuplicateRequestParams requestParams,
-      @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM) List<FieldPath> fields,
-      HttpServletRequest request)
+      PotentialDuplicateRequestParams requestParams, HttpServletRequest request)
       throws BadRequestException {
     validatePaginationParameters(requestParams);
 
@@ -108,7 +102,8 @@ public class DeduplicationController {
           new PageParams(requestParams.getPage(), requestParams.getPageSize(), false);
       org.hisp.dhis.tracker.Page<PotentialDuplicate> page =
           deduplicationService.getPotentialDuplicates(criteria, pageParams);
-      List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(page.getItems(), fields);
+      List<ObjectNode> objectNodes =
+          fieldFilterService.toObjectNodes(page.getItems(), requestParams.getFields());
 
       return ResponseEntity.ok()
           .header(HEADER_CACHE_CONTROL, HEADER_VALUE_NO_STORE)
@@ -120,7 +115,8 @@ public class DeduplicationController {
 
     List<PotentialDuplicate> potentialDuplicates =
         deduplicationService.getPotentialDuplicates(criteria);
-    List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(potentialDuplicates, fields);
+    List<ObjectNode> objectNodes =
+        fieldFilterService.toObjectNodes(potentialDuplicates, requestParams.getFields());
 
     return ResponseEntity.ok()
         .header(HEADER_CACHE_CONTROL, HEADER_VALUE_NO_STORE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
@@ -33,6 +33,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.deduplication.DeduplicationStatus;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
@@ -42,19 +44,70 @@ import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 @Data
 @NoArgsConstructor
 public class PotentialDuplicateRequestParams implements PageRequestParams {
+  private static final String DEFAULT_FIELDS_PARAM =
+      "id,created,lastUpdated,original,duplicate,status";
+
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
-  private boolean totalPages = false;
+  @OpenApi.Description(
+      """
+Get all entries by specifying `paging=false`. Requests are paginated by default.
 
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 
+  @OpenApi.Description(
+      """
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get potential duplicates in given order.
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive.
+""")
   private List<OrderCriteria> order = new ArrayList<>();
 
+  @OpenApi.Description(
+      """
+`<uid1>[,<uid2>...]`
+
+Get potential duplicates for given tracked entities.
+""")
   private List<UID> trackedEntities = new ArrayList<>();
 
+  @OpenApi.Description(
+      """
+Get potential duplicates that are in given status.
+""")
   private DeduplicationStatus status = DeduplicationStatus.OPEN;
+
+  /** Parameter {@code totalPages} is not supported. */
+  @OpenApi.Ignore
+  @Override
+  public boolean isTotalPages() {
+    return false;
+  }
+
+  @OpenApi.Description(
+      """
+Get only the given fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
+[metadata field filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter)
+on how to use it.
+""")
+  @OpenApi.Property(value = String[].class)
+  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
@@ -37,13 +37,14 @@ import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.deduplication.DeduplicationStatus;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 
 @OpenApi.Shared(name = "PotentialDuplicateRequestParams")
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class PotentialDuplicateRequestParams implements PageRequestParams {
+public class PotentialDuplicateRequestParams implements PageRequestParams, FieldsRequestParam {
   private static final String DEFAULT_FIELDS_PARAM =
       "id,created,lastUpdated,original,duplicate,status";
 
@@ -61,14 +62,27 @@ Get given number of items per page.
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  /** Parameter {@code totalPages} is not supported. */
+  @OpenApi.Ignore
+  @Override
+  public boolean isTotalPages() {
+    return false;
+  }
+
   @OpenApi.Description(
       """
-Get all entries by specifying `paging=false`. Requests are paginated by default.
+Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages
 will take more time to return.**
 """)
   private boolean paging = true;
+
+  @OpenApi.Description(
+      """
+Get potential duplicates that are in given status.
+""")
+  private DeduplicationStatus status = DeduplicationStatus.OPEN;
 
   @OpenApi.Description(
       """
@@ -87,19 +101,6 @@ Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive
 Get potential duplicates for given tracked entities.
 """)
   private List<UID> trackedEntities = new ArrayList<>();
-
-  @OpenApi.Description(
-      """
-Get potential duplicates that are in given status.
-""")
-  private DeduplicationStatus status = DeduplicationStatus.OPEN;
-
-  /** Parameter {@code totalPages} is not supported. */
-  @OpenApi.Ignore
-  @Override
-  public boolean isTotalPages() {
-    return false;
-  }
 
   @OpenApi.Description(
       """

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
@@ -35,21 +35,62 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
+import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 
 @OpenApi.Shared(name = "ChangeLogRequestParams")
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class ChangeLogRequestParams implements FieldsRequestParam {
+public class ChangeLogRequestParams implements PageRequestParams, FieldsRequestParam {
 
   private static final String DEFAULT_FIELDS_PARAM = "change,createdAt,createdBy,type";
 
-  private int page = 1;
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
+  @OpenApi.Property(defaultValue = "1")
+  private Integer page;
 
-  private int pageSize = 50;
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
+  @OpenApi.Property(defaultValue = "50")
+  private Integer pageSize;
 
+  /** Parameter {@code totalPages} is not supported. */
+  @OpenApi.Ignore
+  @Override
+  public boolean isTotalPages() {
+    return false;
+  }
+
+  /** Parameter {@code paging} is not supported. Requests are always paginated. */
+  @OpenApi.Ignore
+  @Override
+  public boolean isPaging() {
+    return true;
+  }
+
+  @OpenApi.Description(
+      """
+Get only the given fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
+[metadata field filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter)
+on how to use it.
+""")
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 
+  @OpenApi.Description(
+      """
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get items in given order.
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive.
+""")
   private List<OrderCriteria> order = new ArrayList<>();
 
   private String filter;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
@@ -54,17 +55,39 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class EnrollmentRequestParams implements PageRequestParams {
+public class EnrollmentRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!events,!attributes";
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
+`prev/nextPage` to determine if there is a previous or a next page instead.
+""")
   private boolean totalPages = false;
 
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 
   private List<OrderCriteria> order = new ArrayList<>();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
@@ -64,17 +65,39 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class EventRequestParams implements PageRequestParams {
+public class EventRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
+`prev/nextPage` to determine if there is a previous or a next page instead.
+""")
   private boolean totalPages = false;
 
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 
   private List<OrderCriteria> order = new ArrayList<>();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
@@ -39,24 +39,47 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 
 @OpenApi.Shared(name = "RelationshipRequestParams")
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class RelationshipRequestParams implements PageRequestParams {
+public class RelationshipRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM =
       "relationship,relationshipType,createdAtClient,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
+`prev/nextPage` to determine if there is a previous or a next page instead.
+""")
   private boolean totalPages = false;
 
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 
   private List<OrderCriteria> order = new ArrayList<>();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
@@ -61,17 +62,39 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class TrackedEntityRequestParams implements PageRequestParams {
+public class TrackedEntityRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
 
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
+`prev/nextPage` to determine if there is a previous or a next page instead.
+""")
   private boolean totalPages = false;
 
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
   private boolean paging = true;
 
   private List<OrderCriteria> order = new ArrayList<>();


### PR DESCRIPTION
* implement common tracker paging interface `PageRequestParams` in changeLog parameters
  * this ensures they work like other tracker endpoints
  * lets us reuse the type
* ignore request parameter `totalPages` in endpoints that do not support it and use `PageRequestParams`. Also exclude it from the OpenAPI spec.
  * `/potentialDuplicates`
  * `/tracker/trackedEntities/{id}/changeLogs`
  * `/tracker/events/{id}/changeLogs`
* ignore request parameter `paging` in changeLog endpoints as they are always paginated
* `throw new UnsupportedOperationException("pageTotal is not supported")` in stores of endpoints that don't support it. This is for the service layer where `PageParams.isPageTotal()` could be true if a dev does not remember its not supported.
* `/potentialDuplicates?fields=` change code to match exporters and add test
* add OpenAPI spec directly in request parameters so we remember to add them/keep them up to date

## Next

* simplify `view/Page` and integrate types well `PageRequestParams` -> `tracker/PageParams` -> `tracker/Page` -> `view/Page`
* reuse `TestSetup` to setup metadata and data in tracker integration tests
* reuse `TestSetup` to setup metadata and data in tracker web api tests
* maybe use TE service inside of the deduplication service. I'll do that if there is time. Right now it's odd that the service accepts TEs that might not even exist. That logic is in the controller. ACL is definitely also not done with the same level of detail as in the exporter service 😓 