### PR TITLE
fix: Use correct get single TE for ownhership feature [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
@@ -130,17 +130,20 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
       TrackedEntityProgramOwner teProgramOwner =
           trackedEntityProgramOwnerService.getTrackedEntityProgramOwner(trackedEntity, program);
 
+      // TODO(tracker) jdbc-hibernate: check the impact on performance
+      TrackedEntity hibernateTrackedEntity =
+          manager.get(TrackedEntity.class, trackedEntity.getUid());
       if (teProgramOwner != null && !teProgramOwner.getOrganisationUnit().equals(orgUnit)) {
         ProgramOwnershipHistory programOwnershipHistory =
             new ProgramOwnershipHistory(
                 program,
-                trackedEntity,
+                hibernateTrackedEntity,
                 teProgramOwner.getOrganisationUnit(),
                 teProgramOwner.getLastUpdated(),
                 teProgramOwner.getCreatedBy());
         programOwnershipHistoryService.addProgramOwnershipHistory(programOwnershipHistory);
         trackedEntityProgramOwnerService.updateTrackedEntityProgramOwner(
-            trackedEntity, program, orgUnit);
+            hibernateTrackedEntity, program, orgUnit);
       }
 
       ownerCache.invalidate(getOwnershipCacheKey(trackedEntity::getId, program));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
@@ -158,6 +158,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
       throws ForbiddenException {
     validateGrantTemporaryOwnershipInputs(trackedEntity, program, user);
 
+    // TODO(tracker) jdbc-hibernate: check the impact on performance
     TrackedEntity hibernateTrackedEntity = manager.get(TrackedEntity.class, trackedEntity.getUid());
     if (config.isEnabled(CHANGELOG_TRACKER)) {
       programTempOwnershipAuditService.addProgramTempOwnershipAudit(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
@@ -59,10 +59,10 @@ public class HibernateTrackedEntityProgramOwnerStore
     Query<TrackedEntityProgramOwner> query =
         getQuery(
             "from TrackedEntityProgramOwner tepo where "
-                + "tepo.trackedEntity.id= :teId and "
+                + "tepo.trackedEntity.uid= :teUid and "
                 + "tepo.program.id= :programId");
 
-    query.setParameter("teId", te.getId());
+    query.setParameter("teUid", te.getUid());
     query.setParameter("programId", program.getId());
     return query.uniqueResult();
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -405,6 +405,13 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     List<TrackedEntity> trackedEntities =
         getTrackedEntities(ids.getItems(), operationParams, queryParams, user);
+
+    // TODO(tracker): Push this filter into the store because it is breaking pagination
+    trackedEntities =
+        trackedEntities.stream()
+            .filter(te -> trackerAccessManager.canRead(user, te).isEmpty())
+            .toList();
+
     return ids.withItems(trackedEntities);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -63,10 +63,12 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.audit.TrackedEntityAuditService;
 import org.hisp.dhis.tracker.export.FileResourceStream;
+import org.hisp.dhis.tracker.export.OperationsParamsValidator;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggregate;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -95,6 +97,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   private final RelationshipService relationshipService;
 
   private final FileResourceService fileResourceService;
+
+  private final OperationsParamsValidator operationsParamsValidator;
 
   private final TrackedEntityOperationParamsMapper mapper;
 
@@ -204,9 +208,37 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Nonnull
   @Override
+  public TrackedEntity getNewTrackedEntity(@Nonnull UID uid)
+      throws NotFoundException, ForbiddenException {
+    return getNewTrackedEntity(uid, (Program) null, TrackedEntityParams.FALSE);
+  }
+
+  @Nonnull
+  @Override
   public TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException, BadRequestException {
     return getTrackedEntity(uid, null, TrackedEntityParams.FALSE);
+  }
+
+  @Nonnull
+  @Override
+  public TrackedEntity getNewTrackedEntity(
+      @Nonnull UID trackedEntityUid,
+      @CheckForNull UID programIdentifier,
+      @Nonnull TrackedEntityParams params)
+      throws NotFoundException, ForbiddenException {
+    Program program = null;
+    if (programIdentifier != null) {
+      try {
+        program =
+            operationsParamsValidator.validateProgramAccess(
+                programIdentifier, CurrentUserUtil.getCurrentUserDetails());
+      } catch (BadRequestException e) {
+        throw new NotFoundException(Program.class, programIdentifier.getValue());
+      }
+    }
+
+    return getNewTrackedEntity(trackedEntityUid, program, params);
   }
 
   @Nonnull
@@ -225,6 +257,29 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     return getTrackedEntity(trackedEntityUid, program, params, getCurrentUserDetails());
+  }
+
+  private TrackedEntity getNewTrackedEntity(UID uid, Program program, TrackedEntityParams params)
+      throws NotFoundException, ForbiddenException {
+    Page<TrackedEntity> trackedEntities;
+    try {
+      TrackedEntityOperationParams operationParams =
+          TrackedEntityOperationParams.builder()
+              .trackedEntities(Set.of(uid))
+              .trackedEntityParams(params)
+              .program(program)
+              .build();
+      trackedEntities = getTrackedEntities(operationParams, PageParams.single());
+    } catch (BadRequestException e) {
+      throw new IllegalArgumentException(
+          "this must be a bug in how the TrackedEntityOperationParams are built");
+    }
+
+    if (trackedEntities.getItems().isEmpty()) {
+      throw new NotFoundException(TrackedEntity.class, uid);
+    }
+
+    return trackedEntities.getItems().get(0);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -144,7 +144,7 @@ class TrackedEntityOperationParamsMapper {
   }
 
   private List<TrackedEntityType> getTrackedEntityTypes(Program program, UserDetails user)
-      throws BadRequestException {
+      throws ForbiddenException {
 
     if (program != null) {
       return List.of(program.getTrackedEntityType());
@@ -154,14 +154,14 @@ class TrackedEntityOperationParamsMapper {
   }
 
   private List<TrackedEntityType> filterAndValidateTrackedEntityTypes(UserDetails user)
-      throws BadRequestException {
+      throws ForbiddenException {
     List<TrackedEntityType> trackedEntityTypes =
         trackedEntityTypeService.getAllTrackedEntityType().stream()
             .filter(tet -> aclService.canDataRead(user, tet))
             .toList();
 
     if (trackedEntityTypes.isEmpty()) {
-      throw new BadRequestException("User has no access to any Tracked Entity Type");
+      throw new ForbiddenException("User has no access to any Tracked Entity Type");
     }
 
     return trackedEntityTypes;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -65,7 +65,10 @@ public interface TrackedEntityService {
    * authenticated user. No program attributes are included, only TETAs. Enrollments and
    * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
    * instead to also get the relationships, enrollments and program attributes.
+   *
+   * @deprecated use {@link #getNewTrackedEntity(UID)} instead.
    */
+  @Deprecated(forRemoval = true)
   @Nonnull
   TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException, BadRequestException;
@@ -86,7 +89,10 @@ public interface TrackedEntityService {
    * authenticated user. If {@code program} is defined, program attributes for such program are
    * included, otherwise only TETAs are included. It will include enrollments, relationships,
    * attributes and ownerships as defined in {@code params}.
+   *
+   * @deprecated use {@link #getNewTrackedEntity(UID, UID, TrackedEntityParams)} instead.
    */
+  @Deprecated(forRemoval = true)
   @Nonnull
   TrackedEntity getTrackedEntity(@Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException, BadRequestException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -58,8 +58,28 @@ public interface TrackedEntityService {
    * instead to also get the relationships, enrollments and program attributes.
    */
   @Nonnull
+  TrackedEntity getNewTrackedEntity(@Nonnull UID uid) throws NotFoundException, ForbiddenException;
+
+  /**
+   * Get the tracked entity matching given {@code UID} under the privileges of the currently
+   * authenticated user. No program attributes are included, only TETAs. Enrollments and
+   * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
+   * instead to also get the relationships, enrollments and program attributes.
+   */
+  @Nonnull
   TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException, BadRequestException;
+
+  /**
+   * Get the tracked entity matching given {@code UID} under the privileges of the currently
+   * authenticated user. If {@code program} is defined, program attributes for such program are
+   * included, otherwise only TETAs are included. It will include enrollments, relationships,
+   * attributes and ownerships as defined in {@code params}.
+   */
+  @Nonnull
+  TrackedEntity getNewTrackedEntity(
+      @Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
+      throws NotFoundException, ForbiddenException;
 
   /**
    * Get the tracked entity matching given {@code UID} under the privileges of the currently

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -511,14 +511,14 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
 
-    Exception illegalQueryException =
+    Exception exception =
         assertThrows(
             IllegalQueryException.class,
             () -> mapper.map(operationParams, currentUserWithOrgUnits));
 
     assertEquals(
         "At least 1 attributes should be mentioned in the search criteria.",
-        illegalQueryException.getMessage());
+        exception.getMessage());
   }
 
   @Test
@@ -544,11 +544,11 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).program(PROGRAM_UID).build();
 
-    Exception illegalQueryException =
+    Exception exception =
         assertThrows(
             IllegalQueryException.class,
             () -> mapper.map(operationParams, currentUserWithOrgUnits));
-    assertEquals("maxteicountreached", illegalQueryException.getMessage());
+    assertEquals("maxteicountreached", exception.getMessage());
   }
 
   @Test
@@ -567,10 +567,10 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
-    Exception forbiddenException =
+    Exception exception =
         assertThrows(
             ForbiddenException.class, () -> mapper.map(operationParams, currentUserWithOrgUnits));
 
-    assertEquals("User has no access to any Tracked Entity Type", forbiddenException.getMessage());
+    assertEquals("User has no access to any Tracked Entity Type", exception.getMessage());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -567,10 +567,10 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ACCESSIBLE).build();
 
-    Exception badRequestException =
+    Exception forbiddenException =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(operationParams, currentUserWithOrgUnits));
+            ForbiddenException.class, () -> mapper.map(operationParams, currentUserWithOrgUnits));
 
-    assertEquals("User has no access to any Tracked Entity Type", badRequestException.getMessage());
+    assertEquals("User has no access to any Tracked Entity Type", forbiddenException.getMessage());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
@@ -196,6 +196,9 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
   @Test
   void shouldNotHaveAccessToEnrollmentWithUserAWhenTransferredToAnotherOrgUnit()
       throws ForbiddenException {
+    userA.setTeiSearchOrganisationUnits(Set.of(organisationUnitB));
+    userService.updateUser(userA);
+
     trackerOwnershipAccessManager.transferOwnership(trackedEntityA1, programA, organisationUnitB);
 
     injectSecurityContextUser(userA);
@@ -319,7 +322,9 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
   void shouldNotHaveAccessWhenProgramProtectedAndUserNotInCaptureScopeNorHasTemporaryAccess() {
     userB.setTeiSearchOrganisationUnits(Set.of(organisationUnitA));
     userService.updateUser(userB);
-    assertFalse(trackerOwnershipAccessManager.hasAccess(userDetailsB, trackedEntityA1, programA));
+    assertFalse(
+        trackerOwnershipAccessManager.hasAccess(
+            UserDetails.fromUser(userB), trackedEntityA1, programA));
     assertFalse(
         trackerOwnershipAccessManager.hasAccess(
             UserDetails.fromUser(userB),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
@@ -39,14 +39,12 @@ import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests the {@link TrackerOwnershipController} using (mocked) REST requests.
  *
  * @author Jan Bernitt
  */
-@Transactional
 class TrackerOwnershipControllerTest extends PostgresControllerIntegrationTestBase {
 
   private String orgUnitAUid;
@@ -90,6 +88,24 @@ class TrackerOwnershipControllerTest extends PostgresControllerIntegrationTestBa
                 "/trackedEntityTypes/",
                 "{'name': 'A', 'sharing':{'external':false,'public':'rwrw----'}}"));
 
+    pId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                """
+                                {
+                                  'name':'P1',
+                                  'shortName':'P1',
+                                  'programType':'WITH_REGISTRATION',
+                                  'accessLevel':'PROTECTED',
+                                  'trackedEntityType': {'id': '%s'},
+                                  'organisationUnits': [{'id':'%s'},{'id':'%s'}],
+                                  'sharing':{'external':false,'public':'rwrw----'}
+                                }
+                                """
+                    .formatted(tetId, orgUnitAUid, orgUnitBUid)));
+
     teUid = CodeGenerator.generateUid();
     assertStatus(
         HttpStatus.OK,
@@ -101,30 +117,20 @@ class TrackerOwnershipControllerTest extends PostgresControllerIntegrationTestBa
                {
                  "trackedEntity": "%s",
                  "trackedEntityType": "%s",
-                 "orgUnit": "%s"
+                 "orgUnit": "%s",
+                 "enrollments": [
+                  {
+                    "orgUnit": "%s",
+                    "program": "%s",
+                    "occurredAt": "2025-02-26",
+                    "enrolledAt": "2025-02-26"
+                  }
+                 ]
                }
              ]
             }
             """
-                .formatted(teUid, tetId, orgUnitAUid)));
-
-    pId =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST(
-                "/programs/",
-                """
-                    {
-                      'name':'P1',
-                      'shortName':'P1',
-                      'programType':'WITH_REGISTRATION',
-                      'accessLevel':'PROTECTED',
-                      'trackedEntityType': {'id': '%s'},
-                      'organisationUnits': [{'id':'%s'},{'id':'%s'}],
-                      'sharing':{'external':false,'public':'rwrw----'}
-                    }
-                    """
-                    .formatted(tetId, orgUnitAUid, orgUnitBUid)));
+                .formatted(teUid, tetId, orgUnitAUid, orgUnitAUid, pId)));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -100,7 +100,7 @@ public class TrackerOwnershipController {
     UID orgUnitUid = validateMandatoryDeprecatedUidParameter("ou", ou, "orgUnit", orgUnit);
 
     trackerOwnershipAccessManager.transferOwnership(
-        trackedEntityService.getTrackedEntity(trackedEntity, program, TrackedEntityParams.FALSE),
+        trackedEntityService.getNewTrackedEntity(trackedEntity, program, TrackedEntityParams.FALSE),
         programService.getProgram(program.getValue()),
         organisationUnitService.getOrganisationUnit(orgUnitUid.getValue()));
     return ok("Ownership transferred");
@@ -110,10 +110,10 @@ public class TrackerOwnershipController {
   @ResponseBody
   public WebMessage grantTemporaryAccess(
       @RequestParam UID trackedEntity, @RequestParam String reason, @RequestParam UID program)
-      throws BadRequestException, ForbiddenException, NotFoundException {
+      throws ForbiddenException, NotFoundException {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
-        trackedEntityService.getTrackedEntity(trackedEntity),
+        trackedEntityService.getNewTrackedEntity(trackedEntity),
         programService.getProgram(program.getValue()),
         currentUser,
         reason);


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

In this PR we are starting to change tracker ownership service and controller to use the new and correct `getNewTrackedEntity` method.

***Changes in this PR***

- `getNewTrackedEntity` method is returning a detached entity (that has no `id` set). This is in order to avoid unwanted changes on this object and by consequence unwanted field changes in the DB. Services that expect a managed entity are retrieving one using the `IdentifiableObjectManager` class using `TrackedEntity` uid.

- `TrackedEntityOperationParamsMapper` was throwing a `BadRequestException` when the user had no access to any tracked entity type, it was change to a more suitable `ForbiddenException`

***Open question***
Can we transfer an ownership if there is no ownership present in the system?
When we transfer we are trying to get the tracked entity in the context of a program and if there is no ownership (in other words if the tracked entity is not enrolled or it wasn't previously enrolled) the tracked entity is not found.
Does it make sense or we should search the tracked entity outside the context of any program?

***Bug alert***
There are 2 integration tests failing because the user has no ownership access on the tracked entity, the program is protected and the user has the program organisation unit in its search scope but the user can retrieve the tracked entity.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Move new methods for changelog feature
- Move new methods in tracked entity controller
- Move new methods for deduplication feature
- Move new methods in all remaining places
- Remove old `getTrackedEntity()` methods and rename new ones