### PR TITLE
chore: simplify pager types DHIS2-19021

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstanceService.java
@@ -44,5 +44,18 @@ public interface ProgramNotificationInstanceService {
   List<ProgramNotificationInstance> getProgramNotificationInstances(
       ProgramNotificationInstanceParam programNotificationInstanceParam);
 
+  /**
+   * Get a page of program notification instances. Use {@link
+   * #getProgramNotificationInstances(ProgramNotificationInstanceParam)} if you want all program
+   * notification instances. This method will fetch one extra item than the page size so the caller
+   * can determine if there is a next page.
+   */
+  // TODO(tracker) ProgramNotificationInstances lives in module dhis-api which is why we
+  // cannot reuse code from the dhis-service-tracker module like org.hisp.dhis.tracker.Page. This is
+  // why we cannot return a Page here. We need to make a decision and either move this into
+  // dhis-service-tracker or use metadata patterns/code.
+  List<ProgramNotificationInstance> getProgramNotificationInstancesPage(
+      ProgramNotificationInstanceParam programNotificationInstanceParam);
+
   Long countProgramNotificationInstances(ProgramNotificationInstanceParam params);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.notification;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,11 +42,21 @@ public class DefaultProgramNotificationInstanceService
     implements ProgramNotificationInstanceService {
   private final ProgramNotificationInstanceStore notificationInstanceStore;
 
+  @Nonnull
   @Override
   @Transactional(readOnly = true)
   public List<ProgramNotificationInstance> getProgramNotificationInstances(
       ProgramNotificationInstanceParam programNotificationInstanceParam) {
     return notificationInstanceStore.getProgramNotificationInstances(
+        programNotificationInstanceParam);
+  }
+
+  @Nonnull
+  @Override
+  @Transactional(readOnly = true)
+  public List<ProgramNotificationInstance> getProgramNotificationInstancesPage(
+      ProgramNotificationInstanceParam programNotificationInstanceParam) {
+    return notificationInstanceStore.getProgramNotificationInstancesPage(
         programNotificationInstanceParam);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
@@ -72,12 +72,24 @@ public class HibernateProgramNotificationInstanceStore
             .addPredicates(getPredicates(params, builder))
             .addOrder(root -> builder.desc(root.get("created")));
 
+    return getList(builder, jpaParameters);
+  }
+
+  @Override
+  public List<ProgramNotificationInstance> getProgramNotificationInstancesPage(
+      ProgramNotificationInstanceParam params) {
+    CriteriaBuilder builder = getCriteriaBuilder();
+
+    JpaQueryParameters<ProgramNotificationInstance> jpaParameters =
+        newJpaParameters()
+            .addPredicates(getPredicates(params, builder))
+            .addOrder(root -> builder.desc(root.get("created")));
+
     if (params.isPaging()) {
-      // javax.persistence.TypedQuery position of the first result is numbered from 0 while
-      // user-facing pagination parameters start at 1
       jpaParameters
           .setFirstResult((params.getPage() - 1) * params.getPageSize())
-          .setMaxResults(params.getPageSize());
+          .setMaxResults(
+              params.getPageSize() + 1); // get extra enrollment to determine if there is a nextPage
     }
 
     return getList(builder, jpaParameters);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
@@ -86,10 +86,12 @@ public class HibernateProgramNotificationInstanceStore
             .addOrder(root -> builder.desc(root.get("created")));
 
     if (params.isPaging()) {
+      // javax.persistence.TypedQuery position of the first result is numbered from 0 while
+      // user-facing pagination parameters start at 1
       jpaParameters
           .setFirstResult((params.getPage() - 1) * params.getPageSize())
           .setMaxResults(
-              params.getPageSize() + 1); // get extra enrollment to determine if there is a nextPage
+              params.getPageSize() + 1); // get extra item to determine if there is a nextPage
     }
 
     return getList(builder, jpaParameters);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Page.java
@@ -57,10 +57,17 @@ public class Page<T> {
     return new Page<>(List.of(), 0, 0, 0L, null, null);
   }
 
+  /** Create a page without a total count of items. */
   public Page(@Nonnull List<T> items, @Nonnull PageParams pageParams) {
     this(items, pageParams, null);
   }
 
+  /**
+   * Create a page that optionally supplies a total count of items and indicates if there is a
+   * previous or next page. It is assumed that there is a previous page when the current page is
+   * greater than 1. It is assumed there is a next page if there are more items than the page size.
+   * This means that the store has to fetch one more item than the requested page size.
+   */
   public Page(
       @Nonnull List<T> items, @Nonnull PageParams pageParams, @CheckForNull LongSupplier total) {
     this.page = pageParams.getPage();
@@ -98,18 +105,5 @@ public class Page<T> {
         this.total,
         this.prevPage,
         this.nextPage);
-  }
-
-  public static <T> Page<T> withTotals(List<T> items, int page, int pageSize, long total) {
-    return new Page<>(items, page, pageSize, total, null, null);
-  }
-
-  public static <T> Page<T> withoutTotals(List<T> items, int page, int pageSize) {
-    return new Page<>(items, page, pageSize, null, null, null);
-  }
-
-  public static <T> Page<T> withPrevAndNext(
-      List<T> items, int page, int pageSize, Integer prevPage, Integer nextPage) {
-    return new Page<>(items, page, pageSize, null, prevPage, nextPage);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/PageParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/PageParams.java
@@ -33,8 +33,8 @@ import lombok.Getter;
 import lombok.ToString;
 
 /**
- * {@link PageParams} represent the parameters that configure the page of items to be returned. By
- * default, the total number of items will not be fetched.
+ * {@link PageParams} represent the parameters that configure the page of items to be returned by a
+ * service or store.
  */
 @Getter
 @ToString

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -144,7 +144,7 @@ class ProgramNotificationInstanceControllerTest extends PostgresControllerIntegr
   }
 
   @Test
-  void shouldGetPaginatedItemsFirstPage() {
+  void shouldGetFirstPage() {
     JsonPage page =
         GET(
                 "/programNotificationInstances?enrollment={uid}&page=1&pageSize=1&totalPages=false",
@@ -173,7 +173,7 @@ class ProgramNotificationInstanceControllerTest extends PostgresControllerIntegr
   }
 
   @Test
-  void shouldGetPaginatedItemsLastPage() {
+  void shouldGetLastPage() {
     JsonPage page =
         GET(
                 "/programNotificationInstances?enrollment={uid}&page=2&pageSize=1&totalPages=true",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
@@ -63,7 +63,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @OpenApi.Document(
     entity = ProgramNotificationInstance.class,
-    classifiers = {"team:tracker", "purpose:metadata"})
+    classifiers = {"team:tracker", "purpose:data"})
 @Controller
 @RequestMapping("/api/programNotificationInstances")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
@@ -124,7 +124,7 @@ public class ProgramNotificationInstanceController {
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
           .body(
-              Page.withFullPager(
+              Page.withPager(
                   ProgramNotificationInstanceSchemaDescriptor.PLURAL,
                   page,
                   getRequestURL(request)));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
@@ -28,12 +28,15 @@
 package org.hisp.dhis.webapi.controller.notification;
 
 import static org.hisp.dhis.security.Authorities.ALL;
+import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler.getRequestURL;
 
-import java.util.Date;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.OpenApi.Response.Status;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
@@ -43,14 +46,16 @@ import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.schema.descriptors.ProgramNotificationInstanceSchemaDescriptor;
 import org.hisp.dhis.security.RequiresAuthority;
+import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -78,44 +83,65 @@ public class ProgramNotificationInstanceController {
     this.eventService = eventService;
   }
 
+  @OpenApi.Response(status = Status.OK, value = Page.class)
   @RequiresAuthority(anyOf = ALL)
   @GetMapping(produces = {"application/json"})
-  public @ResponseBody Page<ProgramNotificationInstance> getScheduledMessage(
-      @RequestParam(required = false) UID enrollment,
-      @RequestParam(required = false) UID event,
-      @RequestParam(required = false) Date scheduledAt,
-      @RequestParam(required = false, defaultValue = "true") boolean paging,
-      @RequestParam(required = false, defaultValue = "1") int page,
-      @RequestParam(required = false, defaultValue = "50") int pageSize)
-      throws ForbiddenException, NotFoundException {
+  public @ResponseBody ResponseEntity<Page<ProgramNotificationInstance>> getScheduledMessage(
+      ProgramNotificationInstanceRequestParams requestParams, HttpServletRequest request)
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    validatePaginationParameters(requestParams);
+
     Event storedEvent = null;
-    if (event != null) {
-      storedEvent = eventService.getEvent(event);
+    if (requestParams.getEvent() != null) {
+      storedEvent = eventService.getEvent(requestParams.getEvent());
     }
     Enrollment storedEnrollment = null;
-    if (enrollment != null) {
-      storedEnrollment = enrollmentService.getEnrollment(enrollment);
+    if (requestParams.getEnrollment() != null) {
+      storedEnrollment = enrollmentService.getEnrollment(requestParams.getEnrollment());
     }
+
+    if (requestParams.isPaging()) {
+      PageParams pageParams =
+          new PageParams(
+              requestParams.getPage(), requestParams.getPageSize(), requestParams.isTotalPages());
+      ProgramNotificationInstanceParam params =
+          ProgramNotificationInstanceParam.builder()
+              .enrollment(storedEnrollment)
+              .event(storedEvent)
+              .scheduledAt(requestParams.getScheduledAt())
+              .paging(true)
+              .page(pageParams.getPage())
+              .pageSize(pageParams.getPageSize())
+              .build();
+      List<ProgramNotificationInstance> instances =
+          programNotificationInstanceService.getProgramNotificationInstancesPage(params);
+      org.hisp.dhis.tracker.Page<ProgramNotificationInstance> page =
+          new org.hisp.dhis.tracker.Page<>(
+              instances,
+              pageParams,
+              () -> programNotificationInstanceService.countProgramNotificationInstances(params));
+
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+              Page.withFullPager(
+                  ProgramNotificationInstanceSchemaDescriptor.PLURAL,
+                  page,
+                  getRequestURL(request)));
+    }
+
     ProgramNotificationInstanceParam params =
         ProgramNotificationInstanceParam.builder()
             .enrollment(storedEnrollment)
             .event(storedEvent)
-            .page(page)
-            .pageSize(pageSize)
-            .paging(paging)
-            .scheduledAt(scheduledAt)
+            .scheduledAt(requestParams.getScheduledAt())
+            .paging(false)
             .build();
-
     List<ProgramNotificationInstance> instances =
         programNotificationInstanceService.getProgramNotificationInstances(params);
 
-    if (paging) {
-      long total = programNotificationInstanceService.countProgramNotificationInstances(params);
-      return Page.withPager(
-          ProgramNotificationInstanceSchemaDescriptor.PLURAL,
-          org.hisp.dhis.tracker.Page.withTotals(instances, page, pageSize, total));
-    }
-
-    return Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceRequestParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,21 +25,53 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program.notification;
+package org.hisp.dhis.webapi.controller.notification;
 
-import java.util.List;
-import org.hisp.dhis.common.IdentifiableObjectStore;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 
-/**
- * @author Zubair Asghar
- */
-public interface ProgramNotificationInstanceStore
-    extends IdentifiableObjectStore<ProgramNotificationInstance> {
-  List<ProgramNotificationInstance> getProgramNotificationInstances(
-      ProgramNotificationInstanceParam programNotificationInstanceParam);
+@OpenApi.Shared(name = "ProgramNotificationInstanceRequestParams")
+@OpenApi.Property
+@Data
+@NoArgsConstructor
+public class ProgramNotificationInstanceRequestParams implements PageRequestParams {
+  @OpenApi.Description(
+      """
+Get the given page.
+""")
+  @OpenApi.Property(defaultValue = "1")
+  private Integer page;
 
-  List<ProgramNotificationInstance> getProgramNotificationInstancesPage(
-      ProgramNotificationInstanceParam programNotificationInstanceParam);
+  @OpenApi.Description(
+      """
+Get given number of items per page.
+""")
+  @OpenApi.Property(defaultValue = "50")
+  private Integer pageSize;
 
-  Long countProgramNotificationInstances(ProgramNotificationInstanceParam params);
+  @OpenApi.Description(
+      """
+Get the total number of items and pages in the pager.
+
+**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
+`prev/nextPage` to determine if there is a previous or a next page instead.
+""")
+  private boolean totalPages = false;
+
+  @OpenApi.Description(
+      """
+Get all items by specifying `paging=false`. Requests are paginated by default.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+""")
+  private boolean paging = true;
+
+  UID enrollment;
+  UID event;
+  Date scheduledAt;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateController.java
@@ -32,17 +32,19 @@ import static org.hisp.dhis.security.Authorities.ALL;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateOperationParams;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.query.GetObjectListParams;
-import org.hisp.dhis.schema.descriptors.ProgramNotificationTemplateSchemaDescriptor;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
-import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.StreamingJsonRoot;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -72,26 +74,32 @@ public class ProgramNotificationTemplateController
   // GET
   // -------------------------------------------------------------------------
 
+  @OpenApi.Response(GetObjectListResponse.class)
   @RequiresAuthority(anyOf = ALL)
   @GetMapping(
       produces = {"application/json"},
       value = "/filter")
-  public @ResponseBody Page<ProgramNotificationTemplate> getProgramNotificationTemplates(
-      ProgramNotificationTemplateRequestParams requestParams)
-      throws ConflictException, BadRequestException {
+  public @ResponseBody ResponseEntity<StreamingJsonRoot<ProgramNotificationTemplate>>
+      getProgramNotificationTemplates(ProgramNotificationTemplateRequestParams requestParams)
+          throws ConflictException, BadRequestException {
     ProgramNotificationTemplateOperationParams params = requestParamsMapper.map(requestParams);
 
-    List<ProgramNotificationTemplate> instances =
+    List<ProgramNotificationTemplate> entities =
         programNotificationTemplateService.getProgramNotificationTemplates(params);
 
+    Pager pager = null;
     if (params.isPaging()) {
-      long total = programNotificationTemplateService.countProgramNotificationTemplates(params);
-      return Page.withPager(
-          ProgramNotificationTemplateSchemaDescriptor.PLURAL,
-          org.hisp.dhis.tracker.Page.withTotals(
-              instances, params.getPage(), params.getPageSize(), total));
+      long totalCount =
+          programNotificationTemplateService.countProgramNotificationTemplates(params);
+      pager = new Pager(params.getPage(), totalCount, params.getPageSize());
+      linkService.generatePagerLinks(pager, getEntityClass());
     }
 
-    return Page.withoutPager(ProgramNotificationTemplateSchemaDescriptor.PLURAL, instances);
+    return ResponseEntity.ok(
+        new StreamingJsonRoot<>(
+            pager,
+            getSchema().getCollectionName(),
+            FieldFilterParams.of(entities, List.of("*")),
+            false));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
@@ -57,13 +57,14 @@ Get given number of items per page.
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
-  @OpenApi.Description(
-      """
-Get the total number of items and pages in the pager.
-
-**Only enable this if absolutely necessary as this is resource intensive.** Use the pagers `prev/nextPage` to determine if there is a previous or a next page instead.
-""")
-  private boolean totalPages = false;
+  /**
+   * Parameter {@code totalPages} is not supported. Like other metadata totals are always returned.
+   */
+  @OpenApi.Ignore
+  @Override
+  public boolean isTotalPages() {
+    return true;
+  }
 
   @OpenApi.Description(
       """

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParamsMapper.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.notification;
 
-import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationBounds;
 
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -65,6 +65,6 @@ public class ProgramNotificationTemplateRequestParamsMapper {
       throw new ConflictException("`program` and `programStage` cannot be processed together.");
     }
 
-    validatePaginationParameters(requestParams);
+    validatePaginationBounds(requestParams.getPage(), requestParams.getPageSize());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/PageRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/PageRequestParams.java
@@ -30,13 +30,18 @@ package org.hisp.dhis.webapi.controller.tracker;
 import org.hisp.dhis.common.OpenApi;
 
 /**
- * {@link PageRequestParams} represent the HTTP request parameters that configure whether the
- * response should be paginated and if so how. Tracker supports disabling pagination via {@code
- * paging=false} and enabling pagination via {@code paging=true}. Enabling and disabling parameters
- * are mutually exclusive. We can thus not set default values in our {@code RequestParams} classes
- * as we would not be able to discern a user supplied parameter value from a default value.
+ * Represents the HTTP request parameters for configuring pagination in tracker endpoints. Tracker
+ * endpoints that support disabling pagination do so via {@code paging=false}. Enabling and
+ * disabling parameters are mutually exclusive, so default values cannot be set in {@code
+ * RequestParams} classes as user-supplied values cannot be distinguished from defaults.
  *
- * <p>{@code totalPages=true} is only supported on paginated responses.
+ * <p>{@code totalPages=true} is supported only on paginated responses by some endpoints.
+ *
+ * <p>Define fields with setters for {@code paging} and {@code totalPages} if the endpoint supports
+ * them.
+ *
+ * <p>Define methods {@code isPaging} and {@code isTotalPages} to return appropriate values if the
+ * endpoint does not support them.
  */
 @OpenApi.Shared(name = "TrackerPageRequestParams")
 public interface PageRequestParams {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -109,7 +109,7 @@ public class DeduplicationController {
           .header(HEADER_CACHE_CONTROL, HEADER_VALUE_NO_STORE)
           .contentType(MediaType.APPLICATION_JSON)
           .body(
-              Page.withFullPager(
+              Page.withPager(
                   "potentialDuplicates", page.withItems(objectNodes), getRequestURL(request)));
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -122,8 +122,7 @@ class EnrollmentsExportController {
 
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(
-              Page.withFullPager(ENROLLMENTS, page.withItems(objectNodes), getRequestURL(request)));
+          .body(Page.withPager(ENROLLMENTS, page.withItems(objectNodes), getRequestURL(request)));
     }
 
     List<Enrollment> enrollments =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -381,7 +381,7 @@ class EventsExportController {
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
         .body(
-            Page.withPager(
+            Page.withFullPager(
                 "changeLogs", changeLogs.withItems(objectNodes), getRequestURL(request)));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -181,9 +181,7 @@ class EventsExportController {
 
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
-          .body(
-              Page.withFullPager(
-                  EVENTS, eventsPage.withItems(objectNodes), getRequestURL(request)));
+          .body(Page.withPager(EVENTS, eventsPage.withItems(objectNodes), getRequestURL(request)));
     }
 
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
@@ -381,7 +379,7 @@ class EventsExportController {
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
         .body(
-            Page.withFullPager(
+            Page.withPager(
                 "changeLogs", changeLogs.withItems(objectNodes), getRequestURL(request)));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -122,7 +122,7 @@ class RelationshipsExportController {
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
           .body(
-              Page.withFullPager(
+              Page.withPager(
                   RELATIONSHIPS, relationshipsPage.withItems(objectNodes), getRequestURL(request)));
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -414,7 +414,7 @@ class TrackedEntitiesExportController {
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
         .body(
-            Page.withPager(
+            Page.withFullPager(
                 "changeLogs", changeLogs.withItems(objectNodes), getRequestURL(request)));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -193,7 +193,7 @@ class TrackedEntitiesExportController {
       return ResponseEntity.ok()
           .contentType(MediaType.APPLICATION_JSON)
           .body(
-              Page.withFullPager(
+              Page.withPager(
                   TRACKED_ENTITIES,
                   trackedEntitiesPage.withItems(objectNodes),
                   getRequestURL(request)));
@@ -414,7 +414,7 @@ class TrackedEntitiesExportController {
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_JSON)
         .body(
-            Page.withFullPager(
+            Page.withPager(
                 "changeLogs", changeLogs.withItems(objectNodes), getRequestURL(request)));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -66,23 +66,6 @@ public class Page<T> {
     this.pager = null;
   }
 
-  /**
-   * Create a page with a pager without a total, prev and next page links.
-   *
-   * <p>The pager will thus only show the page and its size.
-   */
-  private Page(String key, List<T> values, int page, int pageSize) {
-    this.items.put(key, values);
-    this.pager = new Pager(page, pageSize, null, null, null, null);
-  }
-
-  /** Create a page with a pager with a total but without prev and next page links. */
-  private Page(String key, List<T> values, int page, int pageSize, long total) {
-    this.items.put(key, values);
-    int pageCount = (int) Math.ceil(total / (double) pageSize);
-    this.pager = new Pager(page, pageSize, total, pageCount, null, null);
-  }
-
   /** Create a page with a pager without a total but with prev and next page links. */
   private Page(
       String key, List<T> values, int page, int pageSize, String prevPage, String nextPage) {
@@ -107,19 +90,8 @@ public class Page<T> {
     this.pager = new Pager(page, pageSize, total, pageCount, prevPage, nextPage);
   }
 
-  /**
-   * Returns a page which will serialize the items into {@link #items} under given {@code key}.
-   * Pagination details will be serialized as well including totals only if {@link
-   * org.hisp.dhis.tracker.Page#getTotal()} is not null.
-   */
-  public static <T> Page<T> withPager(String key, org.hisp.dhis.tracker.Page<T> pager) {
-    if (pager.getTotal() != null) {
-      return new Page<>(
-          key, pager.getItems(), pager.getPage(), pager.getPageSize(), pager.getTotal());
-    }
-    return new Page<>(key, pager.getItems(), pager.getPage(), pager.getPageSize());
-  }
-
+  // TODO(ivo) can I delete this one as well? then rename full pager to withPager or simply use a
+  // constructor?
   /**
    * Returns a page which will serialize the items into {@link #items} under given {@code key}.
    * Previous and next page links will be generated based on the request if {@link

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,73 +56,35 @@ public class Page<T> {
 
   @JsonProperty private final Pager pager;
 
-  /**
-   * Create a page without a pager.
-   *
-   * <p>Only the items will be serialized into {@link #items} under given {@code key}. All other
-   * fields will be omitted from the JSON.
-   */
   private Page(String key, List<T> values) {
     this.items.put(key, values);
     this.pager = null;
   }
 
-  /** Create a page with a pager without a total but with prev and next page links. */
-  private Page(
-      String key, List<T> values, int page, int pageSize, String prevPage, String nextPage) {
-    this.items.put(key, values);
-    this.pager = new Pager(page, pageSize, null, null, prevPage, nextPage);
-  }
-
-  /** Create a page with a pager without a total but with prev and next page links. */
-  private Page(
-      String key,
-      List<T> values,
-      int page,
-      int pageSize,
-      Long total,
-      String prevPage,
-      String nextPage) {
-    this.items.put(key, values);
+  private Page(String key, org.hisp.dhis.tracker.Page<T> pager, String requestURL) {
+    this.items.put(key, pager.getItems());
     Integer pageCount = null;
-    if (total != null) {
-      pageCount = (int) Math.ceil(total / (double) pageSize);
+    if (pager.getTotal() != null) {
+      pageCount = (int) Math.ceil(pager.getTotal() / (double) pager.getPageSize());
     }
-    this.pager = new Pager(page, pageSize, total, pageCount, prevPage, nextPage);
-  }
-
-  // TODO(ivo) can I delete this one as well? then rename full pager to withPager or simply use a
-  // constructor?
-  /**
-   * Returns a page which will serialize the items into {@link #items} under given {@code key}.
-   * Previous and next page links will be generated based on the request if {@link
-   * org.hisp.dhis.tracker.Page#getPrevPage()} or next are not null.
-   */
-  public static <T> Page<T> withPager(
-      String key, org.hisp.dhis.tracker.Page<T> pager, String requestURL) {
     String prevPage = getPageLink(requestURL, pager.getPrevPage());
     String nextPage = getPageLink(requestURL, pager.getNextPage());
-
-    return new Page<>(
-        key, pager.getItems(), pager.getPage(), pager.getPageSize(), prevPage, nextPage);
+    this.pager =
+        new Pager(
+            pager.getPage(), pager.getPageSize(), pager.getTotal(), pageCount, prevPage, nextPage);
   }
 
   /**
    * Returns a page which will serialize the items into {@link #items} under given {@code key}.
    * Previous and next page links will be generated based on the request if {@link
    * org.hisp.dhis.tracker.Page#getPrevPage()} or next are not null. Total and page count will also
-   * be set if the pager has a total.
+   * be set if the pager has a non-null total.
    */
-  public static <T> Page<T> withFullPager(
-      String key, org.hisp.dhis.tracker.Page<T> pager, String requestURL) {
-    return new Page<>(
-        key,
-        pager.getItems(),
-        pager.getPage(),
-        pager.getPageSize(),
-        pager.getTotal(),
-        getPageLink(requestURL, pager.getPrevPage()),
-        getPageLink(requestURL, pager.getNextPage()));
+  public static <T> Page<T> withPager(
+      @Nonnull String key,
+      @Nonnull org.hisp.dhis.tracker.Page<T> pager,
+      @Nonnull String requestURL) {
+    return new Page<>(key, pager, requestURL);
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
@@ -35,21 +35,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.tracker.PageParams;
 import org.junit.jupiter.api.Test;
 
 class PageTest {
-
   @Test
-  void shouldNotSetNoPageLinkIfThereAreNone() {
+  void shouldNotSetNoPageLinksIfThereAreNone() {
     List<String> fruits = List.of("apple", "banana", "cherry");
+    PageParams pageParams = new PageParams(1, 3, false);
     org.hisp.dhis.tracker.Page<String> exportPage =
-        org.hisp.dhis.tracker.Page.withPrevAndNext(fruits, 1, 3, null, null);
+        new org.hisp.dhis.tracker.Page<>(fruits, pageParams);
 
     Page<String> page =
         Page.withPager(
             "fruits",
             exportPage,
             "http://localhost/organisationUnits?page=1&pageSize=3&fields=displayName");
+
+    assertEquals(Map.of("fruits", fruits), page.getItems());
 
     assertEquals(1, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
@@ -63,14 +67,17 @@ class PageTest {
   @Test
   void shouldSetPrevPage() {
     List<String> fruits = List.of("apple", "banana", "cherry");
+    PageParams pageParams = new PageParams(2, 3, false);
     org.hisp.dhis.tracker.Page<String> exportPage =
-        org.hisp.dhis.tracker.Page.withPrevAndNext(fruits, 2, 3, 1, null);
+        new org.hisp.dhis.tracker.Page<>(fruits, pageParams);
 
     Page<String> page =
         Page.withPager(
             "fruits",
             exportPage,
             "http://localhost/organisationUnits?page=2&pageSize=3&fields=displayName");
+
+    assertEquals(Map.of("fruits", fruits), page.getItems());
 
     assertEquals(2, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
@@ -88,17 +95,20 @@ class PageTest {
 
   @Test
   void shouldSetNextPage() {
-    List<String> fruits = List.of("apple", "banana", "cherry");
+    List<String> fruits = List.of("apple", "banana", "cherry", "mango");
+    PageParams pageParams = new PageParams(1, 3, false);
     org.hisp.dhis.tracker.Page<String> exportPage =
-        org.hisp.dhis.tracker.Page.withPrevAndNext(fruits, 2, 3, null, 3);
+        new org.hisp.dhis.tracker.Page<>(fruits, pageParams);
 
     Page<String> page =
         Page.withPager(
             "fruits",
             exportPage,
-            "http://localhost/organisationUnits?page=2&pageSize=3&fields=displayName");
+            "http://localhost/organisationUnits?page=1&pageSize=3&fields=displayName");
 
-    assertEquals(2, page.getPager().getPage());
+    assertEquals(Map.of("fruits", List.of("apple", "banana", "cherry")), page.getItems());
+
+    assertEquals(1, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
     assertNull(page.getPager().getTotal());
     assertNull(page.getPager().getPageCount());
@@ -106,7 +116,7 @@ class PageTest {
     assertNull(page.getPager().getPrevPage());
     assertPagerLink(
         page.getPager().getNextPage(),
-        3,
+        2,
         3,
         "http://localhost/organisationUnits",
         "fields=displayName");


### PR DESCRIPTION
* simplify our types so they integrate well

`controller.tracker.PageRequestParams` -> `tracker.PageParams` -> `tracker.Page` -> `controller.tracker.view/Page`
-----^ input to controller ------------------------------^ input to service/store --- ^ output from service/store -- ^ output from controller

Tracker endpoints that got `pager.prev/nextPage` in https://dhis2.atlassian.net/browse/DHIS2-19021. It also shows the feature support.

| endpoint | get counts via `totalPages=true` | turn off pagination via `paging=false` | has `pager.prev/nextPage` |
|----------|----------------------------------|-----------------------------------|--------------------------|
| `/tracker/trackedEntities` | yes | yes | yes |
| `/tracker/trackedEntities/{uid}/changeLogs` | no | no | yes |
| `/tracker/enrollments` | yes | yes | yes |
| `/tracker/events` | yes | yes | yes |
| `/tracker/events/{uid}/changeLogs` | no | no | yes |
| `/tracker/relationships` | yes | yes | yes |
| `/potentialDuplicates` | no | yes | yes |
| `/programNotificationInstances` | yes | yes | yes |
| `/programNotificationTemplates/filter` (metadata) | counts are always returned | yes | yes |


* `ProgramNotificationInstance` and `ProgramNotificationTemplate` services/stores live in `dhis-api`. We can thus not depend on `dhis-service-tracker`. We need to figure out if this truly is tracker and if so move it into our module.
* `ProgramNotificationTemplate` is actually metadata. I therefore went back to use [metadata code](https://github.com/dhis2/dhis2-core/blob/c1fdfcc10b806849a524f6af8bc456a1303eda9d/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java#L214-L227) in `ProgramNotificationTemplateController`.

