### PR TITLE
perf: use DB query filters for OR root junction when possible [DHIS2-18041]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -31,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.query.Filter;
-import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.schema.Schema;
@@ -51,17 +50,11 @@ public class DefaultQueryPlanner implements QueryPlanner {
   public <T extends IdentifiableObject> QueryPlan<T> planQuery(Query<T> query) {
     autoFill(query);
 
-    // if only one filter, always set to Junction.Type AND
-    if (query.getFilters().size() > 1 && Junction.Type.OR == query.getRootJunctionType()) {
-      return new QueryPlan<>(Query.emptyOf(query), Query.copyOf(query));
-    }
-
     QueryPlan<T> plan = split(query);
     Query<T> memoryQuery = plan.memoryQuery();
     Query<T> dbQuery = plan.dbQuery();
 
-    // if there are any non persisted criterions left, we leave the paging
-    // to the in-memory engine
+    // if there are any non persisted filters, leave the paging to the in-memory engine
     if (!memoryQuery.isEmpty()) {
       dbQuery.setSkipPaging(true);
     } else {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -31,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.schema.Schema;
@@ -92,6 +93,14 @@ public class DefaultQueryPlanner implements QueryPlanner {
       } else {
         memoryQuery.add(filter);
       }
+    }
+    if (query.getRootJunctionType() == Junction.Type.OR
+        && !memoryQuery.getFilters().isEmpty()
+        && !dbQuery.getFilters().isEmpty()) {
+      // OR with some filters DB some filters in-memory => all must be in-memory
+      dbQuery.getFilters().clear();
+      memoryQuery.getFilters().clear();
+      memoryQuery.getFilters().addAll(query.getFilters());
     }
 
     if (query.ordersPersisted()) {


### PR DESCRIPTION
### Summary
Wondering why the query planner would always filter OR root junction entirely via in-memory processing I found that this was a way of masking a bug in the DB query engine which would add the sharing filters directly to the root junction. This is of course wrong. 

For example, when using `?filter=...&filter=...&rootJunction=OR` the DB filter should not be 

```sql
where (<query-filter1> OR <query-filter2> OR <sharing-filter1> OR <sharing-filter2>)
```
but rather

```sql
where (<query-filter1> OR <query-filter2>) AND (<sharing-filter1> AND <sharing-filter2>)
```

With that corrected the odd exception to splitting any query with OR and more than 1 filter to do all filters in memory can be removed. Instead OR can be used if there are only DB filters.

### Performance
The overall query service would give the correct result but unnecessarily using in-memory processing as soon as there were more then 1 filter with OR logic.

### Automatic Testing
I added no extra tests. There are some tests using OR root junction but the coverage isn't great.
However, there are test specifically testing OR with filters where some could be DB filters and others can not, which is the most complicated scenario to handle correctly when actually splitting filters combined with OR.

### Manual Testing
And metadata API query using `?filter=...&filter=...&rootJunction=OR`.