### PR TITLE
fix: Use correct get single TE for changelog feature [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/TrackedEntityRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/TrackedEntityRowCallbackHandler.java
@@ -55,6 +55,7 @@ public class TrackedEntityRowCallbackHandler implements RowCallbackHandler {
     TrackedEntity te = new TrackedEntity();
     te.setUid(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.UID)));
     TrackedEntityType trackedEntityType = new TrackedEntityType();
+    trackedEntityType.setId(rs.getLong(TrackedEntityQuery.getColumnName(COLUMNS.TYPE_ID)));
     trackedEntityType.setUid(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.TYPE_UID)));
     trackedEntityType.setCode(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.TYPE_CODE)));
     trackedEntityType.setName(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.TYPE_NAME)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/TrackedEntityQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/TrackedEntityQuery.java
@@ -45,6 +45,7 @@ public class TrackedEntityQuery {
     INACTIVE,
     DELETED,
     GEOMETRY,
+    TYPE_ID,
     TYPE_UID,
     TYPE_CODE,
     TYPE_NAME,
@@ -71,6 +72,7 @@ public class TrackedEntityQuery {
           .put(COLUMNS.INACTIVE, new TableColumn("te", "inactive"))
           .put(COLUMNS.DELETED, new TableColumn("te", "deleted"))
           .put(COLUMNS.GEOMETRY, new Function("ST_AsBinary", "te", "geometry", "geometry"))
+          .put(COLUMNS.TYPE_ID, new TableColumn("tet", "trackedentitytypeid", "type_id"))
           .put(COLUMNS.TYPE_UID, new TableColumn("tet", "uid", "type_uid"))
           .put(COLUMNS.TYPE_CODE, new TableColumn("tet", "code", "type_code"))
           .put(COLUMNS.TYPE_NAME, new TableColumn("tet", "name", "type_name"))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -78,9 +78,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBase {
   @Autowired private DeduplicationService deduplicationService;
 
@@ -123,6 +121,7 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     manager.save(original);
     manager.save(duplicate);
     program = createProgram('A');
+    program.setTrackedEntityType(trackedEntityType);
     program1 = createProgram('B');
     programService.addProgram(program);
     programService.addProgram(program1);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
@@ -149,13 +149,13 @@ class TrackedEntityChangeLogServiceTest extends TrackerTest {
 
     Exception exception =
         assertThrows(
-            ForbiddenException.class,
+            NotFoundException.class,
             () ->
                 trackedEntityChangeLogService.getTrackedEntityChangeLog(
                     UID.of(trackedEntity), null, defaultOperationParams, defaultPageParams));
 
     assertEquals(
-        String.format("User has no access to TrackedEntity:%s", trackedEntity),
+        String.format("TrackedEntity with id %s could not be found.", trackedEntity),
         exception.getMessage());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
@@ -74,9 +74,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 class TrackedEntitiesChangeLogsControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Autowired private ObjectBundleService objectBundleService;


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

In this PR we are starting to change tracker ownership service and controller to use the new and correct `getNewTrackedEntity` method.

***Changes in this PR***

- Use `getNewTrackedEntity` method in `DefaultTrackedEntityChangeLogService`.

- Map `trackedEntityType` id in order to be used in other services that need managed metadata to work properly. Should we formalize that tracker data are always detached and metadata are always managed, even if they are coming from a tracker service?

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Move new methods for changelog feature
- Move new methods in tracked entity controller
- Move new methods for deduplication feature
- Move new methods in all remaining places
- Remove old `getTrackedEntity()` methods and rename new ones