### PR TITLE
chore: use JSON diff to assert pager

### DIFF
--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -131,7 +131,17 @@
     </dependency>
 
     <!-- Test -->
-
+    <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>
       <artifactId>core</artifactId>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/Assertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/Assertions.java
@@ -116,7 +116,7 @@ public final class Assertions {
           .expected(expected.toJson())
           .actual(actual.toJson())
           .message(
-              "JSON has %d structural differences:\n  %s\n[-- missing, ++ unexpected, >> out-of-order, != value-not-equal]\n"
+              "JSON has %d structural differences:%n  %s%n[-- missing, ++ unexpected, >> out-of-order, != value-not-equal]%n"
                   .formatted(
                       diff.differences().size(),
                       diff.differences().stream().collect(joining("\n  "))))

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/AssertionsTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/AssertionsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.webapi;
+
+import static org.hisp.dhis.test.webapi.Assertions.assertNoDiff;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+class AssertionsTest {
+
+  @Test
+  void testAssertNoDiff() {
+
+    AssertionFailedError ex =
+        assertThrowsExactly(
+            AssertionFailedError.class,
+            () ->
+                assertNoDiff(
+                    """
+                { "page": 1, "pageSize": 50 }""",
+                    """
+                { "paga": 1, "pageSize": 50 }"""));
+    assertEquals(
+        """
+        JSON has 2 structural differences:
+          ++ $.paga: ? <> 1
+          -- $.page: 1 <> ?
+        [-- missing, ++ unexpected, >> out-of-order, != value-not-equal]
+         ==> expected: <{ "page": 1, "pageSize": 50 }> but was: <{ "paga": 1, "pageSize": 50 }>""",
+        ex.getMessage());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/Assertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/Assertions.java
@@ -48,12 +48,15 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.jsontree.JsonDiff;
+import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.util.DateUtils;
+import org.intellij.lang.annotations.Language;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.function.Executable;
@@ -79,6 +82,33 @@ public class Assertions {
 
   private static final DateTimeFormatter DATE_WITH_TIMESTAMP =
       DateTimeFormat.forPattern(DATE_WITH_TIMESTAMP_PATTERN).withZoneUTC();
+
+  public static void assertNoDiff(
+      @Language("json") String expected, @Language("json") String actual) {
+    assertNoDiff(JsonValue.of(expected), JsonValue.of(actual));
+  }
+
+  public static void assertNoDiff(
+      @Language("json") String expected, @Language("json") String actual, JsonDiff.Mode mode) {
+    assertNoDiff(JsonValue.of(expected), JsonValue.of(actual), mode);
+  }
+
+  public static void assertNoDiff(@Language("json") String expected, JsonValue actual) {
+    assertNoDiff(JsonValue.of(expected), actual);
+  }
+
+  public static void assertNoDiff(
+      @Language("json") String expected, JsonValue actual, JsonDiff.Mode mode) {
+    assertNoDiff(JsonValue.of(expected), actual, mode);
+  }
+
+  public static void assertNoDiff(JsonValue expected, JsonValue actual) {
+    assertNoDiff(expected, actual, JsonDiff.Mode.DEFAULT);
+  }
+
+  public static void assertNoDiff(JsonValue expected, JsonValue actual, JsonDiff.Mode mode) {
+    assertEquals(List.of(), expected.diff(actual, mode).differences());
+  }
 
   /**
    * assertHasErrors asserts the report contains only errors of given codes in any order.

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/Assertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/Assertions.java
@@ -48,15 +48,12 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.jsontree.JsonDiff;
-import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.util.DateUtils;
-import org.intellij.lang.annotations.Language;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.function.Executable;
@@ -82,33 +79,6 @@ public class Assertions {
 
   private static final DateTimeFormatter DATE_WITH_TIMESTAMP =
       DateTimeFormat.forPattern(DATE_WITH_TIMESTAMP_PATTERN).withZoneUTC();
-
-  public static void assertNoDiff(
-      @Language("json") String expected, @Language("json") String actual) {
-    assertNoDiff(JsonValue.of(expected), JsonValue.of(actual));
-  }
-
-  public static void assertNoDiff(
-      @Language("json") String expected, @Language("json") String actual, JsonDiff.Mode mode) {
-    assertNoDiff(JsonValue.of(expected), JsonValue.of(actual), mode);
-  }
-
-  public static void assertNoDiff(@Language("json") String expected, JsonValue actual) {
-    assertNoDiff(JsonValue.of(expected), actual);
-  }
-
-  public static void assertNoDiff(
-      @Language("json") String expected, JsonValue actual, JsonDiff.Mode mode) {
-    assertNoDiff(JsonValue.of(expected), actual, mode);
-  }
-
-  public static void assertNoDiff(JsonValue expected, JsonValue actual) {
-    assertNoDiff(expected, actual, JsonDiff.Mode.DEFAULT);
-  }
-
-  public static void assertNoDiff(JsonValue expected, JsonValue actual, JsonDiff.Mode mode) {
-    assertEquals(List.of(), expected.diff(actual, mode).differences());
-  }
 
   /**
    * assertHasErrors asserts the report contains only errors of given codes in any order.

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
-import static org.hisp.dhis.webapi.controller.tracker.Assertions.assertNoDiff;
+import static org.hisp.dhis.test.webapi.Assertions.assertNoDiff;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertPagerLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -192,7 +192,7 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
 
     assertNoDiff(
         """
-        { "page": 1, "pageSize": 50 }""",
+        { "paga": 1, "pageSize": 50 }""",
         page.getPager());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -192,7 +192,7 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
 
     assertNoDiff(
         """
-        { "paga": 1, "pageSize": 50 }""",
+        { "page": 1, "pageSize": 50 }""",
         page.getPager());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.Assertions.assertNoDiff;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertPagerLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -189,10 +190,10 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
         page.getList("trackedEntities", JsonTrackedEntity.class)
             .toList(JsonTrackedEntity::getTrackedEntity));
 
-    JsonPager pager = page.getPager();
-    assertEquals(1, pager.getPage());
-    assertEquals(50, pager.getPageSize());
-    assertHasNoMember(pager, "total", "pageCount");
+    assertNoDiff(
+        """
+        { "page": 1, "pageSize": 50 }""",
+        page.getPager());
   }
 
   @Test

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -91,7 +91,7 @@
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.4</dhis-hisp-quick.version>
     <dhis-hisp-staxwax.version>2.0.0</dhis-hisp-staxwax.version>
-    <dhis-json-tree.version>1.6</dhis-json-tree.version>
+    <dhis-json-tree.version>1.7</dhis-json-tree.version>
 
     <!-- Security -->
     <spring-security.version>6.4.2</spring-security.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -91,7 +91,7 @@
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.4</dhis-hisp-quick.version>
     <dhis-hisp-staxwax.version>2.0.0</dhis-hisp-staxwax.version>
-    <dhis-json-tree.version>1.7</dhis-json-tree.version>
+    <dhis-json-tree.version>1.8</dhis-json-tree.version>
 
     <!-- Security -->
     <spring-security.version>6.4.2</spring-security.version>


### PR DESCRIPTION
An example of how `JsonValue.diff` can be used to write asserts that
* do structural matching
* are more readable
* fail with helpful details

Mainly this allows to ignore details like order of properties or presence of other properties the test does not care about while still allowing comparing the result to a JSON value.
