### PR TITLE
fix: Use correct get single TE for sms feature [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.tracker.imports.sms.SmsImportMapper.map;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.message.MessageSender;
@@ -97,13 +96,13 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
     TrackedEntity trackedEntity = null;
     try {
       trackedEntity =
-          trackedEntityService.getTrackedEntity(
+          trackedEntityService.getNewTrackedEntity(
               UID.of(subm.getTrackedEntityInstance().getUid()),
               UID.of(subm.getTrackerProgram().getUid()),
               TrackedEntityParams.FALSE.withIncludeAttributes(true));
     } catch (NotFoundException e) {
       // new TE will be created
-    } catch (ForbiddenException | BadRequestException e) {
+    } catch (ForbiddenException e) {
       // TODO(DHIS2-18003) we need to map tracker import report errors/warnings to an sms
       return SmsResponse.UNKNOWN_ERROR;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -221,7 +221,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedTrackedEntityLinkedToARelationshipItem()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, NotFoundException {
     RelationshipType rType = createRelationshipType('A');
     rType.getFromConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_INSTANCE);
     rType.getFromConstraint().setProgram(program);
@@ -318,7 +318,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedTrackedEntityAProgramMessage()
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, NotFoundException {
     ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
     programMessageRecipients.setEmailAddresses(Sets.newHashSet("testemail"));
     programMessageRecipients.setPhoneNumbers(Sets.newHashSet("testphone"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -84,6 +84,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
@@ -98,7 +99,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests tracker compression and command based SMS
@@ -112,7 +112,6 @@ import org.springframework.transaction.annotation.Transactional;
  *       org.hisp.dhis.tracker.imports.sms.TrackedEntityRegistrationSMSListener}
  * </ul>
  */
-@Transactional
 class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
   @Autowired private IdentifiableObjectManager manager;
 
@@ -121,6 +120,8 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private IncomingSmsService incomingSmsService;
+
+  @Autowired TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   @Autowired
   @Qualifier("smsMessageSender")
@@ -180,10 +181,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     teaC.setConfidential(false);
     manager.save(teaC, false);
 
-    trackedEntityType.setTrackedEntityTypeAttributes(
-        List.of(
-            new TrackedEntityTypeAttribute(trackedEntityType, teaA),
-            new TrackedEntityTypeAttribute(trackedEntityType, teaB)));
+    trackedEntityType
+        .getTrackedEntityTypeAttributes()
+        .addAll(
+            List.of(
+                new TrackedEntityTypeAttribute(trackedEntityType, teaA),
+                new TrackedEntityTypeAttribute(trackedEntityType, teaB)));
     manager.save(trackedEntityType, false);
 
     trackerProgram = createProgram('A');
@@ -219,7 +222,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldCreateTrackedEntityAndEnrollIt()
-      throws SmsCompressionException, ForbiddenException, NotFoundException, BadRequestException {
+      throws SmsCompressionException, ForbiddenException, NotFoundException {
     EnrollmentSmsSubmission submission = new EnrollmentSmsSubmission();
     int submissionId = 1;
     submission.setSubmissionId(submissionId);
@@ -270,12 +273,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actual.getTrackedEntity()));
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getTrackedEntity(
+            trackedEntityService.getNewTrackedEntity(
                 UID.of(submission.getTrackedEntityInstance().getUid()),
                 UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getTrackedEntity(
+        trackedEntityService.getNewTrackedEntity(
             UID.of(submission.getTrackedEntityInstance().getUid()),
             UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
@@ -301,7 +304,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void shouldEnrollExistingTrackedEntityAndAddUpdateAndDeleteAttributes()
-      throws SmsCompressionException, ForbiddenException, NotFoundException, BadRequestException {
+      throws SmsCompressionException, ForbiddenException, NotFoundException {
     TrackedEntity trackedEntity = trackedEntity();
     // add two tracked entity type value to the TE (one will be updated, the other deleted)
     TrackedEntityAttributeValue teavA = createTrackedEntityAttributeValue('A', trackedEntity, teaA);
@@ -370,12 +373,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actual.getTrackedEntity()));
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getTrackedEntity(
+            trackedEntityService.getNewTrackedEntity(
                 UID.of(submission.getTrackedEntityInstance().getUid()),
                 UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getTrackedEntity(
+        trackedEntityService.getNewTrackedEntity(
             UID.of(submission.getTrackedEntityInstance().getUid()),
             UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
@@ -458,10 +461,10 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     assertNotNull(trackedEntity);
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getTrackedEntity(
+            trackedEntityService.getNewTrackedEntity(
                 UID.of(trackedEntity), UID.of(trackerProgram), TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getTrackedEntity(
+        trackedEntityService.getNewTrackedEntity(
             UID.of(trackedEntity),
             UID.of(trackerProgram),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
@@ -495,6 +498,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     manager.save(enrollment);
     te.getEnrollments().add(enrollment);
     manager.save(te);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(te, trackerProgram, orgUnit);
     return enrollment;
   }
 


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Use `getNewTrackedEntity` method in `EnrollmentSMSListener`.
- Use `getNewTrackedEntity` method in `TrackerAccessManagerTest` and `MaintenanceServiceTest`.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Move new methods in tracked entity controller
- Move new methods for deduplication feature
- Move new methods in all remaining places
- Remove old `getTrackedEntity()` methods and rename new ones
- Add `Optional<T> find(UID)` to our services