### PR TITLE
fix: Remove duplicated validations in changelog service [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,16 +38,11 @@ import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
-import org.hisp.dhis.tracker.acl.TrackerAccessManager;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,11 +52,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
 
   private final TrackedEntityService trackedEntityService;
 
-  private final ProgramService programService;
-
   private final TrackedEntityAttributeService trackedEntityAttributeService;
-
-  private final TrackerAccessManager trackerAccessManager;
 
   private final HibernateTrackedEntityChangeLogStore hibernateTrackedEntityChangeLogStore;
 
@@ -108,14 +98,12 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
         trackedEntityService.getNewTrackedEntity(
             trackedEntityUid, programUid, TrackedEntityParams.FALSE.withIncludeAttributes(true));
 
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-    Set<UID> trackedEntityAttributes = Collections.emptySet();
-    if (programUid != null) {
-      Program program = validateProgram(programUid.getValue());
-      validateOwnership(currentUser, trackedEntity, program);
-    } else {
-      trackedEntityAttributes = validateTrackedEntityAttributes(trackedEntity);
-    }
+    Set<UID> trackedEntityAttributes =
+        trackedEntityAttributeService
+            .getTrackedEntityTypeAttributes(trackedEntity.getTrackedEntityType())
+            .stream()
+            .map(UID::of)
+            .collect(Collectors.toSet());
 
     return hibernateTrackedEntityChangeLogStore.getTrackedEntityChangeLogs(
         trackedEntityUid, programUid, trackedEntityAttributes, operationParams, pageParams);
@@ -130,37 +118,5 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
   @Override
   public Set<Pair<String, Class<?>>> getFilterableFields() {
     return hibernateTrackedEntityChangeLogStore.getFilterableFields();
-  }
-
-  private Program validateProgram(String programUid) throws NotFoundException {
-    Program program = programService.getProgram(programUid);
-    if (program == null) {
-      throw new NotFoundException(Program.class, programUid);
-    }
-
-    return program;
-  }
-
-  private void validateOwnership(
-      UserDetails currentUser, TrackedEntity trackedEntity, Program program)
-      throws NotFoundException {
-    if (!trackerAccessManager
-        .canRead(currentUser, trackedEntity, program, currentUser.isSuper())
-        .isEmpty()) {
-      throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());
-    }
-  }
-
-  private Set<UID> validateTrackedEntityAttributes(TrackedEntity trackedEntity)
-      throws NotFoundException {
-    Set<TrackedEntityAttribute> attributes =
-        trackedEntityAttributeService.getTrackedEntityTypeAttributes(
-            trackedEntity.getTrackedEntityType());
-
-    if (attributes.isEmpty()) {
-      throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());
-    }
-
-    return attributes.stream().map(UID::of).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Remove duplicated validations that are now performed in `getNewTrackedEntity` method.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Move new methods in tracked entity controller
- Move new methods for deduplication feature
- Move new methods in all remaining places
- Remove old `getTrackedEntity()` methods and rename new ones