### PR TITLE
test: allow passing tracker ImportParams to TestSetup DHIS2-19095

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TestSetup.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TestSetup.java
@@ -118,10 +118,18 @@ public class TestSetup {
     return setUpTrackerData("tracker/base_data.json");
   }
 
+  /**
+   * Setup tracker data from a JSON fixture using the default import parameters. Use {@link
+   * #setUpTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
+   */
   public TrackerObjects setUpTrackerData(String path) throws IOException {
+    return setUpTrackerData(path, TrackerImportParams.builder().build());
+  }
+
+  public TrackerObjects setUpTrackerData(String path, TrackerImportParams params)
+      throws IOException {
     TrackerObjects trackerObjects = fromJson(path);
-    assertNoErrors(
-        trackerImportService.importTracker(TrackerImportParams.builder().build(), trackerObjects));
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
     return trackerObjects;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -455,7 +455,7 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/base_data.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/base_data.json");
 
     trackerObjects.getEvents().stream()
         .filter(e -> e.getEvent().equals(event))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -378,7 +378,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/base_data.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/base_data.json");
 
     trackerObjects.getEvents().stream()
         .filter(e -> e.getEvent().equals(event))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/AtomicModeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/AtomicModeIntegrationTest.java
@@ -65,8 +65,7 @@ class AtomicModeIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testImportSuccessWithAtomicModeObjectIfThereIsAnErrorInOneTE() throws IOException {
-    TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/one_valid_te_and_one_invalid.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/one_valid_te_and_one_invalid.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
 
@@ -81,8 +80,7 @@ class AtomicModeIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testImportFailWithAtomicModeAllIfThereIsAnErrorInOneTE() throws IOException {
-    TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/one_valid_te_and_one_invalid.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/one_valid_te_and_one_invalid.json");
     TrackerImportParams params = TrackerImportParams.builder().atomicMode(AtomicMode.ALL).build();
 
     ImportReport trackerImportTeReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -80,7 +80,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   void shouldCorrectlyPopulateCompletedDataWhenCreatingAnEnrollment(EnrollmentStatus status)
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEnrollments().get(0).setStatus(status);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -99,7 +99,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
       EnrollmentStatus savedStatus, EnrollmentStatus updatedStatus)
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEnrollments().get(0).setStatus(savedStatus);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -107,7 +107,7 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
     // update
 
     TrackerObjects updatedTrackerObjects =
-        this.testSetup.fromJson("tracker/event_with_updated_data_values.json");
+        testSetup.fromJson("tracker/event_with_updated_data_values.json");
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     ImportReport importReport = trackerImportService.importTracker(params, updatedTrackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.imports.bundle;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -45,8 +44,6 @@ import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
-import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -106,12 +103,10 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
     assertEquals(4, eventDataValues.size());
     // update
 
-    TrackerObjects updatedTrackerObjects =
-        testSetup.fromJson("tracker/event_with_updated_data_values.json");
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
-    ImportReport importReport = trackerImportService.importTracker(params, updatedTrackerObjects);
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/event_with_updated_data_values.json", params);
+
     List<Event> updatedEvents = manager.getAll(Event.class);
     assertEquals(1, updatedEvents.size());
     Event updatedEvent = manager.get(Event.class, updatedEvents.get(0).getUid());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
@@ -79,7 +79,7 @@ class EventImportTest extends PostgresIntegrationTestBase {
   void shouldPopulateCompletedDataWhenCreatingAnEventWithStatusCompleted()
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
 
     importTracker(params, trackerObjects);
@@ -95,7 +95,7 @@ class EventImportTest extends PostgresIntegrationTestBase {
   void shouldNotPopulateCompletedDataWhenCreatingAnEventWithNotCompletedStatus(EventStatus status)
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEvents().get(0).setStatus(status);
 
     importTracker(params, trackerObjects);
@@ -110,7 +110,7 @@ class EventImportTest extends PostgresIntegrationTestBase {
   void shouldDeleteCompletedDataWhenUpdatingAnEventWithStatusActive()
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
 
     importTracker(params, trackerObjects);
@@ -130,7 +130,7 @@ class EventImportTest extends PostgresIntegrationTestBase {
   void shouldPopulateCompletedDataWhenUpdatingAnEventWithStatusCompleted(EventStatus status)
       throws IOException, ForbiddenException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/te_enrollment_event.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEvents().get(0).setStatus(status);
 
     importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -117,9 +117,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
-
-    assertNoErrors(
-        trackerImportService.importTracker(params, testSetup.fromJson("tracker/single_te.json")));
+    testSetup.setUpTrackerData("tracker/single_te.json", params);
 
     Date lastUpdateAfter = getTrackedEntity().getLastUpdated();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -119,8 +119,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
 
     assertNoErrors(
-        trackerImportService.importTracker(
-            params, this.testSetup.fromJson("tracker/single_te.json")));
+        trackerImportService.importTracker(params, testSetup.fromJson("tracker/single_te.json")));
 
     Date lastUpdateAfter = getTrackedEntity().getLastUpdated();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -91,13 +91,8 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    assertNoErrors(
-        trackerImportService.importTracker(
-            params, testSetup.fromJson("tracker/ownership_te.json")));
-    assertNoErrors(
-        trackerImportService.importTracker(
-            params, testSetup.fromJson("tracker/ownership_enrollment.json")));
+    testSetup.setUpTrackerData("tracker/ownership_te.json");
+    testSetup.setUpTrackerData("tracker/ownership_enrollment.json");
 
     nonSuperUser = userService.getUser("Tu9fv8ezgHl");
   }
@@ -128,13 +123,10 @@ class OwnershipTest extends PostgresIntegrationTestBase {
   void testClientDatesForTrackedEntityEnrollmentEvent() throws IOException {
     User nonSuperUser = userService.getUser(this.nonSuperUser.getUid());
     injectSecurityContextUser(nonSuperUser);
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/ownership_event.json");
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/ownership_event.json");
     manager.flush();
     TrackerObjects teTrackerObjects = testSetup.fromJson("tracker/ownership_te.json");
     TrackerObjects enTrackerObjects = testSetup.fromJson("tracker/ownership_enrollment.json");
-    assertNoErrors(importReport);
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -271,7 +263,9 @@ class OwnershipTest extends PostgresIntegrationTestBase {
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     TrackerObjects trackerObjects =
         testSetup.fromJson("tracker/ownership_te_ok_enrollment_no_access.json");
+
     ImportReport report = trackerImportService.importTracker(params, trackerObjects);
+
     assertEquals(1, report.getStats().getCreated());
     assertEquals(1, report.getStats().getIgnored());
     assertHasOnlyErrors(report, ValidationCode.E1000);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -89,7 +89,7 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport =
         trackerImportService.importTracker(
-            params, this.testSetup.fromJson("tracker/relationships.json"));
+            params, testSetup.fromJson("tracker/relationships.json"));
     assertThat(importReport.getStatus(), is(Status.OK));
     assertThat(importReport.getStats().getCreated(), is(2));
   }
@@ -101,7 +101,7 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
     ImportReport importReport =
         trackerImportService.importTracker(
-            params, this.testSetup.fromJson("tracker/relationships.json"));
+            params, testSetup.fromJson("tracker/relationships.json"));
 
     assertHasError(importReport, ValidationCode.E4020);
     assertThat(importReport.getStats().getIgnored(), is(2));
@@ -110,9 +110,9 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
   @Test
   void successUpdateRelationships() throws IOException {
     TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/relationships.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationships.json");
     trackerImportService.importTracker(trackerImportParams, trackerObjects);
-    trackerObjects = this.testSetup.fromJson("tracker/relationshipToUpdate.json");
+    trackerObjects = testSetup.fromJson("tracker/relationshipToUpdate.json");
     trackerImportParams.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
@@ -124,7 +124,7 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
   @Test
   void shouldFailWhenTryingToUpdateADeletedRelationship() throws IOException {
     TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/relationships.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationships.json");
     trackerImportService.importTracker(trackerImportParams, trackerObjects);
 
     manager.delete(manager.get(Relationship.class, "Nva3Xj2j75W"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -87,9 +87,11 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
   void successImportingRelationships() throws IOException {
     injectSecurityContextUser(userService.getUser("M5zQapPyTZI"));
     TrackerImportParams params = TrackerImportParams.builder().build();
+
     ImportReport importReport =
         trackerImportService.importTracker(
             params, testSetup.fromJson("tracker/relationships.json"));
+
     assertThat(importReport.getStatus(), is(Status.OK));
     assertThat(importReport.getStats().getCreated(), is(2));
   }
@@ -109,13 +111,16 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
   @Test
   void successUpdateRelationships() throws IOException {
-    TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationships.json");
-    trackerImportService.importTracker(trackerImportParams, trackerObjects);
-    trackerObjects = testSetup.fromJson("tracker/relationshipToUpdate.json");
-    trackerImportParams.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
+    testSetup.setUpTrackerData("tracker/relationships.json");
+
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationshipToUpdate.json");
+    TrackerImportParams trackerImportParams =
+        TrackerImportParams.builder()
+            .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
+            .build();
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
+
     assertThat(importReport.getStatus(), is(Status.OK));
     assertThat(importReport.getStats().getCreated(), is(0));
     assertThat(importReport.getStats().getIgnored(), is(1));
@@ -123,15 +128,17 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldFailWhenTryingToUpdateADeletedRelationship() throws IOException {
-    TrackerImportParams trackerImportParams = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationships.json");
-    trackerImportService.importTracker(trackerImportParams, trackerObjects);
+    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/relationships.json");
 
     manager.delete(manager.get(Relationship.class, "Nva3Xj2j75W"));
 
-    trackerImportParams.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
+    TrackerImportParams trackerImportParams =
+        TrackerImportParams.builder()
+            .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
+            .build();
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
+
     assertHasError(importReport, ValidationCode.E4017);
     assertThat(importReport.getStats().getIgnored(), is(2));
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -86,8 +86,6 @@ class ReportSummaryDeleteIntegrationTest extends PostgresIntegrationTestBase {
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerImportParams params = TrackerImportParams.builder().build();
-
     TrackerObjects trackerObjects =
         testSetup.fromJson("tracker/tracker_basic_data_before_deletion.json");
     assertEquals(13, trackerObjects.getTrackedEntities().size());
@@ -95,6 +93,7 @@ class ReportSummaryDeleteIntegrationTest extends PostgresIntegrationTestBase {
     assertEquals(2, trackerObjects.getEvents().size());
     assertEquals(2, trackerObjects.getRelationships().size());
 
+    TrackerImportParams params = TrackerImportParams.builder().build();
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     PersistenceReport persistenceReport = importReport.getPersistenceReport();
 
@@ -127,6 +126,7 @@ class ReportSummaryDeleteIntegrationTest extends PostgresIntegrationTestBase {
     assertEquals(2, trackerObjects.getRelationships().size());
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
     assertDeletedObjects(1, importReport.getPersistenceReport(), TrackerType.RELATIONSHIP);
     assertHasOnlyErrors(importReport, E4016);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
@@ -68,7 +68,7 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedTE() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
 
@@ -83,12 +83,12 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedAndOneUpdatedTE() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/one_update_te_and_one_new_te.json");
+    trackerObjects = testSetup.fromJson("tracker/one_update_te_and_one_new_te.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportTeReport = trackerImportService.importTracker(params, trackerObjects);
@@ -102,13 +102,13 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedAndOneUpdatedTEAndOneInvalidTE() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects =
-        this.testSetup.fromJson("tracker/one_update_te_and_one_new_te_and_one_invalid_te.json");
+        testSetup.fromJson("tracker/one_update_te_and_one_new_te_and_one_invalid_te.json");
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
@@ -125,12 +125,12 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedEnrollment() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -145,12 +145,12 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedEnrollmentAndUpdateSameEnrollment() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -162,7 +162,7 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
     assertEquals(0, trackerImportEnrollmentReport.getStats().getIgnored());
     assertEquals(0, trackerImportEnrollmentReport.getStats().getDeleted());
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     trackerImportEnrollmentReport = trackerImportService.importTracker(params, trackerObjects);
@@ -176,17 +176,16 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneUpdateEnrollmentAndOneCreatedEnrollment() throws IOException {
-    TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/one_update_te_and_one_new_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/one_update_te_and_one_new_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects =
-        this.testSetup.fromJson("tracker/one_update_enrollment_and_one_new_enrollment.json");
+        testSetup.fromJson("tracker/one_update_enrollment_and_one_new_enrollment.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEnrollmentReport =
@@ -202,16 +201,16 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
   @Test
   void testStatsCountForOneUpdateEnrollmentAndOneCreatedEnrollmentAndOneInvalidEnrollment()
       throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/three_tes.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/three_tes.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects =
-        this.testSetup.fromJson("tracker/one_update_and_one_new_and_one_invalid_enrollment.json");
+        testSetup.fromJson("tracker/one_update_and_one_new_and_one_invalid_enrollment.json");
 
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -230,15 +229,15 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneCreatedEvent() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_event.json");
+    trackerObjects = testSetup.fromJson("tracker/single_event.json");
     ImportReport trackerImportEventReport =
         trackerImportService.importTracker(params, trackerObjects);
 
@@ -251,18 +250,18 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneUpdateEventAndOneNewEvent() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_event.json");
+    trackerObjects = testSetup.fromJson("tracker/single_event.json");
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/one_update_event_and_one_new_event.json");
+    trackerObjects = testSetup.fromJson("tracker/one_update_event_and_one_new_event.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport trackerImportEventReport =
@@ -277,19 +276,19 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @Test
   void testStatsCountForOneUpdateEventAndOneNewEventAndOneInvalidEvent() throws IOException {
-    TrackerObjects trackerObjects = this.testSetup.fromJson("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/single_te.json");
     TrackerImportParams params =
         TrackerImportParams.builder().atomicMode(AtomicMode.OBJECT).build();
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_enrollment.json");
+    trackerObjects = testSetup.fromJson("tracker/single_enrollment.json");
     trackerImportService.importTracker(params, trackerObjects);
 
-    trackerObjects = this.testSetup.fromJson("tracker/single_event.json");
+    trackerObjects = testSetup.fromJson("tracker/single_event.json");
     trackerImportService.importTracker(params, trackerObjects);
 
     trackerObjects =
-        this.testSetup.fromJson("tracker/one_update_and_one_new_and_one_invalid_event.json");
+        testSetup.fromJson("tracker/one_update_and_one_new_and_one_invalid_event.json");
     params.setAtomicMode(AtomicMode.OBJECT);
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -42,12 +41,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
-import org.hisp.dhis.tracker.imports.TrackerImportParams;
-import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheatService;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,8 +61,6 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
 
   @Autowired private TrackerPreheatService trackerPreheatService;
-
-  @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
@@ -88,6 +82,7 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
 
     TrackerPreheat preheat =
         trackerPreheatService.preheat(trackerObjects, new TrackerIdSchemeParams());
+
     assertNotNull(preheat.get(OrganisationUnit.class, "cNEZTkdAvmg"));
     assertNotNull(preheat.get(TrackedEntityType.class, "KrYIdvLxkMb"));
     assertNotNull(preheat.get(TrackedEntityAttribute.class, "sYn3tkL3XKa"));
@@ -97,11 +92,7 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedAttributeValueBundleImporter() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_with_tea_data.json");
-
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -38,9 +37,6 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TestSetup;
-import org.hisp.dhis.tracker.imports.TrackerImportParams;
-import org.hisp.dhis.tracker.imports.TrackerImportService;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -58,8 +54,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TrackedEntityProgramAttributeEncryptionTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
-
-  @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
@@ -79,11 +73,7 @@ class TrackedEntityProgramAttributeEncryptionTest extends PostgresIntegrationTes
 
   @Test
   void testTrackedEntityProgramAttributeEncryptedValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    ImportReport importReport =
-        trackerImportService.importTracker(
-            params, testSetup.fromJson("tracker/te_program_with_tea_encryption_data.json"));
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_encryption_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,9 +42,6 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TestSetup;
-import org.hisp.dhis.tracker.imports.TrackerImportParams;
-import org.hisp.dhis.tracker.imports.TrackerImportService;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,8 +57,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
-
-  @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
@@ -82,7 +76,6 @@ class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationT
 
   @Test
   void testTrackedEntityProgramAttributeFileResourceValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
     FileResource fileResource =
         new FileResource(
             "test.pdf",
@@ -94,10 +87,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationT
     File file = File.createTempFile("file-resource", "test");
     fileResourceService.asyncSaveFileResource(fileResource, file);
     assertFalse(fileResource.isAssigned());
-    ImportReport importReport =
-        trackerImportService.importTracker(
-            params, testSetup.fromJson("tracker/te_program_with_tea_fileresource_data.json"));
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_fileresource_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -38,10 +37,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
-import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
-import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,8 +53,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
-
-  @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
@@ -76,10 +70,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValue() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_data.json");
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -91,12 +82,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdate() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_data.json");
-
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
-
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -106,10 +92,11 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
     assertEquals(5, attributeValues.size());
     manager.clear();
     // update
-    trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_update_data.json");
-    params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
-    importReport = trackerImportService.importTracker(params, trackerObjects);
-    assertNoErrors(importReport);
+    TrackerImportParams importParams =
+        TrackerImportParams.builder()
+            .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
+            .build();
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_update_data.json", importParams);
 
     trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -121,12 +108,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdateAndDelete() throws IOException {
-    TrackerImportParams params = TrackerImportParams.builder().build();
-    TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_data.json");
-
-    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
-
-    assertNoErrors(importReport);
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -136,10 +118,11 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
     assertEquals(5, attributeValues.size());
     manager.clear();
     // update
-    trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_update_data.json");
-    params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
-    importReport = trackerImportService.importTracker(params, trackerObjects);
-    assertNoErrors(importReport);
+    TrackerImportParams params =
+        TrackerImportParams.builder()
+            .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
+            .build();
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_update_data.json", params);
 
     trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -149,10 +132,8 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
     assertEquals(5, attributeValues.size());
     manager.clear();
     // delete
-    trackerObjects = testSetup.fromJson("tracker/te_program_with_tea_delete_data.json");
-    params.setImportStrategy(TrackerImportStrategy.DELETE);
-    importReport = trackerImportService.importTracker(params, trackerObjects);
-    assertNoErrors(importReport);
+    params = TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
+    testSetup.setUpTrackerData("tracker/te_program_with_tea_delete_data.json", params);
 
     trackedEntities =
         manager.getAll(TrackedEntity.class).stream().filter(te -> !te.isDeleted()).toList();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
@@ -90,10 +90,9 @@ class TrackerEventBundleServiceTest extends PostgresIntegrationTestBase {
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
     TrackerObjects trackerObjects = testSetup.fromJson("tracker/event_events_and_enrollment.json");
-
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
-
     assertNoErrors(importReport);
+
     assertEquals(8, manager.getAll(Event.class).size());
 
     importReport = trackerImportService.importTracker(params, trackerObjects);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -144,8 +144,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assignProgramRule();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
-            "tracker/programrule/te_enrollment_update_attribute_same_value.json");
+        testSetup.fromJson("tracker/programrule/te_enrollment_update_attribute_same_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -159,14 +158,14 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
       String eventOccurredDate, String previousEventDataValue) throws IOException {
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/three_events_with_different_dates.json");
+        testSetup.fromJson("tracker/programrule/three_events_with_different_dates.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     trackerImportService.importTracker(params, trackerObjects);
 
     assignPreviousEventProgramRule();
 
-    trackerObjects = this.testSetup.fromJson("tracker/programrule/event_with_data_value.json");
+    trackerObjects = testSetup.fromJson("tracker/programrule/event_with_data_value.json");
 
     trackerObjects
         .getEvents()
@@ -243,7 +242,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assignProgramRule();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_update_datavalue_same_value.json");
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_same_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -256,7 +255,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assignProgramRule();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -273,7 +272,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     settingsService.clearCurrentSettings();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -290,7 +289,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     settingsService.clearCurrentSettings();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_update_datavalue_empty_value.json");
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_empty_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
@@ -303,7 +302,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assignToCalculatedValueProgramRule();
     TrackerImportParams params = new TrackerImportParams();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
 
     ImportReport report = trackerImportService.importTracker(params, trackerObjects);
@@ -314,7 +313,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
   private TrackerObjects getEvent(UID eventUid, String occurredDate, String value)
       throws IOException {
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/event_without_date.json");
+        testSetup.fromJson("tracker/programrule/event_without_date.json");
     trackerObjects
         .getEvents()
         .get(0)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
@@ -125,7 +125,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
 
     assertNoErrorsAndNoWarnings(report);
   }
@@ -136,7 +136,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
 
     assertHasOnlyWarnings(report, E1300);
   }
@@ -147,7 +147,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
 
     assertHasOnlyErrors(report, E1300);
   }
@@ -158,7 +158,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/program_event.json"));
+            testSetup.fromJson("tracker/programrule/program_event.json"));
 
     assertHasOnlyWarnings(report, E1300);
   }
@@ -170,7 +170,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/program_event.json"));
+            testSetup.fromJson("tracker/programrule/program_event.json"));
 
     assertHasOnlyErrors(report, E1300);
   }
@@ -181,7 +181,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/program_event.json"));
+            testSetup.fromJson("tracker/programrule/program_event.json"));
 
     assertHasOnlyErrors(report, E1300);
   }
@@ -191,7 +191,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json"));
 
     assertNoErrorsAndNoWarnings(report);
   }
@@ -201,13 +201,13 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
     assertNoErrors(report);
 
     alwaysTrueWarningProgramRule();
     report =
         trackerImportService.importTracker(
-            new TrackerImportParams(), this.testSetup.fromJson("tracker/programrule/event.json"));
+            new TrackerImportParams(), testSetup.fromJson("tracker/programrule/event.json"));
 
     assertHasOnlyWarnings(report, E1300);
   }
@@ -217,13 +217,13 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
     assertNoErrors(report);
 
     alwaysTrueErrorProgramRule();
     report =
         trackerImportService.importTracker(
-            new TrackerImportParams(), this.testSetup.fromJson("tracker/programrule/event.json"));
+            new TrackerImportParams(), testSetup.fromJson("tracker/programrule/event.json"));
 
     assertHasOnlyErrors(report, E1300);
   }
@@ -235,7 +235,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json"));
 
     assertHasOnlyErrors(report, E1300);
   }
@@ -246,7 +246,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_completed_enrollment_event.json"));
+            testSetup.fromJson("tracker/programrule/te_completed_enrollment_event.json"));
 
     assertAll(
         () -> assertHasError(report, E1300, ENROLLMENT_UID),
@@ -258,13 +258,13 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_completed_enrollment.json"));
+            testSetup.fromJson("tracker/programrule/te_completed_enrollment.json"));
     assertNoErrorsAndNoWarnings(report);
 
     onCompleteErrorProgramRule();
     report =
         trackerImportService.importTracker(
-            new TrackerImportParams(), this.testSetup.fromJson("tracker/programrule/event.json"));
+            new TrackerImportParams(), testSetup.fromJson("tracker/programrule/event.json"));
 
     assertNoErrorsAndNoWarnings(report);
   }
@@ -276,7 +276,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     ImportReport report =
         trackerImportService.importTracker(
             new TrackerImportParams(),
-            this.testSetup.fromJson("tracker/programrule/te_enrollment_event_programevent.json"));
+            testSetup.fromJson("tracker/programrule/te_enrollment_event_programevent.json"));
 
     assertAll(
         () -> assertHasError(report, E1300, ENROLLMENT_UID),
@@ -287,8 +287,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
   @Test
   void shouldImportWithWarningWhenARuleWithASyntaxErrorIsTriggered() throws IOException {
     syntaxErrorRule();
-    TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/te_enrollment.json");
+    TrackerObjects trackerObjects = testSetup.fromJson("tracker/programrule/te_enrollment.json");
 
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
@@ -301,7 +300,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
       throws IOException {
     programStageWarningRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json");
+        testSetup.fromJson("tracker/programrule/te_enrollment_completed_event.json");
 
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
@@ -314,7 +313,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
       throws IOException {
     programStageWarningRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
+        testSetup.fromJson(
             "tracker/programrule/te_enrollment_completed_event_from_another_program_stage.json");
 
     ImportReport importReport =
@@ -328,7 +327,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
       throws IOException {
     programStage2WarningRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
+        testSetup.fromJson(
             "tracker/programrule/te_enrollment_event_from_another_program_stage.json");
 
     ImportReport importReport =
@@ -342,7 +341,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
       throws IOException {
     programStage2WarningRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
+        testSetup.fromJson(
             "tracker/programrule/te_enrollment_completed_event_from_another_program_stage.json");
 
     ImportReport importReport =
@@ -356,7 +355,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
       throws IOException {
     programStage2WrongDataElementWarningRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
+        testSetup.fromJson(
             "tracker/programrule/te_enrollment_completed_event_from_another_program_stage.json");
 
     ImportReport importReport =
@@ -369,7 +368,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
   void shouldNotImportWithWhenDataElementHasValue() throws IOException {
     showErrorWhenVariableHasValueRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/te_completed_enrollment_event.json");
+        testSetup.fromJson("tracker/programrule/te_completed_enrollment_event.json");
 
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
@@ -381,7 +380,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
   void shouldImportWithNoWarningsWhenDataElementHasNoValue() throws IOException {
     showErrorWhenVariableHasValueRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson("tracker/programrule/te_enrollment_event_with_no_data_value.json");
+        testSetup.fromJson("tracker/programrule/te_enrollment_event_with_no_data_value.json");
 
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
@@ -393,8 +392,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
   void shouldImportWithNoWarningsWhenDataElementHasNullValue() throws IOException {
     showErrorWhenVariableHasValueRule();
     TrackerObjects trackerObjects =
-        this.testSetup.fromJson(
-            "tracker/programrule/te_enrollment_event_with_null_data_value.json");
+        testSetup.fromJson("tracker/programrule/te_enrollment_event_with_null_data_value.json");
 
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -31,17 +31,13 @@ import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
@@ -396,13 +392,5 @@ public class ProgramStageWorkingListControllerTest extends PostgresControllerInt
                 }
               """
                 .formatted(programId, programStageId, workingListName)));
-  }
-
-  public static void assertNoErrors(ObjectBundleValidationReport report) {
-    assertNotNull(report);
-    List<String> errors = new ArrayList<>();
-    report.forEachErrorReport(err -> errors.add(err.toString()));
-    assertFalse(
-        report.hasErrorReports(), String.format("Expected no errors, instead got: %s%n", errors));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -54,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ProgramStageWorkingListControllerTest extends PostgresControllerIntegrationTestBase {
+class ProgramStageWorkingListControllerTest extends PostgresControllerIntegrationTestBase {
   @Autowired private TestSetup testSetup;
 
   @Autowired private IdentifiableObjectManager manager;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TestSetup.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TestSetup.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker;
 
 import static org.hisp.dhis.feedback.Assertions.assertNoErrors;
+import static org.hisp.dhis.webapi.controller.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -117,14 +118,22 @@ public class TestSetup {
     return setUpTrackerData("tracker/base_data.json");
   }
 
+  /**
+   * Setup tracker data from a JSON fixture using the default import parameters. Use {@link
+   * #setUpTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
+   */
   public TrackerObjects setUpTrackerData(String path) throws IOException {
+    return setUpTrackerData(path, TrackerImportParams.builder().build());
+  }
+
+  public TrackerObjects setUpTrackerData(String path, TrackerImportParams params)
+      throws IOException {
     TrackerObjects trackerObjects = fromJson(path);
-    org.hisp.dhis.webapi.controller.tracker.Assertions.assertNoErrors(
-        trackerImportService.importTracker(TrackerImportParams.builder().build(), trackerObjects));
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
     return trackerObjects;
   }
 
-  private TrackerObjects fromJson(String path) throws IOException {
+  public TrackerObjects fromJson(String path) throws IOException {
     return renderService.fromJson(
         new ClassPathResource(path).getInputStream(), TrackerObjects.class);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 import static org.hisp.dhis.http.HttpStatus.BAD_REQUEST;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.Assertions.*;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContains;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
@@ -43,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -62,9 +62,6 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
-import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.tracker.JsonAttribute;
 import org.hisp.dhis.webapi.controller.tracker.JsonDataValue;
@@ -498,30 +495,5 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
             String.format(
                 "'%s' with uid '%s' should have been created", type.getSimpleName(), uid));
     return t;
-  }
-
-  public static void assertNoErrors(ImportReport report) {
-    assertNotNull(report);
-    assertEquals(
-        Status.OK,
-        report.getStatus(),
-        errorMessage(
-            "Expected import with status OK, instead got:%n", report.getValidationReport()));
-  }
-
-  private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {
-    return () -> {
-      StringBuilder msg = new StringBuilder(errorTitle);
-      report
-          .getErrors()
-          .forEach(
-              e -> {
-                msg.append(e.getErrorCode());
-                msg.append(": ");
-                msg.append(e.getMessage());
-                msg.append('\n');
-              });
-      return msg.toString();
-    };
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.tracker.Assertions.*;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContains;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEnrollmentWithinRelationshipItem;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEventWithinRelationshipItem;
@@ -48,7 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -71,9 +71,6 @@ import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
-import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.trackerdataview.TrackerDataView;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.sharing.UserAccess;
@@ -871,30 +868,5 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
         .filter(r -> r.getRelationship().equals(relationship))
         .findFirst()
         .get();
-  }
-
-  public static void assertNoErrors(ImportReport report) {
-    assertNotNull(report);
-    assertEquals(
-        Status.OK,
-        report.getStatus(),
-        errorMessage(
-            "Expected import with status OK, instead got:%n", report.getValidationReport()));
-  }
-
-  private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {
-    return () -> {
-      StringBuilder msg = new StringBuilder(errorTitle);
-      report
-          .getErrors()
-          .forEach(
-              e -> {
-                msg.append(e.getErrorCode());
-                msg.append(": ");
-                msg.append(e.getMessage());
-                msg.append('\n');
-              });
-      return msg.toString();
-    };
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.tracker.Assertions.*;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContainsAll;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
@@ -47,16 +48,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -84,9 +82,6 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.report.ImportReport;
-import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.sharing.UserAccess;
@@ -1359,39 +1354,6 @@ trackedEntity,trackedEntityType,createdAt,createdAtClient,updatedAt,updatedAtCli
             String.format(
                 "'%s' with uid '%s' should have been created", type.getSimpleName(), uid));
     return t;
-  }
-
-  public static void assertNoErrors(ImportReport report) {
-    assertNotNull(report);
-    assertEquals(
-        Status.OK,
-        report.getStatus(),
-        errorMessage(
-            "Expected import with status OK, instead got:%n", report.getValidationReport()));
-  }
-
-  private static Supplier<String> errorMessage(String errorTitle, ValidationReport report) {
-    return () -> {
-      StringBuilder msg = new StringBuilder(errorTitle);
-      report
-          .getErrors()
-          .forEach(
-              e -> {
-                msg.append(e.getErrorCode());
-                msg.append(": ");
-                msg.append(e.getMessage());
-                msg.append('\n');
-              });
-      return msg.toString();
-    };
-  }
-
-  public static void assertNoErrors(ObjectBundleValidationReport report) {
-    assertNotNull(report);
-    List<String> errors = new ArrayList<>();
-    report.forEachErrorReport(err -> errors.add(err.toString()));
-    assertFalse(
-        report.hasErrorReports(), String.format("Expected no errors, instead got: %s%n", errors));
   }
 
   public static JsonRelationship assertFirstRelationship(


### PR DESCRIPTION
following https://github.com/dhis2/dhis2-core/pull/20125

I changed a couple of tests but not all. Some tests are dedicated to testing the import report so they should keep on using the `importService` directly. There are probably other cases where this is true as well. We can transition any other tests we see when we change them.

* reuse assertions

# Next

* `base_data` depends on `base_metadata`: so create metadata directly via `setupTrackerData()`?
* can we automatically set the admin user? or should we return a custom record or so with the objectBundle, trackerObjects, admin, ...
* make common assertions reusable we still have some duplicate code here for asserting an import was successful
* reuse `base_data.json` like we did for `base_metadata.json` via the `dhis-support-test` module
* settle on one way to set the user in our tests via `testSetup.testAsUser`? This ideally should live in `TestBase` but since we did not get any answer from platform this might be our best solution for now.

## Future

We should figure out some scenarios for our testing like one or two common implementations put into our metadata/data.
* what users/roles typically exist in a tracker implementation
* what typical programs/stages are there
* ...

The metadata we have right now is not really structured with the above in mind.