### PR TITLE
feat: Filter by unary operators on attributes in events [DHIS2-15954]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -121,7 +120,7 @@ class DefaultEventService implements EventService {
               .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
               .events(Set.of(eventUid))
               .eventParams(EventParams.FALSE)
-              .dataElementFilters(Map.of(dataElementUid, List.of()))
+              .filterByDataElement(dataElementUid)
               .build();
       events = getEvents(operationParams, PageParams.single());
     } catch (BadRequestException e) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +44,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
@@ -125,13 +127,13 @@ public class EventOperationParams {
    */
   private List<Order> order;
 
-  @Builder.Default private Set<UID> events = new HashSet<>();
-
   /** Data element filters per data element UID. */
-  @Builder.Default private Map<UID, List<QueryFilter>> dataElementFilters = new HashMap<>();
+  private final Map<UID, List<QueryFilter>> dataElementFilters;
 
   /** Tracked entity attribute filters per attribute UID. */
-  @Builder.Default private Map<UID, List<QueryFilter>> attributeFilters = new HashMap<>();
+  private final Map<UID, List<QueryFilter>> attributeFilters;
+
+  @Builder.Default private Set<UID> events = new HashSet<>();
 
   private boolean includeDeleted;
 
@@ -150,6 +152,10 @@ public class EventOperationParams {
   public static class EventOperationParamsBuilder {
 
     private final List<Order> order = new ArrayList<>();
+
+    private Map<UID, List<QueryFilter>> dataElementFilters = new HashMap<>();
+
+    private Map<UID, List<QueryFilter>> attributeFilters = new HashMap<>();
 
     // Do not remove this unused method. This hides the order field from the builder which Lombok
     // does not support. The repeated order field and private order method prevent access to order
@@ -206,6 +212,51 @@ public class EventOperationParams {
 
     public EventOperationParamsBuilder trackedEntity(TrackedEntity trackedEntity) {
       this.trackedEntity = UID.of(trackedEntity);
+      return this;
+    }
+
+    // Do not remove this unused method. This hides the data element filters field from the builder
+    // which Lombok
+    // does not support. The repeated field and private method prevent access to
+    // the filter map via the builder.
+    // Filters should be added via the filterByDataElement builder methods.
+    private EventOperationParamsBuilder dataElementFilters(
+        Map<UID, List<QueryFilter>> dataElementFilters) {
+      return this;
+    }
+
+    // Do not remove this unused method. This hides the attribute filters field from the builder
+    // which Lombok
+    // does not support. The repeated field and private method prevent access to the filter map via
+    // the builder.
+    // Filters should be added via the filterByAttribute builder methods.
+    private EventOperationParamsBuilder attributeFilters(
+        Map<UID, List<QueryFilter>> attributeFilters) {
+      return this;
+    }
+
+    public EventOperationParamsBuilder filterByDataElement(
+        @Nonnull UID attribute, @Nonnull List<QueryFilter> queryFilters) {
+      this.dataElementFilters.putIfAbsent(attribute, new ArrayList<>());
+      this.dataElementFilters.get(attribute).addAll(queryFilters);
+      return this;
+    }
+
+    public EventOperationParamsBuilder filterByDataElement(@Nonnull UID dataElement) {
+      this.dataElementFilters.putIfAbsent(
+          dataElement, List.of(new QueryFilter(QueryOperator.NNULL)));
+      return this;
+    }
+
+    public EventOperationParamsBuilder filterByAttribute(
+        @Nonnull UID attribute, @Nonnull List<QueryFilter> queryFilters) {
+      this.attributeFilters.putIfAbsent(attribute, new ArrayList<>());
+      this.attributeFilters.get(attribute).addAll(queryFilters);
+      return this;
+    }
+
+    public EventOperationParamsBuilder filterByAttribute(@Nonnull UID attribute) {
+      this.attributeFilters.putIfAbsent(attribute, List.of(new QueryFilter(QueryOperator.NNULL)));
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -444,7 +444,7 @@ class EventQueryParams {
 
   /** Returns attributes that are only ordered by and not present in any filter. */
   public Set<TrackedEntityAttribute> leftJoinAttributes() {
-    return SetUtils.difference(getOrderAttributes().keySet(), this.attributes.keySet());
+    return SetUtils.union(getOrderAttributes().keySet(), this.attributes.keySet());
   }
 
   public Map<TrackedEntityAttribute, List<QueryFilter>> getAttributes() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -28,11 +28,9 @@
 package org.hisp.dhis.tracker.export.event;
 
 import static java.util.Map.entry;
-import static org.hisp.dhis.common.ValueType.NUMERIC_TYPES;
 import static org.hisp.dhis.system.util.SqlUtils.castToNumber;
 import static org.hisp.dhis.system.util.SqlUtils.lower;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.system.util.SqlUtils.singleQuote;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,7 +80,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.query.JpaQueryUtils;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.Page;
@@ -602,55 +599,31 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     return sqlBuilder.toString();
   }
 
-  /**
-   * Generates a single INNER JOIN for each attribute we are filtering or ordering on. We can search
-   * by a range of operators. All searching is using lower() since attribute values are
-   * case-insensitive.
-   */
-  private String joinAttributeValue(
-      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
-    StringBuilder sql = new StringBuilder();
-
+  private String getWhereClauseFromAttributeFilterConditions(
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
+    StringBuilder fromBuilder = new StringBuilder();
     for (Entry<TrackedEntityAttribute, List<QueryFilter>> queryItem :
         params.getAttributes().entrySet()) {
-
       TrackedEntityAttribute tea = queryItem.getKey();
       String teaUid = tea.getUid();
       String teaValueCol = quote(teaUid);
-      String teaCol = quote(teaUid + "ATT");
 
-      sql.append(" inner join trackedentityattributevalue ")
-          .append(teaValueCol)
-          .append(" on ")
-          .append(teaValueCol + ".trackedentityid")
-          .append(" = TE.trackedentityid ")
-          .append(" inner join trackedentityattribute ")
-          .append(teaCol)
-          .append(" on ")
-          .append(teaValueCol + ".trackedentityattributeid")
-          .append(EQUALS)
-          .append(teaCol + ".trackedentityattributeid")
-          .append(AND)
-          .append(teaCol + ".UID")
-          .append(EQUALS)
-          .append(singleQuote(teaUid));
-
-      sql.append(
-          getAttributeFilterQuery(
-              mapSqlParameterSource,
-              queryItem.getValue(),
-              teaCol,
-              teaValueCol,
-              tea.getValueType().isNumeric()));
+      fromBuilder
+          .append(hlp.whereAnd())
+          .append(SPACE)
+          .append(
+              getAttributeFilterQuery(
+                  mapSqlParameterSource,
+                  queryItem.getValue(),
+                  teaValueCol,
+                  tea.getValueType().isNumeric()));
     }
-
-    return sql.toString();
+    return fromBuilder.toString();
   }
 
   private String getAttributeFilterQuery(
       MapSqlParameterSource mapSqlParameterSource,
       List<QueryFilter> filters,
-      String teaCol,
       String teaValueCol,
       boolean isNumericTea) {
 
@@ -658,73 +631,64 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
       return "";
     }
 
-    StringBuilder query = new StringBuilder(AND);
-    // In SQL the order of expressions linked by AND is not
-    // guaranteed.
-    // So when casting to number we need to be sure that the value
-    // to cast is really a number.
-    if (isNumericTea) {
-      query
-          .append(" case when ")
-          .append(lower(teaCol + ".valueType"))
-          .append(" in (")
-          .append(
-              NUMERIC_TYPES.stream()
-                  .map(Enum::name)
-                  .map(StringUtils::lowerCase)
-                  .map(SqlUtils::singleQuote)
-                  .collect(Collectors.joining(",")))
-          .append(")")
-          .append(" then ");
-    }
+    StringBuilder query = new StringBuilder();
 
     List<String> filterStrings = new ArrayList<>();
 
     for (int i = 0; i < filters.size(); i++) {
       QueryFilter filter = filters.get(i);
-      StringBuilder filterString = new StringBuilder();
       final String queryCol =
           isNumericTea ? castToNumber(teaValueCol + ".value") : lower(teaValueCol + ".value");
       int itemType = isNumericTea ? Types.NUMERIC : Types.VARCHAR;
       String parameterKey = "attributeFilter_%s_%d".formatted(teaValueCol.replace("\"", ""), i);
-      mapSqlParameterSource.addValue(
-          parameterKey,
-          isNumericTea
-              ? Double.valueOf(filter.getSqlBindFilter())
-              : StringUtils.lowerCase(filter.getSqlBindFilter()),
-          itemType);
 
-      filterString
-          .append(queryCol)
-          .append(SPACE)
-          .append(filter.getSqlOperator())
-          .append(SPACE)
-          .append(":" + parameterKey);
+      StringBuilder filterString = new StringBuilder();
+      filterString.append(queryCol).append(SPACE);
+
+      filterString.append(
+          switch (filter.getOperator()) {
+            case NULL, NNULL -> filter.getSqlOperator() + SPACE;
+            default -> {
+              mapSqlParameterSource.addValue(
+                  parameterKey,
+                  isNumericTea
+                      ? Double.valueOf(filter.getSqlBindFilter())
+                      : StringUtils.lowerCase(filter.getSqlBindFilter()),
+                  itemType);
+              yield new StringBuilder()
+                  .append(filter.getSqlOperator())
+                  .append(SPACE)
+                  .append(":")
+                  .append(parameterKey)
+                  .append(SPACE);
+            }
+          });
+
       filterStrings.add(filterString.toString());
     }
     query.append(String.join(AND, filterStrings));
-
-    if (isNumericTea) {
-      query.append(" END ");
-    }
 
     return query.toString();
   }
 
   /**
-   * Generates the LEFT JOINs used for attributes we are ordering by (If any). We use LEFT JOIN to
-   * avoid removing any rows if there is no value for a given attribute and te. The result of this
-   * LEFT JOIN is used in the sub-query projection, and ordering in the sub-query and main query.
+   * Generates the LEFT JOINs used for attributes we are ordering and filtering by (If any). We use
+   * LEFT JOIN to avoid removing any rows if there is no value for a given attribute and te. The
+   * result of this LEFT JOIN is used in the sub-query projection, and ordering in the sub-query and
+   * main query.
    *
-   * @return a SQL LEFT JOIN for attributes used for ordering, or empty string if no attributes is
-   *     used in order.
+   * <p>Attribute filtering is handled in {@link
+   * #getWhereClauseFromAttributeFilterConditions(EventQueryParams, MapSqlParameterSource,
+   * SqlHelper)}.
+   *
+   * @return a SQL LEFT JOIN for the relevant attributes, or an empty string if none are provided.
    */
   private String getFromSubQueryJoinOrderByAttributes(EventQueryParams params) {
-    StringBuilder joinOrderAttributes = new StringBuilder();
+    StringBuilder attributes = new StringBuilder();
 
     for (TrackedEntityAttribute orderAttribute : params.leftJoinAttributes()) {
 
-      joinOrderAttributes
+      attributes
           .append(" left join trackedentityattributevalue as ")
           .append(quote(orderAttribute.getUid()))
           .append(" on ")
@@ -737,7 +701,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
           .append(SPACE);
     }
 
-    return joinOrderAttributes.toString();
+    return attributes.toString();
   }
 
   private String getEventSelectQuery(
@@ -842,7 +806,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
                 mapSqlParameterSource,
                 user,
                 hlp,
-                dataElementAndFiltersSql(params, mapSqlParameterSource, hlp, selectBuilder)))
+                dataElementFiltersSql(params, mapSqlParameterSource, hlp, selectBuilder)))
         .toString();
   }
 
@@ -886,7 +850,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
       MapSqlParameterSource mapSqlParameterSource,
       User user,
       SqlHelper hlp,
-      StringBuilder dataElementAndFiltersSql) {
+      StringBuilder dataElementFiltersSql) {
     StringBuilder fromBuilder =
         new StringBuilder(" from event ev ")
             .append("inner join enrollment en on en.enrollmentid=ev.enrollmentid ")
@@ -911,15 +875,18 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         .append("left join trackedentity te on te.trackedentityid=en.trackedentityid ")
         .append("left join userinfo au on (ev.assigneduserid=au.userinfoid) ");
 
-    // JOIN attributes we need to filter on.
-    fromBuilder.append(joinAttributeValue(params, mapSqlParameterSource));
-
-    // LEFT JOIN not filterable attributes we need to sort on.
+    // LEFT JOIN attributes we need to sort on and/or filter by.
+    // fromBuilder.append(joinAttributeValue(params, mapSqlParameterSource));
     fromBuilder.append(getFromSubQueryJoinOrderByAttributes(params));
 
     fromBuilder.append(getCategoryOptionComboQuery(user));
 
-    fromBuilder.append(dataElementAndFiltersSql);
+    fromBuilder.append(dataElementFiltersSql);
+
+    if (!params.getAttributes().isEmpty()) {
+      fromBuilder.append(
+          getWhereClauseFromAttributeFilterConditions(params, mapSqlParameterSource, hlp));
+    }
 
     if (params.getTrackedEntity() != null) {
       mapSqlParameterSource.addValue("trackedentityid", params.getTrackedEntity().getId());
@@ -1271,7 +1238,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
    * For dataElement params, restriction is set in inner join. For query params, restriction is set
    * in where clause.
    */
-  private StringBuilder dataElementAndFiltersSql(
+  private StringBuilder dataElementFiltersSql(
       EventQueryParams params,
       MapSqlParameterSource mapSqlParameterSource,
       SqlHelper hlp,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -876,7 +876,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         .append("left join userinfo au on (ev.assigneduserid=au.userinfoid) ");
 
     // LEFT JOIN attributes we need to sort on and/or filter by.
-    // fromBuilder.append(joinAttributeValue(params, mapSqlParameterSource));
     fromBuilder.append(getFromSubQueryJoinOrderByAttributes(params));
 
     fromBuilder.append(getCategoryOptionComboQuery(user));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -615,6 +615,8 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
 
       fromBuilder
           .append(hlp.whereAnd())
+          .append(" TE.trackedentityid is not null ") // filters out results from event programs
+          .append(AND)
           .append(SPACE)
           .append(
               getAttributeFilterQuery(
@@ -637,7 +639,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     }
 
     StringBuilder query = new StringBuilder();
-
     List<String> filterStrings = new ArrayList<>();
 
     for (int i = 0; i < filters.size(); i++) {
@@ -688,20 +689,20 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
    *
    * @return a SQL LEFT JOIN for the relevant attributes, or an empty string if none are provided.
    */
-  private String getFromSubQueryJoinOrderByAttributes(EventQueryParams params) {
+  private String getLeftJoinFromAttributes(EventQueryParams params) {
     StringBuilder attributes = new StringBuilder();
 
-    for (TrackedEntityAttribute orderAttribute : params.leftJoinAttributes()) {
+    for (TrackedEntityAttribute attribute : params.leftJoinAttributes()) {
       attributes
           .append(" left join trackedentityattributevalue as ")
-          .append(quote(orderAttribute.getUid()))
+          .append(quote(attribute.getUid()))
           .append(" on ")
-          .append(quote(orderAttribute.getUid()))
+          .append(quote(attribute.getUid()))
           .append(".trackedentityid = TE.trackedentityid ")
           .append("and ")
-          .append(quote(orderAttribute.getUid()))
+          .append(quote(attribute.getUid()))
           .append(".trackedentityattributeid = ")
-          .append(orderAttribute.getId())
+          .append(attribute.getId())
           .append(SPACE);
     }
 
@@ -880,7 +881,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         .append("left join userinfo au on (ev.assigneduserid=au.userinfoid) ");
 
     // LEFT JOIN attributes we need to sort on and/or filter by.
-    fromBuilder.append(getFromSubQueryJoinOrderByAttributes(params));
+    fromBuilder.append(getLeftJoinFromAttributes(params));
 
     fromBuilder.append(getCategoryOptionComboQuery(user));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -599,6 +599,11 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     return sqlBuilder.toString();
   }
 
+  /**
+   * Generates the WHERE-clause related to the user provided attribute filters. It will find the
+   * tracked entity attributes that match the given user filter criteria. This condition only
+   * applies when an attribute filter is specified.
+   */
   private String getWhereClauseFromAttributeFilterConditions(
       EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
     StringBuilder fromBuilder = new StringBuilder();
@@ -672,8 +677,8 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
   }
 
   /**
-   * Generates the LEFT JOINs used for attributes we are ordering and filtering by (If any). We use
-   * LEFT JOIN to avoid removing any rows if there is no value for a given attribute and te. The
+   * Generates the LEFT JOIN based on the attributes we are ordering and filtering by, if any. We
+   * use LEFT JOIN to avoid removing any rows if there is no value for a given attribute and te. The
    * result of this LEFT JOIN is used in the sub-query projection, and ordering in the sub-query and
    * main query.
    *
@@ -687,7 +692,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     StringBuilder attributes = new StringBuilder();
 
     for (TrackedEntityAttribute orderAttribute : params.leftJoinAttributes()) {
-
       attributes
           .append(" left join trackedentityattributevalue as ")
           .append(quote(orderAttribute.getUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -254,9 +254,8 @@ public class TrackedEntityOperationParams {
 
     // Do not remove this unused method. This hides the filters field from the builder which Lombok
     // does not support. The repeated filters field and private filters method prevent access to
-    // order
-    // via the builder.
-    // Order should be added via the filterBy builder methods.
+    // the filter map via the builder.
+    // Filters should be added via the filterBy builder methods.
     private TrackedEntityOperationParamsBuilder filters(Map<UID, List<QueryFilter>> filters) {
       return this;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -248,12 +248,9 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams =
         eventBuilder
-            .attributeFilters(
-                Map.of(
-                    UID.of(TEA_1_UID),
-                    List.of(new QueryFilter(QueryOperator.EQ, "2")),
-                    UID.of(TEA_2_UID),
-                    List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
+            .filterByAttribute(UID.of(TEA_1_UID), List.of(new QueryFilter(QueryOperator.EQ, "2")))
+            .filterByAttribute(
+                UID.of(TEA_2_UID), List.of(new QueryFilter(QueryOperator.LIKE, "foo")))
             .build();
 
     EventQueryParams queryParams = mapper.map(operationParams, user);
@@ -272,8 +269,7 @@ class EventOperationParamsMapperTest {
   @Test
   void shouldFailWhenAttributeInGivenAttributeFilterDoesNotExist() {
     UID filterName = UID.generate();
-    EventOperationParams operationParams =
-        eventBuilder.attributeFilters(Map.of(filterName, List.of())).build();
+    EventOperationParams operationParams = eventBuilder.filterByAttribute(filterName).build();
 
     when(trackedEntityAttributeService.getTrackedEntityAttribute(filterName.getValue()))
         .thenReturn(null);
@@ -361,14 +357,12 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams =
         eventBuilder
-            .dataElementFilters(
-                Map.of(
-                    UID.of(DE_1_UID),
-                    List.of(
-                        new QueryFilter(QueryOperator.EQ, "2"),
-                        new QueryFilter(QueryOperator.NNULL)),
-                    UID.of(DE_2_UID),
-                    List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
+            .filterByDataElement(
+                UID.of(DE_1_UID),
+                List.of(
+                    new QueryFilter(QueryOperator.EQ, "2"), new QueryFilter(QueryOperator.NNULL)))
+            .filterByDataElement(
+                UID.of(DE_2_UID), List.of(new QueryFilter(QueryOperator.LIKE, "foo")))
             .build();
 
     EventQueryParams queryParams = mapper.map(operationParams, user);
@@ -387,8 +381,7 @@ class EventOperationParamsMapperTest {
   @Test
   void shouldFailWhenDataElementInGivenDataElementFilterDoesNotExist() {
     UID filterName = UID.generate();
-    EventOperationParams operationParams =
-        eventBuilder.dataElementFilters(Map.of(filterName, List.of())).build();
+    EventOperationParams operationParams = eventBuilder.filterByDataElement(filterName).build();
 
     when(dataElementService.getDataElement(filterName.getValue())).thenReturn(null);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -78,7 +78,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
   private final EventChangeLogOperationParams defaultOperationParams =
       EventChangeLogOperationParams.builder().build();
-  private final PageParams defaultPageParams = new PageParams(null, null, false);
+  private final PageParams defaultPageParams = new PageParams(1, 10, false);
 
   private final DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -922,7 +922,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldFilterByEventsContainingGivenAttributeValueWhenCombiningTwoUnaryOperatorsInFilter()
+  void shouldFilterByEventsContainingGivenAttributeValueWhenCombiningTwoUnaryOperators()
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
@@ -940,9 +940,8 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void
-      shouldFilterByEventsContainingGivenAttributeValueWhenCombiningUnaryAndBinaryOperatorsInFilter()
-          throws ForbiddenException, BadRequestException {
+  void shouldFilterByEventsContainingGivenAttributeValueWhenCombiningUnaryAndBinaryOperators()
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -964,22 +964,13 @@ class EventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
-            .programStage(manager.get(ProgramStage.class, "qLZC0lvvxQH"))
             .eventParams(EventParams.FALSE)
             .filterByAttribute(UID.of("toDelete000"), List.of(new QueryFilter(QueryOperator.NULL)))
             .build();
 
     List<String> events = getEvents(params);
 
-    assertContainsOnly(
-        List.of(
-            "cadc5eGj0j7",
-            "lumVtWwwy0O",
-            "ck7DzdxqLqA",
-            "OTmjvJDn0Fu",
-            "kWjSezkXHVp",
-            "QRYjLTiJTrA"),
-        events);
+    assertContainsOnly(List.of("H0PbzJY8bJG"), events);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -44,7 +44,6 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryOption;
@@ -347,8 +346,8 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%")))
             .build();
 
     List<String> events = getEvents(params);
@@ -368,8 +367,8 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
             .enrollmentStatus(EnrollmentStatus.ACTIVE)
-            .dataElementFilters(
-                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%")))
             .build();
 
     List<String> events = getEvents(params);
@@ -387,8 +386,8 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
             .programType(ProgramType.WITH_REGISTRATION)
-            .dataElementFilters(
-                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%val%")))
             .build();
 
     List<String> events = getEvents(params);
@@ -405,10 +404,8 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement),
-                    List.of(new QueryFilter(QueryOperator.LIKE, "%value00001%"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%value00001%")))
             .build();
 
     List<String> events = getEvents(params);
@@ -425,10 +422,9 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement),
-                    List.of(new QueryFilter(QueryOperator.IN, "value00001;value00002"))))
+            .filterByDataElement(
+                UID.of(dataElement),
+                List.of(new QueryFilter(QueryOperator.IN, "value00001;value00002")))
             .build();
 
     List<String> events = getEvents(params);
@@ -448,9 +444,8 @@ class EventExporterTest extends TrackerTest {
             .program(program)
             .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00001"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00001")))
             .build();
 
     List<String> events = getEvents(params);
@@ -506,9 +501,8 @@ class EventExporterTest extends TrackerTest {
             .program(program)
             .attributeCategoryCombo(UID.of("bjDvmb4bfuf"))
             .attributeCategoryOptions(Set.of(UID.of("xYerKDKCefk")))
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00002"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "value00002")))
             .build();
 
     List<String> events = getEvents(params);
@@ -524,8 +518,8 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EQ, "option1")))
             .build();
 
     List<String> events = getEvents(params);
@@ -541,10 +535,8 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement),
-                    List.of(new QueryFilter(QueryOperator.IN, "option1;option2"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.IN, "option1;option2")))
             .build();
 
     List<String> events = getEvents(params);
@@ -560,8 +552,8 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
+            .filterByDataElement(
+                UID.of(dataElement), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%")))
             .build();
 
     List<String> events = getEvents(params);
@@ -577,12 +569,11 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement),
-                    List.of(
-                        new QueryFilter(QueryOperator.LT, "77"),
-                        new QueryFilter(QueryOperator.GT, "8"))))
+            .filterByDataElement(
+                UID.of(dataElement),
+                List.of(
+                    new QueryFilter(QueryOperator.LT, "77"),
+                    new QueryFilter(QueryOperator.GT, "8")))
             .build();
 
     List<String> events = getEvents(params);
@@ -596,12 +587,10 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .eventParams(EventParams.FALSE)
-            .dataElementFilters(
-                Map.of(
-                    UID.of("GieVkTxp4HH"),
-                    List.of(new QueryFilter(QueryOperator.NNULL)),
-                    UID.of("GieVkTxp4HG"),
-                    List.of(new QueryFilter(QueryOperator.NNULL))))
+            .filterByDataElement(
+                UID.of("GieVkTxp4HH"), List.of(new QueryFilter(QueryOperator.NNULL)))
+            .filterByDataElement(
+                UID.of("GieVkTxp4HG"), List.of(new QueryFilter(QueryOperator.NNULL)))
             .build();
 
     List<String> events = getEvents(params);
@@ -617,8 +606,8 @@ class EventExporterTest extends TrackerTest {
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
             .eventParams(EventParams.FALSE)
-            .dataElementFilters(
-                Map.of(UID.of("DATAEL00002"), List.of(new QueryFilter(QueryOperator.NULL))))
+            .filterByDataElement(
+                UID.of("DATAEL00002"), List.of(new QueryFilter(QueryOperator.NULL)))
             .build();
 
     List<String> events = getEvents(params);
@@ -634,12 +623,11 @@ class EventExporterTest extends TrackerTest {
         operationParamsBuilder
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
-            .dataElementFilters(
-                Map.of(
-                    UID.of(dataElement),
-                    List.of(
-                        new QueryFilter(QueryOperator.IN, "option2"),
-                        new QueryFilter(QueryOperator.NNULL))))
+            .filterByDataElement(
+                UID.of(dataElement),
+                List.of(
+                    new QueryFilter(QueryOperator.IN, "option2"),
+                    new QueryFilter(QueryOperator.NNULL)))
             .build();
 
     List<String> events = getEvents(params);
@@ -655,12 +643,9 @@ class EventExporterTest extends TrackerTest {
             .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStage(programStage)
             .eventParams(EventParams.FALSE)
-            .dataElementFilters(
-                Map.of(
-                    UID.of("DATAEL00002"),
-                    List.of(
-                        new QueryFilter(QueryOperator.NNULL),
-                        new QueryFilter(QueryOperator.NNULL))))
+            .filterByDataElement(
+                UID.of("DATAEL00002"),
+                List.of(new QueryFilter(QueryOperator.NNULL), new QueryFilter(QueryOperator.NNULL)))
             .build();
 
     List<String> events = getEvents(params);
@@ -845,14 +830,10 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void
-      shouldFilterOutEventsWithATrackedEntityWithoutThatAttributeWhenFilterAttributeHasNoQueryFilter()
-          throws ForbiddenException, BadRequestException {
+  void shouldOnlyIncludeEventsWithGivenAttributeWhenFilterAttributeHasNoQueryFilter()
+      throws ForbiddenException, BadRequestException {
     EventOperationParams params =
-        operationParamsBuilder
-            .orgUnit(orgUnit)
-            .attributeFilters(Map.of(UID.of("notUpdated0"), List.of()))
-            .build();
+        operationParamsBuilder.orgUnit(orgUnit).filterByAttribute(UID.of("notUpdated0")).build();
 
     List<String> trackedEntities =
         eventService.getEvents(params).stream()
@@ -867,12 +848,11 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .orgUnit(orgUnit)
-            .attributeFilters(
-                Map.of(
-                    UID.of("numericAttr"),
-                    List.of(
-                        new QueryFilter(QueryOperator.LT, "77"),
-                        new QueryFilter(QueryOperator.GT, "8"))))
+            .filterByAttribute(
+                UID.of("numericAttr"),
+                List.of(
+                    new QueryFilter(QueryOperator.LT, "77"),
+                    new QueryFilter(QueryOperator.GT, "8")))
             .build();
 
     List<String> trackedEntities =
@@ -888,10 +868,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .orgUnit(orgUnit)
-            .attributeFilters(
-                Map.of(
-                    UID.of("toUpdate000"),
-                    List.of(new QueryFilter(QueryOperator.EQ, "summer day"))))
+            .filterByAttribute(
+                UID.of("toUpdate000"), List.of(new QueryFilter(QueryOperator.EQ, "summer day")))
             .build();
 
     List<String> trackedEntities =
@@ -908,12 +886,10 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .orgUnit(orgUnit)
-            .attributeFilters(
-                Map.of(
-                    UID.of("toUpdate000"),
-                    List.of(new QueryFilter(QueryOperator.EQ, "rainy day")),
-                    UID.of("notUpdated0"),
-                    List.of(new QueryFilter(QueryOperator.EQ, "winter day"))))
+            .filterByAttribute(
+                UID.of("toUpdate000"), List.of(new QueryFilter(QueryOperator.EQ, "rainy day")))
+            .filterByAttribute(
+                UID.of("notUpdated0"), List.of(new QueryFilter(QueryOperator.EQ, "winter day")))
             .build();
 
     List<String> trackedEntities =
@@ -930,12 +906,11 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         operationParamsBuilder
             .orgUnit(orgUnit)
-            .attributeFilters(
-                Map.of(
-                    UID.of("toUpdate000"),
-                    List.of(
-                        new QueryFilter(QueryOperator.LIKE, "day"),
-                        new QueryFilter(QueryOperator.LIKE, "in"))))
+            .filterByAttribute(
+                UID.of("toUpdate000"),
+                List.of(
+                    new QueryFilter(QueryOperator.LIKE, "day"),
+                    new QueryFilter(QueryOperator.LIKE, "in")))
             .build();
 
     List<String> trackedEntities =
@@ -944,6 +919,83 @@ class EventExporterTest extends TrackerTest {
             .toList();
 
     assertContainsOnly(List.of("dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
+  void shouldFilterByEventsContainingGivenAttributeValueWhenCombiningTwoUnaryOperatorsInFilter()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
+            .programStage(programStage)
+            .eventParams(EventParams.FALSE)
+            .filterByAttribute(
+                UID.of("dIVt4l5vIOa"),
+                List.of(new QueryFilter(QueryOperator.NNULL), new QueryFilter(QueryOperator.NNULL)))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), events);
+  }
+
+  @Test
+  void
+      shouldFilterByEventsContainingGivenAttributeValueWhenCombiningUnaryAndBinaryOperatorsInFilter()
+          throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .enrollments(UID.of("nxP7UnKhomJ", "TvctPPhpD8z"))
+            .programStage(programStage)
+            .eventParams(EventParams.FALSE)
+            .filterByAttribute(
+                UID.of("toUpdate000"),
+                List.of(
+                    new QueryFilter(QueryOperator.NNULL),
+                    new QueryFilter(QueryOperator.EQ, "rainy day")))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
+  void shouldFilterByEventsNotContainingGivenAttributeValueWhenFilteringByNullValues()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programStage(manager.get(ProgramStage.class, "qLZC0lvvxQH"))
+            .eventParams(EventParams.FALSE)
+            .filterByAttribute(UID.of("toDelete000"), List.of(new QueryFilter(QueryOperator.NULL)))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(
+        List.of(
+            "cadc5eGj0j7",
+            "lumVtWwwy0O",
+            "ck7DzdxqLqA",
+            "OTmjvJDn0Fu",
+            "kWjSezkXHVp",
+            "QRYjLTiJTrA"),
+        events);
+  }
+
+  @Test
+  void shouldFilterByEventsContainingGivenAttributeValueWhenFilteringByNonNullValues()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programStage(programStage)
+            .eventParams(EventParams.FALSE)
+            .filterByAttribute(UID.of("dIVt4l5vIOa"), List.of(new QueryFilter(QueryOperator.NNULL)))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), events);
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.val
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -130,8 +131,6 @@ class EventRequestParamsMapper {
             .eventStatus(eventRequestParams.getStatus())
             .attributeCategoryCombo(eventRequestParams.getAttributeCategoryCombo())
             .attributeCategoryOptions(eventRequestParams.getAttributeCategoryOptions())
-            .dataElementFilters(dataElementFilters)
-            .attributeFilters(attributeFilters)
             .events(eventRequestParams.getEvents())
             .enrollments(eventRequestParams.getEnrollments())
             .includeDeleted(eventRequestParams.isIncludeDeleted())
@@ -139,6 +138,8 @@ class EventRequestParamsMapper {
             .idSchemeParams(idSchemeParams);
 
     mapOrderParam(builder, eventRequestParams.getOrder());
+    mapDataElementFilterParam(builder, dataElementFilters);
+    mapAttributeFilterParam(builder, attributeFilters);
 
     return builder.build();
   }
@@ -159,6 +160,36 @@ class EventRequestParamsMapper {
         builder.orderBy(EventMapper.ORDERABLE_FIELDS.get(order.getField()), order.getDirection());
       } else {
         builder.orderBy(UID.of(order.getField()), order.getDirection());
+      }
+    }
+  }
+
+  private void mapDataElementFilterParam(
+      EventOperationParamsBuilder builder, Map<UID, List<QueryFilter>> dataElementFilters) {
+    if (dataElementFilters == null || dataElementFilters.isEmpty()) {
+      return;
+    }
+
+    for (Entry<UID, List<QueryFilter>> entry : dataElementFilters.entrySet()) {
+      if (entry.getValue().isEmpty()) {
+        builder.filterByDataElement(entry.getKey());
+      } else {
+        builder.filterByDataElement(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  private void mapAttributeFilterParam(
+      EventOperationParamsBuilder builder, Map<UID, List<QueryFilter>> attributeFilters) {
+    if (attributeFilters == null || attributeFilters.isEmpty()) {
+      return;
+    }
+
+    for (Entry<UID, List<QueryFilter>> entry : attributeFilters.entrySet()) {
+      if (entry.getValue().isEmpty()) {
+        builder.filterByAttribute(entry.getKey());
+      } else {
+        builder.filterByAttribute(entry.getKey(), entry.getValue());
       }
     }
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -444,7 +444,8 @@ class EventRequestParamsMapperTest {
 
     Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
-    Map<UID, List<QueryFilter>> expected = Map.of(DE_1_UID, List.of());
+    Map<UID, List<QueryFilter>> expected =
+        Map.of(DE_1_UID, List.of(new QueryFilter(QueryOperator.NNULL)));
     assertEquals(expected, dataElementFilters);
   }
 
@@ -504,7 +505,8 @@ class EventRequestParamsMapperTest {
 
     Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
-    Map<UID, List<QueryFilter>> expected = Map.of(TEA_1_UID, List.of());
+    Map<UID, List<QueryFilter>> expected =
+        Map.of(TEA_1_UID, List.of(new QueryFilter(QueryOperator.NNULL)));
     assertEquals(expected, attributeFilters);
   }
 


### PR DESCRIPTION
The last PR, that introduces unary operators for attribute filters in the event endpoint.
As in the tracked entities endpoint, I'm performing a left join to `trackedentityattributevalue`, which is used for both ordering and filtering. The `where` clause is then built using the user provided attribute filters.

Following the approach in `TrackedEntityQueryParams`, I refactored `EventOperationParamsMapper` to expose `filterByDataElement` and `filterByAttribute` in the service API, so users no longer have to deal with a Map structure.