### PR TITLE
test: rename to import

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TestSetup.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TestSetup.java
@@ -73,24 +73,24 @@ public class TestSetup {
   @Autowired private TrackerImportService trackerImportService;
 
   /**
-   * Set up the base metadata used by most tracker tests.
+   * Import the base metadata used by most tracker tests.
    *
-   * <p>Use {@link #setUpMetadata(String)} (String)}
+   * <p>Use {@link #importMetadata(String)} (String)}
    *
    * <ul>
    *   <li>instead if your test only needs a subset of what the tracker base metadata contains
    *   <li>in addition if your test needs some additional metadata that not all tracker tests need
    * </ul>
    */
-  public ObjectBundle setUpMetadata() throws IOException {
-    return setUpMetadata("tracker/base_metadata.json", null);
+  public ObjectBundle importMetadata() throws IOException {
+    return importMetadata("tracker/base_metadata.json", null);
   }
 
-  public ObjectBundle setUpMetadata(String path) throws IOException {
-    return setUpMetadata(path, null);
+  public ObjectBundle importMetadata(String path) throws IOException {
+    return importMetadata(path, null);
   }
 
-  public ObjectBundle setUpMetadata(String path, User user) throws IOException {
+  public ObjectBundle importMetadata(String path, User user) throws IOException {
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
         renderService.fromMetadata(new ClassPathResource(path).getInputStream(), RenderFormat.JSON);
     ObjectBundleParams params = new ObjectBundleParams();
@@ -105,28 +105,28 @@ public class TestSetup {
   }
 
   /**
-   * Set up the base tracker data used by most tracker tests.
+   * Import the base tracker data used by most tracker tests.
    *
-   * <p>Use {@link #setUpTrackerData(String)}
+   * <p>Use {@link #importTrackerData(String)}
    *
    * <ul>
    *   <li>instead if your test only needs a subset of what the tracker base data contains
    *   <li>in addition if your test needs some additional data that not all tracker tests need
    * </ul>
    */
-  public TrackerObjects setUpTrackerData() throws IOException {
-    return setUpTrackerData("tracker/base_data.json");
+  public TrackerObjects importTrackerData() throws IOException {
+    return importTrackerData("tracker/base_data.json");
   }
 
   /**
-   * Setup tracker data from a JSON fixture using the default import parameters. Use {@link
-   * #setUpTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
+   * Import tracker data from a JSON fixture using the default import parameters. Use {@link
+   * #importTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
    */
-  public TrackerObjects setUpTrackerData(String path) throws IOException {
-    return setUpTrackerData(path, TrackerImportParams.builder().build());
+  public TrackerObjects importTrackerData(String path) throws IOException {
+    return importTrackerData(path, TrackerImportParams.builder().build());
   }
 
-  public TrackerObjects setUpTrackerData(String path, TrackerImportParams params)
+  public TrackerObjects importTrackerData(String path, TrackerImportParams params)
       throws IOException {
     TrackerObjects trackerObjects = fromJson(path);
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
@@ -63,14 +63,14 @@ class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @BeforeEach
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerObjects trackerObjects = testSetup.setUpTrackerData();
+    TrackerObjects trackerObjects = testSetup.importTrackerData();
     TrackerObjects duplicateTrackedEntities =
-        testSetup.setUpTrackerData("tracker/deduplication/potential_duplicates.json");
+        testSetup.importTrackerData("tracker/deduplication/potential_duplicates.json");
 
     trackedEntityAOriginal = testSetup.getTrackedEntity(trackerObjects, "QS6w44flWAf").getUid();
     trackedEntityADuplicate =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -111,12 +111,12 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    testSetup.setUpTrackerData();
+    testSetup.importTrackerData();
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     programStage = get(ProgramStage.class, "NpsdDv6kKSO");
     trackedEntityType = get(TrackedEntityType.class, "ja8NY4PW7Xm");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -85,12 +85,12 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    testSetup.setUpTrackerData();
+    testSetup.importTrackerData();
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     ProgramStage programStage = get(ProgramStage.class, "NpsdDv6kKSO");
     program = programStage.getProgram();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -90,12 +90,12 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
   }
 
   @BeforeEach

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -106,12 +106,12 @@ class EventExporterTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    testSetup.setUpTrackerData();
+    testSetup.importTrackerData();
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     programStage = get(ProgramStage.class, "NpsdDv6kKSO");
     program = programStage.getProgram();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -88,12 +88,12 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
   }
 
   private static Stream<Arguments> provideDateAndUsernameOrderParams() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/OrderAndFilterTrackedEntityChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/OrderAndFilterTrackedEntityChangeLogTest.java
@@ -79,12 +79,12 @@ class OrderAndFilterTrackedEntityChangeLogTest extends PostgresIntegrationTestBa
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
   }
 
   @BeforeEach

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
@@ -75,12 +75,12 @@ class TrackedEntityChangeLogServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
   }
 
   @BeforeEach

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/AtomicModeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/AtomicModeIntegrationTest.java
@@ -57,7 +57,7 @@ class AtomicModeIntegrationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -69,7 +69,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -66,24 +66,24 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     final User userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    testSetup.setUpTrackerData("tracker/single_te.json");
-    testSetup.setUpTrackerData("tracker/single_enrollment.json");
+    testSetup.importTrackerData("tracker/single_te.json");
+    testSetup.importTrackerData("tracker/single_enrollment.json");
     manager.flush();
   }
 
   @Test
   void successWhenEventHasNoProgramAndHasProgramStage() throws IOException {
-    testSetup.setUpTrackerData("tracker/validations/events-with_no_program.json");
+    testSetup.importTrackerData("tracker/validations/events-with_no_program.json");
   }
 
   @Test
   void testEventDataValue() throws IOException {
-    testSetup.setUpTrackerData("tracker/event_with_data_values.json");
+    testSetup.importTrackerData("tracker/event_with_data_values.json");
 
     List<Event> events = manager.getAll(Event.class);
     assertEquals(1, events.size());
@@ -94,7 +94,7 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
 
   @Test
   void testEventDataValueUpdate() throws IOException {
-    testSetup.setUpTrackerData("tracker/event_with_data_values.json");
+    testSetup.importTrackerData("tracker/event_with_data_values.json");
 
     List<Event> events = manager.getAll(Event.class);
     assertEquals(1, events.size());
@@ -105,7 +105,7 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
 
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
-    testSetup.setUpTrackerData("tracker/event_with_updated_data_values.json", params);
+    testSetup.importTrackerData("tracker/event_with_updated_data_values.json", params);
 
     List<Event> updatedEvents = manager.getAll(Event.class);
     assertEquals(1, updatedEvents.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
@@ -69,7 +69,7 @@ class EventImportTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -83,20 +83,20 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/single_te.json");
+    TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/single_te.json");
 
     trackedEntity = trackerObjects.getTrackedEntities().get(0);
 
-    trackerObjects = testSetup.setUpTrackerData("tracker/single_enrollment.json");
+    trackerObjects = testSetup.importTrackerData("tracker/single_enrollment.json");
 
     enrollment = trackerObjects.getEnrollments().get(0);
 
-    trackerObjects = testSetup.setUpTrackerData("tracker/single_event.json");
+    trackerObjects = testSetup.importTrackerData("tracker/single_event.json");
 
     event = trackerObjects.getEvents().get(0);
 
@@ -117,7 +117,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
-    testSetup.setUpTrackerData("tracker/single_te.json", params);
+    testSetup.importTrackerData("tracker/single_te.json", params);
 
     Date lastUpdateAfter = getTrackedEntity().getLastUpdated();
 
@@ -135,14 +135,14 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
     clearSession();
 
-    testSetup.setUpTrackerData("tracker/event_with_data_values.json");
+    testSetup.importTrackerData("tracker/event_with_data_values.json");
 
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
 
     assertNoErrors(
         trackerImportService.importTracker(
-            params, testSetup.setUpTrackerData("tracker/event_with_updated_data_values.json")));
+            params, testSetup.importTrackerData("tracker/event_with_updated_data_values.json")));
 
     clearSession();
 
@@ -483,7 +483,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
   }
 
   private org.hisp.dhis.tracker.imports.domain.Event importEventProgram() throws IOException {
-    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/single_event.json");
+    TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/single_event.json");
     org.hisp.dhis.tracker.imports.domain.Event ev = trackerObjects.getEvents().get(0);
     ev.setEnrollment(null);
     ev.setEvent(UID.generate());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -86,13 +86,13 @@ class OwnershipTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/ownership_metadata.json");
+    testSetup.importMetadata("tracker/ownership_metadata.json");
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    testSetup.setUpTrackerData("tracker/ownership_te.json");
-    testSetup.setUpTrackerData("tracker/ownership_enrollment.json");
+    testSetup.importTrackerData("tracker/ownership_te.json");
+    testSetup.importTrackerData("tracker/ownership_enrollment.json");
 
     nonSuperUser = userService.getUser("Tu9fv8ezgHl");
   }
@@ -123,7 +123,7 @@ class OwnershipTest extends PostgresIntegrationTestBase {
   void testClientDatesForTrackedEntityEnrollmentEvent() throws IOException {
     User nonSuperUser = userService.getUser(this.nonSuperUser.getUid());
     injectSecurityContextUser(nonSuperUser);
-    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/ownership_event.json");
+    TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/ownership_event.json");
     manager.flush();
     TrackerObjects teTrackerObjects = testSetup.fromJson("tracker/ownership_te.json");
     TrackerObjects enTrackerObjects = testSetup.fromJson("tracker/ownership_enrollment.json");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -67,14 +67,14 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);
 
-    testSetup.setUpTrackerData("tracker/single_te.json");
-    testSetup.setUpTrackerData("tracker/single_enrollment.json");
-    testSetup.setUpTrackerData("tracker/single_event.json");
+    testSetup.importTrackerData("tracker/single_te.json");
+    testSetup.importTrackerData("tracker/single_enrollment.json");
+    testSetup.importTrackerData("tracker/single_event.json");
     manager.flush();
   }
 
@@ -111,7 +111,7 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
   @Test
   void successUpdateRelationships() throws IOException {
-    testSetup.setUpTrackerData("tracker/relationships.json");
+    testSetup.importTrackerData("tracker/relationships.json");
 
     TrackerObjects trackerObjects = testSetup.fromJson("tracker/relationshipToUpdate.json");
     TrackerImportParams trackerImportParams =
@@ -128,7 +128,7 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldFailWhenTryingToUpdateADeletedRelationship() throws IOException {
-    TrackerObjects trackerObjects = testSetup.setUpTrackerData("tracker/relationships.json");
+    TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/relationships.json");
 
     manager.delete(manager.get(Relationship.class, "Nva3Xj2j75W"));
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -81,7 +81,7 @@ class ReportSummaryDeleteIntegrationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryIntegrationTest.java
@@ -60,7 +60,7 @@ class ReportSummaryIntegrationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     userA = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(userA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -70,7 +70,7 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/te_with_tea_metadata.json");
+    testSetup.importMetadata("tracker/te_with_tea_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
@@ -92,7 +92,7 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedAttributeValueBundleImporter() throws IOException {
-    testSetup.setUpTrackerData("tracker/te_with_tea_data.json");
+    testSetup.importTrackerData("tracker/te_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -65,7 +65,8 @@ class TrackedEntityProgramAttributeEncryptionTest extends PostgresIntegrationTes
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/te_program_with_tea_encryption_metadata.json", getAdminUser());
+    testSetup.importMetadata(
+        "tracker/te_program_with_tea_encryption_metadata.json", getAdminUser());
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
@@ -73,7 +74,7 @@ class TrackedEntityProgramAttributeEncryptionTest extends PostgresIntegrationTes
 
   @Test
   void testTrackedEntityProgramAttributeEncryptedValue() throws IOException {
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_encryption_data.json");
+    testSetup.importTrackerData("tracker/te_program_with_tea_encryption_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -68,7 +68,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationT
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/te_program_with_tea_fileresource_metadata.json");
+    testSetup.importMetadata("tracker/te_program_with_tea_fileresource_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
@@ -87,7 +87,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationT
     File file = File.createTempFile("file-resource", "test");
     fileResourceService.asyncSaveFileResource(fileResource, file);
     assertFalse(fileResource.isAssigned());
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_fileresource_data.json");
+    testSetup.importTrackerData("tracker/te_program_with_tea_fileresource_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeTest.java
@@ -62,7 +62,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/te_program_with_tea_metadata.json");
+    testSetup.importMetadata("tracker/te_program_with_tea_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
@@ -70,7 +70,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValue() throws IOException {
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
+    testSetup.importTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -82,7 +82,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdate() throws IOException {
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
+    testSetup.importTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -96,7 +96,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_update_data.json", importParams);
+    testSetup.importTrackerData("tracker/te_program_with_tea_update_data.json", importParams);
 
     trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -108,7 +108,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
 
   @Test
   void testTrackedEntityProgramAttributeValueUpdateAndDelete() throws IOException {
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_data.json");
+    testSetup.importTrackerData("tracker/te_program_with_tea_data.json");
 
     List<TrackedEntity> trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -122,7 +122,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_update_data.json", params);
+    testSetup.importTrackerData("tracker/te_program_with_tea_update_data.json", params);
 
     trackedEntities = manager.getAll(TrackedEntity.class);
     assertEquals(1, trackedEntities.size());
@@ -133,7 +133,7 @@ class TrackedEntityProgramAttributeTest extends PostgresIntegrationTestBase {
     manager.clear();
     // delete
     params = TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build();
-    testSetup.setUpTrackerData("tracker/te_program_with_tea_delete_data.json", params);
+    testSetup.importTrackerData("tracker/te_program_with_tea_delete_data.json", params);
 
     trackedEntities =
         manager.getAll(TrackedEntity.class).stream().filter(te -> !te.isDeleted()).toList();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
@@ -64,7 +64,7 @@ class TrackerEventBundleServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/event_metadata.json");
+    testSetup.importMetadata("tracker/event_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerProgramRuleBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerProgramRuleBundleServiceTest.java
@@ -79,7 +79,7 @@ class TrackerProgramRuleBundleServiceTest extends PostgresIntegrationTestBase {
             ProgramNotificationRecipient.USER_GROUP);
     notificationTemplateService.save(pnt);
 
-    ObjectBundle bundle = testSetup.setUpMetadata("tracker/event_metadata.json");
+    ObjectBundle bundle = testSetup.importMetadata("tracker/event_metadata.json");
     ProgramRule programRule =
         createProgramRule(
             'A', bundle.getPreheat().get(PreheatIdentifier.UID, Program.class, "BFcipDERJwr"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -71,13 +71,13 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     userDetails = UserDetails.fromUser(importUser);
     injectSecurityContext(userDetails);
 
-    testSetup.setUpTrackerData();
+    testSetup.importTrackerData();
   }
 
   @BeforeEach

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatIdentifiersTest.java
@@ -80,7 +80,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/identifier_metadata.json");
+    testSetup.importMetadata("tracker/identifier_metadata.json");
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatServiceTest.java
@@ -140,7 +140,7 @@ class TrackerPreheatServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testPreheatEvents() throws IOException {
-    testSetup.setUpMetadata("tracker/event_metadata.json");
+    testSetup.importMetadata("tracker/event_metadata.json");
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -104,7 +104,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    ObjectBundle bundle = testSetup.setUpMetadata();
+    ObjectBundle bundle = testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
@@ -135,7 +135,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     calculatedValuePRV.setValueType(ValueType.TEXT);
     programRuleVariableService.addProgramRuleVariable(calculatedValuePRV);
 
-    testSetup.setUpTrackerData("tracker/programrule/te_enrollment_completed_event.json");
+    testSetup.importTrackerData("tracker/programrule/te_enrollment_completed_event.json");
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
@@ -99,7 +99,7 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    ObjectBundle bundle = testSetup.setUpMetadata();
+    ObjectBundle bundle = testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleVariableIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleVariableIntegrationTest.java
@@ -64,7 +64,7 @@ class ProgramRuleVariableIntegrationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_metadata_with_program_rules_variables.json");
+    testSetup.importMetadata("tracker/tracker_metadata_with_program_rules_variables.json");
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentAttrValidationTest.java
@@ -61,7 +61,7 @@ class EnrollmentAttrValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata_mandatory_attr.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata_mandatory_attr.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -75,7 +75,7 @@ class EnrollmentImportValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
@@ -115,7 +115,7 @@ class EnrollmentSecurityImportValidationTest extends PostgresIntegrationTestBase
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -86,7 +86,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -123,7 +123,7 @@ class EventSecurityImportValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
@@ -65,7 +65,7 @@ class RelationshipSecurityImportValidationTest extends PostgresIntegrationTestBa
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaEncryptionValidationTest.java
@@ -56,7 +56,7 @@ class TeTaEncryptionValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/validations/te-program_with_tea_encryption_metadata.json");
+    testSetup.importMetadata("tracker/validations/te-program_with_tea_encryption_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
@@ -75,7 +75,7 @@ class TeTaValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/validations/te-program_with_tea_fileresource_metadata.json");
+    testSetup.importMetadata("tracker/validations/te-program_with_tea_fileresource_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -82,7 +82,7 @@ class TrackedEntityImportValidationTest extends PostgresIntegrationTestBase {
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata("tracker/tracker_basic_metadata.json");
+    testSetup.importMetadata("tracker/tracker_basic_metadata.json");
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -65,7 +65,7 @@ class ProgramStageWorkingListControllerTest extends PostgresControllerIntegratio
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TestSetup.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TestSetup.java
@@ -73,24 +73,24 @@ public class TestSetup {
   @Autowired private TrackerImportService trackerImportService;
 
   /**
-   * Set up the base metadata used by most tracker tests.
+   * Import the base metadata used by most tracker tests.
    *
-   * <p>Use {@link #setUpMetadata(String)} (String)}
+   * <p>Use {@link #importMetadata(String)} (String)}
    *
    * <ul>
    *   <li>instead if your test only needs a subset of what the tracker base metadata contains
    *   <li>in addition if your test needs some additional metadata that not all tracker tests need
    * </ul>
    */
-  public ObjectBundle setUpMetadata() throws IOException {
-    return setUpMetadata("tracker/base_metadata.json", null);
+  public ObjectBundle importMetadata() throws IOException {
+    return importMetadata("tracker/base_metadata.json", null);
   }
 
-  public ObjectBundle setUpMetadata(String path) throws IOException {
-    return setUpMetadata(path, null);
+  public ObjectBundle importMetadata(String path) throws IOException {
+    return importMetadata(path, null);
   }
 
-  public ObjectBundle setUpMetadata(String path, User user) throws IOException {
+  public ObjectBundle importMetadata(String path, User user) throws IOException {
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
         renderService.fromMetadata(new ClassPathResource(path).getInputStream(), RenderFormat.JSON);
     ObjectBundleParams params = new ObjectBundleParams();
@@ -105,28 +105,28 @@ public class TestSetup {
   }
 
   /**
-   * Set up the base tracker data used by most tracker tests.
+   * Import the base tracker data used by most tracker tests.
    *
-   * <p>Use {@link #setUpTrackerData(String)}
+   * <p>Use {@link #importTrackerData(String)}
    *
    * <ul>
    *   <li>instead if your test only needs a subset of what the tracker base data contains
    *   <li>in addition if your test needs some additional data that not all tracker tests need
    * </ul>
    */
-  public TrackerObjects setUpTrackerData() throws IOException {
-    return setUpTrackerData("tracker/base_data.json");
+  public TrackerObjects importTrackerData() throws IOException {
+    return importTrackerData("tracker/base_data.json");
   }
 
   /**
-   * Setup tracker data from a JSON fixture using the default import parameters. Use {@link
-   * #setUpTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
+   * Import tracker data from a JSON fixture using the default import parameters. Use {@link
+   * #importTrackerData(String, TrackerImportParams)} if you need non-default import parameters.
    */
-  public TrackerObjects setUpTrackerData(String path) throws IOException {
-    return setUpTrackerData(path, TrackerImportParams.builder().build());
+  public TrackerObjects importTrackerData(String path) throws IOException {
+    return importTrackerData(path, TrackerImportParams.builder().build());
   }
 
-  public TrackerObjects setUpTrackerData(String path, TrackerImportParams params)
+  public TrackerObjects importTrackerData(String path, TrackerImportParams params)
       throws IOException {
     TrackerObjects trackerObjects = fromJson(path);
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
@@ -74,14 +74,14 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
 
   @BeforeEach
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
     TrackerObjects duplicateTrackedEntities =
-        testSetup.setUpTrackerData("tracker/deduplication/potential_duplicates.json");
+        testSetup.importTrackerData("tracker/deduplication/potential_duplicates.json");
 
     // potential duplicate A
     trackedEntityAOriginal = testSetup.getTrackedEntity(trackerObjects, "QS6w44flWAf");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -89,12 +89,12 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
 
     manager.flush();
     manager.clear();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -93,12 +93,12 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    testSetup.setUpTrackerData();
+    testSetup.importTrackerData();
     // ensure these are created in the setup
     get(Attribute.class, METADATA_ATTRIBUTE);
     get(Attribute.class, UNUSED_METADATA_ATTRIBUTE);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -97,12 +97,12 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
 
     manager.flush();
     manager.clear();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -111,12 +111,12 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
 
     manager.flush();
     manager.clear();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
@@ -65,12 +65,12 @@ class TrackedEntitiesChangeLogsControllerTest extends PostgresControllerIntegrat
 
   @BeforeEach
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    testSetup.setUpTrackerData("tracker/single_te.json");
+    testSetup.importTrackerData("tracker/single_te.json");
 
     trackedEntity = manager.get(TrackedEntity.class, "IOR1AXXl24H");
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -119,12 +119,12 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
 
   @BeforeAll
   void setUp() throws IOException {
-    testSetup.setUpMetadata();
+    testSetup.importMetadata();
 
     importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 
-    trackerObjects = testSetup.setUpTrackerData();
+    trackerObjects = testSetup.importTrackerData();
 
     manager.flush();
     manager.clear();


### PR DESCRIPTION
following https://github.com/dhis2/dhis2-core/pull/20127 

Rename `setUpMetadata/setUpTrackerData` to `import`. They are test wrappers for metadata and tracker import that assert the import succeeded.

I want to keep the name `setUp` for future methods that do more than just call an importer. See next.

# Next

* `base_data` depends on `base_metadata`: so create metadata directly via `setupTrackerData()`?
* can we automatically set the admin user? or should we return a custom record or so with the objectBundle, trackerObjects, admin, ...
* make common assertions reusable we still have some duplicate code here for asserting an import was successful
* reuse `base_data.json` like we did for `base_metadata.json` via the `dhis-support-test` module
* settle on one way to set the user in our tests via `testSetup.testAsUser`? This ideally should live in `TestBase` but since we did not get any answer from platform this might be our best solution for now.

## Future

We should figure out some scenarios for our testing like one or two common implementations put into our metadata/data.
* what users/roles typically exist in a tracker implementation
* what typical programs/stages are there
* ...

The metadata we have right now is not really structured with the above in mind.