### PR TITLE
fix: (2.41) do not use null attributes to rule-engine[DHIS2-18621]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -187,13 +188,16 @@ class DefaultProgramRuleService implements ProgramRuleService {
         bundle
             .findEnrollmentByUid(enrollmentUid)
             .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getAttributes)
+            .map(this::filterNullAttributes)
             .map(attributes -> attributeValueTrackerConverterService.from(preheat, attributes))
             .orElse(new ArrayList<>());
 
     List<TrackedEntityAttributeValue> payloadAttributeValues =
         bundle
             .findTrackedEntityByUid(teUid)
-            .map(te -> attributeValueTrackerConverterService.from(preheat, te.getAttributes()))
+            .map(org.hisp.dhis.tracker.imports.domain.TrackedEntity::getAttributes)
+            .map(this::filterNullAttributes)
+            .map(attributes -> attributeValueTrackerConverterService.from(preheat, attributes))
             .orElse(Collections.emptyList());
     attributeValues.addAll(payloadAttributeValues);
 
@@ -239,5 +243,12 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(event -> eventTrackerConverterService.fromForRuleEngine(preheat, event));
 
     return Stream.concat(events, bundleEvents).collect(Collectors.toSet());
+  }
+
+  private List<Attribute> filterNullAttributes(List<Attribute> attributes) {
+    return attributes.stream()
+        .filter(Objects::nonNull)
+        .filter(attr -> attr.getValue() != null)
+        .toList();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -103,13 +104,18 @@ class ProgramRuleTest extends TrackerTest {
     dataElement1 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00001");
     DataElement dataElement2 =
         bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00002");
+    TrackedEntityAttribute trackedEntityAttribute =
+        bundle.getPreheat().get(PreheatIdentifier.UID, TrackedEntityAttribute.class, "dIVt4l5vIOa");
     programStageOnInsert =
         bundle.getPreheat().get(PreheatIdentifier.UID, ProgramStage.class, "NpsdDv6kKSO");
     programStageOnComplete =
         bundle.getPreheat().get(PreheatIdentifier.UID, ProgramStage.class, "NpsdDv6kKS2");
     ProgramRuleVariable programRuleVariable =
         createProgramRuleVariableWithDataElement('A', program, dataElement2);
+    ProgramRuleVariable programRuleVariable2 =
+        createProgramRuleVariableWithTEA('B', program, trackedEntityAttribute);
     programRuleVariableService.addProgramRuleVariable(programRuleVariable);
+    programRuleVariableService.addProgramRuleVariable(programRuleVariable2);
     constantService.saveConstant(constant());
 
     injectAdminUser();
@@ -363,6 +369,18 @@ class ProgramRuleTest extends TrackerTest {
   }
 
   @Test
+  void shouldImportWhenTEAHasNullValue() throws IOException {
+    errorProgramRuleWithD2HasValue();
+    TrackerObjects trackerObjects =
+        fromJson("tracker/programrule/tei_completed_enrollment_event.json");
+
+    ImportReport importReport =
+        trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
+
+    assertNoErrors(importReport.getValidationReport());
+  }
+
+  @Test
   void shouldImportWithNoWarningsWhenDataElementHasNoValue() throws IOException {
     showErrorWhenVariableHasValueRule();
     TrackerObjects trackerObjects =
@@ -483,6 +501,17 @@ class ProgramRuleTest extends TrackerTest {
     programRule.setProgramStage(programStage);
     programRule.setCondition(condition);
     return programRule;
+  }
+
+  private void errorProgramRuleWithD2HasValue() {
+    ProgramRule programRule =
+        createProgramRule('H', program, null, "d2:hasValue(#{ProgramRuleVariableB})");
+    programRuleService.addProgramRule(programRule);
+    ProgramRuleAction programRuleAction =
+        createProgramRuleAction(programRule, SHOWERROR, null, null);
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
   }
 
   private ProgramRuleAction createProgramRuleAction(

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_completed_enrollment_event.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_completed_enrollment_event.json
@@ -45,7 +45,18 @@
       "deleted": false,
       "potentialDuplicate": false,
       "relationships": [],
-      "attributes": [],
+      "attributes": [
+        {
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "dIVt4l5vIOa"
+          },
+          "displayName": "Attribute_Identifier_Integer",
+          "storedBy": "admin",
+          "valueType": "INTEGER_POSITIVE",
+          "value": null
+        }
+      ],
       "enrollments": []
     }
   ],


### PR DESCRIPTION
Backport
https://dhis2.atlassian.net/browse/DHIS2-18621