### PR TITLE
chore: Remove unnecessary flaky assert in CDSR e2e test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
@@ -93,9 +93,7 @@ class CompleteDataSetRegistrationsTest extends ApiTest {
     assertEquals(11, taskId.length());
 
     // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
-    ApiResponse taskStatus =
-        systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId, 24);
-    assertTrue(taskStatus.extractList("completed").contains(true));
+    systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId, 24);
 
     // get complete data sets which should be 1 now
     ApiResponse completedResponse2 =


### PR DESCRIPTION
Remove flaky assert which isn't actually needed as the line before only succeeds if the task is seen as completed. No need to double check the response.