### PR TITLE
docs: Rename getTrackedEntity methods [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -95,7 +95,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
       @Nonnull PageParams pageParams)
       throws NotFoundException, ForbiddenException {
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             trackedEntityUid, programUid, TrackedEntityParams.FALSE.withIncludeAttributes(true));
 
     Set<UID> trackedEntityAttributes =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -106,7 +106,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UID trackedEntityUid, UID attributeUid, @CheckForNull UID programUid)
       throws NotFoundException, ForbiddenException {
     TrackedEntity trackedEntity =
-        getNewTrackedEntity(
+        getTrackedEntity(
             trackedEntityUid, programUid, TrackedEntityParams.FALSE.withIncludeAttributes(true));
 
     TrackedEntityAttribute attribute =
@@ -142,14 +142,14 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Nonnull
   @Override
-  public TrackedEntity getNewTrackedEntity(@Nonnull UID uid)
+  public TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException {
-    return getNewTrackedEntity(uid, (Program) null, TrackedEntityParams.FALSE);
+    return getTrackedEntity(uid, (Program) null, TrackedEntityParams.FALSE);
   }
 
   @Nonnull
   @Override
-  public TrackedEntity getNewTrackedEntity(
+  public TrackedEntity getTrackedEntity(
       @Nonnull UID trackedEntityUid,
       @CheckForNull UID programIdentifier,
       @Nonnull TrackedEntityParams params)
@@ -165,10 +165,10 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       }
     }
 
-    return getNewTrackedEntity(trackedEntityUid, program, params);
+    return getTrackedEntity(trackedEntityUid, program, params);
   }
 
-  private TrackedEntity getNewTrackedEntity(UID uid, Program program, TrackedEntityParams params)
+  private TrackedEntity getTrackedEntity(UID uid, Program program, TrackedEntityParams params)
       throws NotFoundException, ForbiddenException {
     Page<TrackedEntity> trackedEntities;
     try {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -54,11 +54,11 @@ public interface TrackedEntityService {
   /**
    * Get the tracked entity matching given {@code UID} under the privileges of the currently
    * authenticated user. No program attributes are included, only TETAs. Enrollments and
-   * relationships are not included. Use {@link #getNewTrackedEntity(UID, UID, TrackedEntityParams)}
+   * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
    * instead to also get the relationships, enrollments and program attributes.
    */
   @Nonnull
-  TrackedEntity getNewTrackedEntity(@Nonnull UID uid) throws NotFoundException, ForbiddenException;
+  TrackedEntity getTrackedEntity(@Nonnull UID uid) throws NotFoundException, ForbiddenException;
 
   /**
    * Get the tracked entity matching given {@code UID} under the privileges of the currently
@@ -67,8 +67,7 @@ public interface TrackedEntityService {
    * attributes and ownerships as defined in {@code params}.
    */
   @Nonnull
-  TrackedEntity getNewTrackedEntity(
-      @Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
+  TrackedEntity getTrackedEntity(@Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException;
 
   /** Get all tracked entities matching given params. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -96,7 +96,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
     TrackedEntity trackedEntity = null;
     try {
       trackedEntity =
-          trackedEntityService.getNewTrackedEntity(
+          trackedEntityService.getTrackedEntity(
               UID.of(subm.getTrackedEntityInstance().getUid()),
               UID.of(subm.getTrackerProgram().getUid()),
               TrackedEntityParams.FALSE.withIncludeAttributes(true));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -239,12 +239,12 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     r.setKey(RelationshipUtils.generateRelationshipKey(r));
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     manager.save(r);
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
     assertNotNull(getRelationship(r.getUid()));
     manager.delete(trackedEntity);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
     manager.delete(r);
     manager.delete(enrollment);
     assertThrows(NotFoundException.class, () -> getRelationship(r.getUid()));
@@ -333,11 +333,11 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .build();
     manager.save(trackedEntityB);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityB)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
     manager.delete(trackedEntityB);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityB)));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
 
     maintenanceService.deleteSoftDeletedTrackedEntities();
@@ -455,7 +455,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     manager.delete(trackedEntityWithAssociations);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityWithAssociations)));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntityWithAssociations)));
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityWithAssociations.getUid()));
     maintenanceService.deleteSoftDeletedTrackedEntities();
     List<Audit> audits =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/acl/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/acl/TrackerAccessManagerTest.java
@@ -202,7 +202,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityA));
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Can read te
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // can write te
@@ -220,7 +220,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityA));
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Can Read
     assertNoErrors(trackerAccessManager.canRead(userDetails, te));
     // Can write
@@ -237,7 +237,7 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
     UserDetails userDetails = UserDetails.fromUser(user);
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     manager.update(trackedEntityType);
-    TrackedEntity te = trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityA));
+    TrackedEntity te = trackedEntityService.getTrackedEntity(UID.of(trackedEntityA));
     // Cannot Read
     assertHasError(trackerAccessManager.canRead(userDetails, te), OWNERSHIP_ACCESS_DENIED);
     // Cannot write

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -121,11 +121,11 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     TrackedEntityAttribute trackedEntityAttribute = createTrackedEntityAttribute('A');
     trackedEntityAttributeService.addTrackedEntityAttribute(trackedEntityAttribute);
     TrackedEntity trackedEntity = createTrackedEntity(trackedEntityAttribute);
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
     removeTrackedEntity(trackedEntity);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
   }
 
   @Test
@@ -136,11 +136,11 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     trackedEntity
         .getTrackedEntityAttributeValues()
         .forEach(trackedEntityAttributeValueService::addTrackedEntityAttributeValue);
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
     removeTrackedEntity(trackedEntity);
     assertThrows(
         NotFoundException.class,
-        () -> trackedEntityService.getNewTrackedEntity(UID.of(trackedEntity)));
+        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
     assertNull(
         trackedEntityAttributeValueService.getTrackedEntityAttributeValue(
             trackedEntity, trackedEntityAttribute));
@@ -162,10 +162,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     manager.save(relationship5);
     manager.flush();
     manager.clear();
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(original)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(duplicate)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(control1)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(control2)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(original)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(duplicate)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control1)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control2)));
 
     removeTrackedEntity(duplicate);
     assertThrows(NotFoundException.class, () -> getRelationship(UID.of(relationship3)));
@@ -174,7 +174,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertNotNull(getRelationship(UID.of(relationship2)));
     assertNotNull(getRelationship(UID.of(relationship5)));
     assertThrows(
-        NotFoundException.class, () -> trackedEntityService.getNewTrackedEntity(UID.of(duplicate)));
+        NotFoundException.class, () -> trackedEntityService.getTrackedEntity(UID.of(duplicate)));
   }
 
   @Test
@@ -200,10 +200,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     manager.update(duplicate);
     manager.update(control1);
     manager.update(control2);
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(original)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(duplicate)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(control1)));
-    assertNotNull(trackedEntityService.getNewTrackedEntity(UID.of(control2)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(original)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(duplicate)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control1)));
+    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control2)));
     removeTrackedEntity(duplicate);
     assertThrows(
         NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment2)));
@@ -211,7 +211,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment3)));
     assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment4)));
     assertThrows(
-        NotFoundException.class, () -> trackedEntityService.getNewTrackedEntity(UID.of(duplicate)));
+        NotFoundException.class, () -> trackedEntityService.getTrackedEntity(UID.of(duplicate)));
   }
 
   private TrackedEntity createTrackedEntity(TrackedEntityAttribute trackedEntityAttribute) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -612,7 +612,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .build();
 
     TrackedEntity te =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
     assertEquals(1, te.getEnrollments().size());
     assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
@@ -727,7 +727,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     manager.update(trackedEntityA);
 
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertContainsOnly(Set.of(enrollmentA), trackedEntity.getEnrollments(), Enrollment::getUid);
@@ -742,7 +742,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     manager.update(trackedEntityA);
 
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
@@ -1928,7 +1928,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), UID.of(programUid), TrackedEntityParams.TRUE));
     assertEquals(
         String.format("Program with id %s could not be found.", programUid),
@@ -1942,7 +1942,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(notExistentTE), UID.of(programA), TrackedEntityParams.TRUE));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", notExistentTE),
@@ -1962,7 +1962,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             ForbiddenException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), UID.of(inaccessibleProgram), TrackedEntityParams.TRUE));
     assertContains(
         String.format("User has no access to program: %s", inaccessibleProgram.getUid()),
@@ -1981,7 +1981,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntity), UID.of(programA), TrackedEntityParams.TRUE));
     assertContains(
         String.format("TrackedEntity with id %s could not be found.", trackedEntity.getUid()),
@@ -2033,7 +2033,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
     assertContains(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA.getUid()),
@@ -2054,7 +2054,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
@@ -2079,7 +2079,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
@@ -2099,7 +2099,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertContains(
@@ -2118,7 +2118,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         assertThrows(
             ForbiddenException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA), null, TrackedEntityParams.TRUE));
 
     assertEquals("User has no access to any Tracked Entity Type", exception.getMessage());
@@ -2128,7 +2128,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   void shouldReturnProgramAttributesWhenSingleTERequestedAndProgramSpecified()
       throws ForbiddenException, NotFoundException {
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertContainsOnly(
@@ -2141,7 +2141,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   void shouldReturnTrackedEntityTypeAttributesOnlyWhenSingleTERequestedAndNoProgramSpecified()
       throws ForbiddenException, NotFoundException {
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), null, TrackedEntityParams.TRUE);
 
     assertContainsOnly(
@@ -2166,7 +2166,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityA,
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE));
   }
 
@@ -2180,7 +2180,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     injectSecurityContext(UserDetails.fromUser(testUser));
 
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertEquals(trackedEntityA.getUid(), trackedEntity.getUid());
@@ -2206,7 +2206,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     injectSecurityContext(UserDetails.fromUser(testUser));
 
     TrackedEntity trackedEntity =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityParams.TRUE);
 
     assertEquals(trackedEntityA.getUid(), trackedEntity.getUid());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
@@ -206,7 +206,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA1.getUid()),
@@ -221,7 +221,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(userB);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
@@ -235,7 +235,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(superUser);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
@@ -246,7 +246,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
   }
 
   @Test
@@ -259,7 +259,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), null, defaultParams));
 
     assertEquals(
@@ -311,7 +311,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA1.getUid()),
@@ -337,7 +337,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA1.getUid()),
@@ -430,7 +430,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(userA);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA1), UID.of(programA), defaultParams));
   }
 
@@ -446,7 +446,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), UID.of(programA), defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA1.getUid()),
@@ -461,7 +461,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     injectSecurityContextUser(userB);
     assertEquals(
         trackedEntityA1,
-        trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityA1), null, defaultParams));
   }
 
   @Test
@@ -472,7 +472,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityA1), null, defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityA1.getUid()),
@@ -486,7 +486,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         trackedEntityB1,
-        trackedEntityService.getNewTrackedEntity(UID.of(trackedEntityB1), null, defaultParams));
+        trackedEntityService.getTrackedEntity(UID.of(trackedEntityB1), null, defaultParams));
   }
 
   @Test
@@ -497,7 +497,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
         assertThrows(
             NotFoundException.class,
             () ->
-                trackedEntityService.getNewTrackedEntity(
+                trackedEntityService.getTrackedEntity(
                     UID.of(trackedEntityB1), null, defaultParams));
     assertEquals(
         String.format("TrackedEntity with id %s could not be found.", trackedEntityB1.getUid()),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -273,12 +273,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actual.getTrackedEntity()));
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getNewTrackedEntity(
+            trackedEntityService.getTrackedEntity(
                 UID.of(submission.getTrackedEntityInstance().getUid()),
                 UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(submission.getTrackedEntityInstance().getUid()),
             UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
@@ -373,12 +373,12 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEqualUids(submission.getTrackedEntityInstance(), actual.getTrackedEntity()));
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getNewTrackedEntity(
+            trackedEntityService.getTrackedEntity(
                 UID.of(submission.getTrackedEntityInstance().getUid()),
                 UID.of(submission.getTrackerProgram().getUid()),
                 TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(submission.getTrackedEntityInstance().getUid()),
             UID.of(submission.getTrackerProgram().getUid()),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));
@@ -461,10 +461,10 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
     assertNotNull(trackedEntity);
     assertDoesNotThrow(
         () ->
-            trackedEntityService.getNewTrackedEntity(
+            trackedEntityService.getTrackedEntity(
                 UID.of(trackedEntity), UID.of(trackerProgram), TrackedEntityParams.FALSE));
     TrackedEntity actualTe =
-        trackedEntityService.getNewTrackedEntity(
+        trackedEntityService.getTrackedEntity(
             UID.of(trackedEntity),
             UID.of(trackerProgram),
             TrackedEntityParams.FALSE.withIncludeAttributes(true));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -160,8 +160,8 @@ public class DeduplicationController {
           "PotentialDuplicate is missing references and cannot be merged.");
     }
 
-    trackedEntityService.getNewTrackedEntity(potentialDuplicate.getOriginal());
-    trackedEntityService.getNewTrackedEntity(potentialDuplicate.getDuplicate());
+    trackedEntityService.getTrackedEntity(potentialDuplicate.getOriginal());
+    trackedEntityService.getTrackedEntity(potentialDuplicate.getDuplicate());
 
     if (mergeObject == null) {
       mergeObject = new MergeObject();
@@ -209,8 +209,8 @@ public class DeduplicationController {
     checkValidTrackedEntity(potentialDuplicate.getOriginal(), "original");
     checkValidTrackedEntity(potentialDuplicate.getDuplicate(), "duplicate");
     checkAlreadyExistingDuplicate(potentialDuplicate);
-    trackedEntityService.getNewTrackedEntity(potentialDuplicate.getOriginal());
-    trackedEntityService.getNewTrackedEntity(potentialDuplicate.getDuplicate());
+    trackedEntityService.getTrackedEntity(potentialDuplicate.getOriginal());
+    trackedEntityService.getTrackedEntity(potentialDuplicate.getDuplicate());
   }
 
   private void checkAlreadyExistingDuplicate(PotentialDuplicate potentialDuplicate)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -299,7 +299,7 @@ class TrackedEntitiesExportController {
         TRACKED_ENTITY_MAPPER.map(
             idSchemeParams,
             errors,
-            trackedEntityService.getNewTrackedEntity(uid, program, trackedEntityParams));
+            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams));
     ensureNoMappingErrors(errors);
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(trackedEntity, fields));
@@ -322,7 +322,7 @@ class TrackedEntitiesExportController {
         TRACKED_ENTITY_MAPPER.map(
             idSchemeParams,
             errors,
-            trackedEntityService.getNewTrackedEntity(uid, program, trackedEntityParams));
+            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams));
     ensureNoMappingErrors(errors);
 
     OutputStream outputStream = response.getOutputStream();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -100,7 +100,7 @@ public class TrackerOwnershipController {
     UID orgUnitUid = validateMandatoryDeprecatedUidParameter("ou", ou, "orgUnit", orgUnit);
 
     trackerOwnershipAccessManager.transferOwnership(
-        trackedEntityService.getNewTrackedEntity(trackedEntity, program, TrackedEntityParams.FALSE),
+        trackedEntityService.getTrackedEntity(trackedEntity, program, TrackedEntityParams.FALSE),
         programService.getProgram(program.getValue()),
         organisationUnitService.getOrganisationUnit(orgUnitUid.getValue()));
     return ok("Ownership transferred");
@@ -113,7 +113,7 @@ public class TrackerOwnershipController {
       throws ForbiddenException, NotFoundException {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
-        trackedEntityService.getNewTrackedEntity(trackedEntity),
+        trackedEntityService.getTrackedEntity(trackedEntity),
         programService.getProgram(program.getValue()),
         currentUser,
         reason);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -153,7 +153,7 @@ class EventRequestParamsMapperTest {
     when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
 
     TrackedEntity trackedEntity = new TrackedEntity();
-    when(trackedEntityService.getNewTrackedEntity(UID.of("qnR1RK4cTIZ"), null, FALSE))
+    when(trackedEntityService.getTrackedEntity(UID.of("qnR1RK4cTIZ"), null, FALSE))
         .thenReturn(trackedEntity);
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID.getValue());


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Rename `getNewTrackedEntity` to `getTrackedEntity`.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Add `Optional<T> find(UID)` to our services
- Fix exception thrown from `TrackedEntityAttributeValueService`