### PR TITLE
chore: Create findTrackedEntity method [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.audit.AuditOperationType.SEARCH;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
@@ -145,6 +146,16 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   public TrackedEntity getTrackedEntity(@Nonnull UID uid)
       throws NotFoundException, ForbiddenException {
     return getTrackedEntity(uid, (Program) null, TrackedEntityParams.FALSE);
+  }
+
+  @Nonnull
+  @Override
+  public Optional<TrackedEntity> findTrackedEntity(@Nonnull UID uid) {
+    try {
+      return Optional.of(getTrackedEntity(uid, (Program) null, TrackedEntityParams.FALSE));
+    } catch (NotFoundException | ForbiddenException e) {
+      return Optional.empty();
+    }
   }
 
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.trackedentity;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
@@ -52,19 +53,40 @@ public interface TrackedEntityService {
       throws NotFoundException, ForbiddenException;
 
   /**
-   * Get the tracked entity matching given {@code UID} under the privileges of the currently
-   * authenticated user. No program attributes are included, only TETAs. Enrollments and
-   * relationships are not included. Use {@link #getTrackedEntity(UID, UID, TrackedEntityParams)}
-   * instead to also get the relationships, enrollments and program attributes.
+   * Finds the tracked entity that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. Returns an {@link Optional} indicating whether the tracked entity
+   * was found.
+   *
+   * @return an {@link Optional} containing the tracked entity if found, or an empty {@link
+   *     Optional} if not
+   */
+  @Nonnull
+  Optional<TrackedEntity> findTrackedEntity(@Nonnull UID uid);
+
+  /**
+   * Retrieves the tracked entity that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. This method only includes TETAs (Tracked Entity Type Attributes)
+   * and excludes program attributes, enrollments, and relationships. To include enrollments,
+   * relationships, and program attributes, use {@link #getTrackedEntity(UID, UID,
+   * TrackedEntityParams)}.
+   *
+   * @return the tracked entity associated with the specified {@code UID}
+   * @throws NotFoundException if the tracked entity cannot be found
+   * @throws ForbiddenException if the user does not have permission to access the tracked entity
    */
   @Nonnull
   TrackedEntity getTrackedEntity(@Nonnull UID uid) throws NotFoundException, ForbiddenException;
 
   /**
-   * Get the tracked entity matching given {@code UID} under the privileges of the currently
-   * authenticated user. If {@code program} is defined, program attributes for such program are
-   * included, otherwise only TETAs are included. It will include enrollments, relationships,
-   * attributes and ownerships as defined in {@code params}.
+   * Retrieves the tracked entity that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. If the {@code program} is provided, the program attributes for
+   * the specified program are included; otherwise, only TETAs (Tracked Entity Type Attributes) are
+   * included. This method also includes any enrollments, relationships, attributes, and ownerships
+   * as defined by the provided {@code params}.
+   *
+   * @return the tracked entity with additional details based on the provided parameters
+   * @throws NotFoundException if the tracked entity cannot be found
+   * @throws ForbiddenException if the user does not have permission to access the tracked entity
    */
   @Nonnull
   TrackedEntity getTrackedEntity(@Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -239,12 +239,10 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     r.setKey(RelationshipUtils.generateRelationshipKey(r));
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     manager.save(r);
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     assertNotNull(getRelationship(r.getUid()));
     manager.delete(trackedEntity);
-    assertThrows(
-        NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     manager.delete(r);
     manager.delete(enrollment);
     assertThrows(NotFoundException.class, () -> getRelationship(r.getUid()));
@@ -317,8 +315,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testDeleteSoftDeletedTrackedEntityAProgramMessage()
-      throws ForbiddenException, NotFoundException {
+  void testDeleteSoftDeletedTrackedEntityAProgramMessage() {
     ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
     programMessageRecipients.setEmailAddresses(Sets.newHashSet("testemail"));
     programMessageRecipients.setPhoneNumbers(Sets.newHashSet("testphone"));
@@ -333,11 +330,9 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .build();
     manager.save(trackedEntityB);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(trackedEntityB)).isPresent());
     manager.delete(trackedEntityB);
-    assertThrows(
-        NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntityB)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(trackedEntityB)).isPresent());
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
 
     maintenanceService.deleteSoftDeletedTrackedEntities();
@@ -453,9 +448,8 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
   @Disabled("until we can inject dhis.conf property overrides")
   void testAuditEntryForDeletionOfSoftDeletedTrackedEntity() {
     manager.delete(trackedEntityWithAssociations);
-    assertThrows(
-        NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntityWithAssociations)));
+    assertFalse(
+        trackedEntityService.findTrackedEntity(UID.of(trackedEntityWithAssociations)).isPresent());
     assertTrue(trackedEntityExistsIncludingDeleted(trackedEntityWithAssociations.getUid()));
     maintenanceService.deleteSoftDeletedTrackedEntities();
     List<Audit> audits =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -28,9 +28,11 @@
 package org.hisp.dhis.tracker.deduplication;
 
 import static org.hisp.dhis.security.Authorities.ALL;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;
@@ -117,30 +119,26 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
   }
 
   @Test
-  void shouldDeleteTrackedEntity() throws NotFoundException, ForbiddenException {
+  void shouldDeleteTrackedEntity() throws NotFoundException {
     TrackedEntityAttribute trackedEntityAttribute = createTrackedEntityAttribute('A');
     trackedEntityAttributeService.addTrackedEntityAttribute(trackedEntityAttribute);
     TrackedEntity trackedEntity = createTrackedEntity(trackedEntityAttribute);
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     removeTrackedEntity(trackedEntity);
-    assertThrows(
-        NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
   }
 
   @Test
-  void shouldDeleteTeAndAttributeValues() throws NotFoundException, ForbiddenException {
+  void shouldDeleteTeAndAttributeValues() throws NotFoundException {
     TrackedEntityAttribute trackedEntityAttribute = createTrackedEntityAttribute('A');
     trackedEntityAttributeService.addTrackedEntityAttribute(trackedEntityAttribute);
     TrackedEntity trackedEntity = createTrackedEntity(trackedEntityAttribute);
     trackedEntity
         .getTrackedEntityAttributeValues()
         .forEach(trackedEntityAttributeValueService::addTrackedEntityAttributeValue);
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     removeTrackedEntity(trackedEntity);
-    assertThrows(
-        NotFoundException.class,
-        () -> trackedEntityService.getTrackedEntity(UID.of(trackedEntity)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     assertNull(
         trackedEntityAttributeValueService.getTrackedEntityAttributeValue(
             trackedEntity, trackedEntityAttribute));
@@ -162,10 +160,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     manager.save(relationship5);
     manager.flush();
     manager.clear();
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(original)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(duplicate)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control1)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control2)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(original)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(control1)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(control2)).isPresent());
 
     removeTrackedEntity(duplicate);
     assertThrows(NotFoundException.class, () -> getRelationship(UID.of(relationship3)));
@@ -173,8 +171,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertNotNull(getRelationship(UID.of(relationship1)));
     assertNotNull(getRelationship(UID.of(relationship2)));
     assertNotNull(getRelationship(UID.of(relationship5)));
-    assertThrows(
-        NotFoundException.class, () -> trackedEntityService.getTrackedEntity(UID.of(duplicate)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
   }
 
   @Test
@@ -200,18 +197,17 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     manager.update(duplicate);
     manager.update(control1);
     manager.update(control2);
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(original)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(duplicate)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control1)));
-    assertNotNull(trackedEntityService.getTrackedEntity(UID.of(control2)));
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(original)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(control1)).isPresent());
+    assertTrue(trackedEntityService.findTrackedEntity(UID.of(control2)).isPresent());
     removeTrackedEntity(duplicate);
     assertThrows(
         NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment2)));
     assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment1)));
     assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment3)));
     assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment4)));
-    assertThrows(
-        NotFoundException.class, () -> trackedEntityService.getTrackedEntity(UID.of(duplicate)));
+    assertFalse(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
   }
 
   private TrackedEntity createTrackedEntity(TrackedEntityAttribute trackedEntityAttribute) {


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Create `findTrackedEntity` method and use it when needed.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Add `Optional<T> find(UID)` to our services
- Fix exception thrown from `TrackedEntityAttributeValueService`