### PR TITLE
chore: Create findEnrollment method [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -81,14 +82,24 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Nonnull
   @Override
-  public Enrollment getEnrollment(@Nonnull UID uid) throws ForbiddenException, NotFoundException {
+  public Optional<Enrollment> findEnrollment(@Nonnull UID uid) {
+    try {
+      return Optional.of(getEnrollment(uid));
+    } catch (NotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Enrollment getEnrollment(@Nonnull UID uid) throws NotFoundException {
     return getEnrollment(uid, EnrollmentParams.FALSE);
   }
 
   @Nonnull
   @Override
   public Enrollment getEnrollment(@Nonnull UID uid, @Nonnull EnrollmentParams params)
-      throws NotFoundException, ForbiddenException {
+      throws NotFoundException {
     Page<Enrollment> enrollments;
     try {
       EnrollmentOperationParams operationParams =
@@ -97,7 +108,7 @@ class DefaultEnrollmentService implements EnrollmentService {
               .enrollmentParams(params)
               .build();
       enrollments = getEnrollments(operationParams, PageParams.single());
-    } catch (BadRequestException e) {
+    } catch (BadRequestException | ForbiddenException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EnrollmentOperationParams are built");
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.enrollment;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
@@ -39,12 +40,40 @@ import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 
 public interface EnrollmentService {
-  @Nonnull
-  Enrollment getEnrollment(UID uid) throws ForbiddenException, NotFoundException;
 
+  /**
+   * Finds the enrollment that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. Returns an {@link Optional} indicating whether the enrollment was
+   * found.
+   *
+   * @return an {@link Optional} containing the enrollment if found, or an empty {@link Optional} if
+   *     not
+   */
   @Nonnull
-  Enrollment getEnrollment(UID uid, EnrollmentParams params)
-      throws NotFoundException, ForbiddenException;
+  Optional<Enrollment> findEnrollment(@Nonnull UID uid);
+
+  /**
+   * Retrieves the enrollment that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. This does not include program attributes,events, and
+   * relationships. To include events, relationships, and program attributes, use {@link
+   * #getEnrollment(UID, EnrollmentParams)}.
+   *
+   * @return the enrollment associated with the specified {@code UID}
+   * @throws NotFoundException if the enrollment cannot be found
+   */
+  @Nonnull
+  Enrollment getEnrollment(UID uid) throws NotFoundException;
+
+  /**
+   * Retrieves the enrollment that matches the given {@code UID} based on the privileges of the
+   * currently authenticated user. This method also includes any events, relationships and program
+   * attributes as defined by the provided {@code params}.
+   *
+   * @return the enrollment associated with the specified {@code UID}
+   * @throws NotFoundException if the enrollment cannot be found
+   */
+  @Nonnull
+  Enrollment getEnrollment(UID uid, EnrollmentParams params) throws NotFoundException;
 
   /** Get all enrollments matching given params. */
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/DefaultNoteService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/DefaultNoteService.java
@@ -53,7 +53,7 @@ public class DefaultNoteService implements NoteService {
   @Transactional
   @Override
   public void addNoteForEnrollment(Note note, UID enrollment)
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws NotFoundException, BadRequestException {
     // Check enrollment existence and access
     enrollmentService.getEnrollment(enrollment);
     validateNote(note);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -258,7 +258,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedEnrollmentWithAProgramMessage()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
     programMessageRecipients.setEmailAddresses(Sets.newHashSet("testemail"));
     programMessageRecipients.setPhoneNumbers(Sets.newHashSet("testphone"));
@@ -274,11 +274,10 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .build();
     manager.save(enrollment);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
 
     manager.delete(enrollment);
-    assertThrows(
-        NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));
 
     maintenanceService.deleteSoftDeletedEnrollments();
@@ -342,7 +341,7 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testDeleteSoftDeletedEnrollmentLinkedToAnEventDataValueChangeLog()
-      throws ForbiddenException, BadRequestException, NotFoundException {
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = createDataElement('A');
     dataElementService.addDataElement(dataElement);
     Event eventA = new Event(enrollment, program.getProgramStageByStage(1));
@@ -354,10 +353,9 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     eventChangeLogService.addEventChangeLog(
         eventA, dataElement, "", "value", UPDATE, getCurrentUsername());
     manager.save(enrollment);
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
     manager.delete(enrollment);
-    assertThrows(
-        NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));
 
     maintenanceService.deleteSoftDeletedEnrollments();
@@ -428,11 +426,10 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     r.setKey(RelationshipUtils.generateRelationshipKey(r));
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     manager.save(r);
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
     assertNotNull(getRelationship(r.getUid()));
     manager.delete(enrollment);
-    assertThrows(
-        NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment)));
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollment)).isPresent());
     manager.delete(r);
     assertThrows(NotFoundException.class, () -> getRelationship(r.getUid()));
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -175,7 +175,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
   }
 
   @Test
-  void shouldDeleteEnrollments() throws ForbiddenException, NotFoundException {
+  void shouldDeleteEnrollments() throws NotFoundException {
     User user =
         createAndAddUser(
             false, "user", Set.of(organisationUnit), Set.of(organisationUnit), ALL.toString());
@@ -202,11 +202,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertTrue(trackedEntityService.findTrackedEntity(UID.of(control1)).isPresent());
     assertTrue(trackedEntityService.findTrackedEntity(UID.of(control2)).isPresent());
     removeTrackedEntity(duplicate);
-    assertThrows(
-        NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollment2)));
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment1)));
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment3)));
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollment4)));
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollment2)).isPresent());
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment1)).isPresent());
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment3)).isPresent());
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollment4)).isPresent());
     assertFalse(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -33,13 +33,13 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.TrackerTestUtils.oneHourAfter;
 import static org.hisp.dhis.tracker.TrackerTestUtils.oneHourBefore;
 import static org.hisp.dhis.tracker.TrackerTestUtils.uids;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -274,7 +274,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentWhenUserHasReadWriteAccessToProgramAndAccessToOrgUnit()
-      throws ForbiddenException, NotFoundException {
+      throws NotFoundException {
     programA.getSharing().setPublicAccess(AccessStringHelper.DATA_READ_WRITE);
     manager.updateNoAcl(programA);
 
@@ -287,7 +287,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentWhenUserHasReadAccessToProgramAndAccessToOrgUnit()
-      throws ForbiddenException, NotFoundException {
+      throws NotFoundException {
     programA.getSharing().setPublicAccess(AccessStringHelper.DATA_READ);
     manager.updateNoAcl(programA);
 
@@ -298,8 +298,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldGetEnrollmentWithEventsWhenUserHasAccessToEvent()
-      throws ForbiddenException, NotFoundException {
+  void shouldGetEnrollmentWithEventsWhenUserHasAccessToEvent() throws NotFoundException {
     EnrollmentParams params = EnrollmentParams.FALSE;
     params = params.withEnrollmentEventsParams(EnrollmentEventsParams.TRUE);
 
@@ -312,7 +311,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldGetEnrollmentWithoutEventsWhenUserHasNoAccessToProgramStage()
-      throws ForbiddenException, NotFoundException {
+      throws NotFoundException {
     programStageA.getSharing().setOwner(admin);
     programStageA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.updateNoAcl(programStageA);
@@ -327,8 +326,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldGetEnrollmentWithRelationshipsWhenUserHasAccessToThem()
-      throws ForbiddenException, NotFoundException {
+  void shouldGetEnrollmentWithRelationshipsWhenUserHasAccessToThem() throws NotFoundException {
     EnrollmentParams params = EnrollmentParams.FALSE;
     params = params.withIncludeRelationships(true);
 
@@ -339,8 +337,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldGetEnrollmentWithoutRelationshipsWhenUserHasAccessToThem()
-      throws ForbiddenException, NotFoundException {
+  void shouldGetEnrollmentWithoutRelationshipsWhenUserHasAccessToThem() throws NotFoundException {
     relationshipTypeA.getSharing().setOwner(admin);
     relationshipTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
 
@@ -354,8 +351,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldGetEnrollmentWithAttributesWhenUserHasAccessToThem()
-      throws ForbiddenException, NotFoundException {
+  void shouldGetEnrollmentWithAttributesWhenUserHasAccessToThem() throws NotFoundException {
     EnrollmentParams params = EnrollmentParams.FALSE;
     params = params.withIncludeAttributes(true);
 
@@ -371,10 +367,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     trackedEntityTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.updateNoAcl(trackedEntityTypeA);
 
-    NotFoundException exception =
-        assertThrows(
-            NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollmentA)));
-    assertContains("could not be found", exception.getMessage());
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
   }
 
   @Test
@@ -383,13 +376,9 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     trackedEntityTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.updateNoAcl(trackedEntityTypeA);
 
-    String nonExistentUid = CodeGenerator.generateUid();
+    UID nonExistentUid = UID.generate();
 
-    NotFoundException exception =
-        assertThrows(
-            NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(nonExistentUid)));
-    assertContains(
-        "Enrollment with id " + nonExistentUid + " could not be found.", exception.getMessage());
+    assertFalse(enrollmentService.findEnrollment(nonExistentUid).isPresent());
   }
 
   @Test
@@ -399,10 +388,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     injectSecurityContextUser(userWithOrgUnitZ);
 
-    NotFoundException exception =
-        assertThrows(
-            NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollmentA)));
-    assertContains("could not be found", exception.getMessage());
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
   }
 
   @Test
@@ -412,10 +398,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     injectSecurityContextUser(userWithOrgUnitZ);
 
-    NotFoundException exception =
-        assertThrows(
-            NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollmentA)));
-    assertContains("could not be found", exception.getMessage());
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
   }
 
   @Test
@@ -423,10 +406,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     programA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.updateNoAcl(programA);
 
-    NotFoundException exception =
-        assertThrows(
-            NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollmentA)));
-    assertContains("could not be found", exception.getMessage());
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
   }
 
   @Test
@@ -756,7 +736,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldNotDeleteNoteWhenDeletingEnrollment() throws ForbiddenException, NotFoundException {
+  void shouldNotDeleteNoteWhenDeletingEnrollment() {
     Note note = new Note();
     note.setCreator(CodeGenerator.generateUid());
     note.setNoteText("text");
@@ -765,12 +745,11 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     manager.save(enrollmentA);
 
-    assertNotNull(enrollmentService.getEnrollment(UID.of(enrollmentA)));
+    assertTrue(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
 
     manager.delete(enrollmentA);
 
-    assertThrows(
-        NotFoundException.class, () -> enrollmentService.getEnrollment(UID.of(enrollmentA)));
+    assertFalse(enrollmentService.findEnrollment(UID.of(enrollmentA)).isPresent());
     assertTrue(manager.exists(Note.class, note.getUid()));
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -265,7 +265,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEquals(SmsMessageStatus.PROCESSED, sms.getStatus()),
         () ->
             assertSmsResponse(submissionId + ":" + SmsResponse.SUCCESS, originator, messageSender));
-    assertDoesNotThrow(() -> enrollmentService.getEnrollment(enrollmentUid));
+    assertTrue(enrollmentService.findEnrollment(enrollmentUid).isPresent());
     Enrollment actual = enrollmentService.getEnrollment(enrollmentUid);
     assertAll(
         "created enrollment",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -134,7 +134,7 @@ class EnrollmentsExportController {
       @OpenApi.Param({UID.class, org.hisp.dhis.program.Enrollment.class}) @PathVariable UID uid,
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
           List<FieldPath> fields)
-      throws NotFoundException, ForbiddenException {
+      throws NotFoundException {
     EnrollmentParams enrollmentParams = fieldsMapper.map(fields);
 
     Enrollment enrollment =


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Create `findEnrollment` method and use it when needed.
- Catch `ForbiddenException` in `getEnrollment` as it can only be thrown when mapping `EnrollmentOperationParams` so if falls into the case here 
`throw new IllegalArgumentException(
          "this must be a bug in how the EnrollmentOperationParams are built");`

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Steps***
- Add `Optional<T> find(UID)` to our services
- Fix exception thrown from `TrackedEntityAttributeValueService`