### PR TITLE
chore: Create findRelationship method [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.export.relationship;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -101,15 +102,25 @@ public class DefaultRelationshipService implements RelationshipService {
     return relationships.withFilteredItems(map(relationships.getItems()));
   }
 
+  @Nonnull
   @Override
-  public Relationship getRelationship(@Nonnull UID uid)
-      throws ForbiddenException, NotFoundException {
+  public Optional<Relationship> findRelationship(@Nonnull UID uid) {
+    try {
+      return Optional.of(getRelationship(uid));
+    } catch (NotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Relationship getRelationship(@Nonnull UID uid) throws NotFoundException {
     Page<Relationship> relationships;
     try {
       relationships =
           getRelationships(
               RelationshipOperationParams.builder(Set.of(uid)).build(), PageParams.single());
-    } catch (BadRequestException e) {
+    } catch (BadRequestException | ForbiddenException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the RelationshipOperationParams are built");
     }
@@ -121,6 +132,7 @@ public class DefaultRelationshipService implements RelationshipService {
     return relationships.getItems().get(0);
   }
 
+  @Nonnull
   @Override
   public List<Relationship> getRelationships(@Nonnull Set<UID> uids)
       throws ForbiddenException, NotFoundException {
@@ -136,6 +148,7 @@ public class DefaultRelationshipService implements RelationshipService {
     }
   }
 
+  @Nonnull
   @Override
   public List<Relationship> getRelationshipsByRelationshipKeys(
       List<RelationshipKey> relationshipKeys) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.relationship;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
@@ -55,6 +56,15 @@ public interface RelationshipService {
   @Nonnull
   Page<Relationship> getRelationships(RelationshipOperationParams params, PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException;
+
+  /**
+   * Get a relationship matching given {@code UID} under the privileges of the currently
+   * authenticated user. Returns an {@link Optional} indicating whether the relationship was found.
+   *
+   * @return an {@link Optional} containing the relationship if found, or an empty {@link Optional}
+   *     if not
+   */
+  Optional<Relationship> findRelationship(UID uid);
 
   /**
    * Get a relationship matching given {@code UID} under the privileges of the currently

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -29,16 +29,13 @@ package org.hisp.dhis.tracker.deduplication;
 
 import static org.hisp.dhis.security.Authorities.ALL;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
@@ -145,7 +142,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
   }
 
   @Test
-  void shouldDeleteRelationShips() throws NotFoundException, ForbiddenException {
+  void shouldDeleteRelationShips() throws NotFoundException {
     RelationshipType relationshipType = createRelationshipType('A');
     relationshipTypeService.addRelationshipType(relationshipType);
     Relationship relationship1 = createTeToTeRelationship(original, control1, relationshipType);
@@ -166,11 +163,11 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertTrue(trackedEntityService.findTrackedEntity(UID.of(control2)).isPresent());
 
     removeTrackedEntity(duplicate);
-    assertThrows(NotFoundException.class, () -> getRelationship(UID.of(relationship3)));
-    assertThrows(NotFoundException.class, () -> getRelationship(UID.of(relationship4)));
-    assertNotNull(getRelationship(UID.of(relationship1)));
-    assertNotNull(getRelationship(UID.of(relationship2)));
-    assertNotNull(getRelationship(UID.of(relationship5)));
+    assertFalse(relationshipService.findRelationship(UID.of(relationship3)).isPresent());
+    assertFalse(relationshipService.findRelationship(UID.of(relationship4)).isPresent());
+    assertTrue(relationshipService.findRelationship(UID.of(relationship1)).isPresent());
+    assertTrue(relationshipService.findRelationship(UID.of(relationship2)).isPresent());
+    assertTrue(relationshipService.findRelationship(UID.of(relationship5)).isPresent());
     assertFalse(trackedEntityService.findTrackedEntity(UID.of(duplicate)).isPresent());
   }
 
@@ -218,9 +215,5 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
 
   private void removeTrackedEntity(TrackedEntity trackedEntity) throws NotFoundException {
     trackerObjectDeletionService.deleteTrackedEntities(List.of(UID.of(trackedEntity)));
-  }
-
-  private Relationship getRelationship(UID uid) throws ForbiddenException, NotFoundException {
-    return relationshipService.getRelationship(uid);
   }
 }


### PR DESCRIPTION
Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Create `findRelationship` method and use it when needed.
- Catch `ForbiddenException` in `getRelationship` as it can only be thrown when requesting relationships by entity and here we are building `RelationshipOperationParams` using relationship `UIDs`.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type

***Next Step***
- Fix exception thrown from `TrackedEntityAttributeValueService`