### PR TITLE
chore: Fix TrackedEntityControllerTest [DHIS2-18541]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -44,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -54,7 +53,6 @@ import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.feedback.ConflictException;
@@ -1016,16 +1014,21 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
   void getAttributeValuesFileByAttributeAndProgramIfFileIsNotFound() {
     TrackedEntity trackedEntity = trackedEntity();
     enroll(trackedEntity, program, orgUnit);
-
-    String fileUid = CodeGenerator.generateUid();
-
-    IllegalQueryException exception =
-        assertThrows(
-            IllegalQueryException.class,
-            () ->
-                addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, fileUid));
-
-    assertStartsWith("FileResource with id '" + fileUid, exception.getMessage());
+    FileResource file = createFileResource('B', "file content".getBytes());
+    manager.save(file, false);
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
+    manager.delete(file);
+    this.switchContextToUser(user);
+    assertStartsWith(
+        "FileResource with id " + file.getUid(),
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
   }
 
   @Test


### PR DESCRIPTION
***Last PR*** 🎉 

Moving `getTrackedEntity()` to use the same code as multiple entities has a big impact in a lot of places in the system and it is going to be done in small steps, changing it feature by feature.

***Changes in this PR***

- Change back test in `TrackedEntityControllerTest`. The support method `addProgramAttributeValue` was throwing an exception when creating an attribute without a valid file attached. Now we are correctly creating the attribute and after deleting the file.

***Challenges in tests***
`TrackedEntityAggregate` is loading data in new threads so they have their own transaction and not committed data are not visible in those threads, that is why we cannot use `@Transactional` annotation when we are importing data and reading in one one transaction.

***Common misconfigurations in tests***
- Create tracked entity and enrollment but do not create an ownership.
- Create a tracker program without a tracked entity type