### PR TITLE
chore: Tidy up find and get methods in tracker exporters [DHIS2-18145]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
@@ -254,7 +254,7 @@ public class DeduplicationHelper {
     }
 
     List<RelationshipType> relationshipTypes =
-        relationshipService.getRelationships(mergeObject.getRelationships()).stream()
+        relationshipService.findRelationships(mergeObject.getRelationships()).stream()
             .map(Relationship::getRelationshipType)
             .distinct()
             .toList();
@@ -264,7 +264,7 @@ public class DeduplicationHelper {
       return "Missing data write access to one or more Relationship Types.";
     }
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(mergeObject.getEnrollments());
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(mergeObject.getEnrollments());
 
     if (enrollments.stream()
         .anyMatch(e -> !aclService.canDataWrite(currentUserDetails, e.getProgram()))) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -107,7 +107,7 @@ class DefaultEnrollmentService implements EnrollmentService {
               .enrollments(Set.of(uid))
               .enrollmentParams(params)
               .build();
-      enrollments = getEnrollments(operationParams, PageParams.single());
+      enrollments = findEnrollments(operationParams, PageParams.single());
     } catch (BadRequestException | ForbiddenException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EnrollmentOperationParams are built");
@@ -122,13 +122,13 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Nonnull
   @Override
-  public List<Enrollment> getEnrollments(@Nonnull Set<UID> uids) throws ForbiddenException {
+  public List<Enrollment> findEnrollments(@Nonnull Set<UID> uids) throws ForbiddenException {
     if (uids.isEmpty()) {
       return List.of();
     }
 
     try {
-      return getEnrollments(EnrollmentOperationParams.builder().enrollments(uids).build());
+      return findEnrollments(EnrollmentOperationParams.builder().enrollments(uids).build());
     } catch (BadRequestException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EnrollmentOperationParams are built");
@@ -137,11 +137,11 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Nonnull
   @Override
-  public List<Enrollment> getEnrollments(@Nonnull EnrollmentOperationParams params)
+  public List<Enrollment> findEnrollments(@Nonnull EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 
-    return getEnrollments(
+    return findEnrollments(
         new ArrayList<>(enrollmentStore.getEnrollments(queryParams)),
         params.getEnrollmentParams(),
         params.isIncludeDeleted(),
@@ -150,14 +150,14 @@ class DefaultEnrollmentService implements EnrollmentService {
 
   @Nonnull
   @Override
-  public Page<Enrollment> getEnrollments(
+  public Page<Enrollment> findEnrollments(
       @Nonnull EnrollmentOperationParams params, PageParams pageParams)
       throws ForbiddenException, BadRequestException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params, getCurrentUserDetails());
 
     Page<Enrollment> enrollmentsPage = enrollmentStore.getEnrollments(queryParams, pageParams);
     List<Enrollment> enrollments =
-        getEnrollments(
+        findEnrollments(
             enrollmentsPage.getItems(),
             params.getEnrollmentParams(),
             params.isIncludeDeleted(),
@@ -174,7 +174,7 @@ class DefaultEnrollmentService implements EnrollmentService {
             .includeDeleted(includeDeleted)
             .build();
     try {
-      return Set.copyOf(eventService.getEvents(eventOperationParams));
+      return Set.copyOf(eventService.findEvents(eventOperationParams));
     } catch (BadRequestException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EventOperationParams are built");
@@ -227,7 +227,7 @@ class DefaultEnrollmentService implements EnrollmentService {
     }
     if (params.isIncludeRelationships()) {
       result.setRelationshipItems(
-          relationshipService.getRelationshipItems(
+          relationshipService.findRelationshipItems(
               TrackerType.ENROLLMENT, UID.of(result), includeDeleted));
     }
     if (params.isIncludeAttributes()) {
@@ -256,7 +256,7 @@ class DefaultEnrollmentService implements EnrollmentService {
     return attributeValues;
   }
 
-  private List<Enrollment> getEnrollments(
+  private List<Enrollment> findEnrollments(
       Iterable<Enrollment> enrollments,
       EnrollmentParams params,
       boolean includeDeleted,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -75,28 +75,28 @@ public interface EnrollmentService {
   @Nonnull
   Enrollment getEnrollment(UID uid, EnrollmentParams params) throws NotFoundException;
 
-  /** Get all enrollments matching given params. */
+  /** Find all enrollments matching given params. */
   @Nonnull
-  List<Enrollment> getEnrollments(EnrollmentOperationParams params)
+  List<Enrollment> findEnrollments(EnrollmentOperationParams params)
       throws BadRequestException, ForbiddenException;
 
   /** Get a page of enrollments matching given params. */
   @Nonnull
-  Page<Enrollment> getEnrollments(EnrollmentOperationParams params, PageParams pageParams)
+  Page<Enrollment> findEnrollments(EnrollmentOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException;
 
   /**
-   * Get event matching given {@code UID} under the privileges the user in the context. This method
-   * does not get the events relationships.
+   * Find all enrollments matching given {@code UID} under the privileges the user in the context.
+   * This method does not get the enrollment relationships.
    */
   @Nonnull
-  List<Enrollment> getEnrollments(@Nonnull Set<UID> uids) throws ForbiddenException;
+  List<Enrollment> findEnrollments(@Nonnull Set<UID> uids) throws ForbiddenException;
 
   /**
-   * Fields the {@link #getEnrollments(EnrollmentOperationParams)} can order enrollments by.
+   * Fields the {@link #findEnrollments(EnrollmentOperationParams)} can order enrollments by.
    * Ordering by fields other than these is considered a programmer error. Validation of user
    * provided field names should occur before calling {@link
-   * #getEnrollments(EnrollmentOperationParams)}.
+   * #findEnrollments(EnrollmentOperationParams)}.
    */
   Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -123,7 +123,7 @@ class DefaultEventService implements EventService {
               .eventParams(EventParams.FALSE)
               .filterByDataElement(dataElementUid)
               .build();
-      events = getEvents(operationParams, PageParams.single());
+      events = findEvents(operationParams, PageParams.single());
     } catch (BadRequestException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EventOperationParams are built");
@@ -192,7 +192,7 @@ class DefaultEventService implements EventService {
               .eventParams(eventParams)
               .idSchemeParams(idSchemeParams)
               .build();
-      events = getEvents(operationParams, PageParams.single());
+      events = findEvents(operationParams, PageParams.single());
     } catch (BadRequestException | ForbiddenException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the EventOperationParams are built");
@@ -235,14 +235,14 @@ class DefaultEventService implements EventService {
 
   @Nonnull
   @Override
-  public List<Event> getEvents(@Nonnull EventOperationParams operationParams)
+  public List<Event> findEvents(@Nonnull EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     List<Event> events = eventStore.getEvents(queryParams);
     if (operationParams.getEventParams().isIncludeRelationships()) {
       for (Event event : events) {
         event.setRelationshipItems(
-            relationshipService.getRelationshipItems(
+            relationshipService.findRelationshipItems(
                 TrackerType.EVENT, UID.of(event), queryParams.isIncludeDeleted()));
       }
     }
@@ -251,7 +251,7 @@ class DefaultEventService implements EventService {
 
   @Nonnull
   @Override
-  public Page<Event> getEvents(
+  public Page<Event> findEvents(
       @Nonnull EventOperationParams operationParams, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
@@ -259,7 +259,7 @@ class DefaultEventService implements EventService {
     if (operationParams.getEventParams().isIncludeRelationships()) {
       for (Event event : events.getItems()) {
         event.setRelationshipItems(
-            relationshipService.getRelationshipItems(
+            relationshipService.findRelationshipItems(
                 TrackerType.EVENT, UID.of(event), queryParams.isIncludeDeleted()));
       }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -89,10 +89,10 @@ public interface EventService {
       throws NotFoundException;
 
   /**
-   * Get all events matching given params under the privileges of the currently authenticated user.
+   * Find all events matching given params under the privileges of the currently authenticated user.
    */
   @Nonnull
-  List<Event> getEvents(@Nonnull EventOperationParams params)
+  List<Event> findEvents(@Nonnull EventOperationParams params)
       throws BadRequestException, ForbiddenException;
 
   /**
@@ -100,14 +100,15 @@ public interface EventService {
    * user.
    */
   @Nonnull
-  Page<Event> getEvents(@Nonnull EventOperationParams params, @Nonnull PageParams pageParams)
+  Page<Event> findEvents(@Nonnull EventOperationParams params, @Nonnull PageParams pageParams)
       throws BadRequestException, ForbiddenException;
 
   /**
-   * Fields the {@link #getEvents(EventOperationParams)} and {@link #getEvents(EventOperationParams,
-   * PageParams)} can order events by. Ordering by fields other than these is considered a
-   * programmer error. Validation of user provided field names should occur before calling {@link
-   * #getEvents(EventOperationParams)} or {@link #getEvents(EventOperationParams, PageParams)}.
+   * Fields the {@link #findEvents(EventOperationParams)} and {@link
+   * #findEvents(EventOperationParams, PageParams)} can order events by. Ordering by fields other
+   * than these is considered a programmer error. Validation of user provided field names should
+   * occur before calling {@link #findEvents(EventOperationParams)} or {@link
+   * #findEvents(EventOperationParams, PageParams)}.
    */
   Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -61,9 +61,10 @@ public class DefaultRelationshipService implements RelationshipService {
   private final HibernateRelationshipStore relationshipStore;
   private final RelationshipOperationParamsMapper mapper;
 
-  // TODO(DHIS2-18883) Pass fields params as a parameter
+  // TODO(DHIS2-19137) Pass fields params as a parameter
+  @Nonnull
   @Override
-  public Set<RelationshipItem> getRelationshipItems(
+  public Set<RelationshipItem> findRelationshipItems(
       TrackerType trackerType, UID uid, boolean includeDeleted) {
     List<RelationshipItem> relationshipItems =
         switch (trackerType) {
@@ -84,8 +85,9 @@ public class DefaultRelationshipService implements RelationshipService {
         .collect(Collectors.toSet());
   }
 
+  @Nonnull
   @Override
-  public List<Relationship> getRelationships(@Nonnull RelationshipOperationParams params)
+  public List<Relationship> findRelationships(@Nonnull RelationshipOperationParams params)
       throws ForbiddenException, NotFoundException, BadRequestException {
     RelationshipQueryParams queryParams = mapper.map(params);
 
@@ -94,7 +96,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   @Nonnull
   @Override
-  public Page<Relationship> getRelationships(
+  public Page<Relationship> findRelationships(
       @Nonnull RelationshipOperationParams params, @Nonnull PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException {
     RelationshipQueryParams queryParams = mapper.map(params);
@@ -118,7 +120,7 @@ public class DefaultRelationshipService implements RelationshipService {
     Page<Relationship> relationships;
     try {
       relationships =
-          getRelationships(
+          findRelationships(
               RelationshipOperationParams.builder(Set.of(uid)).build(), PageParams.single());
     } catch (BadRequestException | ForbiddenException e) {
       throw new IllegalArgumentException(
@@ -134,14 +136,14 @@ public class DefaultRelationshipService implements RelationshipService {
 
   @Nonnull
   @Override
-  public List<Relationship> getRelationships(@Nonnull Set<UID> uids)
+  public List<Relationship> findRelationships(@Nonnull Set<UID> uids)
       throws ForbiddenException, NotFoundException {
     if (uids.isEmpty()) {
       return List.of();
     }
 
     try {
-      return getRelationships(RelationshipOperationParams.builder(uids).build());
+      return findRelationships(RelationshipOperationParams.builder(uids).build());
     } catch (BadRequestException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the RelationshipOperationParams are built");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -44,17 +44,19 @@ import org.hisp.dhis.tracker.TrackerType;
 
 public interface RelationshipService {
 
-  /** Get all relationship items matching given params. */
-  Set<RelationshipItem> getRelationshipItems(
+  /** Find all relationship items matching given params. */
+  @Nonnull
+  Set<RelationshipItem> findRelationshipItems(
       TrackerType trackerType, UID uid, boolean includeDeleted);
 
-  /** Get all relationships matching given params. */
-  List<Relationship> getRelationships(RelationshipOperationParams params)
+  /** Find all relationships matching given params. */
+  @Nonnull
+  List<Relationship> findRelationships(RelationshipOperationParams params)
       throws ForbiddenException, NotFoundException, BadRequestException;
 
   /** Get a page of relationships matching given params. */
   @Nonnull
-  Page<Relationship> getRelationships(RelationshipOperationParams params, PageParams pageParams)
+  Page<Relationship> findRelationships(RelationshipOperationParams params, PageParams pageParams)
       throws ForbiddenException, NotFoundException, BadRequestException;
 
   /**
@@ -64,19 +66,22 @@ public interface RelationshipService {
    * @return an {@link Optional} containing the relationship if found, or an empty {@link Optional}
    *     if not
    */
+  @Nonnull
   Optional<Relationship> findRelationship(UID uid);
 
   /**
    * Get a relationship matching given {@code UID} under the privileges of the currently
    * authenticated user.
    */
+  @Nonnull
   Relationship getRelationship(UID uid) throws ForbiddenException, NotFoundException;
 
   /**
-   * Get relationships matching given {@code UID}s under the privileges of the currently
+   * Find relationships matching given {@code UID}s under the privileges of the currently
    * authenticated user.
    */
-  List<Relationship> getRelationships(@Nonnull Set<UID> uids)
+  @Nonnull
+  List<Relationship> findRelationships(@Nonnull Set<UID> uids)
       throws ForbiddenException, NotFoundException;
 
   /**
@@ -87,10 +92,10 @@ public interface RelationshipService {
   List<Relationship> getRelationshipsByRelationshipKeys(List<RelationshipKey> relationshipKeys);
 
   /**
-   * Fields the {@link #getRelationships(RelationshipOperationParams)} can order relationships by.
+   * Fields the {@link #findRelationships(RelationshipOperationParams)} can order relationships by.
    * Ordering by fields other than these is considered a programmer error. Validation of user
    * provided field names should occur before calling {@link
-   * #getRelationships(RelationshipOperationParams)}.
+   * #findRelationships(RelationshipOperationParams)}.
    */
   Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -189,7 +189,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
               .trackedEntityParams(params)
               .program(program)
               .build();
-      trackedEntities = getTrackedEntities(operationParams, PageParams.single());
+      trackedEntities = findTrackedEntities(operationParams, PageParams.single());
     } catch (BadRequestException e) {
       throw new IllegalArgumentException(
           "this must be a bug in how the TrackedEntityOperationParams are built");
@@ -215,27 +215,28 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Nonnull
   @Override
-  public List<TrackedEntity> getTrackedEntities(
+  public List<TrackedEntity> findTrackedEntities(
       @Nonnull TrackedEntityOperationParams operationParams)
-      throws ForbiddenException, NotFoundException, BadRequestException {
+      throws ForbiddenException, BadRequestException {
     UserDetails user = getCurrentUserDetails();
     TrackedEntityQueryParams queryParams = mapper.map(operationParams, user);
     final List<TrackedEntityIdentifiers> ids = trackedEntityStore.getTrackedEntityIds(queryParams);
 
-    return getTrackedEntities(ids, operationParams, queryParams, user);
+    return findTrackedEntities(ids, operationParams, queryParams, user);
   }
 
+  @Nonnull
   @Override
-  public @Nonnull Page<TrackedEntity> getTrackedEntities(
+  public Page<TrackedEntity> findTrackedEntities(
       @Nonnull TrackedEntityOperationParams operationParams, @Nonnull PageParams pageParams)
-      throws BadRequestException, ForbiddenException, NotFoundException {
+      throws BadRequestException, ForbiddenException {
     UserDetails user = getCurrentUserDetails();
     TrackedEntityQueryParams queryParams = mapper.map(operationParams, user);
     final Page<TrackedEntityIdentifiers> ids =
         trackedEntityStore.getTrackedEntityIds(queryParams, pageParams);
 
     List<TrackedEntity> trackedEntities =
-        getTrackedEntities(ids.getItems(), operationParams, queryParams, user);
+        findTrackedEntities(ids.getItems(), operationParams, queryParams, user);
 
     // TODO(tracker): Push this filter into the store because it is breaking pagination
     trackedEntities =
@@ -246,7 +247,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     return ids.withFilteredItems(trackedEntities);
   }
 
-  private List<TrackedEntity> getTrackedEntities(
+  private List<TrackedEntity> findTrackedEntities(
       List<TrackedEntityIdentifiers> ids,
       TrackedEntityOperationParams operationParams,
       TrackedEntityQueryParams queryParams,
@@ -261,7 +262,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     for (TrackedEntity trackedEntity : trackedEntities) {
       if (operationParams.getTrackedEntityParams().isIncludeRelationships()) {
         trackedEntity.setRelationshipItems(
-            relationshipService.getRelationshipItems(
+            relationshipService.findRelationshipItems(
                 TrackerType.TRACKED_ENTITY, UID.of(trackedEntity), queryParams.isIncludeDeleted()));
       }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -92,21 +92,22 @@ public interface TrackedEntityService {
   TrackedEntity getTrackedEntity(@Nonnull UID uid, UID program, @Nonnull TrackedEntityParams params)
       throws NotFoundException, ForbiddenException;
 
-  /** Get all tracked entities matching given params. */
+  /** Find all tracked entities matching given params. */
   @Nonnull
-  List<TrackedEntity> getTrackedEntities(TrackedEntityOperationParams operationParams)
+  List<TrackedEntity> findTrackedEntities(TrackedEntityOperationParams operationParams)
       throws BadRequestException, ForbiddenException, NotFoundException;
 
   /** Get a page of tracked entities matching given params. */
   @Nonnull
-  Page<TrackedEntity> getTrackedEntities(TrackedEntityOperationParams params, PageParams pageParams)
+  Page<TrackedEntity> findTrackedEntities(
+      TrackedEntityOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException, NotFoundException;
 
   /**
-   * Fields the {@link #getTrackedEntities(TrackedEntityOperationParams)} can order tracked entities
-   * by. Ordering by fields other than these is considered a programmer error. Validation of user
-   * provided field names should occur before calling {@link
-   * #getTrackedEntities(TrackedEntityOperationParams)}.
+   * Fields the {@link #findTrackedEntities(TrackedEntityOperationParams)} can order tracked
+   * entities by. Ordering by fields other than these is considered a programmer error. Validation
+   * of user provided field names should occur before calling {@link
+   * #findTrackedEntities(TrackedEntityOperationParams)}.
    */
   Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentAggregate.java
@@ -74,7 +74,7 @@ class EnrollmentAggregate {
                     .program(ctx.getQueryParams().getEnrolledInTrackerProgram())
                     .build();
             try {
-              result.putAll(id.uid(), enrollmentService.getEnrollments(params));
+              result.putAll(id.uid(), enrollmentService.findEnrollments(params));
             } catch (BadRequestException e) {
               throw new IllegalArgumentException(
                   "this must be a bug in how the EnrollmentOperationParams are built");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -213,7 +213,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
     try {
       events =
           eventService
-              .getEvents(
+              .findEvents(
                   EventOperationParams.builder()
                       .eventParams(EventParams.TRUE)
                       .orgUnitMode(ACCESSIBLE)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -144,7 +144,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
     List<Enrollment> enrollments;
     try {
       Page<Enrollment> enrollmentPage =
-          enrollmentService.getEnrollments(
+          enrollmentService.findEnrollments(
               EnrollmentOperationParams.builder()
                   .trackedEntity(trackedEntity)
                   .program(smsCommand.getProgram())
@@ -213,7 +213,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
             param -> {
               try {
                 Page<TrackedEntity> page =
-                    trackedEntityService.getTrackedEntities(param, new PageParams(1, 2, false));
+                    trackedEntityService.findTrackedEntities(param, new PageParams(1, 2, false));
                 trackedEntities.addAll(page.getItems());
               } catch (BadRequestException | ForbiddenException | NotFoundException e) {
                 // TODO(tracker) Find a better error message for these exceptions

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -140,8 +140,8 @@ class DeduplicationHelperTest extends TestBase {
     when(aclService.canDataWrite(currentUserDetails, relationshipType)).thenReturn(true);
     when(aclService.canDataWrite(currentUserDetails, enrollment.getProgram())).thenReturn(true);
 
-    when(relationshipService.getRelationships(relationshipUids)).thenReturn(getRelationships());
-    when(enrollmentService.getEnrollments(enrollmentUids)).thenReturn(getEnrollments());
+    when(relationshipService.findRelationships(relationshipUids)).thenReturn(getRelationships());
+    when(enrollmentService.findEnrollments(enrollmentUids)).thenReturn(getEnrollments());
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitA)).thenReturn(true);
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitB)).thenReturn(true);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -507,6 +507,6 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
             .includeDeleted(true)
             .build();
 
-    return !enrollmentService.getEnrollments(params).isEmpty();
+    return !enrollmentService.findEnrollments(params).isEmpty();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -148,7 +148,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(1, 3, false))
+            .findTrackedEntities(params, new PageParams(1, 3, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -158,7 +158,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> secondPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(2, 3, true))
+            .findTrackedEntities(params, new PageParams(2, 3, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -168,7 +168,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> thirdPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(3, 3, false))
+            .findTrackedEntities(params, new PageParams(3, 3, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of(), 3, 3, null, 2, null), thirdPage, "past the last page");
@@ -190,14 +190,14 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(1, 1, false))
+            .findTrackedEntities(params, new PageParams(1, 1, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of("dUE514NMOlo"), 1, 1, null, null, 2), firstPage, "first page");
 
     Page<String> secondPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(2, 1, true))
+            .findTrackedEntities(params, new PageParams(2, 1, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -205,7 +205,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> thirdPage =
         trackedEntityService
-            .getTrackedEntities(params, new PageParams(3, 1, false))
+            .findTrackedEntities(params, new PageParams(3, 1, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of(), 3, 1, null, 2, null), thirdPage, "past the last page");
@@ -628,21 +628,21 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         enrollmentService
-            .getEnrollments(operationParams, PageParams.single())
+            .findEnrollments(operationParams, PageParams.single())
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of("nxP7UnKhomJ"), 1, 1, null, null, 2), firstPage, "first page");
 
     Page<String> secondPage =
         enrollmentService
-            .getEnrollments(operationParams, new PageParams(2, 1, false))
+            .findEnrollments(operationParams, new PageParams(2, 1, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
         new Page<>(List.of("TvctPPhpD8z"), 2, 1, null, 1, null), secondPage, "second (last) page");
 
     Page<Enrollment> thirdPage =
-        enrollmentService.getEnrollments(operationParams, new PageParams(3, 1, false));
+        enrollmentService.findEnrollments(operationParams, new PageParams(3, 1, false));
 
     assertEquals(new Page<>(List.of(), 3, 1, null, 2, null), thirdPage, "past the last page");
   }
@@ -659,21 +659,21 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         enrollmentService
-            .getEnrollments(operationParams, new PageParams(1, 1, true))
+            .findEnrollments(operationParams, new PageParams(1, 1, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of("nxP7UnKhomJ"), 1, 1, 2L, null, 2), firstPage, "first page");
 
     Page<String> secondPage =
         enrollmentService
-            .getEnrollments(operationParams, new PageParams(2, 1, true))
+            .findEnrollments(operationParams, new PageParams(2, 1, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
         new Page<>(List.of("TvctPPhpD8z"), 2, 1, 2L, 1, null), secondPage, "second (last) page");
 
     Page<Enrollment> thirdPage =
-        enrollmentService.getEnrollments(operationParams, new PageParams(3, 1, true));
+        enrollmentService.findEnrollments(operationParams, new PageParams(3, 1, true));
 
     assertEquals(new Page<>(List.of(), 3, 1, 2L, 2, null), thirdPage, "past the last page");
   }
@@ -760,20 +760,20 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         eventService
-            .getEvents(operationParams, PageParams.single())
+            .findEvents(operationParams, PageParams.single())
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of("D9PbzJY8bJM"), 1, 1, null, null, 2), firstPage, "first page");
 
     Page<String> secondPage =
         eventService
-            .getEvents(operationParams, new PageParams(2, 1, true))
+            .findEvents(operationParams, new PageParams(2, 1, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
         new Page<>(List.of("pTzf9KYMk72"), 2, 1, 2L, 1, null), secondPage, "second (last) page");
 
-    Page<Event> thirdPage = eventService.getEvents(operationParams, new PageParams(3, 1, false));
+    Page<Event> thirdPage = eventService.findEvents(operationParams, new PageParams(3, 1, false));
 
     assertEquals(new Page<>(List.of(), 3, 1, null, 2, null), thirdPage, "past the last page");
   }
@@ -793,7 +793,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         eventService
-            .getEvents(operationParams, new PageParams(1, 3, false))
+            .findEvents(operationParams, new PageParams(1, 3, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -803,7 +803,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> secondPage =
         eventService
-            .getEvents(operationParams, new PageParams(2, 3, true))
+            .findEvents(operationParams, new PageParams(2, 3, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -811,7 +811,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
         secondPage,
         "second (last) page");
 
-    Page<Event> thirdPage = eventService.getEvents(operationParams, new PageParams(3, 3, true));
+    Page<Event> thirdPage = eventService.findEvents(operationParams, new PageParams(3, 3, true));
 
     assertEquals(new Page<>(List.of(), 3, 3, 6L, 2, null), thirdPage, "past the last page");
   }
@@ -952,7 +952,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), uids(events));
     List<String> trackedEntities =
@@ -972,14 +972,14 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         eventService
-            .getEvents(operationParams, PageParams.single())
+            .findEvents(operationParams, PageParams.single())
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of("D9PbzJY8bJM"), 1, 1, null, null, 2), firstPage, "first page");
 
     Page<String> secondPage =
         eventService
-            .getEvents(operationParams, new PageParams(2, 1, false))
+            .findEvents(operationParams, new PageParams(2, 1, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -987,7 +987,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> thirdPage =
         eventService
-            .getEvents(operationParams, new PageParams(3, 3, false))
+            .findEvents(operationParams, new PageParams(3, 3, false))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(new Page<>(List.of(), 3, 3, null, 2, null), thirdPage, "past the last page");
@@ -1416,7 +1416,7 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> firstPage =
         relationshipService
-            .getRelationships(params, PageParams.single())
+            .findRelationships(params, PageParams.single())
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
@@ -1424,14 +1424,14 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
     Page<String> secondPage =
         relationshipService
-            .getRelationships(params, new PageParams(2, 1, true))
+            .findRelationships(params, new PageParams(2, 1, true))
             .withMappedItems(IdentifiableObject::getUid);
 
     assertEquals(
         new Page<>(List.of(expectedOnPage2), 2, 1, 2L, 1, null), secondPage, "second (last) page");
 
     Page<Relationship> thirdPage =
-        relationshipService.getRelationships(params, new PageParams(3, 1, true));
+        relationshipService.findRelationships(params, new PageParams(3, 1, true));
 
     assertEquals(new Page<>(List.of(), 3, 1, 2L, 2, null), thirdPage, "past the last page");
   }
@@ -1504,22 +1504,22 @@ class OrderAndPaginationExporterTest extends PostgresIntegrationTestBase {
 
   private List<String> getTrackedEntities(TrackedEntityOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
-    return uids(trackedEntityService.getTrackedEntities(params));
+    return uids(trackedEntityService.findTrackedEntities(params));
   }
 
   private List<String> getEnrollments(EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException {
-    return uids(enrollmentService.getEnrollments(params));
+    return uids(enrollmentService.findEnrollments(params));
   }
 
   private List<String> getEvents(EventOperationParams params)
       throws ForbiddenException, BadRequestException {
-    return uids(eventService.getEvents(params));
+    return uids(eventService.findEvents(params));
   }
 
   private List<String> getRelationships(RelationshipOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
-    return uids(relationshipService.getRelationships(params));
+    return uids(relationshipService.findRelationships(params));
   }
 
   private static List<String> uids(List<? extends BaseIdentifiableObject> identifiableObject) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -422,7 +422,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(params);
 
     assertNotNull(enrollments);
     assertContainsOnly(
@@ -440,7 +440,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder().program(programA).orgUnitMode(ACCESSIBLE).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(params);
 
     assertNotNull(enrollments);
     assertContainsOnly(
@@ -458,7 +458,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder().orgUnitMode(CAPTURE).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(params);
 
     assertNotNull(enrollments);
     assertContainsOnly(
@@ -480,7 +480,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .orgUnitMode(ACCESSIBLE)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(params);
 
     assertNotNull(enrollments);
     assertContainsOnly(List.of(enrollmentA.getUid()), uids(enrollments));
@@ -499,7 +499,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .trackedEntity(trackedEntityA)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(params);
 
     assertNotNull(enrollments);
     assertContainsOnly(List.of(enrollmentA.getUid()), uids(enrollments));
@@ -517,7 +517,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .lastUpdated(oneHourBeforeLastUpdated)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertContainsOnly(List.of(enrollmentA), enrollments);
   }
@@ -534,7 +534,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .lastUpdated(oneHourAfterLastUpdated)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertIsEmpty(enrollments);
   }
@@ -553,7 +553,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .programStartDate(oneHourBeforeEnrollmentDate)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertContainsOnly(List.of(enrollmentA), enrollments);
   }
@@ -572,7 +572,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .programStartDate(oneHourAfterEnrollmentDate)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertIsEmpty(enrollments);
   }
@@ -591,7 +591,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .programEndDate(oneHourAfterEnrollmentDate)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertContainsOnly(List.of(enrollmentA), enrollments);
   }
@@ -610,7 +610,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .programEndDate(oneHourBeforeEnrollmentDate)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
 
     assertIsEmpty(enrollments);
   }
@@ -623,7 +623,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(ALL).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(
         List.of(enrollmentA.getUid(), enrollmentChildA.getUid(), enrollmentGrandchildA.getUid()),
         uids(enrollments));
@@ -636,7 +636,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     ForbiddenException exception =
         assertThrows(
-            ForbiddenException.class, () -> enrollmentService.getEnrollments(operationParams));
+            ForbiddenException.class, () -> enrollmentService.findEnrollments(operationParams));
     assertEquals(
         "User is not authorized to query across all organisation units", exception.getMessage());
   }
@@ -650,7 +650,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     ForbiddenException exception =
         assertThrows(
-            ForbiddenException.class, () -> enrollmentService.getEnrollments(operationParams));
+            ForbiddenException.class, () -> enrollmentService.findEnrollments(operationParams));
     assertEquals(
         String.format("Organisation unit is not part of the search scope: %s", orgUnitA.getUid()),
         exception.getMessage());
@@ -664,7 +664,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnitMode(ALL).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(
         List.of(enrollmentA, enrollmentB, enrollmentChildA, enrollmentGrandchildA), enrollments);
   }
@@ -676,7 +676,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnits(orgUnitA).orgUnitMode(DESCENDANTS).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(
         List.of(enrollmentA.getUid(), enrollmentChildA.getUid(), enrollmentGrandchildA.getUid()),
         uids(enrollments));
@@ -689,7 +689,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnits(orgUnitA).orgUnitMode(CHILDREN).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(List.of(enrollmentA.getUid(), enrollmentChildA.getUid()), uids(enrollments));
   }
 
@@ -700,7 +700,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder().orgUnits(orgUnitChildA).orgUnitMode(CHILDREN).build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(
         List.of(enrollmentChildA.getUid(), enrollmentGrandchildA.getUid()), uids(enrollments));
   }
@@ -716,7 +716,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
             .orgUnitMode(CHILDREN)
             .build();
 
-    List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
+    List<Enrollment> enrollments = enrollmentService.findEnrollments(operationParams);
     assertContainsOnly(
         List.of(enrollmentA.getUid(), enrollmentChildA.getUid(), enrollmentGrandchildA.getUid()),
         uids(enrollments));
@@ -731,7 +731,7 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     injectSecurityContextUser(authorizedUser);
     List<Enrollment> enrollments =
-        enrollmentService.getEnrollments(UID.of(enrollmentA, enrollmentB));
+        enrollmentService.findEnrollments(UID.of(enrollmentA, enrollmentB));
     assertIsEmpty(enrollments);
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -122,7 +122,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .orgUnitMode(DESCENDANTS)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -144,7 +144,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.orgUnit(orgUnit).orgUnitMode(DESCENDANTS).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -172,7 +172,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .orgUnitMode(CHILDREN)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -194,7 +194,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.orgUnit(orgUnit).orgUnitMode(CHILDREN).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -215,7 +215,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     ForbiddenException exception =
-        assertThrows(ForbiddenException.class, () -> eventService.getEvents(params));
+        assertThrows(ForbiddenException.class, () -> eventService.findEvents(params));
     assertEquals(
         "Organisation unit is not part of your search scope: DiszpKrYNg8", exception.getMessage());
   }
@@ -231,7 +231,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     ForbiddenException exception =
-        assertThrows(ForbiddenException.class, () -> eventService.getEvents(params));
+        assertThrows(ForbiddenException.class, () -> eventService.findEvents(params));
     assertEquals(
         "Organisation unit is not part of your search scope: DiszpKrYNg8", exception.getMessage());
   }
@@ -247,7 +247,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .orgUnitMode(SELECTED)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -269,7 +269,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.orgUnit(UID.of("DiszpKrYNg8")).orgUnitMode(SELECTED).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -287,7 +287,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.orgUnit(UID.of("RojfDTBhoGC")).orgUnitMode(SELECTED).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -309,7 +309,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .orgUnitMode(SELECTED)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertTrue(events.isEmpty(), "Expected to find no events, but found: " + events.size());
   }
@@ -321,7 +321,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(ACCESSIBLE).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(), "Expected to find events when ou mode accessible and program closed");
@@ -342,7 +342,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.program(program).orgUnitMode(ACCESSIBLE).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(), "Expected to find events when ou mode accessible and program open");
@@ -363,7 +363,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(CAPTURE).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(), "Expected to find events when ou mode capture and program closed");
@@ -384,7 +384,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.program(UID.of("pcxIanBWlSY")).orgUnitMode(ACCESSIBLE).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -413,7 +413,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
             .events(UID.of("lumVtWwwy0O", "cadc5eGj0j7"))
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertContainsOnly(List.of("lumVtWwwy0O", "cadc5eGj0j7"), uids(events));
     List<Executable> executables =
@@ -459,7 +459,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
 
     EventOperationParams params = operationParamsBuilder.orgUnitMode(ALL).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -484,7 +484,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.orgUnit(UID.of("uoNW0E3xXUy")).orgUnitMode(ALL).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(),
@@ -509,7 +509,7 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
 
     EventOperationParams params = operationParamsBuilder.orgUnitMode(ACCESSIBLE).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertFalse(
         events.isEmpty(), "Expected to find events when ou mode ACCESSIBLE and events visible");
@@ -535,6 +535,6 @@ class AclEventExporterTest extends PostgresIntegrationTestBase {
 
   private List<String> getEvents(EventOperationParams params)
       throws ForbiddenException, BadRequestException {
-    return uids(eventService.getEvents(params));
+    return uids(eventService.findEvents(params));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -142,7 +142,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .enrollments(Set.of(UID.of("TvctPPhpD8z")))
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertEquals(
         get(Event.class, "D9PbzJY8bJM").getAssignedUser(), events.get(0).getAssignedUser());
@@ -156,7 +156,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .eventParams(EventParams.TRUE)
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertContainsOnly(List.of("pTzf9KYMk72"), uids(events));
     List<Relationship> relationships =
@@ -172,7 +172,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
     EventOperationParams params =
         operationParamsBuilder.events(Set.of(UID.of("pTzf9KYMk72"))).build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertContainsOnly(List.of("pTzf9KYMk72"), uids(events));
     assertNotes(pTzf9KYMk72.getNotes(), events.get(0).getNotes());
@@ -312,7 +312,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .events(Set.of(UID.of("pTzf9KYMk72")))
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     Event event = events.get(0);
 
@@ -462,7 +462,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .attributeCategoryOptions(UID.of("xwZ2u3WyQR0", "M58XdOfhiJ7"))
             .build();
 
-    List<Event> events = eventService.getEvents(params);
+    List<Event> events = eventService.findEvents(params);
 
     assertContainsOnly(List.of("kWjSezkXHVp", "OTmjvJDn0Fu"), uids(events));
     List<Executable> executables =
@@ -661,7 +661,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -677,7 +677,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -693,7 +693,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -709,7 +709,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -725,7 +725,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -741,7 +741,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -757,7 +757,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -773,7 +773,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -789,7 +789,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -805,7 +805,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -821,7 +821,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -835,7 +835,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
         operationParamsBuilder.orgUnit(orgUnit).filterByAttribute(UID.of("notUpdated0")).build();
 
     List<String> trackedEntities =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .toList();
 
@@ -855,7 +855,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> trackedEntities =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .toList();
 
@@ -872,7 +872,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> trackedEntities =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .toList();
 
@@ -892,7 +892,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> trackedEntities =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .toList();
 
@@ -913,7 +913,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> trackedEntities =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .toList();
 
@@ -996,7 +996,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
             .build();
 
     List<String> enrollments =
-        eventService.getEvents(params).stream()
+        eventService.findEvents(params).stream()
             .map(event -> event.getEnrollment().getUid())
             .toList();
 
@@ -1063,7 +1063,7 @@ class EventExporterTest extends PostgresIntegrationTestBase {
 
   private List<String> getEvents(EventOperationParams params)
       throws ForbiddenException, BadRequestException {
-    return uids(eventService.getEvents(params));
+    return uids(eventService.findEvents(params));
   }
 
   private static List<String> uids(List<? extends BaseIdentifiableObject> identifiableObject) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -241,7 +241,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
 
     RelationshipOperationParams operationParams = RelationshipOperationParams.builder(teA).build();
 
-    List<Relationship> relationships = relationshipService.getRelationships(operationParams);
+    List<Relationship> relationships = relationshipService.findRelationships(operationParams);
 
     assertContainsOnly(
         List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
@@ -256,7 +256,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder(enrollmentA).build();
 
-    List<Relationship> relationships = relationshipService.getRelationships(operationParams);
+    List<Relationship> relationships = relationshipService.findRelationships(operationParams);
 
     assertContainsOnly(
         List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
@@ -271,7 +271,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder(eventA).build();
 
-    List<Relationship> relationships = relationshipService.getRelationships(operationParams);
+    List<Relationship> relationships = relationshipService.findRelationships(operationParams);
 
     assertContainsOnly(
         List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
@@ -313,7 +313,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
 
     assertThrows(
         ForbiddenException.class,
-        () -> relationshipService.getRelationships(operationParams),
+        () -> relationshipService.findRelationships(operationParams),
         "User should not have access to a relationship in case of ownership transfer of a tracked entity");
   }
 
@@ -342,7 +342,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder(trackedEntityFrom).build();
 
-    List<Relationship> relationships = relationshipService.getRelationships(operationParams);
+    List<Relationship> relationships = relationshipService.findRelationships(operationParams);
 
     assertContainsOnly(
         List.of(accessible.getUid()), relationships.stream().map(Relationship::getUid).toList());
@@ -379,7 +379,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
 
     assertThrows(
         ForbiddenException.class,
-        () -> relationshipService.getRelationships(operationParams),
+        () -> relationshipService.findRelationships(operationParams),
         "User should not have access to a relationship in case of missing metadata access to at least one program");
   }
 
@@ -413,7 +413,7 @@ class RelationshipServiceTest extends PostgresIntegrationTestBase {
 
     assertThrows(
         ForbiddenException.class,
-        () -> relationshipService.getRelationships(operationParams),
+        () -> relationshipService.findRelationships(operationParams),
         "User should not have access to a relationship in case of missing data read access to at least one program");
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -572,7 +572,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     BadRequestException ex =
         assertThrows(
             BadRequestException.class,
-            () -> trackedEntityService.getTrackedEntities(operationParams));
+            () -> trackedEntityService.findTrackedEntities(operationParams));
     assertContains(
         "racked entity type is specified but does not exist: " + trackedEntityTypeA.getUid(),
         ex.getMessage());
@@ -589,7 +589,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(
         List.of(trackedEntityA, trackedEntityB, trackedEntityChildA, trackedEntityGrandchildA),
@@ -618,7 +618,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(Set.of(enrollmentA.getUid()), uids(trackedEntities.get(0).getEnrollments()));
@@ -657,7 +657,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -692,7 +692,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -710,7 +710,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .program(programA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities, TrackedEntity::getUid);
     assertContainsOnly(
@@ -764,7 +764,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedStartDate(oneHourBeforeLastUpdated)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -782,7 +782,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedStartDate(oneHourAfterLastUpdated)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -800,7 +800,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedEndDate(oneHourAfterLastUpdated)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -818,7 +818,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedEndDate(oneHourBeforeLastUpdated)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -836,7 +836,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programEnrollmentStartDate(oneHourBeforeEnrollmentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -854,7 +854,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programEnrollmentStartDate(oneHourAfterEnrollmentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -872,7 +872,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programEnrollmentEndDate(oneHourAfterEnrollmentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -890,7 +890,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programEnrollmentEndDate(oneHourBeforeEnrollmentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -908,7 +908,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programIncidentStartDate(oneHourBeforeIncidentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -926,7 +926,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programIncidentStartDate(oneHourAfterIncidentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -944,7 +944,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programIncidentEndDate(oneHourAfterIncidentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -962,7 +962,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .programIncidentEndDate(oneHourBeforeIncidentDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -983,7 +983,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .eventEndDate(oneHourAfterOccurredDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -1004,7 +1004,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .eventEndDate(twoHoursAfterOccurredDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -1025,7 +1025,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .eventEndDate(oneHourBeforeOccurredDate)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -1042,7 +1042,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedEndDate(Date.from(Instant.now().plus(1, ChronoUnit.MINUTES)))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
 
@@ -1056,7 +1056,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .lastUpdatedEndDate(Date.from(Instant.now().plus(1, ChronoUnit.MINUTES)))
             .build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams));
+    assertIsEmpty(trackedEntityService.findTrackedEntities(operationParams));
   }
 
   @Test
@@ -1073,27 +1073,28 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .eventEndDate(Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.COMPLETED).build());
+        trackedEntityService.findTrackedEntities(
+            builder.eventStatus(EventStatus.COMPLETED).build());
     assertEquals(4, trackedEntities.size());
     // Update status to active
     final List<TrackedEntity> limitedTrackedEntities =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.ACTIVE).build());
+        trackedEntityService.findTrackedEntities(builder.eventStatus(EventStatus.ACTIVE).build());
     assertIsEmpty(limitedTrackedEntities);
     // Update status to overdue
     final List<TrackedEntity> limitedTrackedEntities2 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
+        trackedEntityService.findTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
     assertIsEmpty(limitedTrackedEntities2);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities3 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
+        trackedEntityService.findTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
     assertIsEmpty(limitedTrackedEntities3);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities4 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.SCHEDULE).build());
+        trackedEntityService.findTrackedEntities(builder.eventStatus(EventStatus.SCHEDULE).build());
     assertIsEmpty(limitedTrackedEntities4);
     // Update status to visited
     final List<TrackedEntity> limitedTrackedEntities5 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.VISITED).build());
+        trackedEntityService.findTrackedEntities(builder.eventStatus(EventStatus.VISITED).build());
     assertIsEmpty(limitedTrackedEntities5);
   }
 
@@ -1110,7 +1111,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     TrackedEntity trackedEntity = trackedEntities.get(0);
@@ -1131,7 +1132,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     manager.delete(enrollmentA);
     manager.delete(eventA);
 
-    trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -1164,7 +1165,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .includeDeleted(false)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
-    trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -1189,7 +1190,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -1218,7 +1219,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntities(trackedEntityA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertIsEmpty(trackedEntities.get(0).getEnrollments());
@@ -1237,7 +1238,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities, UidObject::getUid);
     assertContainsOnly(
@@ -1267,7 +1268,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -1298,7 +1299,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -1323,7 +1324,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityType(trackedEntityTypeA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     assertAll(
@@ -1355,7 +1356,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -1394,7 +1395,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -1445,7 +1446,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1472,7 +1473,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitB, trackedEntityB);
 
     injectSecurityContextUser(user);
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1495,7 +1496,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitA, trackedEntityA);
 
     injectSecurityContextUser(user);
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1513,7 +1514,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitA, trackedEntityA);
 
     injectSecurityContextUser(user);
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1535,7 +1536,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitA, trackedEntityA);
 
     injectSecurityContextUser(user);
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1553,7 +1554,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitA, trackedEntityA);
 
     injectSecurityContextUser(user);
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1575,7 +1576,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams = createOperationParams(orgUnitA, trackedEntityA);
     injectSecurityContextUser(user);
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1597,7 +1598,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1623,7 +1624,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1648,7 +1649,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.EQ, "M'M")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -1664,7 +1665,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.EQ, "A")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -1680,7 +1681,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.EQ, "Z")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertIsEmpty(trackedEntities);
   }
@@ -1696,7 +1697,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(
         List.of(trackedEntityA, trackedEntityChildA, trackedEntityGrandchildA), trackedEntities);
@@ -1715,7 +1716,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaC), List.of(new QueryFilter(QueryOperator.LIKE, "C")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
 
@@ -1731,7 +1732,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.LIKE, "A")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(
         List.of(trackedEntityA, trackedEntityChildA, trackedEntityGrandchildA), trackedEntities);
@@ -1749,7 +1750,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.LIKE, "A")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -1772,7 +1773,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.NULL)))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntity), trackedEntities);
   }
@@ -1788,7 +1789,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaA), List.of(new QueryFilter(QueryOperator.NNULL)))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(
         List.of(trackedEntityA, trackedEntityChildA, trackedEntityGrandchildA), trackedEntities);
@@ -1807,7 +1808,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
                 List.of(new QueryFilter(QueryOperator.NNULL), new QueryFilter(QueryOperator.NULL)))
             .build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams));
+    assertIsEmpty(trackedEntityService.findTrackedEntities(operationParams));
   }
 
   @Test
@@ -1822,7 +1823,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .filterBy(UID.of(teaB), List.of(new QueryFilter(QueryOperator.EQ, "B")))
             .build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams));
+    assertIsEmpty(trackedEntityService.findTrackedEntities(operationParams));
   }
 
   @Test
@@ -1839,7 +1840,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
                     new QueryFilter(QueryOperator.NNULL), new QueryFilter(QueryOperator.EQ, "B")))
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
   }
@@ -1853,7 +1854,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     ForbiddenException ex =
         assertThrows(
             ForbiddenException.class,
-            () -> trackedEntityService.getTrackedEntities(operationParams));
+            () -> trackedEntityService.findTrackedEntities(operationParams));
 
     assertContains(
         String.format("User has no access to program: %s", programC.getUid()), ex.getMessage());
@@ -1869,7 +1870,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityType(trackedEntityTypeA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
     assertContainsOnly(
         Set.of(trackedEntityA.getUid(), trackedEntityChildA.getUid()), uids(trackedEntities));
   }
@@ -1884,7 +1885,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityType(trackedEntityTypeA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
     assertContainsOnly(
         Set.of(trackedEntityChildA.getUid(), trackedEntityGrandchildA.getUid()),
         uids(trackedEntities));
@@ -1901,7 +1902,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             .trackedEntityType(trackedEntityTypeA)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
     assertContainsOnly(
         Set.of(
             trackedEntityA.getUid(),
@@ -1917,7 +1918,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().orgUnitMode(ALL).program(programA).build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
     assertContainsOnly(Set.of(trackedEntityA.getUid()), uids(trackedEntities));
   }
 
@@ -2000,7 +2001,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder().trackedEntityType(trackedEntityTypeA).build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams));
+    assertIsEmpty(trackedEntityService.findTrackedEntities(operationParams));
   }
 
   @Test
@@ -2016,7 +2017,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
         TrackedEntityOperationParams.builder().trackedEntityType(trackedEntityTypeA).build();
 
     Page<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams, new PageParams(1, 3, false));
+        trackedEntityService.findTrackedEntities(operationParams, new PageParams(1, 3, false));
 
     assertIsEmpty(trackedEntities.getItems());
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -534,7 +534,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
   /**
    * Get with the entity manager because some Store exclude deleted and {@link
-   * TrackedEntityService#getTrackedEntities} use async Spring jdbc Template. So we use the same
+   * TrackedEntityService#findTrackedEntities} use async Spring jdbc Template. So we use the same
    * query for all the entities
    */
   @SuppressWarnings("unchecked")

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
@@ -618,7 +618,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
   private List<String> getTrackedEntities(TrackedEntityOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
-    return uids(trackedEntityService.getTrackedEntities(params));
+    return uids(trackedEntityService.findTrackedEntities(params));
   }
 
   private static Program createProgram(AccessLevel accessLevel) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerH2Test.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerH2Test.java
@@ -107,7 +107,7 @@ class EventsExportControllerH2Test extends H2ControllerIntegrationTestBase {
       String url, String expectedContentType, String expectedAttachment, String encoding)
       throws ForbiddenException, BadRequestException {
 
-    when(eventService.getEvents(any())).thenReturn(List.of());
+    when(eventService.findEvents(any())).thenReturn(List.of());
 
     HttpResponse res = GET(url);
     assertEquals(HttpStatus.OK, res.status());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -444,7 +444,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
                 "Command has been processed successfully", originator, messageSender));
 
     List<Enrollment> enrollments =
-        enrollmentService.getEnrollments(
+        enrollmentService.findEnrollments(
             EnrollmentOperationParams.builder()
                 .program(trackerProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -653,7 +653,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "Command has been processed successfully", originator, smsMessageSender));
 
     List<Event> events =
-        eventService.getEvents(
+        eventService.findEvents(
             EventOperationParams.builder()
                 .program(eventProgram)
                 .orgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)
@@ -720,7 +720,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "Command has been processed successfully", originator, smsMessageSender));
 
     List<Enrollment> enrollments =
-        enrollmentService.getEnrollments(
+        enrollmentService.findEnrollments(
             EnrollmentOperationParams.builder()
                 .trackedEntity(trackedEntity)
                 .program(trackerProgram)
@@ -736,7 +736,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         () -> assertEquals(EnrollmentStatus.ACTIVE, actualEnrollment.getStatus()));
 
     List<Event> events =
-        eventService.getEvents(
+        eventService.findEvents(
             EventOperationParams.builder()
                 .trackedEntity(trackedEntity)
                 .program(trackerProgram)
@@ -806,7 +806,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
                 "Command has been processed successfully", originator, smsMessageSender));
 
     List<Event> events =
-        eventService.getEvents(
+        eventService.findEvents(
             EventOperationParams.builder()
                 .trackedEntity(trackedEntity)
                 .program(trackerProgram)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -112,7 +112,7 @@ class EnrollmentsExportController {
           PageParams.of(
               requestParams.getPage(), requestParams.getPageSize(), requestParams.isTotalPages());
       org.hisp.dhis.tracker.Page<org.hisp.dhis.program.Enrollment> enrollmentsPage =
-          enrollmentService.getEnrollments(operationParams, pageParams);
+          enrollmentService.findEnrollments(operationParams, pageParams);
 
       org.hisp.dhis.tracker.Page<Enrollment> page =
           enrollmentsPage.withMappedItems(ENROLLMENT_MAPPER::map);
@@ -121,7 +121,7 @@ class EnrollmentsExportController {
     }
 
     List<Enrollment> enrollments =
-        enrollmentService.getEnrollments(operationParams).stream()
+        enrollmentService.findEnrollments(operationParams).stream()
             .map(ENROLLMENT_MAPPER::map)
             .toList();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -165,7 +165,7 @@ class EventsExportController {
       EventOperationParams eventOperationParams =
           eventParamsMapper.map(requestParams, idSchemeParams);
       org.hisp.dhis.tracker.Page<Event> eventsPage =
-          eventService.getEvents(eventOperationParams, pageParams);
+          eventService.findEvents(eventOperationParams, pageParams);
 
       MappingErrors errors = new MappingErrors(idSchemeParams);
       org.hisp.dhis.tracker.Page<org.hisp.dhis.webapi.controller.tracker.view.Event> page =
@@ -305,7 +305,7 @@ class EventsExportController {
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        eventService.getEvents(eventOperationParams).stream()
+        eventService.findEvents(eventOperationParams).stream()
             .map(ev -> EVENTS_MAPPER.map(idSchemeParams, errors, ev))
             .toList();
     ensureNoMappingErrors(errors);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -110,7 +110,7 @@ class RelationshipsExportController {
           PageParams.of(
               requestParams.getPage(), requestParams.getPageSize(), requestParams.isTotalPages());
       org.hisp.dhis.tracker.Page<org.hisp.dhis.relationship.Relationship> relationshipsPage =
-          relationshipService.getRelationships(operationParams, pageParams);
+          relationshipService.findRelationships(operationParams, pageParams);
 
       org.hisp.dhis.tracker.Page<Relationship> page =
           relationshipsPage.withMappedItems(RELATIONSHIP_MAPPER::map);
@@ -119,7 +119,7 @@ class RelationshipsExportController {
     }
 
     List<Relationship> relationships =
-        relationshipService.getRelationships(operationParams).stream()
+        relationshipService.findRelationships(operationParams).stream()
             .map(RELATIONSHIP_MAPPER::map)
             .toList();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -177,7 +177,7 @@ class TrackedEntitiesExportController {
           PageParams.of(
               requestParams.getPage(), requestParams.getPageSize(), requestParams.isTotalPages());
       org.hisp.dhis.tracker.Page<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntitiesPage =
-          trackedEntityService.getTrackedEntities(operationParams, pageParams);
+          trackedEntityService.findTrackedEntities(operationParams, pageParams);
 
       MappingErrors errors = new MappingErrors(idSchemeParams);
       org.hisp.dhis.tracker.Page<TrackedEntity> page =
@@ -190,7 +190,7 @@ class TrackedEntitiesExportController {
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).stream()
+        trackedEntityService.findTrackedEntities(operationParams).stream()
             .map(te -> TRACKED_ENTITY_MAPPER.map(idSchemeParams, errors, te))
             .toList();
     ensureNoMappingErrors(errors);
@@ -275,7 +275,7 @@ class TrackedEntitiesExportController {
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
     List<TrackedEntity> result =
-        trackedEntityService.getTrackedEntities(operationParams).stream()
+        trackedEntityService.findTrackedEntities(operationParams).stream()
             .map(te -> TRACKED_ENTITY_MAPPER.map(idSchemeParams, errors, te))
             .toList();
     ensureNoMappingErrors(errors);


### PR DESCRIPTION
I already did most of the job [here](https://dhis2.atlassian.net/browse/DHIS2-18541).

Now I am just make all the service consistent with each other:
- Rename from `get` to `find` also for the methods in the exporters returning a `Collection` or a `Page`
- Make sure all the `find` and `get` methods are annotated with `Nonnull`