### PR TITLE
feat: document filter operators in open api readme [DHIS2-15954]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -196,17 +196,21 @@ NOTE: this query parameter has no effect on a CSV response!
 
 `<filter1>[,<filter2>...]`
 
-Get events matching given filters on data values. A filter is a colon separated data element UID
-with operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw`
-followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`.
-Multiple operator/value pairs for the same data element as
-`filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Operator and values are
+Get events matching the given filters on data values. A filter is a colon separated data element UID
+with optional operator and value pairs. We differentiate between two types of operators: unary and 
+binary. Unary operators don't require a value, while binary operators do.
+- Unary: `filter=H9IlTX2X6SL:null`
+- Binary: `filter=H9IlTX2X6SL:sw:A` 
+
+Special characters like `+` must be percent-encoded (`%2B` instead of `+`). Characters like `:` and
+`,` in filter values must be escaped with `/`. Likewise, `/` needs to be escaped.
+Multiple operators are allowed for the same data element, e.g.,
+`filter=AuPLng5hLbE:gt:438901703:lt:448901704`. Operators and values are
 case-insensitive. A user needs metadata read access to the data element and data read access to the
 program (if the program is without registration) or the program stage (if the program is with
 registration).
 
-Valid operators are:
-
+Valid binary operators are:
 - `EQ` - equal to
 - `IEQ` - equal to
 - `GE` - greater than or equal to
@@ -223,23 +227,30 @@ Valid operators are:
 - `NLIKE` - not like
 - `SW` - starts with
 - `EW` - ends with
+
+Valid unary operators are:
+- `NULL` - has no value
+- `!NULL` - has a value
 
 ### `*.parameter.EventRequestParams.filterAttributes`
 
 `<filter1>[,<filter2>...]`
 
-Get events matching given filters on tracked entity attributes. A filter is a colon separated
-attribute UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with
-operator starts with `sw` followed by a value. Special characters like `+` need to be
-percent-encoded so `%2B` instead of `+`. Characters such as `:` (colon) or `,` (comma), as part of
-the filter value, need to be escaped by / (slash). Likewise, `/` needs to be escaped. Multiple
-operator/value pairs for the same attribute as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are
-allowed. Repeating the same attribute UID is not allowed. Operator and values are case-insensitive.
-A user needs metadata read access to the attribute and data read access to the program (if the
-program is without registration) or to the program stage (if the program is with registration).
+Get events matching the given filters on tracked entity attributes. A filter is a colon separated 
+attribute UID with optional operator and value pairs. We differentiate between two types of
+operators: unary and binary. Unary operators don't require a value, while binary operators do.
+- Unary: `filterAttributes=H9IlTX2X6SL:null`
+- Binary: `filterAttributes=H9IlTX2X6SL:sw:A` 
 
-Valid operators are:
+Special characters like `+` must be percent-encoded (`%2B` instead of `+`). Characters like `:` and 
+`,` in filter values must be escaped with `/`. Likewise, `/` needs to be escaped.
+Multiple operators are allowed for the same attribute, e.g.,
+`filter=AuPLng5hLbE:gt:438901703:lt:448901704`. Operators and values are
+case-insensitive. A user needs metadata read access to the attribute and data read access to the
+program (if the program is without registration) or the program stage (if the program is with
+registration).
 
+Valid binary operators are:
 - `EQ` - equal to
 - `IEQ` - equal to
 - `GE` - greater than or equal to
@@ -256,3 +267,7 @@ Valid operators are:
 - `NLIKE` - not like
 - `SW` - starts with
 - `EW` - ends with
+
+Valid unary operators are:
+- `NULL` - has no value
+- `!NULL` - has a value

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -197,7 +197,9 @@ NOTE: this query parameter has no effect on a CSV response!
 `<filter1>[,<filter2>...]`
 
 Get events matching the given filters on data values. A filter is a colon separated data element UID
-with optional operator and value pairs. We differentiate between two types of operators: unary and 
+with optional operator and value pairs. 
+
+We differentiate between two types of operators: unary and 
 binary. Unary operators don't require a value, while binary operators do.
 - Unary: `filter=H9IlTX2X6SL:null`
 - Binary: `filter=H9IlTX2X6SL:sw:A` 
@@ -211,33 +213,35 @@ program (if the program is without registration) or the program stage (if the pr
 registration).
 
 Valid binary operators are:
-- `EQ` - equal to
-- `IEQ` - equal to
-- `GE` - greater than or equal to
-- `GT` - greater than
-- `LE` - less than or equal to
-- `LT` - less than
-- `NE` - not equal to
-- `NEQ` - not equal to
-- `NIEQ` - not equal to
-- `IN` - equal to one of the multiple values separated by semicolon ";"
-- `ILIKE` - is like (case-insensitive)
-- `LIKE` - like (free text match)
-- `NILIKE` - not like
-- `NLIKE` - not like
-- `SW` - starts with
-- `EW` - ends with
+- `eq` - equal to
+- `ieq` - equal to
+- `ge` - greater than or equal to
+- `gt` - greater than
+- `le` - less than or equal to
+- `lt` - less than
+- `ne` - not equal to
+- `neq` - not equal to
+- `nieq` - not equal to
+- `in` - equal to one of the multiple values separated by semicolon ";"
+- `ilike` - is like (case-insensitive)
+- `like` - like (free text match)
+- `nilike` - not like
+- `nlike` - not like
+- `sw` - starts with
+- `ew` - ends with
 
 Valid unary operators are:
-- `NULL` - has no value
-- `!NULL` - has a value
+- `null` - has no value
+- `!null` - has a value
 
 ### `*.parameter.EventRequestParams.filterAttributes`
 
 `<filter1>[,<filter2>...]`
 
 Get events matching the given filters on tracked entity attributes. A filter is a colon separated 
-attribute UID with optional operator and value pairs. We differentiate between two types of
+attribute UID with optional operator and value pairs. 
+
+We differentiate between two types of
 operators: unary and binary. Unary operators don't require a value, while binary operators do.
 - Unary: `filterAttributes=H9IlTX2X6SL:null`
 - Binary: `filterAttributes=H9IlTX2X6SL:sw:A` 
@@ -251,23 +255,23 @@ program (if the program is without registration) or the program stage (if the pr
 registration).
 
 Valid binary operators are:
-- `EQ` - equal to
-- `IEQ` - equal to
-- `GE` - greater than or equal to
-- `GT` - greater than
-- `LE` - less than or equal to
-- `LT` - less than
-- `NE` - not equal to
-- `NEQ` - not equal to
-- `NIEQ` - not equal to
-- `IN` - equal to one of the multiple values separated by semicolon ";"
-- `ILIKE` - is like (case-insensitive)
-- `LIKE` - like (free text match)
-- `NILIKE` - not like
-- `NLIKE` - not like
-- `SW` - starts with
-- `EW` - ends with
+- `eq` - equal to
+- `ieq` - equal to
+- `ge` - greater than or equal to
+- `gt` - greater than
+- `le` - less than or equal to
+- `lt` - less than
+- `ne` - not equal to
+- `neq` - not equal to
+- `nieq` - not equal to
+- `in` - equal to one of the multiple values separated by semicolon ";"
+- `ilike` - is like (case-insensitive)
+- `like` - like (free text match)
+- `nilike` - not like
+- `nlike` - not like
+- `sw` - starts with
+- `ew` - ends with
 
 Valid unary operators are:
-- `NULL` - has no value
-- `!NULL` - has a value
+- `null` - has no value
+- `!null` - has a value

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -291,18 +291,21 @@ NOTE: This query parameter has no effect on a CSV response!
 
 `<filter1>[,<filter2>...]`
 
-Get tracked entities matching given filters on attributes. A filter is a colon separated attribute
-UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts
-with `sw` followed by a value. Special characters like `+` need to be percent-encoded so `%2B`
-instead of `+`. Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to
-be escaped by `/` (slash). Likewise, `/` needs to be escaped. Multiple operator/value pairs for the
-same attribute as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same
-attribute UID is not allowed. A user needs metadata read access to the attribute and data read
-access to the program (if the program is without registration) or the program stage (if the program
-is with registration).
+Get tracked entities matching the given filters attributes. A filter is a colon separated
+attribute UID with optional operator and value pairs. We differentiate between two types of
+operators: unary and binary. Unary operators don't require a value, while binary operators do.
+- Unary: `filterAttributes=H9IlTX2X6SL:null`
+- Binary: `filterAttributes=H9IlTX2X6SL:sw:A`
 
-Valid operators are:
+Special characters like `+` must be percent-encoded (`%2B` instead of `+`). Characters like `:` and
+`,` in filter values must be escaped with `/`. Likewise, `/` needs to be escaped.
+Multiple operators are allowed for the same attribute, e.g.,
+`filter=AuPLng5hLbE:gt:438901703:lt:448901704`. Operators and values are
+case-insensitive. A user needs metadata read access to the attribute and data read access to the
+program (if the program is without registration) or the program stage (if the program is with
+registration).
 
+Valid binary operators are:
 - `EQ` - equal to
 - `IEQ` - equal to
 - `GE` - greater than or equal to
@@ -319,3 +322,9 @@ Valid operators are:
 - `NLIKE` - not like
 - `SW` - starts with
 - `EW` - ends with
+- `NULL` - has no value
+- `!NULL` - has a value
+
+Valid unary operators are:
+- `NULL` - has no value
+- `!NULL` - has a value

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -292,7 +292,9 @@ NOTE: This query parameter has no effect on a CSV response!
 `<filter1>[,<filter2>...]`
 
 Get tracked entities matching the given filters attributes. A filter is a colon separated
-attribute UID with optional operator and value pairs. We differentiate between two types of
+attribute UID with optional operator and value pairs. 
+
+We differentiate between two types of
 operators: unary and binary. Unary operators don't require a value, while binary operators do.
 - Unary: `filterAttributes=H9IlTX2X6SL:null`
 - Binary: `filterAttributes=H9IlTX2X6SL:sw:A`
@@ -306,25 +308,23 @@ program (if the program is without registration) or the program stage (if the pr
 registration).
 
 Valid binary operators are:
-- `EQ` - equal to
-- `IEQ` - equal to
-- `GE` - greater than or equal to
-- `GT` - greater than
-- `LE` - less than or equal to
-- `LT` - less than
-- `NE` - not equal to
-- `NEQ` - not equal to
-- `NIEQ` - not equal to
-- `IN` - equal to one of the multiple values separated by semicolon ";"
-- `ILIKE` - is like (case-insensitive)
-- `LIKE` - like (free text match)
-- `NILIKE` - not like
-- `NLIKE` - not like
-- `SW` - starts with
-- `EW` - ends with
-- `NULL` - has no value
-- `!NULL` - has a value
+- `eq` - equal to
+- `ieq` - equal to
+- `ge` - greater than or equal to
+- `gt` - greater than
+- `le` - less than or equal to
+- `lt` - less than
+- `ne` - not equal to
+- `neq` - not equal to
+- `nieq` - not equal to
+- `in` - equal to one of the multiple values separated by semicolon ";"
+- `ilike` - is like (case-insensitive)
+- `like` - like (free text match)
+- `nilike` - not like
+- `nlike` - not like
+- `sw` - starts with
+- `ew` - ends with
 
 Valid unary operators are:
-- `NULL` - has no value
-- `!NULL` - has a value
+- `null` - has no value
+- `!null` - has a value


### PR DESCRIPTION
This PR updates `EventExportController.md` and `TrackedEntitiesExportController.md` to align the `dataElement` and `attribute` filters with the expected behavior. It introduces unary operators and fixes some inconsistencies in the existing explanation.

The long-term plan is to move this logic into annotations within the codebase, but for now, this update ensures consistency with the current documentation.