### PR TITLE
fix: Return program attributes in change log [DHIS2-19141]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.user.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -120,8 +119,6 @@ public interface TrackedEntityAttributeService {
    */
   List<TrackedEntityAttribute> getAllTrackedEntityAttributes();
 
-  Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(UserDetails userDetails);
-
   /**
    * Get the tracked entity attributes for given program i.e. program attributes to which the
    * current user must have data read access.
@@ -135,7 +132,7 @@ public interface TrackedEntityAttributeService {
   Set<TrackedEntityAttribute> getTrackedEntityTypeAttributes(TrackedEntityType trackedEntityType);
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
-      UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes);
+      List<Program> programs, List<TrackedEntityType> trackedEntityTypes);
 
   /**
    * Returns all {@link TrackedEntityAttribute} that are candidates for creating trigram indexes.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -238,33 +238,22 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
 
   @Override
   @Transactional(readOnly = true)
-  public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
-      UserDetails userDetails) {
-    List<Program> programs = programService.getAllPrograms();
-    List<TrackedEntityType> trackedEntityTypes = trackedEntityTypeService.getAllTrackedEntityType();
-
-    return getAllUserReadableTrackedEntityAttributes(userDetails, programs, trackedEntityTypes);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public Set<TrackedEntityAttribute> getProgramAttributes(Program program) {
-    return getAllUserReadableTrackedEntityAttributes(
-        CurrentUserUtil.getCurrentUserDetails(), List.of(program), List.of());
+    return getAllUserReadableTrackedEntityAttributes(List.of(program), List.of());
   }
 
   @Override
   @Transactional(readOnly = true)
   public Set<TrackedEntityAttribute> getTrackedEntityTypeAttributes(
       TrackedEntityType trackedEntityType) {
-    return getAllUserReadableTrackedEntityAttributes(
-        CurrentUserUtil.getCurrentUserDetails(), List.of(), List.of(trackedEntityType));
+    return getAllUserReadableTrackedEntityAttributes(List.of(), List.of(trackedEntityType));
   }
 
   @Override
   @Transactional(readOnly = true)
   public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
-      UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes) {
+      List<Program> programs, List<TrackedEntityType> trackedEntityTypes) {
+    UserDetails userDetails = CurrentUserUtil.getCurrentUserDetails();
     Set<TrackedEntityAttribute> attributes = new HashSet<>();
 
     if (programs != null && !programs.isEmpty()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -188,10 +188,7 @@ class DefaultEnrollmentService implements EnrollmentService {
   }
 
   private Enrollment getEnrollment(
-      @Nonnull Enrollment enrollment,
-      @Nonnull EnrollmentParams params,
-      boolean includeDeleted,
-      @Nonnull UserDetails user) {
+      @Nonnull Enrollment enrollment, @Nonnull EnrollmentParams params, boolean includeDeleted) {
     Enrollment result = new Enrollment();
     result.setUid(enrollment.getUid());
 
@@ -233,17 +230,16 @@ class DefaultEnrollmentService implements EnrollmentService {
     if (params.isIncludeAttributes()) {
       result
           .getTrackedEntity()
-          .setTrackedEntityAttributeValues(getTrackedEntityAttributeValues(user, enrollment));
+          .setTrackedEntityAttributeValues(getTrackedEntityAttributeValues(enrollment));
     }
 
     return result;
   }
 
-  private Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
-      UserDetails userDetails, Enrollment enrollment) {
+  private Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(Enrollment enrollment) {
     Set<TrackedEntityAttribute> readableAttributes =
         trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(
-            userDetails, List.of(enrollment.getProgram()), null);
+            List.of(enrollment.getProgram()), null);
     Set<TrackedEntityAttributeValue> attributeValues = new LinkedHashSet<>();
 
     for (TrackedEntityAttributeValue trackedEntityAttributeValue :
@@ -270,7 +266,7 @@ class DefaultEnrollmentService implements EnrollmentService {
               || trackerOwnershipAccessManager.hasAccess(
                   currentUser, enrollment.getTrackedEntity(), enrollment.getProgram()))
           && trackerAccessManager.canRead(currentUser, enrollment, orgUnitMode == ALL).isEmpty()) {
-        enrollmentList.add(getEnrollment(enrollment, params, includeDeleted, currentUser));
+        enrollmentList.add(getEnrollment(enrollment, params, includeDeleted));
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
+import static java.util.Collections.emptyList;
+
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
@@ -38,6 +41,8 @@ import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -51,6 +56,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class DefaultTrackedEntityChangeLogService implements TrackedEntityChangeLogService {
 
   private final TrackedEntityService trackedEntityService;
+
+  private final ProgramService programService;
 
   private final TrackedEntityAttributeService trackedEntityAttributeService;
 
@@ -97,10 +104,14 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
             trackedEntityUid, programUid, TrackedEntityParams.FALSE.withIncludeAttributes(true));
+    Program program =
+        (programUid != null) ? programService.getProgram(programUid.getValue()) : null;
 
     Set<UID> trackedEntityAttributes =
         trackedEntityAttributeService
-            .getTrackedEntityTypeAttributes(trackedEntity.getTrackedEntityType())
+            .getAllUserReadableTrackedEntityAttributes(
+                program != null ? List.of(program) : emptyList(),
+                List.of(trackedEntity.getTrackedEntityType()))
             .stream()
             .map(UID::of)
             .collect(Collectors.toSet());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -27,10 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
-import static java.util.Collections.emptyList;
-
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
@@ -41,7 +38,6 @@ import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -104,16 +100,10 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
     TrackedEntity trackedEntity =
         trackedEntityService.getTrackedEntity(
             trackedEntityUid, programUid, TrackedEntityParams.FALSE.withIncludeAttributes(true));
-    Program program =
-        (programUid != null) ? programService.getProgram(programUid.getValue()) : null;
 
     Set<UID> trackedEntityAttributes =
-        trackedEntityAttributeService
-            .getAllUserReadableTrackedEntityAttributes(
-                program != null ? List.of(program) : emptyList(),
-                List.of(trackedEntity.getTrackedEntityType()))
-            .stream()
-            .map(UID::of)
+        trackedEntity.getTrackedEntityAttributeValues().stream()
+            .map(teav -> UID.of(teav.getAttribute().getUid()))
             .collect(Collectors.toSet());
 
     return hibernateTrackedEntityChangeLogStore.getTrackedEntityChangeLogs(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
@@ -260,17 +260,29 @@ class TrackedEntityChangeLogServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldReturnChangeLogsFromSpecifiedProgramOnlyWhenMultipleLogsExist()
+  void shouldReturnChangeLogsFromSpecifiedProgram()
       throws NotFoundException, ForbiddenException, BadRequestException {
+    String trackedEntity = "dUE514NMOlo";
+    String program = "BFcipDERJnf";
+    String programAttribute = "fRGt4l6yIRb";
+
+    updateAttributeValue(trackedEntity, programAttribute, "updated program attribute value");
+
     Page<TrackedEntityChangeLog> changeLogs =
         trackedEntityChangeLogService.getTrackedEntityChangeLog(
-            UID.of("QS6w44flWAf"),
-            UID.of("BFcipDERJnf"),
-            defaultOperationParams,
-            defaultPageParams);
+            UID.of(trackedEntity), UID.of(program), defaultOperationParams, defaultPageParams);
 
-    assertNumberOfChanges(1, changeLogs.getItems());
-    assertAll(() -> assertCreate("dIVt4l5vIOa", "Value", changeLogs.getItems().get(0)));
+    assertNumberOfChanges(2, changeLogs.getItems());
+    assertAll(
+        () ->
+            assertUpdate(
+                programAttribute,
+                "program attribute value",
+                "updated program attribute value",
+                changeLogs.getItems().get(0)),
+        () ->
+            assertCreate(
+                programAttribute, "program attribute value", changeLogs.getItems().get(1)));
   }
 
   private static void assertNumberOfChanges(int expected, List<TrackedEntityChangeLog> changeLogs) {

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/base_data.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/base_data.json
@@ -129,6 +129,14 @@
             "identifier": "numericAttr"
           },
           "value": "70"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "fRGt4l6yIRb"
+          },
+          "value": "program attribute value"
         }
       ],
       "enrollments": []


### PR DESCRIPTION
After the recent refactor of the `trackedEntityService`, we were no longer fetching program attributes in the tracked entity change logs, even if a program was specified.
This issue was not detected earlier because the test that validates this behavior used a tracked entity attribute that, although defined as a program attribute, was also defined as a tracked entity type attribute. As a result, it was still present in the output.

I'm also removing `getAllUserReadableTrackedEntityAttributes` because it was not used anywhere.