### PR TITLE
fix: (2.39) Prioritise payload event data to trigger rule-engine notifications [DHIS2-19156]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -226,7 +226,7 @@ public class DefaultTrackerProgramRuleService implements TrackerProgramRuleServi
             .filter(event -> event.getEnrollment().equals(enrollmentUid))
             .collect(
                 Collectors.toMap(
-                    Event::getUid,
+                    Event::getEvent,
                     event ->
                         eventTrackerConverterService.fromForRuleEngine(
                             bundle.getPreheat(), event)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -203,36 +203,38 @@ public class DefaultTrackerProgramRuleService implements TrackerProgramRuleServi
     return bundle.getPreheat().getEnrollment(enrollmentUid);
   }
 
-    private Set<ProgramStageInstance> getEventsFromEnrollment(
-            String enrollmentUid, TrackerBundle bundle) {
+  private Set<ProgramStageInstance> getEventsFromEnrollment(
+      String enrollmentUid, TrackerBundle bundle) {
 
-        // Fetch events linked to the enrollment from the database
-        EventQueryParams eventQueryParams = new EventQueryParams();
-        eventQueryParams.setProgramInstances(Set.of(enrollmentUid));
-        List<org.hisp.dhis.dxf2.events.event.Event> dbEvents =
-                eventService.getEvents(eventQueryParams).getEvents();
+    // Fetch events linked to the enrollment from the database
+    EventQueryParams eventQueryParams = new EventQueryParams();
+    eventQueryParams.setProgramInstances(Set.of(enrollmentUid));
+    List<org.hisp.dhis.dxf2.events.event.Event> dbEvents =
+        eventService.getEvents(eventQueryParams).getEvents();
 
-        // Convert DB events to ProgramStageInstances
-        Map<String, ProgramStageInstance> dbProgramStageInstances =
-                dbEvents.stream()
-                        .collect(
-                                Collectors.toMap(
-                                        org.hisp.dhis.dxf2.events.event.Event::getUid,
-                                        e -> programStageInstanceService.getProgramStageInstance(e.getUid())));
+    // Convert DB events to ProgramStageInstances
+    Map<String, ProgramStageInstance> dbProgramStageInstances =
+        dbEvents.stream()
+            .collect(
+                Collectors.toMap(
+                    org.hisp.dhis.dxf2.events.event.Event::getUid,
+                    e -> programStageInstanceService.getProgramStageInstance(e.getUid())));
 
-        // Fetch events from the payload for the given enrollment
-        Map<String, ProgramStageInstance> payloadProgramStageInstances =
-                bundle.getEvents().stream()
-                        .filter(event -> event.getEnrollment().equals(enrollmentUid))
-                        .collect(
-                                Collectors.toMap(
-                                        Event::getUid,
-                                        event -> eventTrackerConverterService.fromForRuleEngine(bundle.getPreheat(), event)));
+    // Fetch events from the payload for the given enrollment
+    Map<String, ProgramStageInstance> payloadProgramStageInstances =
+        bundle.getEvents().stream()
+            .filter(event -> event.getEnrollment().equals(enrollmentUid))
+            .collect(
+                Collectors.toMap(
+                    Event::getUid,
+                    event ->
+                        eventTrackerConverterService.fromForRuleEngine(
+                            bundle.getPreheat(), event)));
 
-        // Merge payload events (prioritized) with DB events
-        dbProgramStageInstances.putAll(payloadProgramStageInstances);
+    // Merge payload events (prioritized) with DB events
+    dbProgramStageInstances.putAll(payloadProgramStageInstances);
 
-        // Return a Set of unique ProgramStageInstances
-        return new HashSet<>(dbProgramStageInstances.values());
-    }
+    // Return a Set of unique ProgramStageInstances
+    return new HashSet<>(dbProgramStageInstances.values());
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleServiceTest.java
@@ -121,6 +121,9 @@ class DefaultTrackerProgramRuleServiceTest extends DhisConvenienceTest {
     when(trackerBundle.getPreheat()).thenReturn(preheat);
     when(eventTrackerConverterService.fromForRuleEngine(any(TrackerPreheat.class), anyList()))
         .thenReturn(programStageInstances);
+    when(eventTrackerConverterService.fromForRuleEngine(
+            any(TrackerPreheat.class), any(Event.class)))
+        .thenReturn(programStageInstances.get(0));
     when(programRuleEngine.evaluateEnrollmentAndEvents(
             any(ProgramInstance.class), anySet(), anyList()))
         .thenReturn(Collections.emptyList());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -46,10 +46,14 @@ import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
+import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
+import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
+import org.hisp.dhis.tracker.sideeffect.TrackerRuleEngineSideEffect;
+import org.hisp.dhis.tracker.sideeffect.TrackerSendMessageSideEffect;
 import org.hisp.dhis.util.DateUtils;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -187,6 +191,52 @@ public class Assertions {
         report.getStatus(),
         errorMessage(
             "Expected import with status OK, instead got:\n", report.getValidationReport()));
+  }
+
+  public static void assertHasNoNotificationSideEffects(TrackerImportReport report) {
+    assertNotNull(report, "The ImportReport should not be null.");
+
+    TrackerTypeReport typeReport =
+        report.getBundleReport().getTypeReportMap().get(TrackerType.EVENT);
+
+    assertNotNull(typeReport, "The TrackerTypeReport for EVENT should not be null.");
+    assertFalse(
+        typeReport.getSideEffectDataBundles().isEmpty(),
+        "Expected side effect data bundles but none were found.");
+
+    TrackerSideEffectDataBundle sideEffectDataBundle = typeReport.getSideEffectDataBundles().get(0);
+
+    List<TrackerRuleEngineSideEffect> ruleEngineSideEffects =
+        sideEffectDataBundle.getEventRuleEffects().values().stream()
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+
+    assertTrue(
+        ruleEngineSideEffects.stream().noneMatch(TrackerSendMessageSideEffect.class::isInstance),
+        "Unexpected notification side effect (TrackerSendMessageSideEffect) found.");
+  }
+
+  public static void assertHasNotificationSideEffects(TrackerImportReport report) {
+    assertNotNull(report, "The ImportReport should not be null.");
+
+    TrackerTypeReport typeReport =
+        report.getBundleReport().getTypeReportMap().get(TrackerType.EVENT);
+
+    assertNotNull(typeReport, "The TrackerTypeReport for EVENT should not be null.");
+    assertFalse(
+        typeReport.getSideEffectDataBundles().isEmpty(),
+        "Expected side effect data bundles but none were found.");
+
+    TrackerSideEffectDataBundle sideEffectDataBundle = typeReport.getSideEffectDataBundles().get(0);
+
+    List<TrackerRuleEngineSideEffect> ruleEngineSideEffects =
+        sideEffectDataBundle.getEventRuleEffects().values().stream()
+            .flatMap(List::stream) // Flatten the list of lists into a single stream
+            .collect(Collectors.toList()); // Collect into a single list
+
+    assertTrue(
+        ruleEngineSideEffects.stream().anyMatch(TrackerSendMessageSideEffect.class::isInstance),
+        "Expected notification side effect (TrackerSendMessageSideEffect) but none were found.");
   }
 
   public static void assertNoErrors(TrackerValidationReport report) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -92,7 +92,7 @@ class ProgramRuleIntegrationTest extends TrackerTest {
 
   private DataElement dataElement2;
 
-  private DataElement dataElement6;
+  private DataElement dataElement3;
 
   @Override
   public void initTest() throws IOException {
@@ -103,7 +103,7 @@ class ProgramRuleIntegrationTest extends TrackerTest {
         bundle.getPreheat().get(PreheatIdentifier.UID, Program.class, "BFcipDERJne");
     dataElement1 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00001");
     dataElement2 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00002");
-    dataElement6 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00006");
+    dataElement3 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00006");
     programStageOnInsert =
         bundle.getPreheat().get(PreheatIdentifier.UID, ProgramStage.class, "NpsdDv6kKSO");
 
@@ -111,7 +111,7 @@ class ProgramRuleIntegrationTest extends TrackerTest {
         createProgramRuleVariableWithDataElement('A', programWithRegistration, dataElement2);
 
     ProgramRuleVariable programRuleVariableDE6 =
-        createProgramRuleVariableWithDataElement('D', programWithRegistration, dataElement6);
+        createProgramRuleVariableWithDataElement('D', programWithRegistration, dataElement3);
     programRuleVariableDE6.setName("integer_prv_de6");
 
     programRuleVariableService.addProgramRuleVariable(programRuleVariable);
@@ -275,7 +275,8 @@ class ProgramRuleIntegrationTest extends TrackerTest {
   }
 
   @Test
-  void shouldImportEventWithWarningsWhenPayloadEventDataIsPrioritized() throws IOException {
+  void shouldImportEventWithNotificationActionWhenPayloadEventDataIsPrioritized()
+      throws IOException {
     storeNotificationProgramRule(
         'I',
         programWithRegistration,

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/event_updated_datavalues.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/event_updated_datavalues.json
@@ -1,0 +1,86 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "status": "ACTIVE",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "createdAtClient": "2019-01-28T11:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "updatedAtClient": "2019-01-28T10:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
+      "attributeCategoryOptions": [],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "dataValues": [
+        {
+          "createdAt": "2019-01-28T12:10:38.113",
+          "updatedAt": "2019-01-28T12:10:38.113",
+          "storedBy": "admin",
+          "providedElsewhere": false,
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00006"
+          },
+          "value": 12
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_with_event_and_no_datavalues.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_with_event_and_no_datavalues.json
@@ -1,0 +1,123 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "createdAtClient": "2020-02-20T10:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "updatedAtClient": "2020-02-20T11:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAt": "2018-01-26T13:48:13.363",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAt": "2018-01-26T17:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    }
+  ],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "status": "ACTIVE",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "createdAtClient": "2019-01-28T11:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "updatedAtClient": "2019-01-28T10:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
+      "attributeCategoryOptions": [],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "dataValues": [],
+      "notes": []
+    }
+  ],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-19156
This PR fixes rule engine notifications by prioritizing event data values from the payload over those retrieved from the database.