### PR TITLE
fix: Unidirectional relationships only consider from end when exporting [DHIS2-19169]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -78,6 +78,10 @@ public class DefaultRelationshipService implements RelationshipService {
     return relationshipItems.stream()
         .filter(
             ri ->
+                ri.getRelationship().getFrom().equals(ri)
+                    || ri.getRelationship().getRelationshipType().isBidirectional())
+        .filter(
+            ri ->
                 trackerAccessManager
                     .canRead(CurrentUserUtil.getCurrentUserDetails(), ri.getRelationship())
                     .isEmpty())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -317,7 +317,8 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
     toSubQuery.where(
         builder.equal(root.get("to"), toRoot.get("id")),
-        builder.equal(toRoot.get(relationshipEntityType), entity.getId()));
+        builder.equal(toRoot.get(relationshipEntityType), entity.getId()),
+        builder.equal(root.get("relationshipType").get("bidirectional"), true));
 
     toSubQuery.select(toRoot.get("id"));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -317,8 +317,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
     toSubQuery.where(
         builder.equal(root.get("to"), toRoot.get("id")),
-        builder.equal(toRoot.get(relationshipEntityType), entity.getId()),
-        builder.equal(root.get("relationshipType").get("bidirectional"), true));
+        builder.equal(toRoot.get(relationshipEntityType), entity.getId()));
 
     toSubQuery.select(toRoot.get("id"));
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -2152,7 +2152,7 @@ public abstract class TestBase {
     relationshipType.setName("RelationshipType_" + relationshipType.getUid());
     relationshipType.setFromConstraint(fromRelationShipConstraint);
     relationshipType.setToConstraint(toRelationShipConstraint);
-
+    relationshipType.setBidirectional(true);
     return relationshipType;
   }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_metadata.json
@@ -1820,6 +1820,7 @@
     },
     {
       "id": "TV9oB9LT3sh",
+      "bidirectional": true,
       "created": "2020-11-20T09:06:23.348",
       "displayFromToName": "Parent Of",
       "displayName": "TA Parent to Child",
@@ -1848,6 +1849,7 @@
     },
     {
       "id": "m1575931405",
+      "bidirectional": true,
       "displayFromToName": "Parent Of",
       "displayName": "Parent to Child",
       "fromConstraint": {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/deduplication/merge/PotentialDuplicatesRelationshipTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/deduplication/merge/PotentialDuplicatesRelationshipTests.java
@@ -82,8 +82,15 @@ public class PotentialDuplicatesRelationshipTests extends PotentialDuplicatesApi
         .getTrackedEntity(teA + "?fields=*")
         .validate()
         .statusCode(200)
-        .body("relationships", hasSize(2))
-        .body("relationships.relationship", hasItems(relationship3, relationship2));
+        .body("relationships", hasSize(1))
+        .body("relationships.relationship", hasItems(relationship2));
+
+    trackerImportExportActions
+        .getTrackedEntity(teC + "?fields=*")
+        .validate()
+        .statusCode(200)
+        .body("relationships", hasSize(1))
+        .body("relationships.relationship", hasItems(relationship3));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -234,16 +234,11 @@ public class RelationshipsTests extends TrackerApiTest {
         .body("stats.ignored", equalTo(0))
         .body("stats.created", equalTo(1));
 
-    // and there is 1 relationship for any of the tracked entities
+    // and there are 2 relationships for any of the tracked entities
     ApiResponse relationshipResponse =
         trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_1);
 
-    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(1));
-
-    relationshipResponse =
-        trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_2);
-
-    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(1));
+    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(2));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -234,11 +234,16 @@ public class RelationshipsTests extends TrackerApiTest {
         .body("stats.ignored", equalTo(0))
         .body("stats.created", equalTo(1));
 
-    // and there are 2 relationships for any of the tracked entities
+    // and there is 1 relationship for any of the tracked entities
     ApiResponse relationshipResponse =
         trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_1);
 
-    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(2));
+    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(1));
+
+    relationshipResponse =
+        trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_2);
+
+    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(1));
   }
 
   @Test
@@ -413,17 +418,7 @@ public class RelationshipsTests extends TrackerApiTest {
         toInstanceId,
         createdRelationships.get(0));
 
-    ApiResponse entityResponse = getEntityInRelationship(toInstance, toInstanceId);
-    validateRelationship(
-        entityResponse,
-        relType,
-        fromInstance,
-        fromInstanceId,
-        toInstance,
-        toInstanceId,
-        createdRelationships.get(0));
-
-    entityResponse = getEntityInRelationship(fromInstance, fromInstanceId);
+    ApiResponse entityResponse = getEntityInRelationship(fromInstance, fromInstanceId);
     validateRelationship(
         entityResponse,
         relType,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -138,6 +138,9 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
   @Test
   void shouldUpdateOnlyFromTrackedEntityWhenUnidirectionalRelationshipIsCreated()
       throws IOException {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
     TrackedEntity fromEntityBeforeUpdate = getTrackedEntity();
     TrackedEntity toEntityBeforeUpdate = getTrackedEntity(anotherTrackedEntity.getUid());
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -265,7 +265,7 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
 
   @Test
   void
-      shouldGetEnrollmentWithNoRelationshipsWhenEnrollmentIsOnToEndOfAUnidirectionalRelationship() {
+      shouldGetEnrollmentWithNoRelationshipsWhenEnrollmentIsOnTheToSideOfAUnidirectionalRelationship() {
     Relationship relationship = get(Relationship.class, "p53a6314631");
 
     assertNotNull(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -260,6 +261,30 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
         () -> assertHasMember(jsonRelationship, "createdAt"),
         () -> assertHasMember(jsonRelationship, "updatedAt"),
         () -> assertHasMember(jsonRelationship, "bidirectional"));
+  }
+
+  @Test
+  void
+      shouldGetEnrollmentWithNoRelationshipsWhenEnrollmentIsOnToEndOfAUnidirectionalRelationship() {
+    Relationship relationship = get(Relationship.class, "p53a6314631");
+
+    assertNotNull(
+        relationship.getTo().getEnrollment(),
+        "test expects relationship to have a 'to' enrollment");
+    RelationshipType relationshipType = relationship.getRelationshipType();
+    relationshipType.setBidirectional(false);
+    manager.save(relationshipType);
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET(
+                "/tracker/enrollments?enrollments={id}&fields=*&includeDeleted=true",
+                relationship.getTo().getEnrollment().getUid())
+            .content(HttpStatus.OK)
+            .getList("enrollments", JsonEnrollment.class)
+            .get(0)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(jsonRelationships.stream().toList());
   }
 
   @ParameterizedTest

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -313,7 +313,7 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
   }
 
   @Test
-  void shouldGetEventWithNoRelationshipsWhenEventIsOnToEndOfAUnidirectionalRelationship() {
+  void shouldGetEventWithNoRelationshipsWhenEventIsOnTheToSideOfAUnidirectionalRelationship() {
     TrackedEntity from = trackedEntity();
     Event to = event(enrollment(from));
     Relationship relationship = relationship(from, to);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -326,7 +326,7 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonList<JsonRelationship> relationships =
-        GET("/tracker/events/?events={id}&fields=relationships&includeDeleted=true", to.getUid())
+        GET("/tracker/events/?events={id}&fields=relationships", to.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class)
             .get(0)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -237,6 +237,20 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   }
 
   @Test
+  void shouldGetNoRelationshipsByEventWhenRelationshipTypeIsUnidirectionalAndEventIsOnToEnd() {
+    RelationshipType relationshipType =
+        manager.get(RelationshipType.class, relationship1.getRelationshipType().getIdentifier());
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?event={uid}", relationship1To.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(jsonRelationships.stream().toList());
+  }
+
+  @Test
   void shouldGetRelationshipsByEventWithAllFields() {
     JsonList<JsonRelationship> jsonRelationships =
         GET("/tracker/relationships?event={uid}&fields=*", relationship1To.getUid())
@@ -340,6 +354,21 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     assertHasOnlyMembers(jsonRelationship, "relationship", "relationshipType", "from", "to");
     assertHasOnlyUid(relationship2From.getUid(), "trackedEntity", jsonRelationship.getFrom());
     assertHasOnlyUid(relationship2To.getUid(), "enrollment", jsonRelationship.getTo());
+  }
+
+  @Test
+  void
+      shouldGetNoRelationshipsByEnrollmentWhenRelationshipTypeIsUnidirectionalAndEnrollmentIsOnToEnd() {
+    RelationshipType relationshipType =
+        manager.get(RelationshipType.class, relationship2.getRelationshipType().getIdentifier());
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?enrollment=" + relationship2To.getUid())
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(jsonRelationships.stream().toList());
   }
 
   @Test
@@ -476,6 +505,30 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
         jsonRelationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
     assertHasOnlyUid(relationship1From.getUid(), "trackedEntity", jsonRelationship.getFrom());
     assertHasOnlyUid(relationship1To.getUid(), "event", jsonRelationship.getTo());
+  }
+
+  @Test
+  void
+      shouldGetNoRelationshipsByTrackedEntityWhenRelationshipTypeIsUnidirectionalAndTrackedEntityIsOnToEnd() {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+
+    assertEquals(
+        "QesgJkTyTCk",
+        manager
+            .get(org.hisp.dhis.relationship.Relationship.class, "N8800829a58")
+            .getTo()
+            .getTrackedEntity()
+            .getUid(),
+        "test expects relationship to have 'to' tracked entity with uid `QesgJkTyTCk`");
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?trackedEntity={trackedEntity}", "QesgJkTyTCk")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(jsonRelationships.stream().toList());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -243,7 +243,9 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
 
-    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "LCSfHnurnNB");
+    Relationship relationship = getRelationship(UID.of("x8919212736"));
+
+    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "QRYjLTiJTrA");
     assertHasSize(
         1,
         to.getRelationshipItems(),
@@ -254,7 +256,14 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
-    assertIsEmpty(jsonRelationships.stream().toList());
+    JsonRelationship jsonRelationship =
+        assertContains(
+            jsonRelationships,
+            rel -> relationship.getUid().getValue().equals(rel.getRelationship()),
+            "expected to find relationship " + relationship.getUid());
+
+    assertRelationship(relationship, jsonRelationship);
+    assertHasOnlyUid(UID.of(to), "event", jsonRelationship.getTo());
   }
 
   @Test
@@ -382,7 +391,10 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
-    assertIsEmpty(jsonRelationships.stream().toList());
+    JsonRelationship jsonRelationship = assertFirstRelationship(relationship2, jsonRelationships);
+    assertHasOnlyMembers(jsonRelationship, "relationship", "relationshipType", "from", "to");
+    assertHasOnlyUid(relationship2From.getUid(), "trackedEntity", jsonRelationship.getFrom());
+    assertHasOnlyUid(relationship2To.getUid(), "enrollment", jsonRelationship.getTo());
   }
 
   @Test
@@ -528,6 +540,8 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
 
+    Relationship relationship = getRelationship(UID.of("N8800829a58"));
+
     org.hisp.dhis.trackedentity.TrackedEntity to =
         manager.get(org.hisp.dhis.trackedentity.TrackedEntity.class, "QesgJkTyTCk");
     assertHasSize(
@@ -540,7 +554,14 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
-    assertIsEmpty(jsonRelationships.stream().toList());
+    JsonRelationship jsonRelationship =
+        assertContains(
+            jsonRelationships,
+            rel -> relationship.getUid().getValue().equals(rel.getRelationship()),
+            "expected to find relationship " + relationship.getUid());
+
+    assertRelationship(relationship, jsonRelationship);
+    assertHasOnlyUid(UID.of(to), "trackedEntity", jsonRelationship.getTo());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -243,7 +243,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
 
-    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "pTzf9KYMk72");
+    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "LCSfHnurnNB");
     assertHasSize(
         1,
         to.getRelationshipItems(),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -243,7 +243,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
 
-    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "D9PbzJY8bJM");
+    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "pTzf9KYMk72");
     assertHasSize(
         1,
         to.getRelationshipItems(),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 import static org.hisp.dhis.http.HttpStatus.FORBIDDEN;
 import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.Assertions.*;
@@ -237,13 +238,19 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
   }
 
   @Test
-  void shouldGetNoRelationshipsByEventWhenRelationshipTypeIsUnidirectionalAndEventIsOnToEnd() {
-    RelationshipType relationshipType =
-        manager.get(RelationshipType.class, relationship1.getRelationshipType().getIdentifier());
+  void shouldGetNoRelationshipsByEventWhenRelationshipTypeIsUnidirectionalAndEventIsOnTheToSide() {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "TV9oB9LT3sh");
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
+
+    org.hisp.dhis.program.Event to = manager.get(org.hisp.dhis.program.Event.class, "D9PbzJY8bJM");
+    assertHasSize(
+        1,
+        to.getRelationshipItems(),
+        "test expects relationship to have 'to' event with uid " + to.getUid());
+
     JsonList<JsonRelationship> jsonRelationships =
-        GET("/tracker/relationships?event={uid}", relationship1To.getUid())
+        GET("/tracker/relationships?event={uid}", to.getUid())
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
@@ -358,13 +365,20 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
   @Test
   void
-      shouldGetNoRelationshipsByEnrollmentWhenRelationshipTypeIsUnidirectionalAndEnrollmentIsOnToEnd() {
-    RelationshipType relationshipType =
-        manager.get(RelationshipType.class, relationship2.getRelationshipType().getIdentifier());
+      shouldGetNoRelationshipsByEnrollmentWhenRelationshipTypeIsUnidirectionalAndEnrollmentIsOnTheToSide() {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "xLmPUYJX8Ks");
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
+
+    org.hisp.dhis.program.Enrollment to =
+        manager.get(org.hisp.dhis.program.Enrollment.class, "nxP7UnKhomJ");
+    assertHasSize(
+        1,
+        to.getRelationshipItems(),
+        "test expects relationship to have 'to' enrollment with uid " + to.getUid());
+
     JsonList<JsonRelationship> jsonRelationships =
-        GET("/tracker/relationships?enrollment=" + relationship2To.getUid())
+        GET("/tracker/relationships?enrollment=" + to.getUid())
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 
@@ -509,22 +523,20 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
   @Test
   void
-      shouldGetNoRelationshipsByTrackedEntityWhenRelationshipTypeIsUnidirectionalAndTrackedEntityIsOnToEnd() {
+      shouldGetNoRelationshipsByTrackedEntityWhenRelationshipTypeIsUnidirectionalAndTrackedEntityIsOnTheToSide() {
     RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);
 
-    assertEquals(
-        "QesgJkTyTCk",
-        manager
-            .get(org.hisp.dhis.relationship.Relationship.class, "N8800829a58")
-            .getTo()
-            .getTrackedEntity()
-            .getUid(),
-        "test expects relationship to have 'to' tracked entity with uid `QesgJkTyTCk`");
+    org.hisp.dhis.trackedentity.TrackedEntity to =
+        manager.get(org.hisp.dhis.trackedentity.TrackedEntity.class, "QesgJkTyTCk");
+    assertHasSize(
+        1,
+        to.getRelationshipItems(),
+        "test expects relationship to have 'to' tracked entity with uid " + to.getUid());
 
     JsonList<JsonRelationship> jsonRelationships =
-        GET("/tracker/relationships?trackedEntity={trackedEntity}", "QesgJkTyTCk")
+        GET("/tracker/relationships?trackedEntity={trackedEntity}", to.getUid())
             .content(HttpStatus.OK)
             .getList("relationships", JsonRelationship.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -345,6 +345,47 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
   }
 
   @Test
+  void
+      shouldGetTrackedEntityWithNoRelationshipsWhenTrackedEntityIsOnToEndOfAUnidirectionalRelationship() {
+    TrackedEntity to = get(TrackedEntity.class, "QesgJkTyTCk");
+    assertHasSize(
+        1, to.getRelationshipItems(), "test expects a tracked entity with one relationship");
+
+    JsonList<JsonRelationship> rels =
+        GET("/tracker/trackedEntities?trackedEntities={id}&fields=relationships", to.getUid())
+            .content(HttpStatus.OK)
+            .getList("trackedEntities", JsonTrackedEntity.class)
+            .get(0)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(rels.stream().toList());
+  }
+
+  @Test
+  void
+      shouldGetNoRelationshipsByTrackedEntityWhenRelationshipTypeIsUnidirectionalAndTrackedEntityIsOnToEnd() {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+
+    assertEquals(
+        "QesgJkTyTCk",
+        manager
+            .get(org.hisp.dhis.relationship.Relationship.class, "N8800829a58")
+            .getTo()
+            .getTrackedEntity()
+            .getUid(),
+        "test expects relationship to have 'to' tracked entity with uid `QesgJkTyTCk`");
+
+    JsonList<JsonRelationship> jsonRelationships =
+        GET("/tracker/relationships?trackedEntity={trackedEntity}", "QesgJkTyTCk")
+            .content(HttpStatus.OK)
+            .getList("relationships", JsonRelationship.class);
+
+    assertIsEmpty(jsonRelationships.stream().toList());
+  }
+
+  @Test
   void getTrackedEntityByIdWithFieldsRelationships() {
     TrackedEntity from = get(TrackedEntity.class, "mHWCacsGYYn");
     assertHasSize(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -347,6 +347,10 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
   @Test
   void
       shouldGetTrackedEntityWithNoRelationshipsWhenTrackedEntityIsOnToEndOfAUnidirectionalRelationship() {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+
     TrackedEntity to = get(TrackedEntity.class, "QesgJkTyTCk");
     assertHasSize(
         1, to.getRelationshipItems(), "test expects a tracked entity with one relationship");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -366,30 +366,6 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
   }
 
   @Test
-  void
-      shouldGetNoRelationshipsByTrackedEntityWhenRelationshipTypeIsUnidirectionalAndTrackedEntityIsOnToEnd() {
-    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
-    relationshipType.setBidirectional(false);
-    manager.update(relationshipType);
-
-    assertEquals(
-        "QesgJkTyTCk",
-        manager
-            .get(org.hisp.dhis.relationship.Relationship.class, "N8800829a58")
-            .getTo()
-            .getTrackedEntity()
-            .getUid(),
-        "test expects relationship to have 'to' tracked entity with uid `QesgJkTyTCk`");
-
-    JsonList<JsonRelationship> jsonRelationships =
-        GET("/tracker/relationships?trackedEntity={trackedEntity}", "QesgJkTyTCk")
-            .content(HttpStatus.OK)
-            .getList("relationships", JsonRelationship.class);
-
-    assertIsEmpty(jsonRelationships.stream().toList());
-  }
-
-  @Test
   void getTrackedEntityByIdWithFieldsRelationships() {
     TrackedEntity from = get(TrackedEntity.class, "mHWCacsGYYn");
     assertHasSize(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -346,7 +346,7 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
 
   @Test
   void
-      shouldGetTrackedEntityWithNoRelationshipsWhenTrackedEntityIsOnToEndOfAUnidirectionalRelationship() {
+      shouldGetTrackedEntityWithNoRelationshipsWhenTrackedEntityIsOnTheToSideOfAUnidirectionalRelationship() {
     RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
     relationshipType.setBidirectional(false);
     manager.update(relationshipType);


### PR DESCRIPTION
***How relationships should work***
Relationships are entities that connect 2 tracker objects (tracked entity, enrollment and event) and they can be of 2 types: unidirectional or bidirectional.

![Screenshot 2025-03-11 at 12 36 56](https://github.com/user-attachments/assets/4daa2f3b-367f-4cea-85a0-c9d360f8e1b4)

A unidirectional relationship from A to C connects A to C, but does not connect C to A.
A bidirectional relationship from A to B connects A to B and connects B to A.

`/tracker/trackedEntities/{TrackedEntityA}?fields=relationships` returns `{relationshipA, relationshipB}`
`/tracker/trackedEntities/{TrackedEntityB}?fields=relationships` returns `{relationshipA}`
`/tracker/trackedEntities/{TrackedEntityC}?fields=relationships` returns `{}`

What does it mean "connects"?
It means that retrieving entity A, we can retrieve the relationships for A (`{relationshipA, relationshipB}`) and retrieve the other ends of the relationships (`{B,C}`).
If a relationship is unidirectional only "works" in one direction, so in the case of a unidirectional relationship from A to C, when retrieving C, we cannot retrieve such relationship (ie. `/tracker/trackedEntities/{TEc}?fields=relationships` should not return `relationshipB`).

***Status before the fix***
We were treating all relationships as bidirectional, any end of the relationship could retrieve the relationship.

***Status after the fix***
Tracker objects could retrieve only "outgoing" relationships (where the relationship is bidirectional or the object  is in the "from" end and the relationship is unidirectional).

Is "outgoing" a good and clear enough term to be used in the docs?