### PR TITLE
fix: correct redirects for global shell

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.springframework.stereotype.Component;
@@ -72,7 +73,10 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       throws IOException, ServletException {
     String globalShellAppName = settingsProvider.getCurrentSettings().getGlobalShellAppName();
     if (globalShellAppName.isEmpty() || !appManager.exists(globalShellAppName)) {
-      chain.doFilter(request, response);
+      boolean redirected = redirectDisabledGlobalShell(request, response, getContextRelativePath(request));
+      if (!redirected) {
+        chain.doFilter(request, response);
+      }
       return;
     }
 
@@ -87,6 +91,32 @@ public class GlobalShellFilter extends OncePerRequestFilter {
     }
 
     chain.doFilter(request, response);
+  }
+
+  private boolean redirectDisabledGlobalShell(HttpServletRequest request, HttpServletResponse response, String path)
+      throws IOException {
+    Matcher m = APP_IN_GLOBAL_SHELL_PATTERN.matcher(path);
+    
+    if (m.matches()) {
+      String appName = m.group(1);
+      App app = appManager.getApp(appName);
+
+      String targetPath;
+      if (app != null) {
+        log.debug("Installed app {} found", appName);
+        targetPath = app.getLaunchUrl();
+      } else if (AppManager.BUNDLED_APPS.contains(appName)) {
+        log.debug("Bundled app {} found", appName);
+        targetPath = String.join("/", request.getContextPath(), AppManager.BUNDLED_APP_PREFIX + appName);
+      } else {
+        log.debug("App {} not found", appName);
+        targetPath = request.getContextPath() + "/";
+      }
+      log.debug("Redirecting to {}", targetPath);
+      response.sendRedirect(targetPath);
+      return true;
+    }
+    return false;
   }
 
   private boolean redirectLegacyAppPaths(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
@@ -73,7 +73,8 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       throws IOException, ServletException {
     String globalShellAppName = settingsProvider.getCurrentSettings().getGlobalShellAppName();
     if (globalShellAppName.isEmpty() || !appManager.exists(globalShellAppName)) {
-      boolean redirected = redirectDisabledGlobalShell(request, response, getContextRelativePath(request));
+      boolean redirected =
+          redirectDisabledGlobalShell(request, response, getContextRelativePath(request));
       if (!redirected) {
         chain.doFilter(request, response);
       }
@@ -93,10 +94,10 @@ public class GlobalShellFilter extends OncePerRequestFilter {
     chain.doFilter(request, response);
   }
 
-  private boolean redirectDisabledGlobalShell(HttpServletRequest request, HttpServletResponse response, String path)
-      throws IOException {
+  private boolean redirectDisabledGlobalShell(
+      HttpServletRequest request, HttpServletResponse response, String path) throws IOException {
     Matcher m = APP_IN_GLOBAL_SHELL_PATTERN.matcher(path);
-    
+
     if (m.matches()) {
       String appName = m.group(1);
       App app = appManager.getApp(appName);
@@ -107,7 +108,8 @@ public class GlobalShellFilter extends OncePerRequestFilter {
         targetPath = app.getLaunchUrl();
       } else if (AppManager.BUNDLED_APPS.contains(appName)) {
         log.debug("Bundled app {} found", appName);
-        targetPath = String.join("/", request.getContextPath(), AppManager.BUNDLED_APP_PREFIX + appName);
+        targetPath =
+            String.join("/", request.getContextPath(), AppManager.BUNDLED_APP_PREFIX + appName);
       } else {
         log.debug("App {} not found", appName);
         targetPath = request.getContextPath() + "/";


### PR DESCRIPTION
This updates the redirects sent in the GlobalShellFilter.  In particular:

1. Only redirect from legacy apps to the global shell when receiving a top-level navigation request (header `Sec-Fetch-Mode=navigate`) https://dhis2.atlassian.net/browse/DHIS2-18454
2. Redirect from global app shell paths `/apps/<appName>` back to the original path (i.e. `/dhis-web-<appName>` or `/api/apps/<appName>`), in case someone has started with Global Shell enabled and later disabled it. [DHIS2-19166](https://dhis2.atlassian.net/browse/DHIS2-19166)

Will follow up with integration tests for all global shell cases in separate PR, since that will be quite helpful here but the infrastructure doesn't exist yet

[DHIS2-19166]: https://dhis2.atlassian.net/browse/DHIS2-19166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ