### PR TITLE
test: fix wrong HTTP header Content-Type

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/http/HttpClientAdapter.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/http/HttpClientAdapter.java
@@ -103,7 +103,7 @@ public interface HttpClientAdapter {
   }
 
   static Header ContentType(String mimeType) {
-    return Header("ContentType", mimeType);
+    return Header("Content-Type", mimeType);
   }
 
   static Header ContentType(Path file) {
@@ -207,7 +207,7 @@ public interface HttpClientAdapter {
     List<Header> headers = new ArrayList<>();
     for (RequestComponent c : components) {
       if (c instanceof Header header) {
-        if (header.name().equalsIgnoreCase("ContentType")) {
+        if (header.name().equalsIgnoreCase("Content-Type")) {
           // last provided content type wins
           contentMediaType = header.value().toString();
         } else {


### PR DESCRIPTION
fix bug in `HttpClientAdapter.ContentType`: wrong [HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) lead to the header not actually being set in https://github.com/dhis2/dhis2-core/blob/5f32ce23c66a2b75018a2cba07529f58e998710e/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/ControllerIntegrationTestBase.java#L205