### PR TITLE
fix: Log event DE changes only when enabled by config [DHIS2-19200]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.acl;
 
-import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
-
 import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -38,7 +36,6 @@ import org.hibernate.Hibernate;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -70,7 +67,6 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
   private final ProgramTempOwnershipAuditService programTempOwnershipAuditService;
   private final ProgramTempOwnerService programTempOwnerService;
   private final ProgramOwnershipHistoryService programOwnershipHistoryService;
-  private final DhisConfigurationProvider config;
   private final UserService userService;
   private final ProgramService programService;
   private final IdentifiableObjectManager manager;
@@ -83,7 +79,6 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
       ProgramTempOwnerService programTempOwnerService,
       ProgramOwnershipHistoryService programOwnershipHistoryService,
       ProgramService programService,
-      DhisConfigurationProvider config,
       IdentifiableObjectManager manager) {
 
     this.userService = userService;
@@ -92,7 +87,6 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
     this.programOwnershipHistoryService = programOwnershipHistoryService;
     this.programTempOwnerService = programTempOwnerService;
     this.programService = programService;
-    this.config = config;
     this.manager = manager;
     this.ownerCache = cacheProvider.createProgramOwnerCache();
     this.tempOwnerCache = cacheProvider.createProgramTempOwnerCache();
@@ -163,7 +157,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
 
     // TODO(tracker) jdbc-hibernate: check the impact on performance
     TrackedEntity hibernateTrackedEntity = manager.get(TrackedEntity.class, trackedEntity.getUid());
-    if (config.isEnabled(CHANGELOG_TRACKER)) {
+    if (trackedEntity.getTrackedEntityType().isAllowAuditLog()) {
       programTempOwnershipAuditService.addProgramTempOwnershipAudit(
           new ProgramTempOwnershipAudit(
               program, hibernateTrackedEntity, reason, user.getUsername()));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export.event;
 import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -44,6 +45,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.Page;
@@ -58,6 +60,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
 
   private final EventService eventService;
   private final HibernateEventChangeLogStore hibernateEventChangeLogStore;
+  private final DhisConfigurationProvider config;
 
   @Nonnull
   @Override
@@ -92,6 +95,9 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
       String value,
       ChangeLogType changeLogType,
       String userName) {
+    if (config.isDisabled(CHANGELOG_TRACKER)) {
+      return;
+    }
 
     EventChangeLog eventChangeLog =
         new EventChangeLog(
@@ -104,6 +110,10 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   @Transactional
   public void addFieldChangeLog(
       @Nonnull Event currentEvent, @Nonnull Event event, @Nonnull String username) {
+    if (config.isDisabled(CHANGELOG_TRACKER)) {
+      return;
+    }
+
     logIfChanged(
         "occurredAt", Event::getOccurredDate, this::formatDate, currentEvent, event, username);
     logIfChanged(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.acl;
+
+import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
+import static org.hisp.dhis.test.TestBase.createProgram;
+import static org.hisp.dhis.test.TestBase.createTrackedEntity;
+import static org.hisp.dhis.test.TestBase.createTrackedEntityType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.common.AccessLevel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramOwnershipHistoryService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramTempOwnerService;
+import org.hisp.dhis.program.ProgramTempOwnershipAudit;
+import org.hisp.dhis.program.ProgramTempOwnershipAuditService;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTrackerOwnershipManagerTest {
+
+  @Mock private UserService userService;
+
+  @Mock private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
+
+  @Mock private ProgramTempOwnershipAuditService programTempOwnershipAuditService;
+
+  @Mock private ProgramTempOwnerService programTempOwnerService;
+
+  @Mock private ProgramOwnershipHistoryService programOwnershipHistoryService;
+
+  @Mock private ProgramService programService;
+
+  @Mock private IdentifiableObjectManager manager;
+
+  @Mock private CacheProvider cacheProvider;
+
+  @Mock private Cache<Object> ownerCache;
+
+  @Mock private Cache<Object> tempOwnerCache;
+
+  @InjectMocks private DefaultTrackerOwnershipManager trackerOwnershipManager;
+
+  private Program program;
+  private UserDetails userDetails;
+  private String reason;
+  private OrganisationUnit orgUnit;
+
+  @BeforeEach
+  void setUp() {
+    when(cacheProvider.createProgramOwnerCache()).thenReturn(ownerCache);
+    when(cacheProvider.createProgramTempOwnerCache()).thenReturn(tempOwnerCache);
+
+    trackerOwnershipManager =
+        new DefaultTrackerOwnershipManager(
+            userService,
+            trackedEntityProgramOwnerService,
+            cacheProvider,
+            programTempOwnershipAuditService,
+            programTempOwnerService,
+            programOwnershipHistoryService,
+            programService,
+            manager);
+
+    orgUnit = createOrganisationUnit("org unit");
+    orgUnit.setPath(orgUnit.getUid());
+    program = createProgram('A');
+    program.setAccessLevel(AccessLevel.PROTECTED);
+    User user = new User();
+    user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
+    userDetails = UserDetails.fromUser(user);
+    reason = "breaking the glass";
+
+    when(ownerCache.get(any(), any())).thenReturn(orgUnit);
+  }
+
+  @Test
+  void shouldLogProgramOwnershipChangeWhenTrackedEntityTypeAuditEnabled()
+      throws ForbiddenException {
+    TrackedEntity trackedEntity = createTrackedEntityWithAuditLog(true);
+
+    trackerOwnershipManager.grantTemporaryOwnership(trackedEntity, program, userDetails, reason);
+
+    verify(programTempOwnershipAuditService, times(1))
+        .addProgramTempOwnershipAudit(any(ProgramTempOwnershipAudit.class));
+  }
+
+  @Test
+  void shouldNotLogProgramOwnershipChangeWhenTrackedEntityTypeAuditDisabled()
+      throws ForbiddenException {
+    TrackedEntity trackedEntity = createTrackedEntityWithAuditLog(false);
+
+    trackerOwnershipManager.grantTemporaryOwnership(trackedEntity, program, userDetails, reason);
+
+    verify(programTempOwnershipAuditService, never())
+        .addProgramTempOwnershipAudit(any(ProgramTempOwnershipAudit.class));
+  }
+
+  private TrackedEntity createTrackedEntityWithAuditLog(boolean isAllowAuditLog) {
+    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
+    trackedEntityType.setAllowAuditLog(isAllowAuditLog);
+    TrackedEntity trackedEntity = createTrackedEntity('A', orgUnit, trackedEntityType);
+    trackedEntity.setTrackedEntityType(trackedEntityType);
+
+    return trackedEntity;
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -109,6 +109,8 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
 
   @BeforeEach
   void setUp() {
+    config.getProperties().put(CHANGELOG_TRACKER.getKey(), "on");
+
     owner = makeUser("owner");
 
     coc = categoryService.getDefaultCategoryOptionCombo();
@@ -145,8 +147,6 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
     dataValue.setDataElement(dataElement.getUid());
     dataValue.setStoredBy("user");
     dataValue.setValue(DATA_ELEMENT_VALUE);
-
-    config.getProperties().put(CHANGELOG_TRACKER.getKey(), "on");
 
     event = event(enrollment(trackedEntity()));
     event.getEventDataValues().add(dataValue);


### PR DESCRIPTION
- As done for [tracked entity attributes](https://github.com/dhis2/dhis2-core/pull/20249), we will log changes in data values only when the `CHANGELOG_TRACKER` config is enabled.

- On the other side, we'll only log that a user breaks the glass if the tracked entity type is configured to allow logs. I've created a unit test to validate such behavior because `programTempOwnershipAuditService` can create new entries but doesn't have a method to fetch them.