### PR TITLE
fix: Update updatedAt field for tracked entity when deleting relationship [DHIS2-9767]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
@@ -34,6 +34,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -41,6 +44,7 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.common.SoftDeletableObject;
+import org.hisp.dhis.common.UID;
 
 /**
  * @author Abyot Asalefew
@@ -87,6 +91,19 @@ public class Relationship extends SoftDeletableObject implements Serializable {
   // -------------------------------------------------------------------------
   // Getters and setters
   // -------------------------------------------------------------------------
+
+  @JsonIgnore
+  public Set<UID> getTrackedEntityOrigins() {
+    Set<UID> uids = new HashSet<>();
+
+    Optional.ofNullable(this.getFrom().getTrackedEntity()).map(UID::of).ifPresent(uids::add);
+
+    if (this.getRelationshipType().isBidirectional()) {
+      Optional.ofNullable(this.getTo().getTrackedEntity()).map(UID::of).ifPresent(uids::add);
+    }
+
+    return uids;
+  }
 
   @JsonProperty
   public Date getCreatedAtClient() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -28,9 +28,7 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import jakarta.persistence.EntityManager;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -121,15 +119,7 @@ public class RelationshipPersister
 
   @Override
   protected Set<UID> getUpdatedTrackedEntities(org.hisp.dhis.relationship.Relationship entity) {
-    Set<UID> uids = new HashSet<>();
-
-    Optional.ofNullable(entity.getFrom().getTrackedEntity()).map(UID::of).ifPresent(uids::add);
-
-    if (entity.getRelationshipType().isBidirectional()) {
-      Optional.ofNullable(entity.getTo().getTrackedEntity()).map(UID::of).ifPresent(uids::add);
-    }
-
-    return uids;
+    return entity.getTrackedEntityOrigins();
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -175,6 +175,56 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldUpdateOnlyFromTrackedEntityWhenUnidirectionalRelationshipIsDeleted()
+      throws IOException {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(false);
+    manager.update(relationshipType);
+
+    testSetup.importTrackerData("tracker/relationshipTEtoTE.json");
+    clearSession();
+
+    TrackedEntity fromEntityBeforeUpdate = getTrackedEntity();
+    TrackedEntity toEntityBeforeUpdate = getTrackedEntity(anotherTrackedEntity.getUid());
+    clearSession();
+
+    testSetup.importTrackerData(
+        "tracker/relationshipTEtoTE.json",
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build());
+
+    TrackedEntity fromEntityAfterUpdate = getTrackedEntity();
+    TrackedEntity toEntityAfterUpdate = getTrackedEntity(anotherTrackedEntity.getUid());
+
+    assertTrackedEntityUpdated(fromEntityBeforeUpdate, fromEntityAfterUpdate, importUser);
+    assertTrackedEntityNotUpdated(toEntityBeforeUpdate, toEntityAfterUpdate);
+  }
+
+  @Test
+  void shouldUpdateFromAndToTrackedEntitiesWhenBidirectionalRelationshipIsDeleted()
+      throws IOException {
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "m1575931405");
+    relationshipType.setBidirectional(true);
+    manager.update(relationshipType);
+
+    testSetup.importTrackerData("tracker/relationshipTEtoTE.json");
+    clearSession();
+
+    TrackedEntity fromEntityBeforeUpdate = getTrackedEntity();
+    TrackedEntity toEntityBeforeUpdate = getTrackedEntity(anotherTrackedEntity.getUid());
+    clearSession();
+
+    testSetup.importTrackerData(
+        "tracker/relationshipTEtoTE.json",
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.DELETE).build());
+
+    TrackedEntity fromEntityAfterUpdate = getTrackedEntity();
+    TrackedEntity toEntityAfterUpdate = getTrackedEntity(anotherTrackedEntity.getUid());
+
+    assertTrackedEntityUpdated(fromEntityBeforeUpdate, fromEntityAfterUpdate, importUser);
+    assertTrackedEntityUpdated(toEntityBeforeUpdate, toEntityAfterUpdate, importUser);
+  }
+
+  @Test
   void shouldUpdateTrackedEntityWhenEventIsUpdated() throws IOException {
     TrackedEntity entityBeforeUpdate = getTrackedEntity();
 


### PR DESCRIPTION
I missed one case from this [PR](https://github.com/dhis2/dhis2-core/pull/20192)
We need to update `updatedAt` field for tracked entity when a relationship originated from such tracked entity is deleted.

I moved the logic to get the tracked entities to be updated inside `Relationship` class in `getTrackedEntityOrigins` method.