### PR TITLE
fix: Throw 404 when owner outside of capture scope [DHIS2-19210]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -2239,6 +2239,22 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldGetTrackedEntityWhenRequestingSingleTEEnrolledInProtectedProgramAndUserInCaptureScope()
+      throws ForbiddenException, NotFoundException {
+    user.setTeiSearchOrganisationUnits(Set.of());
+    user.setOrganisationUnits(Set.of(orgUnitB));
+    injectSecurityContextUser(user);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityB, programB, orgUnitB);
+
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            UID.of(trackedEntityB.getUid()), UID.of(programB.getUid()), TrackedEntityParams.FALSE);
+
+    assertEquals(trackedEntityB.getUid(), trackedEntity.getUid());
+  }
+
+  @Test
   void
       shouldFailWhenRequestingSingleTEEnrolledInProtectedProgramWhenUserInSearchScopeButNotInCaptureScope() {
     trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
@@ -2251,6 +2267,26 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
                 UID.of(trackedEntityB.getUid()),
                 UID.of(programB.getUid()),
                 TrackedEntityParams.FALSE));
+  }
+
+  @Test
+  void shouldGetTrackedEntityWhenRequestingSingleTEEnrolledInClosedAndUserInCaptureScope()
+      throws ForbiddenException, NotFoundException {
+    injectAdminIntoSecurityContext();
+    makeProgramDataAndMetadataAccessible(programC);
+    Enrollment enrollment = createEnrollment(programC, trackedEntityB, orgUnitB);
+    manager.save(enrollment);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityB, programC, orgUnitB);
+    user.setTeiSearchOrganisationUnits(Set.of());
+    user.setOrganisationUnits(Set.of(orgUnitB));
+    injectSecurityContextUser(user);
+
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            UID.of(trackedEntityB.getUid()), UID.of(programC.getUid()), TrackedEntityParams.FALSE);
+
+    assertEquals(trackedEntityB.getUid(), trackedEntity.getUid());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -2224,11 +2224,26 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldFailWhenRequestingSingleTEEnrolledInOpenProgramWhenUserNotInSearchScope() {
+    user.setTeiSearchOrganisationUnits(Set.of(orgUnitB));
+    user.setOrganisationUnits(Set.of(orgUnitB));
+    injectSecurityContextUser(user);
+
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () ->
+            trackedEntityService.getTrackedEntity(
+                UID.of(trackedEntityA.getUid()),
+                UID.of(programA.getUid()),
+                TrackedEntityParams.FALSE));
+  }
+
+  @Test
   void
-      shouldFailWhenRequestingSingleTEEnrolledInProtectedProgramWhenUserInSearchScopeButNotIfNoCaptureScope() {
+      shouldFailWhenRequestingSingleTEEnrolledInProtectedProgramWhenUserInSearchScopeButNotInCaptureScope() {
     trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
         trackedEntityB, programB, orgUnitB);
-    manager.update(trackedEntityA);
+
     Assertions.assertThrows(
         NotFoundException.class,
         () ->
@@ -2240,7 +2255,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void
-      shouldFailWhenRequestingSingleTEEnrolledInClosedProgramWhenUserInSearchScopeButNotIfNoCaptureScope() {
+      shouldFailWhenRequestingSingleTEEnrolledInClosedProgramWhenUserInSearchScopeButNotInCaptureScope() {
     injectAdminIntoSecurityContext();
     makeProgramDataAndMetadataAccessible(programC);
     Enrollment enrollment = createEnrollment(programC, trackedEntityB, orgUnitB);


### PR DESCRIPTION
When requesting a single tracked entity, we were not validating the user access to the TE/program combination when the program was specified in the request.
This PR fixes the issue.