### PR TITLE
fix: Missing ou groups/level in metadata [DHIS2-19149]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/OrganisationUnitResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/OrganisationUnitResolver.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import static org.hisp.dhis.common.CodeGenerator.isValidUid;
 import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
@@ -170,7 +169,7 @@ public class OrganisationUnitResolver {
       }
     } else if (dimensionUid.startsWith(KEY_ORGUNIT_GROUP)) {
       return idObjectManager.getObject(
-          OrganisationUnitGroup.class, idScheme, substringAfter(dimensionUid, SEPARATOR));
+          OrganisationUnitGroup.class, idScheme, substringAfterLast(dimensionUid, SEPARATOR));
     } else if (isValidUid(dimensionUid)) {
       return idObjectManager.getObject(OrganisationUnit.class, idScheme, dimensionUid);
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FilterUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FilterUtils.java
@@ -27,15 +27,9 @@
  */
 package org.hisp.dhis.webapi.utils;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.apache.commons.lang3.StringUtils.substringAfterLast;
-import static org.hisp.dhis.common.IdentifiableObjectUtils.SEPARATOR;
-
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -77,27 +71,5 @@ public class FilterUtils {
     }
 
     return result;
-  }
-
-  /**
-   * It reads the given list of Org. Unit identifiers and returns only the uid of each level or
-   * group.
-   *
-   * @param ouIdentifiers the list of org. units identifiers. ie: LEVEL-1-m9lBJogzE95,
-   *     OU_GROUP-tDZVQ1WtwpA.
-   * @return the list of org. units uids.
-   */
-  public static List<String> getOrgUnitLevelsGroups(List<String> ouIdentifiers) {
-    Set<String> uids = new HashSet<>();
-
-    if (isNotEmpty(ouIdentifiers)) {
-      for (String uid : ouIdentifiers) {
-        if (uid.contains(SEPARATOR)) {
-          uids.add(substringAfterLast(uid, SEPARATOR));
-        }
-      }
-    }
-
-    return uids.stream().toList();
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FilterUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FilterUtils.java
@@ -27,9 +27,15 @@
  */
 package org.hisp.dhis.webapi.utils;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.hisp.dhis.common.IdentifiableObjectUtils.SEPARATOR;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -71,5 +77,27 @@ public class FilterUtils {
     }
 
     return result;
+  }
+
+  /**
+   * It reads the given list of Org. Unit identifiers and returns only the uid of each level or
+   * group.
+   *
+   * @param ouIdentifiers the list of org. units identifiers. ie: LEVEL-1-m9lBJogzE95,
+   *     OU_GROUP-tDZVQ1WtwpA.
+   * @return the list of org. units uids.
+   */
+  public static List<String> getOrgUnitLevelsGroups(List<String> ouIdentifiers) {
+    Set<String> uids = new HashSet<>();
+
+    if (isNotEmpty(ouIdentifiers)) {
+      for (String uid : ouIdentifiers) {
+        if (uid.contains(SEPARATOR)) {
+          uids.add(substringAfterLast(uid, SEPARATOR));
+        }
+      }
+    }
+
+    return uids.stream().toList();
   }
 }


### PR DESCRIPTION
This PR fixes the `metaData` object in EventVisualization.

It now considers Org. Unit LEVELs and GROUPs.

Example:
```
   "metaData": {
        "Vth0fbpFcsO": {
            "uid": "Vth0fbpFcsO",
            "code": "OU_233310",
            "name": "Kono"
        },
        "CXw2yu5fodb": {
            "uid": "CXw2yu5fodb",
            "code": "CHC",
            "name": "CHC"
        },
        "S33cRBsnXPo": {
            "uid": "S33cRBsnXPo",
            "code": "DE_862347",
            "name": "Inpatient Place of Infection"
        },
        "O6uvpzGd5pu": {
            "uid": "O6uvpzGd5pu",
            "code": "OU_264",
            "name": "Bo"
        },
        "H1KlN4QIauv": {
            "uid": "H1KlN4QIauv",
            "name": "National"
        }
    },
```