### PR TITLE
fix: OpenAPI - consider rendering choices for HTML cache

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -237,7 +237,9 @@ public class OpenApiController {
       OpenApiGenerationParams generation,
       OpenApiRenderingParams rendering) {
     String cacheKey =
-        generation.isSkipCache() ? null : scoping.getCacheKey() + generation.getDocumentCacheKey();
+        generation.isSkipCache()
+            ? null
+            : scoping.getCacheKey() + generation.getDocumentCacheKey() + rendering.getCacheKey();
     return HTML_CACHE.get(
         cacheKey,
         () -> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerationParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerationParams.java
@@ -79,13 +79,16 @@ public class OpenApiGenerationParams {
   boolean includeXProperties = false;
 
   /**
-   * @return cache key to use for {@link Api} objects, null when no cache should be used
+   * @return cache key to use for {@link Api} objects
    */
   @OpenApi.Ignore
   String getApiCacheKey() {
     return expandedRefs ? "full-extended" : "full-default";
   }
 
+  /**
+   * @return cache key used for generated JSON/YAML documents
+   */
   @OpenApi.Ignore
   String getDocumentCacheKey() {
     return getApiCacheKey() + "-" + (includeXProperties ? "x" : "s");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderingParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiRenderingParams.java
@@ -48,4 +48,17 @@ public class OpenApiRenderingParams {
     Values of a shared enum with less than the limit values will show the first n values up to limit
     directly where the type is used""")
   int inlineEnumsLimit = 0;
+
+  /**
+   * @return part of the overall cache key added to reflect the rendering parameters for the HTML
+   *     document cache
+   */
+  @OpenApi.Ignore
+  String getCacheKey() {
+    String key = "";
+    if (source) key += "-s";
+    if (inlineEnumsLimit != 0) key += "-e" + inlineEnumsLimit;
+    if (sortEndpointsByMethod) key += "-s";
+    return key;
+  }
 }


### PR DESCRIPTION
### Summary
The HTML rendering options were not considered for the HTML document cache key so the first option combination that ended up in cache was served for all possible option combinations. Note that this only affected the rendering options, not the document scope or analysis options.

### Manual Testing
* open `/api/openapi.html?scope=controller:ProgramMessageController&source=true`
* open `/api/openapi.html?scope=controller:ProgramMessageController&source=false`
* check that one has sources, the other does not