### PR TITLE
chore: allow testing sync using docker-compose DHIS2-18991 [2.39]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 x-web-base: &web-base
   image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
   volumes:
-    - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
     - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
   environment:
     JAVA_OPTS:
@@ -17,6 +16,9 @@ x-web-base: &web-base
 
 x-db-base: &db-base
   image: ghcr.io/baosystems/postgis:12-3.3
+  # uncomment to enable query logging
+  # command:
+  #   ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
   volumes:
     - db-dump:/docker-entrypoint-initdb.d/
   environment:
@@ -41,6 +43,8 @@ x-db-base: &db-base
 services:
   web:
     <<: *web-base
+    volumes:
+      - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
     ports:
       - "127.0.0.1:8080:8080" # DHIS2
       - "127.0.0.1:8081:8081" # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
@@ -61,6 +65,8 @@ services:
   # https://github.com/dhis2/wow-backend/blob/c190287f8bf6493ed6f93d10bda4e764fcaf9930/guides/testing/metadata_sync_testing.md
   web-sync:
     <<: *web-base
+    volumes:
+      - ./docker/dhis-sync.conf:/opt/dhis2/dhis.conf:ro
     profiles: [sync]
     ports:
       - "127.0.0.1:8082:8080" # DHIS2

--- a/docker/dhis-sync.conf
+++ b/docker/dhis-sync.conf
@@ -1,0 +1,7 @@
+connection.dialect = org.hibernate.dialect.PostgreSQLDialect
+connection.driver_class = org.postgresql.Driver
+connection.url = jdbc:postgresql://db-sync/dhis
+connection.username = dhis
+connection.password = dhis
+
+tracker.import.preheat.cache.enabled=off


### PR DESCRIPTION
the second instance `web-sync` needs to connect to its own DB `db-sync`. The easiest way is to use a separate `dhis.conf`. Other solutions are really hacky like only being able to inline the config into the `docker-compose.yml` if we override the command that starts DHIS2 with a shell script that adds the config as heredoc.