### PR TITLE
fix: Use different TE validation flow when breaking the glass [DHIS2-18877]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManager.java
@@ -226,7 +226,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
         program.getTrackedEntityType().getUid(), trackedEntity.getTrackedEntityType().getUid())) {
       throw new ForbiddenException(
           String.format(
-              "Temporary ownership not created. The the tracked entity type of the program %s differs from that of the tracked entity %s.",
+              "Temporary ownership not created. The tracked entity type of the program %s differs from that of the tracked entity %s.",
               program.getTrackedEntityType().getUid(),
               trackedEntity.getTrackedEntityType().getUid()));
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramTempOwnerService;
 import org.hisp.dhis.program.ProgramTempOwnershipAudit;
 import org.hisp.dhis.program.ProgramTempOwnershipAuditService;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
@@ -85,6 +86,8 @@ class DefaultTrackerOwnershipManagerTest {
 
   @Mock private Cache<Object> tempOwnerCache;
 
+  @Mock private AclService aclService;
+
   @InjectMocks private DefaultTrackerOwnershipManager trackerOwnershipManager;
 
   private Program program;
@@ -106,7 +109,8 @@ class DefaultTrackerOwnershipManagerTest {
             programTempOwnerService,
             programOwnershipHistoryService,
             programService,
-            manager);
+            manager,
+            aclService);
 
     orgUnit = createOrganisationUnit("org unit");
     orgUnit.setPath(orgUnit.getUid());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/acl/DefaultTrackerOwnershipManagerTest.java
@@ -94,6 +94,7 @@ class DefaultTrackerOwnershipManagerTest {
   private UserDetails userDetails;
   private String reason;
   private OrganisationUnit orgUnit;
+  private TrackedEntityType trackedEntityType;
 
   @BeforeEach
   void setUp() {
@@ -116,18 +117,23 @@ class DefaultTrackerOwnershipManagerTest {
     orgUnit.setPath(orgUnit.getUid());
     program = createProgram('A');
     program.setAccessLevel(AccessLevel.PROTECTED);
+    trackedEntityType = createTrackedEntityType('A');
+    program.setTrackedEntityType(trackedEntityType);
     User user = new User();
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
     userDetails = UserDetails.fromUser(user);
     reason = "breaking the glass";
 
     when(ownerCache.get(any(), any())).thenReturn(orgUnit);
+    when(aclService.canDataRead(userDetails, program)).thenReturn(true);
   }
 
   @Test
   void shouldLogProgramOwnershipChangeWhenTrackedEntityTypeAuditEnabled()
       throws ForbiddenException {
     TrackedEntity trackedEntity = createTrackedEntityWithAuditLog(true);
+    when(aclService.canDataRead(userDetails, trackedEntity.getTrackedEntityType()))
+        .thenReturn(true);
 
     trackerOwnershipManager.grantTemporaryOwnership(trackedEntity, program, userDetails, reason);
 
@@ -139,6 +145,8 @@ class DefaultTrackerOwnershipManagerTest {
   void shouldNotLogProgramOwnershipChangeWhenTrackedEntityTypeAuditDisabled()
       throws ForbiddenException {
     TrackedEntity trackedEntity = createTrackedEntityWithAuditLog(false);
+    when(aclService.canDataRead(userDetails, trackedEntity.getTrackedEntityType()))
+        .thenReturn(true);
 
     trackerOwnershipManager.grantTemporaryOwnership(trackedEntity, program, userDetails, reason);
 
@@ -147,7 +155,6 @@ class DefaultTrackerOwnershipManagerTest {
   }
 
   private TrackedEntity createTrackedEntityWithAuditLog(boolean isAllowAuditLog) {
-    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.setAllowAuditLog(isAllowAuditLog);
     TrackedEntity trackedEntity = createTrackedEntity('A', orgUnit, trackedEntityType);
     trackedEntity.setTrackedEntityType(trackedEntityType);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
@@ -492,7 +492,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
                     trackedEntityA1, programA, userDetailsA, "test temporary ownership"));
 
     assertStartsWith(
-        "Temporary ownership not created. The the tracked entity type of the program",
+        "Temporary ownership not created. The tracked entity type of the program",
         exception.getMessage());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/ownership/TrackerOwnershipManagerTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.tracker.TrackerTestUtils.uids;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -99,6 +100,8 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
   @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
+  private TrackedEntityType trackedEntityType;
+
   private TrackedEntity trackedEntityA1;
 
   private TrackedEntity trackedEntityB1;
@@ -127,7 +130,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
     organisationUnitB = createOrganisationUnit('B');
     organisationUnitService.addOrganisationUnit(organisationUnitB);
 
-    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
+    trackedEntityType = createTrackedEntityType('A');
     trackedEntityTypeService.addTrackedEntityType(trackedEntityType);
     trackedEntityType.setSharing(Sharing.builder().publicAccess(AccessStringHelper.FULL).build());
     trackedEntityTypeService.updateTrackedEntityType(trackedEntityType);
@@ -189,7 +192,7 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
                     trackedEntityA1, programA, userDetailsB, "testing reason"));
 
     assertEquals(
-        "The owner of the entity-program combination is not in the user's search scope.",
+        "Temporary ownership not created. The owner of the entity-program combination is not in the user's search scope.",
         exception.getMessage());
   }
 
@@ -418,6 +421,78 @@ class TrackerOwnershipManagerTest extends PostgresIntegrationTestBase {
 
     assertEquals(
         "Temporary ownership not created. Program supplied is not a tracker program.",
+        exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenGrantingTemporaryAccessIfTrackedEntitySuppliedIsNull() {
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () ->
+                trackerOwnershipAccessManager.grantTemporaryOwnership(
+                    null, programA, userDetailsA, "test temporary ownership"));
+
+    assertEquals(
+        "Temporary ownership not created. Tracked entity supplied does not exist.",
+        exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenGrantingTemporaryAccessIfUserHasNoAccessToProgram() {
+    programA.setSharing(Sharing.builder().publicAccess(AccessStringHelper.DEFAULT).build());
+    programService.updateProgram(programA);
+
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () ->
+                trackerOwnershipAccessManager.grantTemporaryOwnership(
+                    trackedEntityA1, programA, userDetailsA, "test temporary ownership"));
+
+    assertStartsWith(
+        "Temporary ownership not created. User has no data read access to program",
+        exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenGrantingTemporaryAccessIfUserHasNoAccessToTET() {
+    trackedEntityType.setSharing(
+        Sharing.builder().publicAccess(AccessStringHelper.DEFAULT).build());
+    trackedEntityTypeService.updateTrackedEntityType(trackedEntityType);
+    trackedEntityA1.setTrackedEntityType(trackedEntityType);
+    manager.update(trackedEntityA1);
+
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () ->
+                trackerOwnershipAccessManager.grantTemporaryOwnership(
+                    trackedEntityA1, programA, userDetailsA, "test temporary ownership"));
+
+    assertStartsWith(
+        "Temporary ownership not created. User has no data read access to tracked entity type",
+        exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenGrantingTemporaryAccessIfProgramTETDifferentThanTEs() {
+    TrackedEntityType differentTET = createTrackedEntityType('B');
+    trackedEntityTypeService.addTrackedEntityType(differentTET);
+    differentTET.setSharing(Sharing.builder().publicAccess(AccessStringHelper.FULL).build());
+    trackedEntityTypeService.updateTrackedEntityType(differentTET);
+    trackedEntityA1.setTrackedEntityType(differentTET);
+    manager.update(trackedEntityA1);
+
+    Exception exception =
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () ->
+                trackerOwnershipAccessManager.grantTemporaryOwnership(
+                    trackedEntityA1, programA, userDetailsA, "test temporary ownership"));
+
+    assertStartsWith(
+        "Temporary ownership not created. The the tracked entity type of the program",
         exception.getMessage());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipControllerTest.java
@@ -31,7 +31,6 @@ import static java.util.Collections.emptySet;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
@@ -238,23 +237,8 @@ class TrackerOwnershipControllerTest extends PostgresControllerIntegrationTestBa
         200,
         "OK",
         "Temporary Ownership granted",
-        POST("/tracker/ownership/override?trackedEntity={tei}&program={prog}&reason=42", teUid, pId)
+        POST("/tracker/ownership/override?trackedEntity={te}&program={prog}&reason=42", teUid, pId)
             .content(HttpStatus.OK));
-  }
-
-  @Test
-  void shouldFailToOverrideWhenGivenTrackedEntityAndTrackedEntityInstanceParameters() {
-    assertEquals(
-        "Only one parameter of 'trackedEntityInstance' and 'trackedEntity' must be specified. "
-            + "Prefer 'trackedEntity' as 'trackedEntityInstance' will be removed.",
-        POST(
-                "/tracker/ownership/override?trackedEntity={tei}&"
-                    + "trackedEntityInstance={tei}&program={prog}&&reason=42",
-                teUid,
-                teUid,
-                pId)
-            .error(HttpStatus.BAD_REQUEST)
-            .getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ownership/TrackerOwnershipController.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.val
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -42,6 +43,7 @@ import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.acl.TrackerOwnershipManager;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
@@ -80,6 +82,8 @@ public class TrackerOwnershipController {
 
   @Autowired private OrganisationUnitService organisationUnitService;
 
+  @Autowired private IdentifiableObjectManager manager;
+
   // -------------------------------------------------------------------------
   // 1. Transfer ownership if the logged in user is part of the owner ou.
   // 2. Break the glass and override ownership.
@@ -110,10 +114,11 @@ public class TrackerOwnershipController {
   @ResponseBody
   public WebMessage grantTemporaryAccess(
       @RequestParam UID trackedEntity, @RequestParam String reason, @RequestParam UID program)
-      throws ForbiddenException, NotFoundException {
+      throws ForbiddenException {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
-        trackedEntityService.getTrackedEntity(trackedEntity),
+        // TODO(tracker) jdbc-hibernate: check the impact on performance
+        manager.get(TrackedEntity.class, trackedEntity.getValue()),
         programService.getProgram(program.getValue()),
         currentUser,
         reason);


### PR DESCRIPTION
### Issue
When breaking the glass, we can't use the regular flow and call `trackedEntityService.getTrackedEntity()` , because it validates whether the user has access to the owner of the TE/program couple.
That means, if the program is protected, it will check the user has capture scope access to that owner, and it in this case it won't, as that's the whole point of breaking the glass.

### Fix
For this reason, we will get the TE from the manager and run a separate set of validations just for the case when the user breaks the glass. Some of them were already in place, the ones I added are:
- TE not null
- Data access to program
- Data access to TET
- program TET is equal to TE TET