### PR TITLE
perf: avoid accessing DE options if not needed [DHIS2-18135]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -474,16 +474,16 @@ public class ValidationUtils {
       return "data_element_or_type_null_or_empty";
     }
 
+    // note: avoid accessing options if not necessary for perf reasons
     if (valueType.isMultiText()) {
       OptionSet options = dataElement.getOptionSet();
       if (options == null) return "data_element_lacks_option_set";
-      if (!options.hasAllOptions(ValueType.splitMultiText(value))) return "value_not_valid_option";
-    } else {
-      if (validateOptions) {
-        OptionSet options = dataElement.getOptionSet();
-        if (options != null && options.getOptionByCode(value) == null)
-          return "value_not_valid_option";
-      }
+      if (validateOptions && !options.hasAllOptions(ValueType.splitMultiText(value)))
+        return "value_not_valid_option";
+    } else if (validateOptions) {
+      OptionSet options = dataElement.getOptionSet();
+      if (options != null && options.getOptionByCode(value) == null)
+        return "value_not_valid_option";
     }
 
     return valueIsValid(value, valueType);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -474,19 +474,15 @@ public class ValidationUtils {
       return "data_element_or_type_null_or_empty";
     }
 
-    OptionSet options = dataElement.getOptionSet();
-
-    if (valueType.isMultiText() && options == null) {
-      return "data_element_lacks_option_set";
-    }
-
-    if (validateOptions && options != null) {
-      if (!valueType.isMultiText() && options.getOptionByCode(value) == null) {
-        return "value_not_valid_option";
-      }
-
-      if (valueType.isMultiText() && !options.hasAllOptions(ValueType.splitMultiText(value))) {
-        return "value_not_valid_option";
+    if (valueType.isMultiText()) {
+      OptionSet options = dataElement.getOptionSet();
+      if (options == null) return "data_element_lacks_option_set";
+      if (!options.hasAllOptions(ValueType.splitMultiText(value))) return "value_not_valid_option";
+    } else {
+      if (validateOptions) {
+        OptionSet options = dataElement.getOptionSet();
+        if (options != null && options.getOptionByCode(value) == null)
+          return "value_not_valid_option";
       }
     }
 


### PR DESCRIPTION
### Summary
The code is not a change in behaviour. It only prevents accessing `OptionSet options = dataElement.getOptionSet();` if the `options` variable is not needed. This is based on the assumption that this validation is called for each data value and this might be the cause of fetching options every single time.

This is by no means a comprehensive solution. A proper validation would not use the object model but pre-fetch all required options for the entire import in one query. But as so often for that to be possible we do need to know the scope of the import upfront. The current import still allows to put arbitrary data values in the same import and so fetching all required options is difficult and only possible if the input is processed 2 times, once to analyse the data values and a second time to process them. 