### PR TITLE
fix: correct context path handling for global shell

### DIFF
--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -21,17 +21,17 @@ jobs:
       INSTANCE_HOST: 'https://dev.im.dhis2.org'
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
-      - name: Wait for API tests
-        # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
-        # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
-        # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
-        # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
-        uses: t3chguy/wait-on-check-action@master
-        with:
-          ref: ${{ github.head_ref }}
-          check-name: 'api-test'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allowed-conclusions: success
+      # - name: Wait for API tests
+      #   # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
+      #   # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
+      #   # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
+      #   # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
+      #   uses: t3chguy/wait-on-check-action@master
+      #   with:
+      #     ref: ${{ github.head_ref }}
+      #     check-name: 'api-test'
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     allowed-conclusions: success
 
       - name: 'Get latest IM tag'
         id: latest-im-tag

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -21,17 +21,17 @@ jobs:
       INSTANCE_HOST: 'https://dev.im.dhis2.org'
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
-      # - name: Wait for API tests
-      #   # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
-      #   # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
-      #   # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
-      #   # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
-      #   uses: t3chguy/wait-on-check-action@master
-      #   with:
-      #     ref: ${{ github.head_ref }}
-      #     check-name: 'api-test'
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-      #     allowed-conclusions: success
+      - name: Wait for API tests
+        # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
+        # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
+        # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
+        # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
+        uses: t3chguy/wait-on-check-action@master
+        with:
+          ref: ${{ github.head_ref }}
+          check-name: 'api-test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allowed-conclusions: success
 
       - name: 'Get latest IM tag'
         id: latest-im-tag

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
@@ -72,8 +72,6 @@ class AppResourceTest extends ApiTest {
           });
 
   private static final String SERVER_BASE = "http://web:8080";
-  private static final String META_BASE_URL_TAG =
-      "<meta name=\"dhis2-base-url\" content=\"" + SERVER_BASE + "\"/>";
 
   @Test
   @DisplayName("Redirect location should have correct format")
@@ -131,7 +129,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from /?redirect=false
@@ -140,7 +137,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from index.html?shell=false
@@ -149,7 +145,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from /?shell=false
@@ -158,7 +153,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Append trailing slash and redirect
@@ -199,7 +193,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from / (service-worker)
@@ -210,7 +203,6 @@ class AppResourceTest extends ApiTest {
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Redirect index.action
@@ -265,7 +257,6 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -276,7 +267,6 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -287,7 +277,6 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
-      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -302,14 +291,14 @@ class AppResourceTest extends ApiTest {
     }
 
     // Redirect to original app with ?shell=false
-    {
-      ResponseEntity<String> response = getAuthenticated(prefix + "/dashboard?shell=false");
-      assertEquals(HttpStatus.FOUND, response.getStatusCode());
-      List<String> location = response.getHeaders().get("Location");
-      assertNotNull(location);
-      assertEquals(1, location.size());
-      assertEquals(SERVER_BASE + "/dhis-web-dashboard/index.html?shell=false", location.get(0));
-    }
+    // {
+    //   ResponseEntity<String> response = getAuthenticated(prefix + "/dashboard?shell=false");
+    //   assertEquals(HttpStatus.FOUND, response.getStatusCode());
+    //   List<String> location = response.getHeaders().get("Location");
+    //   assertNotNull(location);
+    //   assertEquals(1, location.size());
+    //   assertEquals(SERVER_BASE + "/dhis-web-dashboard/index.html?shell=false", location.get(0));
+    // }
 
     // Global shell service-worker
     {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
@@ -33,6 +33,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,7 +70,9 @@ class AppResourceTest extends ApiTest {
               connection.setInstanceFollowRedirects(false);
             }
           });
+  
   private static final String SERVER_BASE = "http://web:8080";
+  private static final String META_BASE_URL_TAG = "<meta name=\"dhis2-base-url\" content=\"" +  SERVER_BASE + "\"/>";
 
   @Test
   @DisplayName("Redirect location should have correct format")
@@ -107,7 +110,7 @@ class AppResourceTest extends ApiTest {
       List<String> location = response.getHeaders().get("Location");
       assertNotNull(location);
       assertEquals(1, location.size());
-      assertEquals("/apps/" + app + "?answer=42", location.get(0));
+      assertEquals(SERVER_BASE + "/apps/" + app + "?answer=42", location.get(0));
     }
 
     // Redirect to global shell from / (default) with forwarded querystring
@@ -117,7 +120,7 @@ class AppResourceTest extends ApiTest {
       List<String> location = response.getHeaders().get("Location");
       assertNotNull(location);
       assertEquals(1, location.size());
-      assertEquals("/apps/" + app + "?answer=42", location.get(0));
+      assertEquals(SERVER_BASE + "/apps/" + app + "?answer=42", location.get(0));
     }
 
     // Serve index.html from index.html?redirect=false
@@ -126,7 +129,8 @@ class AppResourceTest extends ApiTest {
           getAuthenticated(prefix + app + "/index.html?redirect=false");
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
-      // TODO: Confirm content-type and template replacement
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from /?redirect=false
@@ -134,6 +138,8 @@ class AppResourceTest extends ApiTest {
       ResponseEntity<String> response = getAuthenticated(prefix + app + "/?redirect=false");
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from index.html?shell=false
@@ -141,7 +147,8 @@ class AppResourceTest extends ApiTest {
       ResponseEntity<String> response = getAuthenticated(prefix + app + "/index.html?shell=false");
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
-      // TODO: Confirm content-type and template replacement
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from /?shell=false
@@ -149,6 +156,8 @@ class AppResourceTest extends ApiTest {
       ResponseEntity<String> response = getAuthenticated(prefix + app + "/?shell=false");
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Append trailing slash and redirect
@@ -188,6 +197,8 @@ class AppResourceTest extends ApiTest {
       ResponseEntity<String> response = getAuthenticated(prefix + app + "/index.html", headers);
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Serve index.html from / (service-worker)
@@ -197,6 +208,8 @@ class AppResourceTest extends ApiTest {
       ResponseEntity<String> response = getAuthenticated(prefix + app + "/", headers);
       assertEquals(HttpStatus.OK, response.getStatusCode());
       assertNotNull(response.getBody());
+      assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
     }
 
     // Redirect index.action
@@ -251,6 +264,7 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -261,6 +275,7 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -271,6 +286,7 @@ class AppResourceTest extends ApiTest {
       assertNotNull(response.getBody());
       assertNotNull(response.getHeaders().getContentType());
       assertEquals("text/html;charset=UTF-8", response.getHeaders().getContentType().toString());
+      assertTrue(response.getBody().contains(META_BASE_URL_TAG));
       // TODO: Confirm template replacement
     }
 
@@ -285,14 +301,14 @@ class AppResourceTest extends ApiTest {
     }
 
     // Redirect to original app with ?shell=false
-    // {
-    //   ResponseEntity<String> response = getAuthenticated(prefix + "/dashboard?shell=false");
-    //   assertEquals(HttpStatus.FOUND, response.getStatusCode());
-    //   List<String> location = response.getHeaders().get("Location");
-    //   assertNotNull(location);
-    //   assertEquals(1, location.size());
-    //   assertEquals(SERVER_BASE + "/dhis-web-dashboard/index.html?shell=false", location.get(0));
-    // }
+    {
+      ResponseEntity<String> response = getAuthenticated(prefix + "/dashboard?shell=false");
+      assertEquals(HttpStatus.FOUND, response.getStatusCode());
+      List<String> location = response.getHeaders().get("Location");
+      assertNotNull(location);
+      assertEquals(1, location.size());
+      assertEquals(SERVER_BASE + "/dhis-web-dashboard/index.html?shell=false", location.get(0));
+    }
 
     // Global shell service-worker
     {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
@@ -33,7 +33,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/apps/AppResourceTest.java
@@ -70,9 +70,10 @@ class AppResourceTest extends ApiTest {
               connection.setInstanceFollowRedirects(false);
             }
           });
-  
+
   private static final String SERVER_BASE = "http://web:8080";
-  private static final String META_BASE_URL_TAG = "<meta name=\"dhis2-base-url\" content=\"" +  SERVER_BASE + "\"/>";
+  private static final String META_BASE_URL_TAG =
+      "<meta name=\"dhis2-base-url\" content=\"" + SERVER_BASE + "\"/>";
 
   @Test
   @DisplayName("Redirect location should have correct format")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -188,7 +188,8 @@ public class AppController {
 
     log.debug("Rendering resource {} from app {}", resource, application.getKey());
 
-    ResourceResult resourceResult = appManager.getAppResource(application, resource, fullContextPath);
+    ResourceResult resourceResult =
+        appManager.getAppResource(application, resource, fullContextPath);
     if (resourceResult instanceof ResourceFound found) {
       serveResource(request, response, found.resource());
       return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -187,8 +187,7 @@ public class AppController {
 
     log.debug("Rendering resource {} from app {}", resource, application.getKey());
 
-    ResourceResult resourceResult =
-        appManager.getAppResource(application, resource, baseUrl);
+    ResourceResult resourceResult = appManager.getAppResource(application, resource, baseUrl);
     if (resourceResult instanceof ResourceFound found) {
       serveResource(request, response, found.resource());
       return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -65,7 +65,6 @@ import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.hisp.dhis.webapi.utils.HttpServletRequestPaths;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -107,21 +106,21 @@ public class AppController {
 
   @GetMapping(value = "/menu", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody Map<String, List<WebModule>> getWebModules(HttpServletRequest request) {
-    String contextPath = HttpServletRequestPaths.getContextPath(request);
+    String baseUrl = contextService.getContextPath();
 
-    List<WebModule> modules = appManager.getMenu(contextPath);
+    List<WebModule> modules = appManager.getMenu(baseUrl);
     return Map.of("modules", modules);
   }
 
   @GetMapping(produces = ContextUtils.CONTENT_TYPE_JSON)
   public ResponseEntity<List<App>> getApps(@RequestParam(required = false) String key) {
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    String contextPath = contextService.getContextPath();
+    String baseUrl = contextService.getContextPath();
 
     List<App> apps = new ArrayList<>();
 
     if (key != null) {
-      App app = appManager.getApp(key, contextPath);
+      App app = appManager.getApp(key, baseUrl);
 
       if (app == null) {
         return ResponseEntity.notFound().build();
@@ -129,9 +128,9 @@ public class AppController {
 
       apps.add(app);
     } else if (!filters.isEmpty()) {
-      apps = appManager.filterApps(filters, contextPath);
+      apps = appManager.filterApps(filters, baseUrl);
     } else {
-      apps = appManager.getApps(contextPath);
+      apps = appManager.getApps(baseUrl);
     }
     return ResponseEntity.ok(apps);
   }
@@ -166,9 +165,9 @@ public class AppController {
   public void renderApp(
       @PathVariable("app") String appName, HttpServletRequest request, HttpServletResponse response)
       throws IOException, WebMessageException, ForbiddenException {
-    String relativeContextPath = request.getContextPath();
-    String fullContextPath = HttpServletRequestPaths.getContextPath(request);
-    App application = appManager.getApp(appName, fullContextPath);
+    String contextPath = request.getContextPath();
+    String baseUrl = contextService.getContextPath();
+    App application = appManager.getApp(appName, baseUrl);
 
     if (application == null) {
       throw new WebMessageException(notFound("App '" + appName + "' not found."));
@@ -184,12 +183,12 @@ public class AppController {
     }
 
     // Get page requested
-    String resource = getResourcePath(request.getPathInfo(), application, relativeContextPath);
+    String resource = getResourcePath(request.getPathInfo(), application, contextPath);
 
     log.debug("Rendering resource {} from app {}", resource, application.getKey());
 
     ResourceResult resourceResult =
-        appManager.getAppResource(application, resource, fullContextPath);
+        appManager.getAppResource(application, resource, baseUrl);
     if (resourceResult instanceof ResourceFound found) {
       serveResource(request, response, found.resource());
       return;
@@ -268,8 +267,6 @@ public class AppController {
   private String getResourcePath(String path, App app, String contextPath) {
     String resourcePath = path;
     String appPrefix = "/" + AppManager.INSTALLED_APP_PREFIX + app.getKey();
-
-    log.info("getResourcePath {} {} {}", path, contextPath, appPrefix);
 
     if (resourcePath.startsWith(contextPath)) {
       resourcePath = resourcePath.substring(contextPath.length());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -166,7 +166,7 @@ public class AppController {
   public void renderApp(
       @PathVariable("app") String appName, HttpServletRequest request, HttpServletResponse response)
       throws IOException, WebMessageException, ForbiddenException {
-    String relativeContextPath = request.getServletPath();
+    String relativeContextPath = request.getContextPath();
     String fullContextPath = HttpServletRequestPaths.getContextPath(request);
     App application = appManager.getApp(appName, fullContextPath);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -166,7 +166,7 @@ public class AppController {
   public void renderApp(
       @PathVariable("app") String appName, HttpServletRequest request, HttpServletResponse response)
       throws IOException, WebMessageException, ForbiddenException {
-    String contextPath = HttpServletRequestPaths.getContextPath(request);
+    String contextPath = request.getContextPath();
     App application = appManager.getApp(appName, contextPath);
 
     if (application == null) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
@@ -172,7 +172,7 @@ public class GlobalShellFilter extends OncePerRequestFilter {
     String referer = request.getHeader(REFERER_HEADER);
     boolean isServiceWorkerRequest = referer != null && referer.endsWith(SERVICE_WORKER_JS);
 
-    log.info(
+    log.debug(
         "redirectLegacyAppPaths: path = {}, queryString = {}, referer = {}",
         path,
         queryString,
@@ -224,7 +224,7 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, String resource)
       throws IOException, ServletException {
 
-    log.info("Serving global shell resource {}", resource);
+    log.debug("Serving global shell resource {}", resource);
 
     String globalShellAppName = settingsProvider.getCurrentSettings().getGlobalShellAppName();
     App globalShellApp = appManager.getApp(globalShellAppName);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.webapi.utils.HttpServletRequestPaths;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -84,10 +85,13 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       @Nonnull HttpServletResponse response,
       @Nonnull FilterChain chain)
       throws IOException, ServletException {
+    
     boolean globalShellEnabled = settingsProvider.getCurrentSettings().getGlobalShellEnabled();
+    String path = getContextRelativePath(request);
+
     if (!globalShellEnabled) {
       boolean redirected =
-          redirectDisabledGlobalShell(request, response, getContextRelativePath(request));
+          redirectDisabledGlobalShell(request, response, path);
       log.debug("GlobalShellFilter.doFilterInternal: redirectDisabledGlobalShell = {}", redirected);
       if (!redirected) {
         chain.doFilter(request, response);
@@ -95,7 +99,6 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       return;
     }
 
-    String path = getContextRelativePath(request);
     if (redirectLegacyAppPaths(request, response, path)) {
       log.debug("GlobalShellFilter.doFilterInternal: redirectLegacyAppPaths = true");
       return;
@@ -113,6 +116,7 @@ public class GlobalShellFilter extends OncePerRequestFilter {
   private boolean redirectDisabledGlobalShell(
       HttpServletRequest request, HttpServletResponse response, String path) throws IOException {
     Matcher m = APP_IN_GLOBAL_SHELL_PATTERN.matcher(path);
+    String baseUrl = HttpServletRequestPaths.getContextPath(request);
 
     if (m.matches()) {
       String appName = m.group(1);
@@ -122,13 +126,9 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       if (app != null) {
         log.debug("Installed app {} found", appName);
         targetPath = app.getLaunchUrl();
-      } else if (AppManager.BUNDLED_APPS.contains(appName)) {
-        log.debug("Bundled app {} found", appName);
-        targetPath =
-            String.join("/", request.getContextPath(), AppManager.BUNDLED_APP_PREFIX + appName);
       } else {
         log.debug("App {} not found", appName);
-        targetPath = request.getContextPath() + "/";
+        targetPath = baseUrl;
       }
 
       targetPath = withQueryString(targetPath, request.getQueryString());
@@ -136,12 +136,17 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       log.debug("Redirecting to {}", targetPath);
       response.sendRedirect(targetPath);
       return true;
+    } else if (path.startsWith(GLOBAL_SHELL_PATH_PREFIX)) {
+      log.debug("Redirecting to instance root");
+      response.sendRedirect(baseUrl);
+      return true;
     }
     return false;
   }
 
   private boolean redirectLegacyAppPaths(
       HttpServletRequest request, HttpServletResponse response, String path) throws IOException {
+    String baseUrl = HttpServletRequestPaths.getContextPath(request);
     String queryString = request.getQueryString();
     Matcher m = LEGACY_APP_PATH_PATTERN.matcher(path);
 
@@ -175,7 +180,7 @@ public class GlobalShellFilter extends OncePerRequestFilter {
         referer);
 
     if (isIndexPath && !isServiceWorkerRequest && !hasRedirectFalse) {
-      String targetPath = request.getContextPath() + GLOBAL_SHELL_PATH_PREFIX + appName;
+      String targetPath = baseUrl + GLOBAL_SHELL_PATH_PREFIX + appName;
       targetPath = withQueryString(targetPath, queryString);
       response.sendRedirect(targetPath);
       log.debug("Redirecting to global shell {}", targetPath);
@@ -205,17 +210,24 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       log.debug("Serving global shell index.  Original path: {}", path);
       serveGlobalShellResource(request, response, "index.html");
     } else {
-      log.debug("Serving global shell resource. Path {}", path);
+      String resource = path.substring(GLOBAL_SHELL_PATH_PREFIX.length());
+      if (resource.isEmpty()) {
+        resource = "index.html";
+      }
+      
+      log.debug("Serving global shell resource. Path {}, resolved resource {}", path, resource);
       // Serve global app shell resources
       serveGlobalShellResource(
-          request, response, path.substring(GLOBAL_SHELL_PATH_PREFIX.length()));
+          request, response, resource);
     }
   }
 
   private void serveGlobalShellResource(
       HttpServletRequest request, HttpServletResponse response, String resource)
       throws IOException, ServletException {
-
+    
+    log.info("Serving global shell resource {}", resource);
+    
     String globalShellAppName = settingsProvider.getCurrentSettings().getGlobalShellAppName();
     App globalShellApp = appManager.getApp(globalShellAppName);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/GlobalShellFilter.java
@@ -85,13 +85,12 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       @Nonnull HttpServletResponse response,
       @Nonnull FilterChain chain)
       throws IOException, ServletException {
-    
+
     boolean globalShellEnabled = settingsProvider.getCurrentSettings().getGlobalShellEnabled();
     String path = getContextRelativePath(request);
 
     if (!globalShellEnabled) {
-      boolean redirected =
-          redirectDisabledGlobalShell(request, response, path);
+      boolean redirected = redirectDisabledGlobalShell(request, response, path);
       log.debug("GlobalShellFilter.doFilterInternal: redirectDisabledGlobalShell = {}", redirected);
       if (!redirected) {
         chain.doFilter(request, response);
@@ -214,20 +213,19 @@ public class GlobalShellFilter extends OncePerRequestFilter {
       if (resource.isEmpty()) {
         resource = "index.html";
       }
-      
+
       log.debug("Serving global shell resource. Path {}, resolved resource {}", path, resource);
       // Serve global app shell resources
-      serveGlobalShellResource(
-          request, response, resource);
+      serveGlobalShellResource(request, response, resource);
     }
   }
 
   private void serveGlobalShellResource(
       HttpServletRequest request, HttpServletResponse response, String resource)
       throws IOException, ServletException {
-    
+
     log.info("Serving global shell resource {}", resource);
-    
+
     String globalShellAppName = settingsProvider.getCurrentSettings().getGlobalShellAppName();
     App globalShellApp = appManager.getApp(globalShellAppName);
 


### PR DESCRIPTION
Fix an issue when deployed to non-root context paths.

If you have previously experienced an issue with your instance you may need to clear the cache storage in your browser (Dev Tools -> Application tab -> Cache Storage -> "Delete" each one) and unregister all service workers.

For testing incognito mode also works