### PR TITLE
fix: make sure apps properly are loaded outside war files [DHIS2-19247]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -43,7 +43,6 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.cache.Cache;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -78,14 +77,20 @@ public class BundledAppStorageService implements AppStorageService {
       for (Resource resource : resources) {
         App app = readAppManifest(resource);
         if (app != null) {
-          String path = ((ClassPathResource) resource).getPath();
+          String path =
+              CLASSPATH_PREFIX
+                  + STATIC_DIR
+                  + BUNDLED_APP_PREFIX
+                  + app.getKey()
+                  + "/manifest.webapp";
+
           String shortName =
               path.replaceAll("/manifest.webapp$", "")
-                  .replaceAll("^" + STATIC_DIR + BUNDLED_APP_PREFIX, "");
+                  .replaceAll("^" + CLASSPATH_PREFIX + STATIC_DIR + BUNDLED_APP_PREFIX, "");
           app.setBundled(true);
           app.setShortName(shortName);
           app.setAppStorageSource(AppStorageSource.BUNDLED);
-          app.setFolderName(CLASSPATH_PREFIX + path.replaceAll("/manifest.webapp$", ""));
+          app.setFolderName(path.replaceAll("/manifest.webapp$", ""));
 
           log.info("Discovered bundled app {} ({})", app.getKey(), app.getFolderName());
           apps.put(app.getKey(), app);


### PR DESCRIPTION
This fixes [an issue](https://dhis2.atlassian.net/browse/DHIS2-19247) where apps discovery fails when running dhis2-core without it being packaged first. 

The problem is that Spring's ResourcePatternResolver is too clever - in a WAR file, it returns a Classpath Resource, which works fine when trying to get the path using ` String path = ((ClassPathResource) resource).getPath();` . But outside of a package, it then returns a FileResource which fails to be cast into a ClassPathResource in that line causing an exception on discovery.

The class path URL works though for loading the apps, in both packaged and non-packaged cases, as we are using ResourceLoader and Resource (rather than FileResource or ClassPathResource)  [here](https://vscode.dev/github/dhis2/dhis2-core/blob/fix/load-apps-outside-war/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java#L151-L152)) . 

So we only need to update that line to construct the classpath url without resorting to using ClassPathResource.