### PR TITLE
fix: duplicate authorities in the authority endpoint

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
@@ -29,9 +29,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -84,5 +87,22 @@ class AuthoritiesControllerTest extends H2ControllerIntegrationTestBase {
 
     // System authorities fom Authorities enum
     assertTrue(listIds.contains("ALL"));
+  }
+
+  @Test
+  void testNoDuplicateAuthorities() {
+    JsonArray systemAuthorities = GET("/authorities").content().getArray("systemAuthorities");
+    List<String> listIds =
+        systemAuthorities.asList(JsonObject.class).stream()
+            .map(o -> o.getString("id").string())
+            .toList();
+    Set<String> uniqueIds = new HashSet<>(listIds);
+    assertEquals(
+        uniqueIds.size(),
+        listIds.size(),
+        "Found duplicate authorities in response: List size="
+            + listIds.size()
+            + ", Unique size="
+            + uniqueIds.size());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -79,7 +79,7 @@ public class AuthoritiesController {
   public Map<String, List<Map<String, String>>> getAuthorities(HttpServletResponse response) {
     I18n i18n = i18nManager.getI18n();
 
-    List<String> authorities = new ArrayList<>();
+    Set<String> authorities = new HashSet<>();
 
     Collection<String> systemAuthorities = authoritiesProvider.getSystemAuthorities();
     authorities.addAll(systemAuthorities);


### PR DESCRIPTION
Fix duplicate authorities in API response (DHIS2-18741)
Issue
The /api/authorities endpoint was returning duplicate authorities in the response. Specifically, the authority F_MOBILE_SENDSMS appeared twice with the same ID and name. This was caused by the getAuthorities() method in the AuthoritiesController using an ArrayList to collect authorities from multiple sources without deduplication.
Fix
Modified the getAuthorities() method in AuthoritiesController.java to use a HashSet instead of an ArrayList when collecting authorities from different sources. This ensures that duplicate authorities are automatically removed due to the set's unique element constraint.
Apply to d17f54d9f26f...
authorities
Test
Added a new test method testNoDuplicateAuthorities() to AuthoritiesControllerTest.java that verifies:
No duplicate authorities exist in the response by comparing the size of the original list with a deduplicated set
The F_MOBILE_SENDSMS authority that was previously duplicated now appears exactly once
Result
The authorities endpoint now returns a clean list of unique authorities, maintaining the original functionality while removing duplicates. All tests pass successfully.