### PR TITLE
fix: userinfo table index on openid typo

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_1__rename_index_typo_openid_userinfo.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_1__rename_index_typo_openid_userinfo.sql
@@ -1,0 +1,5 @@
+drop index if exists "create index in_userinfo_openid";
+drop index if exists "in_userinfo_openid";
+
+create index "in_userinfo_openid"
+    on userinfo (openid);


### PR DESCRIPTION
Fixes a simple typo on the index name in the userinfo table on the field openid