### PR TITLE
fix: correctly set caching etag and lastModified headers when serving app resources [DHIS2-19245]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -37,19 +37,15 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.security.Authorities.M_DHIS_WEB_APP_MANAGEMENT;
 
 import com.google.common.collect.Lists;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
@@ -215,20 +211,27 @@ public class AppController {
     } else {
       log.warn("Internal server error - no resource result.  This is a bug.");
       throw new WebMessageException(
-          error("Failed to locate resource for app '" + appName + "'.", "AppManager should always return a ResourceResult, this is a bug."));
+          error(
+              "Failed to locate resource for app '" + appName + "'.",
+              "AppManager should always return a ResourceResult, this is a bug."));
     }
   }
 
   private void serveResource(
-      HttpServletRequest request, HttpServletResponse response, ResourceFound resourceResult, App app)
+      HttpServletRequest request,
+      HttpServletResponse response,
+      ResourceFound resourceResult,
+      App app)
       throws IOException {
     String filename = resourceResult.resource().getFilename();
     log.debug("Serving app resource, filename: {}", filename);
 
     // Use a combination of app version and last modified timestamp to generate an ETag
     // This is to ensure that the ETag changes when the app is updated
-    // There is no guarantee that a new app uploaded will have a different version number, so we need to include the last modified timestamp
-    // Similarly, with classPath resources the lastModified timestamp may be missing or not reliable, so we need to include the version number
+    // There is no guarantee that a new app uploaded will have a different version number, so we
+    // need to include the last modified timestamp
+    // Similarly, with classPath resources the lastModified timestamp may be missing or not
+    // reliable, so we need to include the version number
     // See also AppHtmlNoCacheFilter for cache control headers set on index.html responses
 
     long lastModified = resourceResult.resource().lastModified();
@@ -241,7 +244,6 @@ public class AppController {
       response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
       return;
     }
-
 
     String mimeType =
         resourceResult.mimeType() == null

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -31,20 +31,25 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.forbidden;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.security.Authorities.M_DHIS_WEB_APP_MANAGEMENT;
 
 import com.google.common.collect.Lists;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
@@ -55,6 +60,7 @@ import org.hisp.dhis.appmanager.ResourceResult.ResourceFound;
 import org.hisp.dhis.appmanager.ResourceResult.ResourceNotFound;
 import org.hisp.dhis.appmanager.webmodules.WebModule;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.HashUtils;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -168,19 +174,21 @@ public class AppController {
     String baseUrl = contextService.getContextPath();
     App application = appManager.getApp(appName, baseUrl);
 
+    log.debug("Rendering app resource {}", request.getPathInfo());
+
     if (application == null) {
-      log.info("App not found: {}", appName);
+      log.debug("App {} not found", appName);
       throw new WebMessageException(notFound("App '" + appName + "' not found."));
     }
 
     if (!appManager.isAccessible(application)) {
-      log.info("User does not have access to app: {}", appName);
+      log.debug("User does not have access to app {}", appName);
       throw new WebMessageException(
           forbidden("User does not have access to app '" + appName + "'."));
     }
 
     if (application.getAppState() == AppStatus.DELETION_IN_PROGRESS) {
-      log.info("App deletion in progress: {}", appName);
+      log.debug("App deletion in progress {}", appName);
       throw new WebMessageException(
           conflict("App '" + appName + "' deletion is still in progress."));
     }
@@ -188,40 +196,52 @@ public class AppController {
     // Get page requested
     String resource = getResourcePath(request.getPathInfo(), application, contextPath);
 
-    log.info("Rendering resource {} from app {}", resource, application.getKey());
+    log.debug("Rendering resource {} from app {}", resource, application.getKey());
 
     ResourceResult resourceResult = appManager.getAppResource(application, resource, baseUrl);
     if (resourceResult instanceof ResourceFound found) {
-      serveResource(request, response, found);
+      serveResource(request, response, found, application);
     } else if (resourceResult instanceof Redirect redirect) {
       String redirectUrl = TextUtils.cleanUrlPathOnly(application.getBaseUrl(), redirect.path());
       String queryString = request.getQueryString();
       if (queryString != null) {
         redirectUrl += "?" + queryString;
       }
-      log.info(String.format("App resource redirected to: %s", redirectUrl));
+      log.debug(String.format("App resource redirected to: %s", redirectUrl));
       response.sendRedirect(redirectUrl);
     } else if (resourceResult instanceof ResourceNotFound) {
-      log.info("Resource not found: {}", resource);
+      log.debug("Resource not found: {}", resource);
       response.sendError(HttpServletResponse.SC_NOT_FOUND);
     } else {
-      log.info("Internal server error - no resource result");
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      log.warn("Internal server error - no resource result.  This is a bug.");
+      throw new WebMessageException(
+          error("Failed to locate resource for app '" + appName + "'.", "AppManager should always return a ResourceResult, this is a bug."));
     }
   }
 
   private void serveResource(
-      HttpServletRequest request, HttpServletResponse response, ResourceFound resourceResult)
+      HttpServletRequest request, HttpServletResponse response, ResourceFound resourceResult, App app)
       throws IOException {
     String filename = resourceResult.resource().getFilename();
-    log.info("App filename: '{}'", filename);
+    log.debug("Serving app resource, filename: {}", filename);
 
-    if (new ServletWebRequest(request, response)
-        .checkNotModified(resourceResult.resource().lastModified())) {
-      log.info("Resource not modified: {}", filename);
+    // Use a combination of app version and last modified timestamp to generate an ETag
+    // This is to ensure that the ETag changes when the app is updated
+    // There is no guarantee that a new app uploaded will have a different version number, so we need to include the last modified timestamp
+    // Similarly, with classPath resources the lastModified timestamp may be missing or not reliable, so we need to include the version number
+    // See also AppHtmlNoCacheFilter for cache control headers set on index.html responses
+
+    long lastModified = resourceResult.resource().lastModified();
+    String etagSource = String.format("%s-%s", app.getVersion(), String.valueOf(lastModified));
+    String etag = HashUtils.hashMD5(etagSource.getBytes());
+
+    log.info("Generated etag {} from source {}, lastModified {}", etag, etagSource);
+    if (new ServletWebRequest(request, response).checkNotModified(etag, lastModified)) {
+      log.info("Resource not modified (etag {}, lastModified {})", etag, lastModified);
       response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
       return;
     }
+
 
     String mimeType =
         resourceResult.mimeType() == null
@@ -235,11 +255,14 @@ public class AppController {
     long contentLength = appManager.getUriContentLength(resourceResult.resource());
 
     response.setContentLengthLong(contentLength);
-    log.info(
-        "Serving resource: {} (contentType: {}, contentLength: {})",
+
+    log.debug(
+        "Serving resource: {} (contentType: {}, contentLength: {}, lastModified: {}, etag: {})",
         filename,
         mimeType,
-        contentLength);
+        contentLength,
+        String.valueOf(lastModified),
+        etag);
     StreamUtils.copyThenCloseInputStream(
         resourceResult.resource().getInputStream(), response.getOutputStream());
   }
@@ -299,7 +322,7 @@ public class AppController {
     // that only files inside app directory can be resolved)
     resourcePath = REGEX_REMOVE_PROTOCOL.matcher(resourcePath).replaceAll("");
 
-    log.info("Resource path: {} => {}", path, resourcePath);
+    log.debug("Resource path: {} => {}", path, resourcePath);
 
     return resourcePath;
   }


### PR DESCRIPTION
This solves an issue with caching headers used to determine if a 304 Not Modified response should be returned by the server (or by an intermediate cache)

Prior to this change, only the lastModified header was set.  For bundled apps the lastModified date of the file was indeterminate so this was always set to Jan 1, 1970.  

This was the behavior before 2.42 as well for installed apps.  Bundled apps were served natively by spring and correctly set some of these headers.

Before this change (missing headers - left: 2.41, right: before)

![Screenshot 2025-03-18 at 22 29 53](https://github.com/user-attachments/assets/fab6ac68-f9b7-488f-87ff-0fec8ae4e45d)
![Screenshot 2025-03-18 at 22 29 02](https://github.com/user-attachments/assets/9565b96a-b782-4288-9406-e7779b375354)
![Screenshot 2025-03-18 at 22 15 09](https://github.com/user-attachments/assets/a956a048-8cbe-425f-a73c-4dc6e5b8e01f)
![Screenshot 2025-03-18 at 22 13 31](https://github.com/user-attachments/assets/1cafcffd-7c89-4e48-b199-e4502d8d4062)

After this change (left: 2.41, right: after)
![Screenshot 2025-03-20 at 12 19 58](https://github.com/user-attachments/assets/8b46c451-f7d2-4344-9992-680834157aaa)
