### PR TITLE
fix: OpenAPI generation flakiness where sometimes a referenced schema is not included 

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -94,9 +94,6 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
         GET("/openapi/openapi.json?failOnNameClash=true&failOnInconsistency=true").content();
     SwaggerParseResult result =
         new OpenAPIParser().readContents(doc.node().getDeclaration(), null, null);
-    if (!result.getMessages().isEmpty()) {
-      System.out.println("error");
-    }
     assertEquals(List.of(), result.getMessages(), "There should not be any errors");
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -94,6 +94,9 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
         GET("/openapi/openapi.json?failOnNameClash=true&failOnInconsistency=true").content();
     SwaggerParseResult result =
         new OpenAPIParser().readContents(doc.node().getDeclaration(), null, null);
+    if (!result.getMessages().isEmpty()) {
+      System.out.println("error");
+    }
     assertEquals(List.of(), result.getMessages(), "There should not be any errors");
   }
 
@@ -130,7 +133,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testGetOpenApiDocumentHtml_DomainFilter() {
     String html =
-        GET("/openapi/openapi.html?scope=entity.DataElement", Accept(TEXT_HTML_VALUE))
+        GET("/openapi/openapi.html?scope=entity:DataElement", Accept(TEXT_HTML_VALUE))
             .content(TEXT_HTML_VALUE);
     assertContains("#DataElement", html);
   }
@@ -138,7 +141,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testGetOpenApiDocument_DefaultValue() {
     // defaults in parameter objects (from Property analysis)
-    JsonObject users = GET("/openapi/openapi.json?scope=path./api/users").content();
+    JsonObject users = GET("/openapi/openapi.json?scope=path:/api/users").content();
     JsonObject sharedParams = users.getObject("components.parameters");
     assertEquals(50, sharedParams.getNumber("{GistParams.pageSize}.schema.default").integer());
     assertEquals(
@@ -146,7 +149,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
     assertTrue(sharedParams.getBoolean("{GistParams.translate}.schema.default").booleanValue());
 
     // defaults in individual parameters (from endpoint method parameter analysis)
-    JsonObject fileResources = GET("/openapi/openapi.json?scope=path./api/fileResources").content();
+    JsonObject fileResources = GET("/openapi/openapi.json?scope=path:/api/fileResources").content();
     JsonObject domain =
         fileResources
             .get("paths./api/fileResources/.post.parameters")
@@ -157,7 +160,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
             .orElse(JsonMixed.of("{}"));
     assertEquals("DATA_VALUE", domain.getString("schema.default").string());
 
-    JsonObject audits = GET("/openapi/openapi.json?scope=path./api/audits").content();
+    JsonObject audits = GET("/openapi/openapi.json?scope=path:/api/audits").content();
     JsonObject pageSize =
         audits
             .getArray("paths./api/audits/trackedEntity.get.parameters")
@@ -220,7 +223,7 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testGetOpenApiDocument_ReadOnly() {
-    JsonObject doc = GET("/openapi/openapi.json?scope=entity.JobConfiguration").content();
+    JsonObject doc = GET("/openapi/openapi.json?scope=entity:JobConfiguration").content();
     JsonObject jobConfiguration = doc.getObject("components.schemas.JobConfiguration");
     JsonObject jobConfigurationParams = doc.getObject("components.schemas.JobConfigurationParams");
     assertTrue(jobConfiguration.isObject());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.webapi.openapi.OpenApiObject;
 import org.hisp.dhis.webapi.openapi.OpenApiObject.ParameterObject;
 import org.hisp.dhis.webapi.openapi.OpenApiObject.ResponseObject;
 import org.hisp.dhis.webapi.openapi.OpenApiObject.SchemaObject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
@@ -90,7 +89,6 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  @Disabled("JB: temporary until we find the cause of flakiness")
   void testGetOpenApiDocumentJson_NoValidationErrors() {
     JsonObject doc =
         GET("/openapi/openapi.json?failOnNameClash=true&failOnInconsistency=true").content();
@@ -243,7 +241,6 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  @Disabled("JB: temporary until we find the cause of flakiness")
   void testGetOpenApiDocument_CodeGeneration() throws IOException {
     JsonObject doc = GET("/openapi/openapi.json?failOnNameClash=true").content();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -56,7 +56,6 @@ import org.hisp.dhis.dataset.CompleteDataSetRegistration;
 import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
-import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.dataset.CompleteDataSetRegistrationExchangeService;
 import org.hisp.dhis.dxf2.dataset.ExportParams;
@@ -90,8 +89,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Halvdan Hoem Grelland <halvdan@dhis2.org>
  */
+@OpenApi.EntityType(CompleteDataSetRegistration.class)
 @OpenApi.Document(
-    entity = DataValue.class,
+    entity = CompleteDataSetRegistration.class,
     classifiers = {"team:platform", "purpose:data"})
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceController.java
@@ -64,6 +64,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Zubair Asghar
  */
+@OpenApi.EntityType(ProgramNotificationInstance.class)
 @OpenApi.Document(
     entity = ProgramNotificationInstance.class,
     classifiers = {"team:tracker", "purpose:data"})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiClassifications.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiClassifications.java
@@ -30,9 +30,10 @@
 package org.hisp.dhis.webapi.openapi;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingInt;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -113,7 +114,9 @@ public record ApiClassifications(
 
   static Set<Class<?>> matches(
       @Nonnull Set<Class<?>> controllers, @Nonnull Map<String, Set<String>> filters) {
-    return controllers.stream().filter(c -> matches(filters, c)).collect(toUnmodifiableSet());
+    return controllers.stream()
+        .filter(c -> matches(filters, c))
+        .collect(toCollection((() -> new TreeSet<>(comparing(Class::getName)))));
   }
 
   private static boolean matches(@Nonnull Map<String, Set<String>> filters, Class<?> controller) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
@@ -34,10 +34,10 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.UnaryOperator;
@@ -90,7 +90,7 @@ final class ApiDescriptions {
 
   private final Class<?> target;
 
-  private final Map<String, String> entries = new HashMap<>();
+  private final Map<String, String> entries = new TreeMap<>();
 
   static ApiDescriptions of(Class<?> target) {
     return CACHE.computeIfAbsent(target, ApiDescriptions::ofUncached);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.webapi.openapi;
 
 import static java.util.Arrays.copyOfRange;
 import static java.util.Arrays.stream;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -64,7 +66,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
@@ -111,7 +114,7 @@ final class ApiExtractor {
 
   record Configuration(boolean ignoreTypeAs) {}
 
-  private static final Map<Class<?>, Api.SchemaGenerator> GENERATORS = new ConcurrentHashMap<>();
+  private static final Map<Class<?>, Api.SchemaGenerator> GENERATORS = newClassMap();
 
   public static void register(Class<?> type, Api.SchemaGenerator generator) {
     GENERATORS.put(type, generator);
@@ -200,7 +203,9 @@ final class ApiExtractor {
 
     // request media types
     Set<MediaType> consumes =
-        mapping.consumes().stream().map(MediaType::parseMediaType).collect(toSet());
+        mapping.consumes().stream()
+            .map(MediaType::parseMediaType)
+            .collect(toCollection(TreeSet::new));
     if (consumes.isEmpty()) {
       // assume JSON if nothing is set explicitly
       consumes.add(MediaType.APPLICATION_JSON);
@@ -286,7 +291,9 @@ final class ApiExtractor {
       Api.Endpoint endpoint, EndpointMapping mapping, Set<MediaType> consumes) {
     Method source = mapping.source();
     Set<MediaType> produces =
-        mapping.produces().stream().map(MediaType::parseMediaType).collect(toSet());
+        mapping.produces().stream()
+            .map(MediaType::parseMediaType)
+            .collect(toCollection(TreeSet::new));
     if (produces.isEmpty()) {
       // either make symmetric or assume JSON as standard
       if (consumes.contains(MediaType.APPLICATION_JSON)
@@ -412,7 +419,7 @@ final class ApiExtractor {
                         header.name(),
                         header.description(),
                         extractSchema(endpoint, null, header.type())))
-            .collect(toSet());
+            .collect(toCollection(TreeSet::new));
     Set<MediaType> produces =
         response.mediaTypes().length == 0
             ? defaultProduces
@@ -664,13 +671,18 @@ final class ApiExtractor {
             .getIn()
             .getIn()
             .getGeneratorSchemas()
-            .computeIfAbsent(genType, key -> new ConcurrentHashMap<>());
+            .computeIfAbsent(genType, key -> newClassMap());
     schema.getSharedName().setValue(getGeneratorTypeSharedName(genType, schema));
     if (schema.isShared()) {
       Api.Schema shared = genTypes.putIfAbsent(ofType, schema);
       if (shared != null) schema = shared; // this makes sure the same instance is reused
     }
     return type == genType ? schema : Api.Schema.ofArray(type, type).withElements(schema).sealed();
+  }
+
+  @Nonnull
+  private static <T> TreeMap<Class<?>, T> newClassMap() {
+    return new TreeMap<>(comparing(Class::getName));
   }
 
   private static String getGeneratorTypeSharedName(Class<?> genType, Api.Schema schema) {
@@ -710,6 +722,9 @@ final class ApiExtractor {
     Api.Schema s = api.getSchemas().get(type);
     if (s != null) {
       return s;
+    }
+    if (type.isAnnotation()) {
+      return Api.Schema.ofAny(type);
     }
     UnaryOperator<Api.Schema> addShared =
         schema -> {
@@ -815,8 +830,9 @@ final class ApiExtractor {
       if (rawType == Class.class) {
         return Api.Schema.ofSimple(rawType);
       }
-      Type typeArg0 = pt.getActualTypeArguments()[0];
-      if (Collection.class.isAssignableFrom(rawType) && rawType.isInterface()
+      Type[] actualTypes = pt.getActualTypeArguments();
+      Type typeArg0 = actualTypes[0];
+      if (Collection.class.isAssignableFrom(rawType) && actualTypes.length == 1
           || rawType == Iterable.class
           || rawType == Stream.class
           || rawType == JsonList.class) {
@@ -826,12 +842,21 @@ final class ApiExtractor {
             .withElements(extractTypeSchema(endpoint, typeArg0))
             .sealed();
       }
-      if (Map.class.isAssignableFrom(rawType) && rawType.isInterface()) {
+      if (Map.class.isAssignableFrom(rawType) && actualTypes.length == 2) {
         return Api.Schema.ofObject(source, rawType)
             .withEntries(
-                extractTypeSchema(endpoint, typeArg0),
-                extractTypeSchema(endpoint, pt.getActualTypeArguments()[1]))
+                extractTypeSchema(endpoint, typeArg0), extractTypeSchema(endpoint, actualTypes[1]))
             .sealed();
+      }
+      if (Map.class.isAssignableFrom(rawType) && actualTypes.length == 1) {
+        Type extended = rawType.getGenericSuperclass();
+        if (extended instanceof ParameterizedType pst) {
+          return Api.Schema.ofObject(source, rawType)
+              .withEntries(
+                  extractTypeSchema(endpoint, pst.getActualTypeArguments()[0]),
+                  extractTypeSchema(endpoint, typeArg0))
+              .sealed();
+        }
       }
       if (JsonMap.class.isAssignableFrom(rawType)) {
         return Api.Schema.ofObject(source, rawType)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
@@ -32,20 +32,16 @@ package org.hisp.dhis.webapi.openapi;
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
 
 import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
@@ -174,7 +170,7 @@ public class ApiIntegrator {
    * <p>All shared types are transferred to {@link Api.Components#getSchemas()}.
    */
   private void nameSharedSchemas() {
-    Map<String, List<Api.Schema>> sharedSchemasByName = new LinkedHashMap<>();
+    Map<String, List<Api.Schema>> sharedSchemasByName = new TreeMap<>();
     Consumer<Api.Schema> addSchema =
         schema ->
             sharedSchemasByName
@@ -229,7 +225,7 @@ public class ApiIntegrator {
    */
   private void nameSharedParameters() {
     Map<String, List<Map.Entry<Class<?>, List<Api.Parameter>>>> sharedParametersByName =
-        new HashMap<>();
+        new TreeMap<>();
     api.getComponents()
         .getParameters()
         .entrySet()
@@ -251,7 +247,7 @@ public class ApiIntegrator {
             params.get(0).getValue().forEach(p -> p.getSharedName().setValue(name));
           } else {
             // there might be a clash if a parameter name occurs in more than one
-            Set<String> usedNames = new HashSet<>();
+            Set<String> usedNames = new TreeSet<>();
             params.stream()
                 .flatMap(e -> e.getValue().stream())
                 .forEach(
@@ -287,9 +283,9 @@ public class ApiIntegrator {
           if (params.size() > 1) {
             List<Api.Parameter> paramsInNamespace =
                 params.stream().flatMap(e -> e.getValue().stream()).toList();
-            Set<String> names =
-                paramsInNamespace.stream().map(Api.Parameter::getName).collect(toSet());
-            if (paramsInNamespace.size() > names.size()) {
+            int names =
+                (int) paramsInNamespace.stream().map(Api.Parameter::getName).distinct().count();
+            if (paramsInNamespace.size() > names) {
               throw new IllegalStateException(createParamNameClashMessage(name, params));
             }
           }
@@ -346,16 +342,16 @@ public class ApiIntegrator {
     }
     Api.Schema input = Api.Schema.ofObject(output.getSource(), schemaType);
     output.getInput().setValue(input);
+    input.getDirection().setValue(Api.Schema.Direction.IN);
     if (output.isShared()) {
       String name = output.getSharedName().getValue() + "Params";
       Map<String, Api.Schema> schemas = api.getComponents().getSchemas();
       if (schemas.containsKey(name)) name = output.getSharedName().getValue() + "_Params";
       input.getSharedName().setValue(name);
       api.getGeneratorSchemas()
-          .computeIfAbsent(Api.Schema.Direction.class, k -> new ConcurrentHashMap<>())
+          .computeIfAbsent(Api.Schema.Direction.class, k -> newClassMap())
           .put(schemaType, input);
     }
-    input.getDirection().setValue(Api.Schema.Direction.IN);
     output.getProperties().stream()
         .filter(Api.Property::isInput)
         .forEach(p -> input.getProperties().add(p.withType(generateInputReferenceSchema(p))));
@@ -374,7 +370,7 @@ public class ApiIntegrator {
     Class<?> schemaType = of.getIdentifyAs();
     Api.Schema object = Api.Schema.ofObject(of.getSource(), schemaType);
     Map<Class<?>, Api.Schema> idSchemas =
-        api.getGeneratorSchemas().computeIfAbsent(UID.class, key -> new ConcurrentHashMap<>());
+        api.getGeneratorSchemas().computeIfAbsent(UID.class, key -> newClassMap());
 
     Api.Schema idType =
         idSchemas.computeIfAbsent(
@@ -386,6 +382,11 @@ public class ApiIntegrator {
             });
     object.addProperty(new Api.Property(null, "id", true, idType));
     return object;
+  }
+
+  @Nonnull
+  private static <T> TreeMap<Class<?>, T> newClassMap() {
+    return new TreeMap<>(comparing(Class::getName));
   }
 
   /*
@@ -552,7 +553,7 @@ public class ApiIntegrator {
     if (endpoints.size() == 1) return Map.of("", endpoints.get(0));
 
     Api.Endpoint defaultEndpoint = getDefaultEndpoint(endpoints);
-    Map<String, Api.Endpoint> endpointsByFragment = new HashMap<>();
+    Map<String, Api.Endpoint> endpointsByFragment = new TreeMap<>();
     for (Api.Endpoint endpoint : endpoints) {
       if (!endpoint.equals(defaultEndpoint)) {
         if (isMergeable(endpoint, defaultEndpoint)) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/DirectType.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/DirectType.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonBoolean;
 import org.hisp.dhis.jsontree.JsonDate;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonNumber;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
@@ -78,6 +79,7 @@ import org.intellij.lang.annotations.Language;
 import org.locationtech.jts.geom.Geometry;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 /**
  * A type mapping between a Java type and its OpenAPI form that is specified directly in terms of an
@@ -247,6 +249,7 @@ class DirectType {
     oneOf(JsonPointer.class, schema -> schema.type("string"));
 
     oneOf(JsonValue.class, schema -> schema.type("any"));
+    oneOf(JsonMixed.class, schema -> schema.type("any"));
     oneOf(JsonObject.class, schema -> schema.type("object"));
     oneOf(JsonArray.class, schema -> schema.type("array"));
     oneOf(JsonString.class, schema -> schema.type("string"));
@@ -256,6 +259,8 @@ class DirectType {
 
     oneOf(Geometry.class, schema -> schema.type("object"));
     oneOf(JobParameters.class, schema -> schema.type("object"));
+
+    oneOf(StreamingResponseBody.class, schema -> schema.type("any"));
   }
 
   private static <T extends Enum<T>> List<String> enums(Class<T> type, Function<T, String> name) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -594,10 +594,6 @@ public class OpenApiGenerator extends JsonGenerator {
     // needs a copy as we modify the iterated collection in the forEach
     new TreeSet<>(pathSchemaRefs).forEach(name -> addPathSchemaRefs(name, expanded));
     // now remove those schemas that are not referenced
-    if (!pathSchemaRefs.contains("RelationshipItemParams")
-        && api.getComponents().getSchemas().size() > 900) {
-      System.out.println("removed?");
-    }
     api.getComponents().getSchemas().keySet().removeIf(name -> !pathSchemaRefs.contains(name));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -37,12 +37,12 @@ import static org.hisp.dhis.webapi.openapi.Api.Schema.Direction.OUT;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -122,13 +122,13 @@ public class OpenApiGenerator extends JsonGenerator {
   private final Api api;
   private final Info info;
   private final OpenApiGenerationParams params;
-  private final Map<String, List<Api.Endpoint>> endpointsByBaseOperationId = new HashMap<>();
+  private final Map<String, List<Api.Endpoint>> endpointsByBaseOperationId = new TreeMap<>();
 
   /**
    * Accumulates the schema references used during generation of the OpenAPI {@code paths} part.
    * This is later used to ensure no schema is added to the output that isn't actually referenced.
    */
-  private final Set<String> pathSchemaRefs = new HashSet<>();
+  private final Set<String> pathSchemaRefs = new TreeSet<>();
 
   private OpenApiGenerator(
       Api api,
@@ -592,8 +592,12 @@ public class OpenApiGenerator extends JsonGenerator {
     // in that set
     Set<String> expanded = new HashSet<>();
     // needs a copy as we modify the iterated collection in the forEach
-    Set.copyOf(pathSchemaRefs).forEach(name -> addPathSchemaRefs(name, expanded));
+    new TreeSet<>(pathSchemaRefs).forEach(name -> addPathSchemaRefs(name, expanded));
     // now remove those schemas that are not referenced
+    if (!pathSchemaRefs.contains("RelationshipItemParams")
+        && api.getComponents().getSchemas().size() > 900) {
+      System.out.println("removed?");
+    }
     api.getComponents().getSchemas().keySet().removeIf(name -> !pathSchemaRefs.contains(name));
   }
 
@@ -608,9 +612,13 @@ public class OpenApiGenerator extends JsonGenerator {
   private void addPathSchemaRefs(Api.Schema schema, Set<String> expanded) {
     if (schema.isShared()) {
       String name = schema.getSharedName().getValue();
-      addPathSchemaRefs(name, expanded);
-      if (expanded.contains(name)) return;
+      if (!expanded.contains(name)) {
+        pathSchemaRefs.add(name);
+        expanded.add(name);
+        schema.getProperties().forEach(p -> addPathSchemaRefs(p.getType(), expanded));
+      }
+    } else {
+      schema.getProperties().forEach(p -> addPathSchemaRefs(p.getType(), expanded));
     }
-    schema.getProperties().forEach(p -> addPathSchemaRefs(p.getType(), expanded));
   }
 }


### PR DESCRIPTION
### Summary
The main change is to use collections that maintain a defined order to avoid having the order of operations vary between runs and between JDKs. This mainly means to use `TreeSet` and `TreeMap` where possible, use `toCollection` instead of `toSet` when collecting streams to a set, and avoid `Set.copyOf`. This is either to eliminate the issue or to make it reproducible.

The second change is how schema usages are tracked before schemas considered unused are removed (see `OpenApiGenerator.addPathSchemaRefs`). I am not sure the old code did miss to follow (expand) a type in some cases but in any case the new code is more clear on that.

Overall I am not sure this really fixed the flakiness. I could reproduce the issue about 1/10 runs locally at the start. After doing the main work I failed to get it again. At the very least it seems much more unlikely to happen. 

**Findings (for future debug if needed)**

I found that the schema complained about by validation as missing is indeed missing and that it is the only one out of all that is gone. At the time of debugging there were 921 schemas for a full API but sometimes it would just be 920. My main suspect is that due to reordering in the processing and an issue with the identification of included schemas the missing schema would sometimes be removed as "unused". But I failed to confirm that. 

**Other Fixes**

* fixed test scenarios use of  `scope` parameter value syntax (worked because the entire API also included the part under test)
* fixed entity type of some objects I noticed were not accurate
* fixed class types extending `Collection` to also map to an array schema
* fixed map with fixed key type (1 generic) also map to object schema
* fixed `JsonMixed` to map to _any_ schema
* fixed `StreamingResponseBody` to map to _any_ schema