### PR TITLE
feat: add SQL functions for standard deviation and variance (Clickhouse) [DHIS2-19280]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -385,7 +385,7 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
     } else if (aggType.isAggregationType(AVERAGE) && aggType.isBooleanDataType()) {
       sql = "sum(daysxvalue) / sum(daysno) * 100";
     } else if (SIMPLE_AGGREGATION_TYPES.contains(aggType.getAggregationType())) {
-      sql = String.format("%s(%s)", aggType.getAggregationType().getValue(), valueColumn);
+      sql = resolveAggregationType(aggType.getAggregationType(), valueColumn);
     } else { // SUM and no value
       sql = "sum(" + valueColumn + ")";
     }
@@ -1041,5 +1041,20 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
    */
   private String quoteAliasCommaSeparate(Collection<String> items) {
     return items.stream().map(this::quoteAlias).collect(Collectors.joining(","));
+  }
+
+  /**
+   * Build the SQL function string for the given aggregation type and value.
+   *
+   * @param aggregationType aggregation type
+   * @param value value to be aggregated
+   * @return SQL function string
+   */
+  private String resolveAggregationType(AggregationType aggregationType, String value) {
+    return switch (aggregationType) {
+      case STDDEV -> sqlBuilder.stddev(value);
+      case VARIANCE -> sqlBuilder.variance(value);
+      default -> String.format("%s(%s)", aggregationType.getValue(), value);
+    };
   }
 }

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilder.java
@@ -307,6 +307,16 @@ public class ClickHouseSqlBuilder extends AbstractSqlBuilder {
     return String.format("log10(%s)", expression);
   }
 
+  @Override
+  public String stddev(String expression) {
+    return String.format("stddevSamp(%s)", expression);
+  }
+
+  @Override
+  public String variance(String expression) {
+    return String.format("varSamp(%s)", expression);
+  }
+
   // Statements
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -309,7 +309,15 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
     return String.format("log(%s, 10)", expression);
   }
 
-  // Statements
+  @Override
+  public String stddev(String expression) {
+    return String.format("stddev(%s)", expression);
+  }
+
+  @Override
+  public String variance(String expression) {
+    return String.format("variance(%s)", expression);
+  }
 
   @Override
   public String createTable(Table table) {

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
@@ -328,6 +328,16 @@ public class PostgreSqlBuilder extends AbstractSqlBuilder {
     return String.format("log(%s)", expression);
   }
 
+  @Override
+  public String stddev(String expression) {
+    return String.format("stddev(%s)", expression);
+  }
+
+  @Override
+  public String variance(String expression) {
+    return String.format("variance(%s)", expression);
+  }
+
   // Statements
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
@@ -378,7 +378,7 @@ public interface SqlBuilder {
   String stddev(String expression);
 
   /**
-   * Generates a SQL fragment that computes the variance of the specified expression. * Variance
+   * Generates a SQL fragment that computes the variance of the specified expression. Variance
    * measures how far a set of numbers are spread out from their average value. A higher variance
    * indicates greater data dispersion.
    *

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/SqlBuilder.java
@@ -369,6 +369,25 @@ public interface SqlBuilder {
   String log10(String expression);
 
   /**
+   * Generates a SQL fragment that compute the standard deviation of the specified expression.
+   *
+   * @param expression a numeric expression or column name for which to compute the standard
+   *     deviation.
+   * @return a SQL fragment that calculates the standard deviation of the given expression.
+   */
+  String stddev(String expression);
+
+  /**
+   * Generates a SQL fragment that computes the variance of the specified expression. * Variance
+   * measures how far a set of numbers are spread out from their average value. A higher variance
+   * indicates greater data dispersion.
+   *
+   * @param expression a numeric expression or column name for which to compute the variance.
+   * @return a SQL fragment that calculates the variance of the given expression.
+   */
+  String variance(String expression);
+
+  /**
    * Returns a conditional statement.
    *
    * @param condition the condition to evaluate.

--- a/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/ClickHouseSqlBuilderTest.java
@@ -312,6 +312,16 @@ class ClickHouseSqlBuilderTest {
     assertEquals("log10(value)", sqlBuilder.log10("value"));
   }
 
+  @Test
+  void testStandardDeviation() {
+    assertEquals("stddevSamp(value)", sqlBuilder.stddev("value"));
+  }
+
+  @Test
+  void testVariance() {
+    assertEquals("varSamp(value)", sqlBuilder.variance("value"));
+  }
+
   // Statements
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
@@ -372,6 +372,16 @@ class DorisSqlBuilderTest {
     assertEquals("log(value, 10)", sqlBuilder.log10("value"));
   }
 
+  @Test
+  void testStandardDeviation() {
+    assertEquals("stddev(value)", sqlBuilder.stddev("value"));
+  }
+
+  @Test
+  void testVariance() {
+    assertEquals("variance(value)", sqlBuilder.variance("value"));
+  }
+
   // Statements
 
   @Test


### PR DESCRIPTION
## Summary

Make sure that the SQL functions `stddev` and `variance` can run in Clickhouse: add the functions to `SqlBuilder`.

## How to test

- Set `clickhouse` as analytics db
- Run this query on latest SL db:
  - `/api/43/analytics?dimension=dx:BOSZApCrBni;Cm4XUw6VAxv;CxlYcbqio4v;F53rTVTmSuF;FHD3wiSM7Sn;GMd99K8gVut;I5MLuG16arn;Jtf34kNZhzP;LVaUdM3CERi;NJnhOzjaLYk;RF4VFVGdFRO;XTqOHygxDj5;aIJZ2d2QgVV;cYeuwXTCPkU;dGdeotKpRed;eRwOwCpMzyP;fbfJHSPpUQD;hfdmMSPBgLG;iKGjnOOaPlE;kVOiLDV4OC6;oLfWYAJhZb2;rNEpbBxSyu7;wfKKFhBn0Q0;zYkwbCBALhn,pe:LAST_12_MONTHS&filter=ou:USER_ORGUNIT&aggregationType=STDDEV&displayProperty=NAME&includeNumDen=true&skipMeta=true&skipData=false`