### PR TITLE
fix: Missing OU in metadata items [DHIS2-18884]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -570,6 +570,8 @@ public abstract class AbstractAnalyticsService {
       }
     }
 
+    metadataItemMap.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
+
     return metadataItemMap;
   }
 


### PR DESCRIPTION
Adding missed code during backport.
It was causing the absence of organization units in the `metaData` object.