### PR TITLE
fix: Fetch org unit path when getting TE [DHIS2-19282]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/TrackedEntityRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/TrackedEntityRowCallbackHandler.java
@@ -72,6 +72,7 @@ public class TrackedEntityRowCallbackHandler implements RowCallbackHandler {
     orgUnit.setUid(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.ORGUNIT_UID)));
     orgUnit.setCode(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.ORGUNIT_CODE)));
     orgUnit.setName(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.ORGUNIT_NAME)));
+    orgUnit.setPath(rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.ORGUNIT_PATH)));
     orgUnit.setAttributeValues(
         AttributeValues.of(
             rs.getString(TrackedEntityQuery.getColumnName(COLUMNS.ORGUNIT_ATTRIBUTE_VALUES))));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/TrackedEntityQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/TrackedEntityQuery.java
@@ -56,6 +56,7 @@ public class TrackedEntityQuery {
     ORGUNIT_UID,
     ORGUNIT_CODE,
     ORGUNIT_NAME,
+    ORGUNIT_PATH,
     ORGUNIT_ATTRIBUTE_VALUES,
     TRACKEDENTITYID,
 
@@ -87,6 +88,7 @@ public class TrackedEntityQuery {
           .put(COLUMNS.ORGUNIT_UID, new TableColumn("o", "uid", "ou_uid"))
           .put(COLUMNS.ORGUNIT_CODE, new TableColumn("o", "code", "ou_code"))
           .put(COLUMNS.ORGUNIT_NAME, new TableColumn("o", "name", "ou_name"))
+          .put(COLUMNS.ORGUNIT_PATH, new TableColumn("o", "path", "ou_path"))
           .put(
               COLUMNS.ORGUNIT_ATTRIBUTE_VALUES,
               new TableColumn("o", "attributevalues", "ou_attributevalues"))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -602,6 +602,34 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldReturnTrackedEntitiesWithCorrectOrgUnitPropertiesMappedWhenTrackedEntityAccessible()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(orgUnitChildA)
+            .orgUnitMode(SELECTED)
+            .trackedEntityType(trackedEntityTypeA)
+            .build();
+
+    final List<TrackedEntity> trackedEntities =
+        trackedEntityService.findTrackedEntities(operationParams);
+
+    assertContainsOnly(List.of(trackedEntityChildA), trackedEntities);
+    assertEquals(
+        trackedEntityChildA.getOrganisationUnit().getUid(),
+        trackedEntities.get(0).getOrganisationUnit().getUid());
+    assertEquals(
+        trackedEntityChildA.getOrganisationUnit().getCode(),
+        trackedEntities.get(0).getOrganisationUnit().getCode());
+    assertEquals(
+        trackedEntityChildA.getOrganisationUnit().getName(),
+        trackedEntities.get(0).getOrganisationUnit().getName());
+    assertEquals(
+        trackedEntityChildA.getOrganisationUnit().getStoredPath(),
+        trackedEntities.get(0).getOrganisationUnit().getStoredPath());
+  }
+
+  @Test
   void shouldReturnTrackedEntityIncludingAllAttributesEnrollmentsEventsRelationshipsOwners()
       throws ForbiddenException, NotFoundException, BadRequestException {
     // this was declared as "remove ownership"; unclear to me how this is removing ownership


### PR DESCRIPTION
Get the TE org unit path from the DB, so we can use it when checking the access to a TE/program owner.
Currently we don't set the path value, so access to a TE is always rejected.
Note that this only happens when there's no owner to a TE/program pair and we default to the registering org unit.