### PR TITLE
fix: Missing OU in metadata items [DHIS2-18884]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -407,19 +408,14 @@ public abstract class AbstractAnalyticsService {
         optionItems.addAll(getItemOptionsAsFilter(params.getItemOptions(), params.getItems()));
       }
 
-      Map<String, Object> items = new HashMap<>();
-      items.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
-
       if (params.isComingFromQuery()) {
-        items.putAll(getMetadataItems(params, periodKeywords, optionItems, grid));
+        metadata.put(ITEMS.getKey(), getMetadataItems(params, periodKeywords, optionItems, grid));
         metadata.put(
             DIMENSIONS.getKey(), getDimensionItems(params, Optional.of(optionsPresentInGrid)));
       } else {
-        items.putAll(getMetadataItems(params));
+        metadata.put(ITEMS.getKey(), getMetadataItems(params));
         metadata.put(DIMENSIONS.getKey(), getDimensionItems(params, empty()));
       }
-
-      metadata.put(ITEMS.getKey(), items);
 
       maybeAddOrgUnitHierarchyInfo(params, metadata, grid);
 
@@ -571,7 +567,11 @@ public abstract class AbstractAnalyticsService {
       }
     }
 
-    metadataItemMap.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
+    Map<String, MetadataItem> metadataForOuDataElements =
+        organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params);
+    for (Entry<String, MetadataItem> entry : metadataForOuDataElements.entrySet()) {
+      metadataItemMap.putIfAbsent(entry.getKey(), entry.getValue());
+    }
 
     return metadataItemMap;
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -407,14 +407,19 @@ public abstract class AbstractAnalyticsService {
         optionItems.addAll(getItemOptionsAsFilter(params.getItemOptions(), params.getItems()));
       }
 
+      Map<String, Object> items = new HashMap<>();
+      items.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
+
       if (params.isComingFromQuery()) {
-        metadata.put(ITEMS.getKey(), getMetadataItems(params, periodKeywords, optionItems, grid));
+        items.putAll(getMetadataItems(params, periodKeywords, optionItems, grid));
         metadata.put(
             DIMENSIONS.getKey(), getDimensionItems(params, Optional.of(optionsPresentInGrid)));
       } else {
-        metadata.put(ITEMS.getKey(), getMetadataItems(params));
+        items.putAll(getMetadataItems(params));
         metadata.put(DIMENSIONS.getKey(), getDimensionItems(params, empty()));
       }
+
+      metadata.put(ITEMS.getKey(), items);
 
       maybeAddOrgUnitHierarchyInfo(params, metadata, grid);
 
@@ -504,8 +509,6 @@ public abstract class AbstractAnalyticsService {
                     item.getItemId(),
                     new MetadataItem(
                         item.getItem().getDisplayName(), includeDetails ? item.getItem() : null)));
-
-    metadataItemMap.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
 
     return metadataItemMap;
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -568,6 +568,8 @@ public abstract class AbstractAnalyticsService {
       }
     }
 
+    metadataItemMap.putAll(organisationUnitResolver.getMetadataItemsForOrgUnitDataElements(params));
+
     return metadataItemMap;
   }
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -184,7 +184,7 @@
 
     <!-- Div. utils -->
     <version.debezium>2.7.3.Final</version.debezium>
-    <guava.version>33.4.0-jre</guava.version>
+    <guava.version>33.4.5-jre</guava.version>
     <jsr305.version>3.0.2</jsr305.version>
     <imgscalr-lib.version>4.2</imgscalr-lib.version>
     <google-api-client.version>2.7.2</google-api-client.version>


### PR DESCRIPTION
Adding missed code during backport.
It was causing the absence of organization units in the `metaData` object.