### PR TITLE
chore: avoid long ids in option SPI

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionService.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.feedback.ErrorMessage;
  * @author Lars Helge Overland
  */
 public interface OptionService {
-  String ID = OptionService.class.getName();
 
   // -------------------------------------------------------------------------
   // OptionSet
@@ -57,8 +56,6 @@ public interface OptionService {
 
   ErrorMessage validateOption(OptionSet optionSet, Option option);
 
-  OptionSet getOptionSet(long id);
-
   OptionSet getOptionSet(String uid);
 
   OptionSet getOptionSetByName(String name);
@@ -69,15 +66,13 @@ public interface OptionService {
 
   List<OptionSet> getAllOptionSets();
 
-  List<Option> getOptions(long optionSetId, String name, Integer max);
+  List<Option> getOptions(String optionSetId, String name, Integer max);
 
   // -------------------------------------------------------------------------
   // Option
   // -------------------------------------------------------------------------
 
   void updateOption(Option option);
-
-  Option getOption(long id);
 
   Option getOptionByCode(String code);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionService.java
@@ -86,8 +86,6 @@ public interface OptionService {
 
   void updateOptionGroup(OptionGroup group);
 
-  OptionGroup getOptionGroup(long id);
-
   OptionGroup getOptionGroup(String uid);
 
   void deleteOptionGroup(OptionGroup group);
@@ -101,8 +99,6 @@ public interface OptionService {
   long saveOptionGroupSet(OptionGroupSet group);
 
   void updateOptionGroupSet(OptionGroupSet group);
-
-  OptionGroupSet getOptionGroupSet(long id);
 
   OptionGroupSet getOptionGroupSet(String uid);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionStore.java
@@ -31,10 +31,12 @@ package org.hisp.dhis.option;
 
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.UID;
 
 /**
  * @author Chau Thu Tran
  */
 public interface OptionStore extends IdentifiableObjectStore<Option> {
-  List<Option> getOptions(long optionSetId, String key, Integer max);
+
+  List<Option> getOptions(UID optionSetId, String key, Integer max);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/DefaultOptionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/DefaultOptionService.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -117,12 +118,6 @@ public class DefaultOptionService implements OptionService {
 
   @Override
   @Transactional(readOnly = true)
-  public OptionSet getOptionSet(long id) {
-    return optionSetStore.get(id);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public OptionSet getOptionSet(String uid) {
     return optionSetStore.getByUid(uid);
   }
@@ -157,13 +152,13 @@ public class DefaultOptionService implements OptionService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<Option> getOptions(long optionSetId, String key, Integer max) {
+  public List<Option> getOptions(String optionSetId, String key, Integer max) {
     List<Option> options;
 
     if (key != null || max != null) {
       // Use query as option set size might be very high
 
-      options = optionStore.getOptions(optionSetId, key, max);
+      options = optionStore.getOptions(UID.of(optionSetId), key, max);
     } else {
       // Return all from object association to preserve custom order
 
@@ -179,12 +174,6 @@ public class DefaultOptionService implements OptionService {
   @Transactional
   public void updateOption(Option option) {
     optionStore.update(option);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public Option getOption(long id) {
-    return optionStore.get(id);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/DefaultOptionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/DefaultOptionService.java
@@ -208,12 +208,6 @@ public class DefaultOptionService implements OptionService {
 
   @Override
   @Transactional(readOnly = true)
-  public OptionGroup getOptionGroup(long id) {
-    return optionGroupStore.get(id);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public OptionGroup getOptionGroup(String uid) {
     return optionGroupStore.getByUid(uid);
   }
@@ -246,12 +240,6 @@ public class DefaultOptionService implements OptionService {
   @Transactional
   public void updateOptionGroupSet(OptionGroupSet group) {
     optionGroupSetStore.update(group);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public OptionGroupSet getOptionGroupSet(long id) {
-    return optionGroupSetStore.get(id);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.option.hibernate;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.hibernate.query.Query;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionStore;
@@ -59,10 +60,10 @@ public class HibernateOptionStore extends HibernateIdentifiableObjectStore<Optio
   // -------------------------------------------------------------------------
 
   @Override
-  public List<Option> getOptions(long optionSetId, String key, Integer max) {
+  public List<Option> getOptions(UID optionSetId, String key, Integer max) {
     String hql =
         "select option from OptionSet as optionset "
-            + "join optionset.options as option where optionset.id = :optionSetId ";
+            + "join optionset.options as option where optionset.uid = :optionSetId ";
 
     if (key != null) {
       hql += "and lower(option.name) like lower('%" + key + "%') ";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
@@ -72,7 +72,7 @@ public class HibernateOptionStore extends HibernateIdentifiableObjectStore<Optio
     hql += "order by option.sortOrder";
 
     Query<Option> query = getQuery(hql);
-    query.setParameter("optionSetId", optionSetId);
+    query.setParameter("optionSetId", optionSetId.getValue());
 
     if (max != null) {
       query.setMaxResults(max);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/DefaultPdfDataEntryFormService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/DefaultPdfDataEntryFormService.java
@@ -458,7 +458,7 @@ public class DefaultPdfDataEntryFormService implements PdfDataEntryFormService {
           // TODO: This gets repeated <- Create an array of the
           // options. and apply only once.
           List<Option> options =
-              optionService.getOptions(optionSet.getId(), query, MAX_OPTIONS_DISPLAYED);
+              optionService.getOptions(optionSet.getUid(), query, MAX_OPTIONS_DISPLAYED);
 
           addCell_WithDropDownListField(
               table,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
@@ -156,7 +156,7 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
   @Test
   void testGetList() throws ConflictException {
     optionService.saveOptionSet(optionSetA);
-    String uidA = optionGroupA.getUid();
+    String uidA = optionSetA.getUid();
     List<Option> options = optionService.getOptions(uidA, "OptA", 10);
     assertEquals(2, options.size());
     options = optionService.getOptions(uidA, "OptA1", 10);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
@@ -111,9 +111,9 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
     long idA = optionService.saveOptionSet(optionSetA);
     long idB = optionService.saveOptionSet(optionSetB);
     long idC = optionService.saveOptionSet(optionSetC);
-    OptionSet actualA = optionService.getOptionSet(idA);
-    OptionSet actualB = optionService.getOptionSet(idB);
-    OptionSet actualC = optionService.getOptionSet(idC);
+    OptionSet actualA = optionService.getOptionSet(optionSetA.getUid());
+    OptionSet actualB = optionService.getOptionSet(optionSetB.getUid());
+    OptionSet actualC = optionService.getOptionSet(optionSetC.getUid());
     assertEquals(optionSetA, actualA);
     assertEquals(optionSetB, actualB);
     assertEquals(optionSetC, actualC);
@@ -156,15 +156,16 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
   @Test
   void testGetList() throws ConflictException {
     long idA = optionService.saveOptionSet(optionSetA);
-    List<Option> options = optionService.getOptions(idA, "OptA", 10);
+    String uidA = optionGroupA.getUid();
+    List<Option> options = optionService.getOptions(uidA, "OptA", 10);
     assertEquals(2, options.size());
-    options = optionService.getOptions(idA, "OptA1", 10);
+    options = optionService.getOptions(uidA, "OptA1", 10);
     assertEquals(1, options.size());
-    options = optionService.getOptions(idA, "OptA1", null);
+    options = optionService.getOptions(uidA, "OptA1", null);
     assertEquals(1, options.size());
-    options = optionService.getOptions(idA, "Opt", null);
+    options = optionService.getOptions(uidA, "Opt", null);
     assertEquals(4, options.size());
-    options = optionService.getOptions(idA, "Opt", 3);
+    options = optionService.getOptions(uidA, "Opt", 3);
     assertEquals(3, options.size());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionServiceTest.java
@@ -108,9 +108,9 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testSaveGet() throws ConflictException {
-    long idA = optionService.saveOptionSet(optionSetA);
-    long idB = optionService.saveOptionSet(optionSetB);
-    long idC = optionService.saveOptionSet(optionSetC);
+    optionService.saveOptionSet(optionSetA);
+    optionService.saveOptionSet(optionSetB);
+    optionService.saveOptionSet(optionSetC);
     OptionSet actualA = optionService.getOptionSet(optionSetA.getUid());
     OptionSet actualB = optionService.getOptionSet(optionSetB.getUid());
     OptionSet actualC = optionService.getOptionSet(optionSetC.getUid());
@@ -155,7 +155,7 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetList() throws ConflictException {
-    long idA = optionService.saveOptionSet(optionSetA);
+    optionService.saveOptionSet(optionSetA);
     String uidA = optionGroupA.getUid();
     List<Option> options = optionService.getOptions(uidA, "OptA", 10);
     assertEquals(2, options.size());
@@ -177,15 +177,15 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
     optionGroupA.getMembers().add(option1);
     optionGroupA.getMembers().add(option2);
     optionGroupB.getMembers().add(option3);
-    long idA = optionService.saveOptionGroup(optionGroupA);
-    long idB = optionService.saveOptionGroup(optionGroupB);
-    long idC = optionService.saveOptionGroup(optionGroupC);
-    assertEquals(optionGroupA, optionService.getOptionGroup(idA));
-    assertEquals(optionGroupB, optionService.getOptionGroup(idB));
-    assertEquals(optionGroupC, optionService.getOptionGroup(idC));
-    assertEquals(2, optionService.getOptionGroup(idA).getMembers().size());
-    assertEquals(1, optionService.getOptionGroup(idB).getMembers().size());
-    assertEquals(0, optionService.getOptionGroup(idC).getMembers().size());
+    optionService.saveOptionGroup(optionGroupA);
+    optionService.saveOptionGroup(optionGroupB);
+    optionService.saveOptionGroup(optionGroupC);
+    assertEquals(optionGroupA, optionService.getOptionGroup(optionGroupA.getUid()));
+    assertEquals(optionGroupB, optionService.getOptionGroup(optionGroupB.getUid()));
+    assertEquals(optionGroupC, optionService.getOptionGroup(optionGroupC.getUid()));
+    assertEquals(2, optionService.getOptionGroup(optionGroupA.getUid()).getMembers().size());
+    assertEquals(1, optionService.getOptionGroup(optionGroupB.getUid()).getMembers().size());
+    assertEquals(0, optionService.getOptionGroup(optionGroupC.getUid()).getMembers().size());
   }
 
   // -------------------------------------------------------------------------
@@ -202,14 +202,14 @@ class OptionServiceTest extends PostgresIntegrationTestBase {
     optionGroupSetA.getMembers().add(optionGroupA);
     optionGroupSetA.getMembers().add(optionGroupB);
     optionGroupSetB.getMembers().add(optionGroupC);
-    long idA = optionService.saveOptionGroupSet(optionGroupSetA);
-    long idB = optionService.saveOptionGroupSet(optionGroupSetB);
-    long idC = optionService.saveOptionGroupSet(optionGroupSetC);
-    assertEquals(optionGroupSetA, optionService.getOptionGroupSet(idA));
-    assertEquals(optionGroupSetB, optionService.getOptionGroupSet(idB));
-    assertEquals(optionGroupSetC, optionService.getOptionGroupSet(idC));
-    assertEquals(2, optionService.getOptionGroupSet(idA).getMembers().size());
-    assertEquals(1, optionService.getOptionGroupSet(idB).getMembers().size());
-    assertEquals(0, optionService.getOptionGroupSet(idC).getMembers().size());
+    optionService.saveOptionGroupSet(optionGroupSetA);
+    optionService.saveOptionGroupSet(optionGroupSetB);
+    optionService.saveOptionGroupSet(optionGroupSetC);
+    assertEquals(optionGroupSetA, optionService.getOptionGroupSet(optionGroupSetA.getUid()));
+    assertEquals(optionGroupSetB, optionService.getOptionGroupSet(optionGroupSetB.getUid()));
+    assertEquals(optionGroupSetC, optionService.getOptionGroupSet(optionGroupSetC.getUid()));
+    assertEquals(2, optionService.getOptionGroupSet(optionGroupSetA.getUid()).getMembers().size());
+    assertEquals(1, optionService.getOptionGroupSet(optionGroupSetB.getUid()).getMembers().size());
+    assertEquals(0, optionService.getOptionGroupSet(optionGroupSetC.getUid()).getMembers().size());
   }
 }


### PR DESCRIPTION
Looking into option validation I noticed that there are `long` IDs being used in the options SPI so I updated that to use `String`/`UID` instead. 