### PR TITLE
chore: Improve e2e test, remove redundant assert

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -90,8 +90,7 @@ class GeoJsonImportTest extends ApiTest {
     assertEquals(11, taskId.length());
 
     // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
-    ApiResponse taskStatus = systemActions.waitUntilTaskCompleted("GEOJSON_IMPORT", taskId, 24);
-    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
+    systemActions.waitUntilTaskCompleted("GEOJSON_IMPORT", taskId, 24);
 
     // get org unit again which should now contain geometry property
     ApiResponse getUpdatedOrgUnit = restApiActions.get("/ImspTQPwCqd");


### PR DESCRIPTION
Remove unnecessary assert check on payload. The previous line already checks if the task is completed or not.