### PR TITLE
fix: exception when order idesc with non-text property

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.query;
 
+import static org.hisp.dhis.query.JpaQueryUtils.isPropertyTypeText;
 import static org.hisp.dhis.query.JpaQueryUtils.stringPredicateIgnoreCase;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
@@ -185,7 +186,9 @@ public class JpaCriteriaQueryEngine implements QueryEngine {
       jakarta.persistence.criteria.Order getOrderPredicate(
           CriteriaBuilder builder, Root<T> root, @Nonnull Order order) {
 
-    if (order.isIgnoreCase()) {
+    if (order.isIgnoreCase()
+        && order.getProperty() != null
+        && isPropertyTypeText(order.getProperty())) {
       return order.isAscending()
           ? builder.asc(builder.lower(root.get(order.getProperty().getFieldName())))
           : builder.desc(builder.lower(root.get(order.getProperty().getFieldName())));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -30,6 +30,9 @@
 package org.hisp.dhis.query;
 
 import static java.util.stream.Collectors.joining;
+import static org.hisp.dhis.schema.PropertyType.EMAIL;
+import static org.hisp.dhis.schema.PropertyType.TEXT;
+import static org.hisp.dhis.schema.PropertyType.USERNAME;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
@@ -416,6 +419,10 @@ public class JpaQueryUtils {
             generateSQlQueryForSharingCheck(
                 tableName + ".sharing", access, userId, getGroupsIds(userGroupIds)))
         + ")";
+  }
+
+  public static boolean isPropertyTypeText(Property property) {
+    return List.of(TEXT, EMAIL, USERNAME).contains(property.getPropertyType());
   }
 
   private static String getGroupsIds(UserDetails user) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -1306,6 +1306,25 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
     assertEquals("Child Health", response.get(1).getDisplayName());
   }
 
+  @Test
+  void testSortNoneTextCaseInsensitive() {
+    POST(
+            "/categories/",
+            "{'name':'Child Health', 'shortName':'CAT1','dataDimensionType':'DISAGGREGATION','lastUpdated':'2017-05-19T15:13:52.488'}")
+        .content(HttpStatus.CREATED);
+    POST(
+            "/categories/",
+            "{'name':'births attended by', 'shortName':'CAT2','dataDimensionType':'DISAGGREGATION', 'lastUpdated':'2017-05-19T15:14:52.488'}")
+        .content(HttpStatus.CREATED);
+
+    JsonList<JsonIdentifiableObject> response =
+        GET("/categories?order=craeted:idesc")
+            .content()
+            .getList("categories", JsonIdentifiableObject.class);
+    assertEquals("births attended by", response.get(0).getDisplayName());
+    assertEquals("Child Health", response.get(1).getDisplayName());
+  }
+
   private void assertErrorMandatoryAttributeRequired(String attrId, HttpResponse response) {
     JsonError msg = response.content(HttpStatus.CONFLICT).as(JsonError.class);
     JsonList<JsonErrorReport> errorReports = msg.getTypeReport().getErrorReports();


### PR DESCRIPTION
### Issue
- Try to sort a metadata resource with order=lastUpdated:iasc or order=lastUpdated:idesc and got below exception
```
"httpStatus": "Conflict","httpStatusCode": 409,"status": "ERROR","message": "ERROR: function lower(timestamp without time zone) does not exist\n  Hint: No function matches the given name and argument types. You might need to add explicit type casts.\n  Position: 1100"
```

### Fix
- Add check for non-text property and return order without `lower()` function

### Test
- Added controller test.