### PR TITLE
refactor: Rename methods for stats and type report

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/Stats.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/Stats.java
@@ -35,6 +35,9 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 
 /**
+ * New immutable instances are returned for all operations. Make sure to use the returned instance
+ * if updated stats are to be tracked correctly.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author david mackessy
  */
@@ -50,20 +53,24 @@ public record Stats(
     return created + updated + deleted + ignored;
   }
 
-  public Stats withCreated(int created) {
-    return new Stats(this.created + created, this.updated, this.deleted, this.ignored);
+  public Stats createdInc(int amount) {
+    return new Stats(this.created + amount, this.updated, this.deleted, this.ignored);
   }
 
-  public Stats withUpdated(int updated) {
-    return new Stats(this.created, this.updated + updated, this.deleted, this.ignored);
+  public Stats updatedInc(int amount) {
+    return new Stats(this.created, this.updated + amount, this.deleted, this.ignored);
   }
 
-  public Stats withDeleted(int deleted) {
-    return new Stats(this.created, this.updated, this.deleted + deleted, this.ignored);
+  public Stats deletedInc(int amount) {
+    return new Stats(this.created, this.updated, this.deleted + amount, this.ignored);
   }
 
-  public Stats withIgnored(int ignored) {
-    return new Stats(this.created, this.updated, this.deleted, this.ignored + ignored);
+  public Stats deletedDec(int amount) {
+    return new Stats(this.created, this.updated, this.deleted - amount, this.ignored);
+  }
+
+  public Stats ignoredInc(int amount) {
+    return new Stats(this.created, this.updated, this.deleted, this.ignored + amount);
   }
 
   public Stats withStats(@Nonnull Stats stats) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypeReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/TypeReport.java
@@ -214,27 +214,27 @@ public class TypeReport implements ErrorReportContainer {
         .toString();
   }
 
-  public void withStatsIncCreated(int amount) {
-    stats = stats.withCreated(amount);
+  public void createdInc(int amount) {
+    stats = stats.createdInc(amount);
   }
 
-  public void withStatsIncUpdated(int amount) {
-    stats = stats.withUpdated(amount);
+  public void updatedInc(int amount) {
+    stats = stats.updatedInc(amount);
   }
 
-  public void withStatsIncDeleted(int amount) {
-    stats = stats.withDeleted(amount);
+  public void deletedInc(int amount) {
+    stats = stats.deletedInc(amount);
   }
 
-  public void withStatsDecDeleted(int amount) {
-    stats = stats.withDeleted(-amount);
+  public void deletedDec(int amount) {
+    stats = stats.deletedDec(amount);
   }
 
-  public void withStatsIncIgnored(int amount) {
-    stats = stats.withIgnored(amount);
+  public void ignoredInc(int amount) {
+    stats = stats.ignoredInc(amount);
   }
 
-  public void withAllStatsIgnored() {
+  public void ignoreAll() {
     stats =
         new Stats(0, 0, 0, (stats.created() + stats.updated() + stats.deleted() + stats.ignored()));
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/StatsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/StatsTest.java
@@ -56,14 +56,14 @@ class StatsTest {
 
   public static Stream<Arguments> statsValues() {
     return Stream.of(
-        Arguments.of(new Stats(0, 0, 0, 0).withCreated(1), new Stats(1, 0, 0, 0)),
-        Arguments.of(new Stats(0, 0, 0, 0).withUpdated(1), new Stats(0, 1, 0, 0)),
-        Arguments.of(new Stats(0, 0, 0, 0).withDeleted(1), new Stats(0, 0, 1, 0)),
-        Arguments.of(new Stats(0, 0, 0, 0).withIgnored(1), new Stats(0, 0, 0, 1)),
-        Arguments.of(new Stats(3, 4, 5, 6).withCreated(1), new Stats(4, 4, 5, 6)),
-        Arguments.of(new Stats(3, 4, 5, 6).withUpdated(1), new Stats(3, 5, 5, 6)),
-        Arguments.of(new Stats(3, 4, 5, 6).withDeleted(1), new Stats(3, 4, 6, 6)),
-        Arguments.of(new Stats(3, 4, 5, 6).withIgnored(1), new Stats(3, 4, 5, 7)),
+        Arguments.of(new Stats(0, 0, 0, 0).createdInc(1), new Stats(1, 0, 0, 0)),
+        Arguments.of(new Stats(0, 0, 0, 0).updatedInc(1), new Stats(0, 1, 0, 0)),
+        Arguments.of(new Stats(0, 0, 0, 0).deletedInc(1), new Stats(0, 0, 1, 0)),
+        Arguments.of(new Stats(0, 0, 0, 0).ignoredInc(1), new Stats(0, 0, 0, 1)),
+        Arguments.of(new Stats(3, 4, 5, 6).createdInc(1), new Stats(4, 4, 5, 6)),
+        Arguments.of(new Stats(3, 4, 5, 6).updatedInc(1), new Stats(3, 5, 5, 6)),
+        Arguments.of(new Stats(3, 4, 5, 6).deletedInc(1), new Stats(3, 4, 6, 6)),
+        Arguments.of(new Stats(3, 4, 5, 6).ignoredInc(1), new Stats(3, 4, 5, 7)),
         Arguments.of(new Stats(0, 0, 0, 0).withStats(new Stats(1, 1, 1, 1)), new Stats(1, 1, 1, 1)),
         Arguments.of(
             new Stats(1, 2, 3, 4).withStats(new Stats(9, 9, 9, 0)), new Stats(10, 11, 12, 4)));

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypeReportTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/feedback/TypeReportTest.java
@@ -117,13 +117,13 @@ class TypeReportTest {
   void allStatsIgnoredTest() {
     // given
     TypeReport typeReport = new TypeReport(DataElement.class);
-    typeReport.withStatsIncCreated(1);
-    typeReport.withStatsIncUpdated(2);
-    typeReport.withStatsIncDeleted(3);
-    typeReport.withStatsIncIgnored(4);
+    typeReport.createdInc(1);
+    typeReport.updatedInc(2);
+    typeReport.deletedInc(3);
+    typeReport.ignoredInc(4);
 
     // when
-    typeReport.withAllStatsIgnored();
+    typeReport.ignoreAll();
 
     // then
     assertEquals(new Stats(0, 0, 0, 10), typeReport.getStats());
@@ -133,7 +133,7 @@ class TypeReportTest {
   @DisplayName("Type report with decremented delete has correct values")
   void decDeleteTest() {
     TypeReport typeReport = new TypeReport(DataElement.class);
-    typeReport.withStatsDecDeleted(1);
+    typeReport.deletedDec(1);
     assertEquals(new Stats(0, 0, -1, 0), typeReport.getStats());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -130,7 +130,7 @@ public class DefaultMetadataImportService implements MetadataImportService {
 
       log.info("(" + bundle.getUsername() + ") Import:Commit took " + commitTimer.toString());
     } else {
-      report.getTypeReports().forEach(TypeReport::withAllStatsIgnored);
+      report.getTypeReports().forEach(TypeReport::ignoreAll);
       report.setStatus(Status.ERROR);
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
@@ -114,9 +114,9 @@ public class DefaultCollectionService implements CollectionService {
         item -> {
           if (!collection.contains(item)) {
             collection.add(item);
-            report.withStatsIncUpdated(1);
+            report.updatedInc(1);
           } else {
-            report.withStatsIncIgnored(1);
+            report.ignoredInc(1);
           }
         });
     validateAndThrowErrors(() -> schemaValidator.validateProperty(property, object));
@@ -142,9 +142,9 @@ public class DefaultCollectionService implements CollectionService {
             validateAndThrowErrors(() -> schemaValidator.validateProperty(property, object));
             collection.add(object);
             manager.update(item);
-            report.withStatsIncUpdated(1);
+            report.updatedInc(1);
           } else {
-            report.withStatsIncIgnored(1);
+            report.ignoredInc(1);
           }
         });
     entityManager.refresh(object);
@@ -194,9 +194,9 @@ public class DefaultCollectionService implements CollectionService {
         item -> {
           if (collection.contains(item)) {
             collection.remove(item);
-            report.withStatsIncDeleted(1);
+            report.deletedInc(1);
           } else {
-            report.withStatsIncIgnored(1);
+            report.ignoredInc(1);
           }
         });
   }
@@ -221,9 +221,9 @@ public class DefaultCollectionService implements CollectionService {
             validateAndThrowErrors(() -> schemaValidator.validateProperty(owningProperty, item));
             collection.remove(object);
             manager.update(item);
-            report.withStatsIncDeleted(1);
+            report.deletedInc(1);
           } else {
-            report.withStatsIncIgnored(1);
+            report.ignoredInc(1);
           }
         });
     entityManager.refresh(object);
@@ -318,7 +318,7 @@ public class DefaultCollectionService implements CollectionService {
         ObjectReport objectReport = new ObjectReport(itemType, index, item.getUid());
         objectReport.addErrorReport(new ErrorReport(itemType, errorCode, ex.getMessage()));
         report.addObjectReport(objectReport);
-        report.withStatsIncIgnored(1);
+        report.ignoredInc(1);
       }
       index++;
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -423,8 +423,8 @@ public class DefaultObjectBundleService implements ObjectBundleService {
     } catch (DeleteNotAllowedException ex) {
       objectReport.addErrorReport(
           new ErrorReport(klass, new ErrorMessage(ex.getMessage(), ErrorCode.E4030, null)));
-      typeReport.withStatsIncIgnored(1);
-      typeReport.withStatsDecDeleted(1);
+      typeReport.ignoredInc(1);
+      typeReport.deletedDec(1);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/NotOwnerReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/NotOwnerReferencesCheck.java
@@ -84,7 +84,7 @@ public class NotOwnerReferencesCheck implements ValidationCheck {
     }
 
     if (typeReport.hasErrorReports() && AtomicMode.ALL == bundle.getAtomicMode()) {
-      typeReport.withStatsIncIgnored(1);
+      typeReport.ignoredInc(1);
     }
 
     return typeReport;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ObjectValidationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ObjectValidationCheck.java
@@ -78,7 +78,7 @@ public interface ObjectValidationCheck extends ValidationCheck {
             reportBox[0] = report;
           }
           report.addObjectReport(objectReport);
-          report.withStatsIncIgnored(1);
+          report.ignoredInc(1);
         });
     return reportBox[0] == null ? TypeReport.empty(klass) : reportBox[0];
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -90,7 +90,7 @@ public class ReferencesCheck implements ValidationCheck {
     }
 
     if (typeReport.hasErrorReports() && AtomicMode.ALL == bundle.getAtomicMode()) {
-      typeReport.withStatsIncIgnored(1);
+      typeReport.ignoredInc(1);
     }
 
     return typeReport;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidationFactory.java
@@ -87,17 +87,17 @@ public class ValidationFactory {
       List<T> persistedObjects,
       List<T> nonPersistedObjects) {
     if (bundle.getImportMode().isCreateAndUpdate()) {
-      typeReport.withStatsIncCreated(nonPersistedObjects.size());
-      typeReport.withStatsIncUpdated(persistedObjects.size());
+      typeReport.createdInc(nonPersistedObjects.size());
+      typeReport.updatedInc(persistedObjects.size());
 
     } else if (bundle.getImportMode().isCreate()) {
-      typeReport.withStatsIncCreated(nonPersistedObjects.size());
+      typeReport.createdInc(nonPersistedObjects.size());
 
     } else if (bundle.getImportMode().isUpdate()) {
-      typeReport.withStatsIncUpdated(persistedObjects.size());
+      typeReport.updatedInc(persistedObjects.size());
 
     } else if (bundle.getImportMode().isDelete()) {
-      typeReport.withStatsIncDeleted(persistedObjects.size());
+      typeReport.deletedInc(persistedObjects.size());
     }
     return typeReport;
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -123,7 +123,7 @@ class UserControllerTest {
   void updateUserGroups() {
     when(userService.getUser("def2")).thenReturn(user);
 
-    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.withStatsIncUpdated(1)))) {
+    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.updatedInc(1)))) {
       userController.updateUserGroups("def2", parsedUser, currentUser);
     }
 
@@ -136,8 +136,7 @@ class UserControllerTest {
 
   @Test
   void updateUserGroupsNotOk() {
-    if (isInStatusUpdatedOK(
-        createReportWith(Status.ERROR, report -> report.withStatsIncUpdated(1)))) {
+    if (isInStatusUpdatedOK(createReportWith(Status.ERROR, report -> report.updatedInc(1)))) {
       userController.updateUserGroups("def2", parsedUser, currentUser);
     }
 
@@ -147,7 +146,7 @@ class UserControllerTest {
 
   @Test
   void updateUserGroupsNotUpdated() {
-    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.withStatsIncCreated(1)))) {
+    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.createdInc(1)))) {
       userController.updateUserGroups("def2", parsedUser, currentUser);
     }
 
@@ -167,7 +166,7 @@ class UserControllerTest {
     when(userService.getUser("def2")).thenReturn(user);
     when(userService.getUserByUsername(any())).thenReturn(currentUser);
 
-    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.withStatsIncUpdated(1)))) {
+    if (isInStatusUpdatedOK(createReportWith(Status.OK, report -> report.updatedInc(1)))) {
       userController.updateUserGroups("def2", parsedUser, currentUser);
     }
 


### PR DESCRIPTION
Rename the increment and decrement methods in `Stats` & `TypeReport` for:
- created
- updated
- deleted
- ignored

The increment method by amount _n_ is required for collection sizes, so all have been kept looking consistent.