### PR TITLE
chore: update app-management version in apps-to-bundle

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -1,7 +1,7 @@
 [
   "https://github.com/d2-ci/aggregate-data-entry-app#v101.0.5",
   "https://github.com/d2-ci/approval-app#v100.0.17",
-  "https://github.com/d2-ci/app-management-app#v100.4.2",
+  "https://github.com/d2-ci/app-management-app#v100.4.4",
   "https://github.com/d2-ci/cache-cleaner-app#v100.1.18",
   "https://github.com/d2-ci/capture-app#v101.33.0",
   "https://github.com/d2-ci/dashboard-app#v101.1.3",


### PR DESCRIPTION
This bumps the bundled version of app-management to include a bug fix - https://dhis2.atlassian.net/browse/DHIS2-19253 (approved by RCB)

relates to PR: https://github.com/dhis2/app-management-app/pull/586