### PR TITLE
fix: correctly fall back to installed app display name if no bundled translation found [DHIS2-19319]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -260,7 +260,7 @@ public class DefaultAppManager implements AppManager {
             .map(
                 module -> {
                   String bundledAppNameTranslation =
-                      i18nManager.getI18n().getString(module.getName());
+                      i18nManager.getI18n().getString(module.getName(), module.getDisplayName());
                   module.setDisplayName(bundledAppNameTranslation);
                   return module;
                 })


### PR DESCRIPTION
Previously, the fallback if no translation was found in the core's bundled i18n strings would be the app's short name.  This caused non-bundled apps to display their short name instead of their (untranslated) display name in the command palette.

Before:
![image (36)](https://github.com/user-attachments/assets/cb344730-d9ae-4f9d-9040-ef248c47e835)

After:
![Screenshot 2025-03-25 at 15 22 30](https://github.com/user-attachments/assets/fbaa9efe-14bc-454e-87a6-43a9c0a9e746)
