### PR TITLE
fix: bump bundled global shell and app management versions

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -1,7 +1,7 @@
 [
   "https://github.com/d2-ci/aggregate-data-entry-app#v101.0.5",
   "https://github.com/d2-ci/approval-app#v100.0.17",
-  "https://github.com/d2-ci/app-management-app#v100.4.2",
+  "https://github.com/d2-ci/app-management-app#v100.4.4",
   "https://github.com/d2-ci/cache-cleaner-app#v100.1.18",
   "https://github.com/d2-ci/capture-app#v101.33.0",
   "https://github.com/d2-ci/dashboard-app#v101.1.3",
@@ -26,6 +26,6 @@
   "https://github.com/d2-ci/user-app#v100.7.1",
   "https://github.com/d2-ci/user-profile-app#v100.7.2",
   "https://github.com/d2-ci/login-app#v100.4.3",
-  "https://github.com/d2-ci/global-shell-app#v1.7.2",
+  "https://github.com/d2-ci/global-shell-app#v1.7.3",
   "https://github.com/d2-ci/line-listing-app#v102.1.0"
 ]


### PR DESCRIPTION
This has been approved by RCB

App management: [DHIS2-19253](https://dhis2.atlassian.net/browse/DHIS2-19253)
Global shell: [DHIS2-19260](https://dhis2.atlassian.net/browse/DHIS2-19260)

[DHIS2-19253]: https://dhis2.atlassian.net/browse/DHIS2-19253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-19260]: https://dhis2.atlassian.net/browse/DHIS2-19260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ