### PR TITLE
fix: read most recent settings in notifier queue worker [DHIS2-19317]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/configuration/NotifierConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/configuration/NotifierConfig.java
@@ -32,7 +32,7 @@ package org.hisp.dhis.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hisp.dhis.condition.RedisDisabledCondition;
 import org.hisp.dhis.condition.RedisEnabledCondition;
-import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.system.notification.DefaultNotifier;
 import org.hisp.dhis.system.notification.InMemoryNotifierStore;
 import org.hisp.dhis.system.notification.Notifier;
@@ -58,17 +58,15 @@ public class NotifierConfig {
   @SuppressWarnings("unchecked")
   @Bean("notifier")
   @Conditional(RedisEnabledCondition.class)
-  public Notifier redisNotifier(
-      ObjectMapper objectMapper, SystemSettingsProvider settingsProvider) {
+  public Notifier redisNotifier(ObjectMapper objectMapper, SystemSettingsService settings) {
     NotifierStore store = new RedisNotifierStore((RedisTemplate<String, String>) redisTemplate);
-    return new DefaultNotifier(store, objectMapper, settingsProvider, System::currentTimeMillis);
+    return new DefaultNotifier(store, objectMapper, settings, System::currentTimeMillis);
   }
 
   @Bean("notifier")
   @Conditional(RedisDisabledCondition.class)
-  public Notifier inMemoryNotifier(
-      ObjectMapper objectMapper, SystemSettingsProvider settingsProvider) {
+  public Notifier inMemoryNotifier(ObjectMapper objectMapper, SystemSettingsService settings) {
     return new DefaultNotifier(
-        new InMemoryNotifierStore(), objectMapper, settingsProvider, System::currentTimeMillis);
+        new InMemoryNotifierStore(), objectMapper, settings, System::currentTimeMillis);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/FakeRedis.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/FakeRedis.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -72,8 +73,10 @@ record FakeRedis(
     RedisOperations<String, String> api) {
 
   static Notifier notifier(SystemSettings settings, LongSupplier clock) {
+    SystemSettingsService settingsService = mock(SystemSettingsService.class);
+    when(settingsService.getCurrentSettings()).thenReturn(settings);
     return new DefaultNotifier(
-        new RedisNotifierStore(new FakeRedis().api()), new ObjectMapper(), () -> settings, clock);
+        new RedisNotifierStore(new FakeRedis().api()), new ObjectMapper(), settingsService, clock);
   }
 
   FakeRedis() {

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/InMemoryNotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/InMemoryNotifierTest.java
@@ -29,8 +29,12 @@
  */
 package org.hisp.dhis.system.notification;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
 
 /**
  * Tests the {@link Notifier} API for the {@link InMemoryNotifierStore} implementation.
@@ -43,7 +47,10 @@ class InMemoryNotifierTest extends NotifierStoreTest {
 
   @Override
   void setUpNotifier(SystemSettings settings) {
+    SystemSettingsService settingsService = mock(SystemSettingsService.class);
+    when(settingsService.getCurrentSettings()).thenReturn(settings);
     notifier =
-        new DefaultNotifier(new InMemoryNotifierStore(), new ObjectMapper(), () -> settings, clock);
+        new DefaultNotifier(
+            new InMemoryNotifierStore(), new ObjectMapper(), settingsService, clock);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -59,14 +59,7 @@ import org.junit.jupiter.api.Test;
  */
 class NotifierTest {
 
-  private final SystemSettingsService settingsService = mock(SystemSettingsService.class);
-
-  private final Notifier notifier =
-      new DefaultNotifier(
-          new InMemoryNotifierStore(),
-          new ObjectMapper(),
-          settingsService,
-          System::currentTimeMillis);
+  private final Notifier notifier;
 
   private final JobConfiguration analyticsTable;
   private final JobConfiguration metadataImport;
@@ -83,7 +76,14 @@ class NotifierTest {
     dataImport2 = new JobConfiguration(null, DATAVALUE_IMPORT);
     dataImport3 = new JobConfiguration(null, DATAVALUE_IMPORT);
     dataImport4 = new JobConfiguration(null, DATAVALUE_IMPORT);
+    SystemSettingsService settingsService = mock(SystemSettingsService.class);
     when(settingsService.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
+    this.notifier =
+        new DefaultNotifier(
+            new InMemoryNotifierStore(),
+            new ObjectMapper(),
+            settingsService,
+            System::currentTimeMillis);
   }
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -35,6 +35,8 @@ import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
 import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.waitAtMost;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,6 +51,7 @@ import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -56,11 +59,13 @@ import org.junit.jupiter.api.Test;
  */
 class NotifierTest {
 
+  private final SystemSettingsService settingsService = mock(SystemSettingsService.class);
+
   private final Notifier notifier =
       new DefaultNotifier(
           new InMemoryNotifierStore(),
           new ObjectMapper(),
-          () -> SystemSettings.of(Map.of()),
+          settingsService,
           System::currentTimeMillis);
 
   private final JobConfiguration analyticsTable;
@@ -78,6 +83,7 @@ class NotifierTest {
     dataImport2 = new JobConfiguration(null, DATAVALUE_IMPORT);
     dataImport3 = new JobConfiguration(null, DATAVALUE_IMPORT);
     dataImport4 = new JobConfiguration(null, DATAVALUE_IMPORT);
+    when(settingsService.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
   }
 
   @Test


### PR DESCRIPTION
### Summary
When using the `notifierMaxMessagesPerJob` setting to limit the number of messages per job the change had no effect.
The cause was that settings were read in a worker thread and so the settings would effectively never expire. The worker itself has to call `clearCurrentSettings()` to invalidate the settings for the thread.

### Manual Testing
* `POST` to `/api/43/systemSettings/notifierMaxMessagesPerJob?value=6` to limit to 6 messages
* run the resource table generation in the data administration app
* check the message count `/api/system/tasks/RESOURCE_TABLE?gist=false`
* maybe change the setting to another value, like 4 and repeat the other steps and check the 2nd run now has that number of messages (note: a table generation usually has at most 8 messages ATM)