### PR TITLE
fix: correctly fall back to installed app display name if no bundled translation found

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -260,7 +260,7 @@ public class DefaultAppManager implements AppManager {
             .map(
                 module -> {
                   String bundledAppNameTranslation =
-                      i18nManager.getI18n().getString(module.getName());
+                      i18nManager.getI18n().getString(module.getName(), module.getDisplayName());
                   module.setDisplayName(bundledAppNameTranslation);
                   return module;
                 })


### PR DESCRIPTION
Backport of #20394 

(cherry picked from commit d14db5e2c6aaa8209136c0cfb6521007bd9af57e)