### PR TITLE
fix: validation of filter parser DHIS2-19331

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -120,6 +120,10 @@ public enum QueryOperator {
     return COMPARISON_OPERATORS.contains(this);
   }
 
+  public boolean isBinary() {
+    return !isUnary();
+  }
+
   public boolean isUnary() {
     return UNARY_OPERATORS.contains(this);
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/QueryOperatorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/QueryOperatorTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,5 +47,15 @@ class QueryOperatorTest {
     assertFalse(QueryOperator.GT.isEqualTo());
     assertFalse(QueryOperator.LT.isLike());
     assertFalse(QueryOperator.EQ.isLike());
+  }
+
+  @Test
+  void testNotNull() {
+    assertEquals(QueryOperator.NNULL, QueryOperator.fromString("!null"));
+  }
+
+  @Test
+  void testNull() {
+    assertEquals(QueryOperator.NULL, QueryOperator.fromString("null"));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.tracker.export.FilterParser;
 
 /**
  * RequestParamUtils are functions used to parse and transform tracker request parameters. This
@@ -283,7 +284,7 @@ public class RequestParamsValidator {
   /**
    * Validate the {@code filter} request parameter in change log tracker exporters. Allowed filter
    * values are {@code supportedFieldNames}. Only one field name at a time can be specified. If the
-   * endpoint supports UIDs use {@link #parseFilters(String)}.
+   * endpoint supports UIDs use {@link FilterParser#parseFilters(String)}.
    */
   public static void validateFilter(String filter, Set<Pair<String, Class<?>>> supportedFields)
       throws BadRequestException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestParamsValidator.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
-import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
@@ -38,25 +37,16 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.QueryFilter;
-import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -74,33 +64,7 @@ public class RequestParamsValidator {
     throw new IllegalStateException("Utility class");
   }
 
-  private static final String INVALID_FILTER = "Query item or filter is invalid: ";
-
-  private static final char COMMA_SEPARATOR = ',';
-
-  private static final char ESCAPE = '/';
-
   private static final String SUPPORTED_CHANGELOG_FILTER_OPERATOR = "eq";
-
-  /**
-   * Negative lookahead to avoid wrong split of comma-separated list of filters when one or more
-   * filter value contain comma. It skips comma escaped by slash
-   */
-  private static final Pattern FILTER_LIST_SPLIT =
-      Pattern.compile("(?<!" + ESCAPE + ")" + COMMA_SEPARATOR);
-
-  /**
-   * Negative lookahead to avoid wrong split when filter value contains colon. It skips colon
-   * escaped by slash
-   */
-  public static final Pattern FILTER_ITEM_SPLIT =
-      Pattern.compile("(?<!" + ESCAPE + ")" + DIMENSION_NAME_SEP);
-
-  private static final String COMMA_STRING = Character.toString(COMMA_SEPARATOR);
-
-  private static final String ESCAPE_COMMA = ESCAPE + COMMA_STRING;
-
-  private static final String ESCAPE_COLON = ESCAPE + DIMENSION_NAME_SEP;
 
   /**
    * Helps us transition request parameters that contained semicolon separated UIDs (deprecated) to
@@ -332,159 +296,6 @@ public class RequestParamsValidator {
     }
   }
 
-  /**
-   * Parse given {@code input} string representing a filter for an object referenced by a UID like a
-   * tracked entity attribute. Refer to {@link #parseSanitizedFilters(Map, String)}} for details on
-   * the expected input format.
-   *
-   * @return filters by UIDs
-   */
-  public static Map<UID, List<QueryFilter>> parseFilters(String input) throws BadRequestException {
-    Map<UID, List<QueryFilter>> result = new HashMap<>();
-    if (StringUtils.isBlank(input)) {
-      return result;
-    }
-
-    for (String uidOperatorValue : filterList(input)) {
-      parseSanitizedFilters(result, uidOperatorValue);
-    }
-    return result;
-  }
-
-  /**
-   * Accumulate {@link QueryFilter}s per TEA UID by parsing given input string of format
-   * {uid}[:{operator}:{value}]. Only the TEA UID is mandatory. Multiple operator:value pairs are
-   * allowed. A {@link QueryFilter} for each operator:value pair is added to the corresponding TEA
-   * UID.
-   *
-   * @throws BadRequestException filter is neither multiple nor single operator:value format
-   */
-  private static void parseSanitizedFilters(Map<UID, List<QueryFilter>> result, String input)
-      throws BadRequestException {
-    int uidIndex = input.indexOf(DIMENSION_NAME_SEP) + 1;
-
-    if (uidIndex == 0 || input.length() == uidIndex) {
-      UID uid = UID.of(input.replace(DIMENSION_NAME_SEP, ""));
-      result.putIfAbsent(uid, new ArrayList<>());
-      return;
-    }
-
-    UID uid = UID.of(input.substring(0, uidIndex - 1));
-    result.putIfAbsent(uid, new ArrayList<>());
-
-    String[] filters = FILTER_ITEM_SPLIT.split(input.substring(uidIndex));
-    validateFilterLength(filters, result, uid, input);
-  }
-
-  private static void validateFilterLength(
-      String[] filters, Map<UID, List<QueryFilter>> result, UID uid, String input)
-      throws BadRequestException {
-    switch (filters.length) {
-      case 1 -> addQueryFilter(result, uid, filters[0], null, input);
-      case 2 -> handleOperators(filters, result, uid, input);
-      case 3 -> handleMixedOperators(filters, result, uid, input);
-      case 4 -> handleMultipleBinaryOperators(filters, result, uid, input);
-      default -> throw new BadRequestException(INVALID_FILTER + input);
-    }
-  }
-
-  private static void addQueryFilter(
-      Map<UID, List<QueryFilter>> result, UID uid, String operator, String value, String input)
-      throws BadRequestException {
-    result.get(uid).add(operatorValueQueryFilter(operator, value, input));
-  }
-
-  private static void handleOperators(
-      String[] filters, Map<UID, List<QueryFilter>> result, UID uid, String input)
-      throws BadRequestException {
-    QueryOperator firstOperator =
-        findQueryOperatorFromFilter(filters[0])
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format("'%s' is not a valid operator: %s", filters[0], input)));
-
-    if (!firstOperator.isUnary()) {
-      addQueryFilter(result, uid, filters[0], filters[1], input);
-      return;
-    }
-
-    QueryOperator secondOperator =
-        findQueryOperatorFromFilter(filters[1])
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format(
-                            "Operator '%s' in filter can't be used with a value: %s",
-                            filters[0], input)));
-
-    if (secondOperator.isUnary()) {
-      addQueryFilter(result, uid, filters[0], null, input);
-      addQueryFilter(result, uid, filters[1], null, input);
-    }
-  }
-
-  private static void handleMixedOperators(
-      String[] filters, Map<UID, List<QueryFilter>> result, UID uid, String input)
-      throws BadRequestException {
-    Optional<QueryOperator> firstOperator = findQueryOperatorFromFilter(filters[0]);
-    if (firstOperator.map(QueryOperator::isUnary).orElse(false)) {
-      addQueryFilter(result, uid, filters[0], null, input);
-      addQueryFilter(result, uid, filters[1], filters[2], input);
-      return;
-    }
-
-    Optional<QueryOperator> thirdOperator = findQueryOperatorFromFilter(filters[2]);
-    if (thirdOperator.map(QueryOperator::isUnary).orElse(false)) {
-      addQueryFilter(result, uid, filters[0], filters[1], input);
-      addQueryFilter(result, uid, filters[2], null, input);
-      return;
-    }
-
-    throw new BadRequestException(INVALID_FILTER + input);
-  }
-
-  private static void handleMultipleBinaryOperators(
-      String[] filters, Map<UID, List<QueryFilter>> result, UID uid, String input)
-      throws BadRequestException {
-
-    List<String> unaryOperators = getUnaryOperatorsInFilter(filters);
-    switch (unaryOperators.size()) {
-      case 0 -> {
-        for (int i = 0; i < filters.length; i += 2) {
-          addQueryFilter(result, uid, filters[i], filters[i + 1], input);
-        }
-      }
-      case 1 ->
-          throw new BadRequestException(
-              String.format(
-                  "Operator '%s' in filter can't be used with a value: %s",
-                  unaryOperators.get(0), input));
-      default ->
-          throw new BadRequestException(
-              String.format("A maximum of two operators can be used in a filter: %s", input));
-    }
-  }
-
-  private static Optional<QueryOperator> findQueryOperatorFromFilter(String filter) {
-    return Arrays.stream(QueryOperator.values())
-        .filter(qo -> qo.name().equalsIgnoreCase(filter.replace("!", "n")))
-        .findFirst();
-  }
-
-  private static List<String> getUnaryOperatorsInFilter(String[] filters) {
-    Set<String> unaryOperators =
-        Arrays.stream(QueryOperator.values())
-            .filter(QueryOperator::isUnary)
-            .map(qo -> qo.name().toLowerCase())
-            .collect(Collectors.toSet());
-
-    return Arrays.stream(filters)
-        .map(f -> f.toLowerCase().replace("!", "n"))
-        .filter(unaryOperators::contains)
-        .toList();
-  }
-
   public static OrganisationUnitSelectionMode validateOrgUnitModeForTrackedEntities(
       Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode, Set<UID> trackedEntities)
       throws BadRequestException {
@@ -580,102 +391,5 @@ public class RequestParamsValidator {
     if (StringUtils.isNotEmpty(request.getParameter(dimension))) {
       throw new BadRequestException(message);
     }
-  }
-
-  private static QueryFilter operatorValueQueryFilter(String operator, String value, String filter)
-      throws BadRequestException {
-    if (StringUtils.isEmpty(operator)) {
-      throw new BadRequestException(INVALID_FILTER + filter);
-    }
-
-    QueryOperator queryOperator;
-    try {
-      queryOperator = QueryOperator.fromString(operator);
-    } catch (IllegalArgumentException exception) {
-      throw new BadRequestException(INVALID_FILTER + filter);
-    }
-
-    if (queryOperator == null) {
-      throw new BadRequestException(INVALID_FILTER + filter);
-    }
-
-    if (queryOperator.isUnary()) {
-      if (!StringUtils.isEmpty(value)) {
-        throw new BadRequestException(
-            String.format(
-                "Operator %s in filter can't be used with a value: %s",
-                queryOperator.name(), filter));
-      }
-      return new QueryFilter(queryOperator);
-    }
-
-    if (StringUtils.isEmpty(value)) {
-      throw new BadRequestException("Operator in filter must be be used with a value: " + filter);
-    }
-
-    return new QueryFilter(queryOperator, escapedFilterValue(value));
-  }
-
-  /** Replace escaped comma or colon */
-  private static String escapedFilterValue(String value) {
-    return value.replace(ESCAPE_COMMA, COMMA_STRING).replace(ESCAPE_COLON, DIMENSION_NAME_SEP);
-  }
-
-  /**
-   * Given an attribute filter list, first, it removes the escape chars in order to be able to split
-   * by comma and collect the filter list. Then, it recreates the original filters by restoring the
-   * escapes chars if any.
-   *
-   * @return a filter list split by comma
-   */
-  private static List<String> filterList(String filterItem) {
-    Map<Integer, Boolean> escapesToRestore = new HashMap<>();
-
-    StringBuilder filterListToEscape = new StringBuilder(filterItem);
-
-    List<String> filters = new LinkedList<>();
-
-    for (int i = 0; i < filterListToEscape.length() - 1; i++) {
-      if (filterListToEscape.charAt(i) == ESCAPE && filterListToEscape.charAt(i + 1) == ESCAPE) {
-        filterListToEscape.delete(i, i + 2);
-        escapesToRestore.put(i, false);
-      }
-    }
-
-    String[] escapedFilterList = FILTER_LIST_SPLIT.split(filterListToEscape);
-
-    int beginning = 0;
-
-    for (String escapedFilter : escapedFilterList) {
-      filters.add(
-          restoreEscape(
-              escapesToRestore,
-              new StringBuilder(escapedFilter),
-              beginning,
-              escapedFilter.length()));
-      beginning += escapedFilter.length() + 1;
-    }
-
-    return filters;
-  }
-
-  /**
-   * Restores the escape char in a filter based on the position in the original filter. It uses a
-   * pad as in a filter there can be more than one escape char removed.
-   *
-   * @return a filter with restored escape chars
-   */
-  private static String restoreEscape(
-      Map<Integer, Boolean> escapesToRestore, StringBuilder filter, int beginning, int end) {
-    int pad = 0;
-    for (Map.Entry<Integer, Boolean> slashPositionInFilter : escapesToRestore.entrySet()) {
-      if (!slashPositionInFilter.getValue()
-          && slashPositionInFilter.getKey() <= (beginning + end)) {
-        filter.insert(slashPositionInFilter.getKey() - beginning + pad++, ESCAPE);
-        escapesToRestore.put(slashPositionInFilter.getKey(), true);
-      }
-    }
-
-    return filter.toString();
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.BadRequestException;
+
+/**
+ * Parser for the <code>filter</code> (<code>filterAttribute</code>) request parameter.
+ *
+ * <p><code>/changeLogs?filter</code> validation is implemented in {@link
+ * org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator} and its parsing in its mapper.
+ * The requirements for these endpoints are slightly different. We use this parser for changeLogs as
+ * soon as we need to support escaped values like dates which contain the segment separator ':'.
+ */
+public class FilterParser {
+  private FilterParser() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  private static final char ESCAPE = '/';
+  private static final String ESCAPE_STRING = Character.toString(ESCAPE);
+  private static final String ESCAPED_ESCAPE = ESCAPE + ESCAPE_STRING;
+  private static final char COMMA = ',';
+  private static final String COMMA_STRING = Character.toString(COMMA);
+  private static final String ESCAPED_COMMA = ESCAPE + COMMA_STRING;
+  private static final char COLON = ':';
+  private static final String COLON_STRING = Character.toString(COLON);
+  private static final String ESCAPED_COLON = ESCAPE + COLON_STRING;
+
+  /**
+   * Parse given {@code input} string representing one or more filters for objects referenced by a
+   * UID like a tracked entity attribute or data element.
+   *
+   * <p>The expected input format is <br>
+   * <code>{uid}[:{operator}[:{value}]][,{uid}[:{operator}[:{value}]]]</code> <br>
+   * The value is mandatory and only allowed for binary operators. Multiple operator or
+   * operator:value pairs are allowed. A {@link QueryFilter} for each operator[:value] pair is added
+   * to the corresponding UID in the input order.
+   *
+   * <p>This method assumes that the input
+   *
+   * <ul>
+   *   <li>has been percent-decoded already
+   * </ul>
+   *
+   * @return accumulated {@link QueryFilter}s per UID
+   * @throws BadRequestException if the input is invalid
+   */
+  public static Map<UID, List<QueryFilter>> parseFilters(
+      @Nonnull String parameterName, @CheckForNull String input) throws BadRequestException {
+    try {
+      return parseFilters(input);
+    } catch (Exception e) {
+      throw new BadRequestException(parameterName + "=" + input + " is invalid. " + e.getMessage());
+    }
+  }
+
+  public static Map<UID, List<QueryFilter>> parseFilters(String input) throws BadRequestException {
+    Map<UID, List<QueryFilter>> result = new HashMap<>();
+    if (StringUtils.isBlank(input)) {
+      return result;
+    }
+
+    int start = 0;
+    int end = 0;
+    UID uid = null;
+    String operator = null;
+    String valueOrOperator = null;
+    while (end < input.length()) {
+      char curChar = input.charAt(end);
+      // skip escaped slash, colon and comma which allow users to pass them as part of values
+      if (curChar == ESCAPE
+          && end + 1 < input.length()
+          && (input.charAt(end + 1) == ESCAPE
+              || input.charAt(end + 1) == COLON
+              || input.charAt(end + 1) == COMMA)) {
+        end = end + 2;
+        continue;
+      }
+
+      // get next segment
+      if (curChar == COLON || curChar == COMMA) {
+        if (uid == null
+            && (curChar == COLON || end - start > 0)) { // empty commas like "," ",," are ignored
+          uid = uid(input.substring(start, end));
+        } else if (operator == null) {
+          operator = input.substring(start, end);
+        } else {
+          valueOrOperator = input.substring(start, end);
+        }
+        start = end + 1;
+      }
+
+      // state transitions
+      if (curChar == COMMA) { // transition back to initial state
+        addFilter(result, uid, operator, valueOrOperator);
+
+        uid = null;
+        operator = null;
+        valueOrOperator = null;
+      } else if (curChar == COLON && valueOrOperator != null) {
+        // we only keep track of two segments after the uid so we need to consume at least the first
+        // if it is a unary operator or both if its a binary operator
+        QueryOperator parsedOperator = getQueryOperator(uid, operator);
+        if (parsedOperator.isUnary()) {
+          // ensure the next segment (valueOrOperator) is a valid operator as the unary operator
+          // cannot have a value
+          validateUnaryOperatorHasNoValue(uid, operator, valueOrOperator);
+          addFilter(result, uid, operator, null);
+
+          operator = valueOrOperator;
+        } else {
+          addFilter(result, uid, operator, valueOrOperator);
+
+          operator = null;
+        }
+
+        // the uid is not reset as it might get another operator or operator:value pair
+        valueOrOperator = null;
+      }
+
+      end++;
+    }
+
+    if (start < end) { // consume remaining input
+      if (uid == null) {
+        uid = uid(input.substring(start, end));
+      } else if (operator == null) {
+        operator = input.substring(start, end);
+      } else {
+        valueOrOperator = input.substring(start, end);
+      }
+    }
+    addFilter(result, uid, operator, valueOrOperator);
+
+    return result;
+  }
+
+  private static UID uid(String uid) throws BadRequestException {
+    try {
+      return UID.of(uid);
+    } catch (IllegalArgumentException exception) {
+      throw new BadRequestException(exception.getMessage());
+    }
+  }
+
+  @Nonnull
+  private static QueryOperator getQueryOperator(@Nonnull UID uid, String operator)
+      throws BadRequestException {
+    try {
+      QueryOperator parsedOperator = QueryOperator.fromString(operator);
+      if (parsedOperator == null) {
+        throw new BadRequestException(
+            "UID '" + uid + "' is missing an operator (or has too many ':').");
+      }
+      return parsedOperator;
+    } catch (IllegalArgumentException exception) {
+      throw new BadRequestException("'" + operator + "' is not a valid operator.");
+    }
+  }
+
+  private static Optional<QueryOperator> validateUnaryOperatorHasNoValue(
+      @Nonnull UID uid, @Nonnull String operator, @CheckForNull String valueOrOperator)
+      throws BadRequestException {
+    QueryOperator parsedOperator = getQueryOperator(uid, operator);
+    Optional<QueryOperator> nextOperator = findQueryOperator(valueOrOperator);
+    if (parsedOperator.isUnary()
+        && StringUtils.isNotEmpty(valueOrOperator)
+        && nextOperator.isEmpty()) {
+      throw new BadRequestException("Unary operator '" + operator + "' cannot have a value.");
+    }
+    return nextOperator;
+  }
+
+  private static Optional<QueryOperator> findQueryOperator(String operator) {
+    try {
+      return Optional.ofNullable(QueryOperator.fromString(operator));
+    } catch (IllegalArgumentException exception) {
+      return Optional.empty();
+    }
+  }
+
+  private static void addFilter(
+      @Nonnull Map<UID, List<QueryFilter>> result,
+      @CheckForNull UID uid,
+      @CheckForNull String operator,
+      @CheckForNull String valueOrOperator)
+      throws BadRequestException {
+    if (uid == null) {
+      return;
+    }
+
+    result.putIfAbsent(uid, new ArrayList<>());
+
+    if (operator == null) {
+      return;
+    }
+
+    QueryOperator parsedOperator = getQueryOperator(uid, operator);
+    Optional<QueryOperator> nextOperator =
+        validateUnaryOperatorHasNoValue(uid, operator, valueOrOperator);
+    if (parsedOperator.isUnary()) {
+      result.get(uid).add(new QueryFilter(parsedOperator));
+      if (nextOperator.isPresent() && nextOperator.get().isUnary()) {
+        result.get(uid).add(new QueryFilter(nextOperator.get()));
+      } else if (nextOperator.isPresent() && nextOperator.get().isBinary()) {
+        throw new BadRequestException(
+            "Binary operator '" + valueOrOperator + "' must have a value.");
+      }
+    } else {
+      if (StringUtils.isEmpty(valueOrOperator)) {
+        throw new BadRequestException("Binary operator '" + operator + "' must have a value.");
+      }
+
+      result.get(uid).add(new QueryFilter(parsedOperator, removeEscapeCharacters(valueOrOperator)));
+    }
+
+    if (result.get(uid).size() > 2) {
+      throw new BadRequestException("A maximum of two operators can be used in a filter.");
+    }
+  }
+
+  /** Remove escape character '/' from escaped comma or colon */
+  private static String removeEscapeCharacters(String value) {
+    return value
+        .replace(ESCAPED_ESCAPE, ESCAPE_STRING)
+        .replace(ESCAPED_COMMA, COMMA_STRING)
+        .replace(ESCAPED_COLON, DIMENSION_NAME_SEP);
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
@@ -54,9 +54,13 @@ import org.hisp.dhis.feedback.BadRequestException;
  * separator ':'.
  */
 public class FilterParser {
+
   private FilterParser() {
     throw new IllegalStateException("Utility class");
   }
+
+  /** Slash, comma and colon have a width of 1 in the input string. */
+  public static final int SEPARATOR_CHAR_COUNT = 1;
 
   private static final char ESCAPE = '/';
   private static final String ESCAPE_STRING = Character.toString(ESCAPE);
@@ -110,11 +114,13 @@ public class FilterParser {
     int length = input.length();
     while (end < length) {
       int curChar = input.codePointAt(end);
-      int charCount = Character.charCount(curChar);
+      int charCount =
+          Character.charCount(
+              curChar); // so we iterate characters spanning more than char(16-bytes)
 
       // skip escaped slash, colon and comma which allow users to pass them as part of values
-      if (curChar == ESCAPE && end + 1 < length) {
-        int nextChar = input.codePointAt(end + 1);
+      if (curChar == ESCAPE && end + SEPARATOR_CHAR_COUNT < length) {
+        int nextChar = input.codePointAt(end + SEPARATOR_CHAR_COUNT);
         if (nextChar == ESCAPE || nextChar == COLON || nextChar == COMMA) {
           end += charCount + Character.charCount(nextChar);
           continue;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
@@ -257,8 +257,8 @@ public class FilterParser {
       result.get(uid).add(new QueryFilter(parsedOperator, removeEscapeCharacters(valueOrOperator)));
     }
 
-    if (result.get(uid).size() > 2) {
-      throw new BadRequestException("A maximum of two operators can be used in a filter.");
+    if (result.get(uid).size() > 3) {
+      throw new BadRequestException("A maximum of three operators can be used in a filter.");
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
@@ -49,8 +49,9 @@ import org.hisp.dhis.feedback.BadRequestException;
  *
  * <p><code>/changeLogs?filter</code> validation is implemented in {@link
  * org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator} and its parsing in its mapper.
- * The requirements for these endpoints are slightly different. We use this parser for changeLogs as
- * soon as we need to support escaped values like dates which contain the segment separator ':'.
+ * The requirements for these endpoints are slightly different. We should use this parser for
+ * changeLogs as soon as we need to support escaped values like dates which contain the segment
+ * separator ':'.
  */
 public class FilterParser {
   private FilterParser() {
@@ -112,8 +113,8 @@ public class FilterParser {
       int charCount = Character.charCount(curChar);
 
       // skip escaped slash, colon and comma which allow users to pass them as part of values
-      if (curChar == ESCAPE && end + charCount < length) {
-        int nextChar = input.codePointAt(end + charCount);
+      if (curChar == ESCAPE && end + 1 < length) {
+        int nextChar = input.codePointAt(end + 1);
         if (nextChar == ESCAPE || nextChar == COLON || nextChar == COMMA) {
           end += charCount + Character.charCount(nextChar);
           continue;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParser.java
@@ -106,16 +106,18 @@ public class FilterParser {
     UID uid = null;
     String operator = null;
     String valueOrOperator = null;
-    while (end < input.length()) {
-      char curChar = input.charAt(end);
+    int length = input.length();
+    while (end < length) {
+      int curChar = input.codePointAt(end);
+      int charCount = Character.charCount(curChar);
+
       // skip escaped slash, colon and comma which allow users to pass them as part of values
-      if (curChar == ESCAPE
-          && end + 1 < input.length()
-          && (input.charAt(end + 1) == ESCAPE
-              || input.charAt(end + 1) == COLON
-              || input.charAt(end + 1) == COMMA)) {
-        end = end + 2;
-        continue;
+      if (curChar == ESCAPE && end + charCount < length) {
+        int nextChar = input.codePointAt(end + charCount);
+        if (nextChar == ESCAPE || nextChar == COLON || nextChar == COMMA) {
+          end += charCount + Character.charCount(nextChar);
+          continue;
+        }
       }
 
       // get next segment
@@ -128,7 +130,7 @@ public class FilterParser {
         } else {
           valueOrOperator = input.substring(start, end);
         }
-        start = end + 1;
+        start = end + charCount;
       }
 
       // state transitions
@@ -159,7 +161,7 @@ public class FilterParser {
         valueOrOperator = null;
       }
 
-      end++;
+      end += charCount;
     }
 
     if (start < end) { // consume remaining input

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -31,10 +31,10 @@ package org.hisp.dhis.webapi.controller.tracker.export.event;
 
 import static java.util.Collections.emptySet;
 import static org.hisp.dhis.util.ObjectUtils.applyIfNotNull;
-import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateOrgUnitModeForEnrollmentsAndEvents;
+import static org.hisp.dhis.webapi.controller.tracker.export.FilterParser.parseFilters;
 
 import java.util.List;
 import java.util.Map;
@@ -86,9 +86,10 @@ class EventRequestParamsMapper {
             eventRequestParams.getEnrollmentStatus());
 
     validateFilter(eventRequestParams.getFilter(), eventRequestParams.getEvents());
-    Map<UID, List<QueryFilter>> dataElementFilters = parseFilters(eventRequestParams.getFilter());
+    Map<UID, List<QueryFilter>> dataElementFilters =
+        parseFilters("filter", eventRequestParams.getFilter());
     Map<UID, List<QueryFilter>> attributeFilters =
-        parseFilters(eventRequestParams.getFilterAttributes());
+        parseFilters("filterAttributes", eventRequestParams.getFilterAttributes());
 
     validateUpdateDurationParams(eventRequestParams);
     validateOrderParams(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -30,10 +30,10 @@
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import static org.hisp.dhis.util.ObjectUtils.applyIfNotNull;
-import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateOrgUnitModeForTrackedEntities;
+import static org.hisp.dhis.webapi.controller.tracker.export.FilterParser.parseFilters;
 
 import java.util.List;
 import java.util.Map;
@@ -98,7 +98,8 @@ class TrackedEntityRequestParamsMapper {
     validateRequestParams(
         trackedEntityRequestParams, trackedEntityRequestParams.getTrackedEntities());
 
-    Map<UID, List<QueryFilter>> filters = parseFilters(trackedEntityRequestParams.getFilter());
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters("filter", trackedEntityRequestParams.getFilter());
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.tracker.export.FilterParser.parseFilters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Tests {@link FilterParser}. */
+class FilterParserTest {
+  @Test
+  void shouldParseBinaryOperatorWithUnicodeCodePointsOutsideAsciiRange()
+      throws BadRequestException {
+    String value = "𞸀𞸁";
+    assertTrue(
+        value.codePoints().anyMatch(cp -> cp > 0xFFFF),
+        "String contains characters exceeding 16-bit range");
+
+    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO:like:" + value);
+
+    assertEquals(
+        Map.of(UID.of("TvjwTPToKHO"), List.of(new QueryFilter(QueryOperator.LIKE, value))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithMultipleDistinctIdentifiersAndOperators() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters("TvjwTPToKHO:lt:20:gt:10,cy2oRh2sNr6:like:foo");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(
+                new QueryFilter(QueryOperator.LT, "20"), new QueryFilter(QueryOperator.GT, "10")),
+            UID.of("cy2oRh2sNr6"),
+            List.of(new QueryFilter(QueryOperator.LIKE, "foo"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithMultipleRepeatedIdentifiers() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters("TvjwTPToKHO:lt:20,cy2oRh2sNr6:like:foo,TvjwTPToKHO:gt:10");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(
+                new QueryFilter(QueryOperator.LT, "20"), new QueryFilter(QueryOperator.GT, "10")),
+            UID.of("cy2oRh2sNr6"),
+            List.of(new QueryFilter(QueryOperator.LIKE, "foo"))),
+        filters);
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO",
+        "TvjwTPToKHO:",
+        "TvjwTPToKHO,",
+      })
+  @ParameterizedTest
+  void shouldParseFiltersWithIdentifierOnly(String input) throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(input);
+
+    assertEquals(Map.of(UID.of("TvjwTPToKHO"), List.of()), filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithIdentifiersOnly() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO,cy2oRh2sNr6");
+
+    assertEquals(
+        Map.of(UID.of("TvjwTPToKHO"), List.of(), UID.of("cy2oRh2sNr6"), List.of()), filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithBlankInput() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(" ");
+
+    assertTrue(filters.isEmpty());
+  }
+
+  @ValueSource(
+      strings = {
+        ",", ",,",
+      })
+  @ParameterizedTest
+  void shouldParseFiltersWithJustCommas(String input) throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(input);
+
+    assertTrue(filters.isEmpty());
+  }
+
+  @Test
+  void shouldParseFiltersWithValueContainingEscapedColon() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("cy2oRh2sNr6:like:project/:x/:eq/:2");
+
+    assertEquals(
+        Map.of(
+            UID.of("cy2oRh2sNr6"), List.of(new QueryFilter(QueryOperator.LIKE, "project:x:eq:2"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithValueContainingEscapedComma() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("cy2oRh2sNr6:like:project/,x/:eq/:2");
+
+    assertEquals(
+        Map.of(
+            UID.of("cy2oRh2sNr6"), List.of(new QueryFilter(QueryOperator.LIKE, "project,x:eq:2"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithValueContainingEscapedSlash() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("cy2oRh2sNr6:like:project//x/:eq/:2");
+
+    assertEquals(
+        Map.of(
+            UID.of("cy2oRh2sNr6"), List.of(new QueryFilter(QueryOperator.LIKE, "project/x:eq:2"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithDateRangeContainingEscapedColon() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters(
+            "TvjwTPToKHO:ge:2020-01-01T00/:00/:00.001 +05/:30:le:2021-01-01T00/:00/:00.001 +05/:30");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(
+                new QueryFilter(QueryOperator.GE, "2020-01-01T00:00:00.001 +05:30"),
+                new QueryFilter(QueryOperator.LE, "2021-01-01T00:00:00.001 +05:30"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithTextRangeContainingEscapedColon() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters("TvjwTPToKHO:sw:project/:x:ew:project/:le/:");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(
+                new QueryFilter(QueryOperator.SW, "project:x"),
+                new QueryFilter(QueryOperator.EW, "project:le:"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithEscapedSlashAndComma() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters =
+        parseFilters(
+            """
+TvjwTPToKHO:eq:project///,/,//,\
+cy2oRh2sNr6:eq:project//,\
+cy2oRh2sNr7:eq:project//""");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(new QueryFilter(QueryOperator.EQ, "project/,,/")),
+            UID.of("cy2oRh2sNr6"),
+            List.of(new QueryFilter(QueryOperator.EQ, "project/")),
+            UID.of("cy2oRh2sNr7"),
+            List.of(new QueryFilter(QueryOperator.EQ, "project/"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithMultipleOperatorsAndEscapedColon() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO:like:value1/::like:value2");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(
+                new QueryFilter(QueryOperator.LIKE, "value1:"),
+                new QueryFilter(QueryOperator.LIKE, "value2"))),
+        filters);
+  }
+
+  @ValueSource(strings = {"TvjwTPToKHO:!null", "TvjwTPToKHO:!null:", "TvjwTPToKHO:!null,"})
+  @ParameterizedTest
+  void shouldParseFiltersWithSingleUnaryOperator(String input) throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(input);
+
+    assertEquals(
+        Map.of(UID.of("TvjwTPToKHO"), List.of(new QueryFilter(QueryOperator.NNULL))), filters);
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO:!null:null",
+        "TvjwTPToKHO:!null:null:",
+        "TvjwTPToKHO:!null:null,",
+      })
+  @ParameterizedTest
+  void shouldParseFiltersWithSingleIdentifierAndMultipleUnaryOperators(String input)
+      throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(input);
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(new QueryFilter(QueryOperator.NNULL), new QueryFilter(QueryOperator.NULL))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithCombinedUnaryAndBinaryOperators() throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO:null:gt:10");
+
+    assertEquals(
+        Map.of(
+            UID.of("TvjwTPToKHO"),
+            List.of(new QueryFilter(QueryOperator.NULL), new QueryFilter(QueryOperator.GT, "10"))),
+        filters);
+  }
+
+  @Test
+  void shouldParseFiltersWithBinaryOperatorValueBeingNull() throws BadRequestException {
+    // null is not a reserved keyword like in Java so it will be used as a value if it follows a
+    // binary operator
+    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO:eq:null");
+
+    assertEquals(
+        Map.of(UID.of("TvjwTPToKHO"), List.of(new QueryFilter(QueryOperator.EQ, "null"))), filters);
+  }
+
+  @Test
+  void shouldFailWhenOperatorDoesNotExist() {
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> parseFilters("TvjwTPToKHO:lke:value"));
+
+    assertContains("'lke' is not a valid operator", exception.getMessage());
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO::null,cy2oRh2sNr6:!null",
+        "TvjwTPToKHO::gt:10",
+        "TvjwTPToKHO::gt:10,",
+        "TvjwTPToKHO::gt:10:",
+      })
+  @ParameterizedTest
+  void shouldFailWhenOperatorIsEmpty(String input) {
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> parseFilters(input));
+
+    assertContains("UID 'TvjwTPToKHO' is missing an operator", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailReportingTheParameterNameAndInput() {
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class, () -> parseFilters("filterAttributes", "nouid:eq:2"));
+
+    assertContains("filterAttributes=nouid:eq:2 is invalid", exception.getMessage());
+  }
+
+  @ValueSource(strings = {"nouid:eq:2", ":", "::", ",:", " ,", ", ,"})
+  @ParameterizedTest
+  void shouldFailWhenUIDIsInvalid(String input) {
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> parseFilters(input));
+
+    assertContains("UID must be an alphanumeric string", exception.getMessage());
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO:lt",
+        "TvjwTPToKHO:lt:",
+        "TvjwTPToKHO:lt::",
+        "TvjwTPToKHO:lt,",
+        "TvjwTPToKHO:lt::gt:10",
+        "TvjwTPToKHO:lt::gt:10:",
+        "TvjwTPToKHO:gt:10:lt",
+        "TvjwTPToKHO:null:lt",
+        "TvjwTPToKHO:null:lt,",
+        "TvjwTPToKHO:null:lt:",
+      })
+  @ParameterizedTest
+  void shouldFailWhenBinaryOperatorIsMissingAValue(String input) {
+    Exception exception = assertThrows(BadRequestException.class, () -> parseFilters(input));
+
+    assertContains("Binary operator 'lt' must have a value", exception.getMessage());
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO:null:!null:value",
+        "TvjwTPToKHO:!null:value:eq:2",
+        "TvjwTPToKHO:!null:value",
+        "TvjwTPToKHO:null:!null:value:",
+        "TvjwTPToKHO:!null:value:eq:2:",
+        "TvjwTPToKHO:gt:10:!null:value",
+        "TvjwTPToKHO:!null:value:",
+        "TvjwTPToKHO:null:!null:value,",
+        "TvjwTPToKHO:!null:value:eq:2,",
+        "TvjwTPToKHO:!null:value,"
+      })
+  @ParameterizedTest
+  void shouldFailWhenUnaryOperatorHasAValue(String input) {
+    Exception exception = assertThrows(BadRequestException.class, () -> parseFilters(input));
+
+    assertContains("Unary operator '!null' cannot have a value", exception.getMessage());
+  }
+
+  @ValueSource(
+      strings = {
+        "TvjwTPToKHO:gt:10:null:!null",
+        "TvjwTPToKHO:gt:10:null:!null:",
+        "TvjwTPToKHO:gt:10:null,TvjwTPToKHO:!null",
+        "TvjwTPToKHO:gt:10:null:!null",
+      })
+  @ParameterizedTest
+  void shouldFailParsingFiltersWithMoreThanTwoOperatorsForASingleIdentifier(String input) {
+    Exception exception = assertThrows(BadRequestException.class, () -> parseFilters(input));
+
+    assertStartsWith("A maximum of two operators can be used in a filter", exception.getMessage());
+  }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
@@ -355,15 +355,15 @@ cy2oRh2sNr7:eq:project//""");
 
   @ValueSource(
       strings = {
-        "TvjwTPToKHO:gt:10:null:!null",
-        "TvjwTPToKHO:gt:10:null:!null:",
-        "TvjwTPToKHO:gt:10:null,TvjwTPToKHO:!null",
-        "TvjwTPToKHO:gt:10:null:!null",
+        "TvjwTPToKHO:gt:10:null:!null:null",
+        "TvjwTPToKHO:gt:10:null:!null:null:",
+        "TvjwTPToKHO:gt:10:null,TvjwTPToKHO:!null:null",
       })
   @ParameterizedTest
-  void shouldFailParsingFiltersWithMoreThanTwoOperatorsForASingleIdentifier(String input) {
+  void shouldFailParsingFiltersWithMoreThanThreeOperatorsForASingleIdentifier(String input) {
     Exception exception = assertThrows(BadRequestException.class, () -> parseFilters(input));
 
-    assertStartsWith("A maximum of two operators can be used in a filter", exception.getMessage());
+    assertStartsWith(
+        "A maximum of three operators can be used in a filter", exception.getMessage());
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
@@ -195,7 +195,7 @@ class FilterParserTest {
   void shouldParseFiltersWithEscapedSlashAndComma() throws BadRequestException {
     Map<UID, List<QueryFilter>> filters =
         parseFilters(
-            """
+"""
 TvjwTPToKHO:eq:project///,/,//,\
 cy2oRh2sNr6:eq:project//,\
 cy2oRh2sNr7:eq:project//""");

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/FilterParserTest.java
@@ -251,9 +251,11 @@ cy2oRh2sNr7:eq:project//""");
         filters);
   }
 
-  @Test
-  void shouldParseFiltersWithCombinedUnaryAndBinaryOperators() throws BadRequestException {
-    Map<UID, List<QueryFilter>> filters = parseFilters("TvjwTPToKHO:null:gt:10");
+  @ValueSource(strings = {"TvjwTPToKHO:null:gt:10", "TvjwTPToKHO:null,TvjwTPToKHO:gt:10"})
+  @ParameterizedTest
+  void shouldParseFiltersWithCombinedUnaryAndBinaryOperators(String input)
+      throws BadRequestException {
+    Map<UID, List<QueryFilter>> filters = parseFilters(input);
 
     assertEquals(
         Map.of(


### PR DESCRIPTION
This change is to the parsing of the tracker `filter` request parameter `filter=qrur9Dvnyt5:gt:10:lt:20:!null` used on `/tracker/trackedEntities?filter=` and `/tracker/events?filter=...&filterAttributes=...`.

The previous implementation relied on a mix of string replaces (due to escaped separator characters like `/:`, `/,`), regular expression matching and string splitting into individual filters and segments (uid, operator and value). The previous implementation also used multiple passes over the input string. The addition of unary operators `null`, `!null` made the implementation more complex. I also found a bug in the validation of unary operators having a value. I believe that bug is due to the complexity of the implementation.

This implementation is iterating over the input once*. We keep track of 3 segments

```
qrur9Dvnyt5:gt:10
^^^^^^^^^^^ ^^ ^^
     uid    operator
                operatorOrValue
```

You can think of the parsing function as a state machine with the above as the 3 states. Unescaped `:` separate segments and unescaped `,` separate filters.

![DHIS2-19331 dot](https://github.com/user-attachments/assets/31fbc617-6ffc-4d9d-9c93-0475b7a3cff5)


We collect a filter once we have reached a `,`, the end of input or 3 segments and a `:`.

Most of the complexity we have is due to users being able to mix unary/binary operators. Additionally, due to us wanting to provide error messages that help user to fix their filters by themselves.

(*it's almost one pass as I kept the `removeEscapeCharacters` method which iterates over the value to unescape the `/`, `:`, `,`. I don't think we need to optimize this.)

## Behavior change

We had a limit of 2 operators per UID in a single request parameter 😅 

This meant

`filter=foo:sw:3:ew:5:neq:345`

was not allowed, while splitting it across multiple parameters was

`filter=foo:sw:3:ew:5&filter=foo:neq:345`

Since both mean the same thing we now consistently apply the limit to operators per UID. We also increased the limit to 3 so users can maybe combine operators like `sw`, `ew` and `neq`. This limit can be increased in the future or dropped. We don't really know where it came from. Maybe it was a limitation in the implementation.

## Bug

```http
### binary operator with no value following a unary operator does not fail but should
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=VBqh0ynB2wv&
  fields=dataValues[dataElement,value]&
  filter=qrur9Dvnyt5:!null:gt
```

Now fails with

```json
{
  "httpStatus": "Bad Request",
  "httpStatusCode": 400,
  "status": "ERROR",
  "message": "filter=qrur9Dvnyt5:!null:gt is invalid. Binary operator 'gt' must have a value.",
  "errorCode": "E1003"
}
```

```http
### previously lead to 400: UID must be an alphanumeric string of 11 characters starting with a letter, but was:
# we do accept empty commas, so we should also let this one go
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=VBqh0ynB2wv&
  fields=dataValues[dataElement,value]&
  filter=F3ogKBuviRA,,qrur9Dvnyt5,
```

This will now work and the empty `,,` is ignored.

## Example error messages

All error messages are now prefixed with `<paramName>=<value> is invalid`. The new messages below are shown without the prefix.

* `nouid:eq:2` which contains an invalid UID
  * before: failed with `IllegalArgumentException` the `UID must be an alphanumeric string of 11...` message
  * now: fails with `BadRequestException` and the `UID must be an alphanumeric string of 11...` message
* `TvjwTPToKHO:lt::gt:10` which contains multiple binary operators one of which does not have a value
  * before: `Operator in filter must be be used with a value: TvjwTPToKHO:lt::gt:10`
  * now: `Binary operator 'lt' must have a value` 
* `TvjwTPToKHO::null,cy2oRh2sNr6:!null`
  * before: `Query item or filter is invalid: qrur9Dvnyt5::gt:10`
  * now: `UID 'TvjwTPToKHO' is missing an operator (or has too many ':').`
* `filter=qrur9Dvnyt5:nll`
  * before: `Query item or filter is invalid: qrur9Dvnyt5:nll`
  * now: `'nll' is not a valid operator`

We are now pointing the user to which part of the filter is wrong.

## Tests

Added more tests as I was trying to understand the old implementation. One of which shows we do support filter values with unicode code points beyond the ASCII range.

## Previous changes to `filter` parsing

These are some important changes we made in the past

* https://github.com/dhis2/dhis2-core/pull/13981
* https://github.com/dhis2/dhis2-core/pull/19778