### PR TITLE
fix: null shortname in metadata [DHIS2-19248] (#20326)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementOptionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementOptionDimensionItem.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.ValueType;
@@ -80,6 +81,15 @@ public class ProgramDataElementOptionDimensionItem extends BaseDimensionalItemOb
     this.program = program;
     this.dataElement = dataElement;
     this.option = option;
+  }
+
+  @Override
+  public String getDisplayProperty(DisplayProperty displayProperty) {
+    return format(
+        "%s (%s, %s)",
+        option.getDisplayProperty(displayProperty),
+        dataElement.getDisplayProperty(displayProperty),
+        program.getDisplayProperty(displayProperty));
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttributeOptionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttributeOptionDimensionItem.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.legend.LegendSet;
@@ -93,6 +94,15 @@ public class ProgramTrackedEntityAttributeOptionDimensionItem extends BaseDimens
         option.getDisplayShortName(),
         attribute.getDisplayShortName(),
         program.getDisplayShortName());
+  }
+
+  @Override
+  public String getDisplayProperty(DisplayProperty displayProperty) {
+    return format(
+        "%s (%s, %s)",
+        option.getDisplayProperty(displayProperty),
+        attribute.getDisplayProperty(displayProperty),
+        program.getDisplayProperty(displayProperty));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -966,8 +966,8 @@ public final class AnalyticsUtils {
           MetadataItem metadataItem =
               includeMetadataDetails
                   ? new MetadataItem(
-                      optionSet.getName(), optionSet.getUid(), new LinkedHashSet<>(options))
-                  : new MetadataItem(optionSet.getName());
+                      optionSet.getDisplayName(), optionSet.getUid(), new LinkedHashSet<>(options))
+                  : new MetadataItem(optionSet.getDisplayName());
 
           map.put(metadataKey, metadataItem);
         });

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
@@ -87,4 +87,38 @@ public class AnalyticsQueryDv16AutoTest extends AnalyticsApiTest {
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
   }
+
+  @Test
+  public void programDataElementOptionShortNameInMetaData() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:USER_ORGUNIT")
+            .add("skipData=true")
+            .add("includeMetadataDetails=true")
+            .add("includeNumDen=true")
+            .add("displayProperty=SHORTNAME")
+            .add("skipMeta=false")
+            .add(
+                "dimension=dx:qDkgAbB5Jlk.XCMLePzaZiL.vak9GKjzzAP;qDkgAbB5Jlk.XCMLePzaZiL.zPVS0EAEwia,pe:LAST_12_MONTHS");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(0)))
+        .body("rows", hasSize(equalTo(0)))
+        .body("height", equalTo(0))
+        .body("width", equalTo(0))
+        .body("headerWidth", equalTo(0));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"202408\":{\"uid\":\"202408\",\"code\":\"202408\",\"name\":\"August 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-08-01T00:00:00.000\",\"endDate\":\"2024-08-31T00:00:00.000\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"202409\":{\"uid\":\"202409\",\"code\":\"202409\",\"name\":\"September 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-09-01T00:00:00.000\",\"endDate\":\"2024-09-30T00:00:00.000\"},\"202406\":{\"uid\":\"202406\",\"code\":\"202406\",\"name\":\"June 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-06-01T00:00:00.000\",\"endDate\":\"2024-06-30T00:00:00.000\"},\"202407\":{\"uid\":\"202407\",\"code\":\"202407\",\"name\":\"July 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-07-01T00:00:00.000\",\"endDate\":\"2024-07-31T00:00:00.000\"},\"202404\":{\"uid\":\"202404\",\"code\":\"202404\",\"name\":\"April 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-04-01T00:00:00.000\",\"endDate\":\"2024-04-30T00:00:00.000\"},\"202405\":{\"uid\":\"202405\",\"code\":\"202405\",\"name\":\"May 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-05-01T00:00:00.000\",\"endDate\":\"2024-05-31T00:00:00.000\"},\"qDkgAbB5Jlk.XCMLePzaZiL.vak9GKjzzAP\":{\"name\":\"No (Symptoms, Case)\",\"dimensionItemType\":\"PROGRAM_DATA_ELEMENT_OPTION\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"},\"202501\":{\"uid\":\"202501\",\"code\":\"202501\",\"name\":\"January 2025\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2025-01-01T00:00:00.000\",\"endDate\":\"2025-01-31T00:00:00.000\"},\"202403\":{\"uid\":\"202403\",\"code\":\"202403\",\"name\":\"March 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-03-01T00:00:00.000\",\"endDate\":\"2024-03-31T00:00:00.000\"},\"202502\":{\"uid\":\"202502\",\"code\":\"202502\",\"name\":\"February 2025\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2025-02-01T00:00:00.000\",\"endDate\":\"2025-02-28T00:00:00.000\"},\"202411\":{\"uid\":\"202411\",\"code\":\"202411\",\"name\":\"November 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-11-01T00:00:00.000\",\"endDate\":\"2024-11-30T00:00:00.000\"},\"202412\":{\"uid\":\"202412\",\"code\":\"202412\",\"name\":\"December 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-12-01T00:00:00.000\",\"endDate\":\"2024-12-31T00:00:00.000\"},\"LAST_12_MONTHS\":{\"name\":\"Last 12 months\"},\"202410\":{\"uid\":\"202410\",\"code\":\"202410\",\"name\":\"October 2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-10-01T00:00:00.000\",\"endDate\":\"2024-10-31T00:00:00.000\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"XCMLePzaZiL.qtswn9lMSXN\":{\"uid\":\"qtswn9lMSXN\",\"name\":\"Yes/No\",\"options\":[{\"code\":\"YES\",\"uid\":\"zPVS0EAEwia\"},{\"code\":\"NO\",\"uid\":\"vak9GKjzzAP\"}]},\"dx\":{\"uid\":\"dx\",\"name\":\"Data\",\"dimensionType\":\"DATA_X\"},\"pe\":{\"uid\":\"pe\",\"name\":\"Period\",\"dimensionType\":\"PERIOD\"},\"qDkgAbB5Jlk.XCMLePzaZiL.zPVS0EAEwia\":{\"name\":\"Yes (Symptoms, Case)\",\"dimensionItemType\":\"PROGRAM_DATA_ELEMENT_OPTION\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"}},\"dimensions\":{\"dx\":[\"qDkgAbB5Jlk.XCMLePzaZiL.vak9GKjzzAP\",\"qDkgAbB5Jlk.XCMLePzaZiL.zPVS0EAEwia\"],\"pe\":[\"202403\",\"202404\",\"202405\",\"202406\",\"202407\",\"202408\",\"202409\",\"202410\",\"202411\",\"202412\",\"202501\",\"202502\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
@@ -169,6 +169,13 @@
       "version": {
         "min": 42
       }
+    },
+    {
+      "name": "programDataElementOptionShortNameInMetaData",
+      "query": "/api/analytics?dimension=dx:qDkgAbB5Jlk.XCMLePzaZiL.vak9GKjzzAP;qDkgAbB5Jlk.XCMLePzaZiL.zPVS0EAEwia,pe:LAST_12_MONTHS&filter=ou:USER_ORGUNIT&displayProperty=SHORTNAME&includeNumDen=true&skipMeta=false&skipData=true&includeMetadataDetails=true",
+      "version": {
+        "min": 42
+      }
     }
   ]
 }


### PR DESCRIPTION
**_Backport from master (2.43)_**

When we set `displayProperty` to **_SHORTNAME_** (in the URL) the API returns `null` when no short name is defined.
We should default to the regular name, instead. ie:

`https://play.im.dhis2.org/dev/api/analytics?dimension=dx:qDkgAbB5Jlk.XCMLePzaZiL.vak9GKjzzAP;qDkgAbB5Jlk.XCMLePzaZiL.zPVS0EAEwia,pe:LAST_12_MONTHS&filter=ou:USER_ORGUNIT&displayProperty=SHORTNAME&includeNumDen=true&skipMeta=false&skipData=true&includeMetadataDetails=true`

This fix forces the use of the overridden version of the `getDisplayProperty` method, which takes care of printing the correct name based on the given `DisplayProperty` object

