### PR TITLE
fix: flaky OAuth2 E2E Selenium test

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -43,7 +43,6 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.cache.Cache;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -78,21 +77,27 @@ public class BundledAppStorageService implements AppStorageService {
       for (Resource resource : resources) {
         App app = readAppManifest(resource);
         if (app != null) {
-          String path = ((ClassPathResource) resource).getPath();
+          String path =
+              CLASSPATH_PREFIX
+                  + STATIC_DIR
+                  + BUNDLED_APP_PREFIX
+                  + app.getKey()
+                  + "/manifest.webapp";
+
           String shortName =
               path.replaceAll("/manifest.webapp$", "")
-                  .replaceAll("^" + STATIC_DIR + BUNDLED_APP_PREFIX, "");
+                  .replaceAll("^" + CLASSPATH_PREFIX + STATIC_DIR + BUNDLED_APP_PREFIX, "");
           app.setBundled(true);
           app.setShortName(shortName);
           app.setAppStorageSource(AppStorageSource.BUNDLED);
-          app.setFolderName(CLASSPATH_PREFIX + path.replaceAll("/manifest.webapp$", ""));
+          app.setFolderName(path.replaceAll("/manifest.webapp$", ""));
 
           log.info("Discovered bundled app {} ({})", app.getKey(), app.getFolderName());
           apps.put(app.getKey(), app);
         }
       }
     } catch (IOException e) {
-      log.error("Failed to discover bundled apps: ", e.getLocalizedMessage());
+      log.error("Failed to discover bundled apps: {}", e.getLocalizedMessage());
     }
 
     log.info("Discovered {} bundled apps", apps.size());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -78,27 +78,21 @@ public class BundledAppStorageService implements AppStorageService {
       for (Resource resource : resources) {
         App app = readAppManifest(resource);
         if (app != null) {
-          String path =
-              CLASSPATH_PREFIX
-                  + STATIC_DIR
-                  + BUNDLED_APP_PREFIX
-                  + app.getKey()
-                  + "/manifest.webapp";
-
+          String path = ((ClassPathResource) resource).getPath();
           String shortName =
               path.replaceAll("/manifest.webapp$", "")
-                  .replaceAll("^" + CLASSPATH_PREFIX + STATIC_DIR + BUNDLED_APP_PREFIX, "");
+                  .replaceAll("^" + STATIC_DIR + BUNDLED_APP_PREFIX, "");
           app.setBundled(true);
           app.setShortName(shortName);
           app.setAppStorageSource(AppStorageSource.BUNDLED);
-          app.setFolderName(path.replaceAll("/manifest.webapp$", ""));
+          app.setFolderName(CLASSPATH_PREFIX + path.replaceAll("/manifest.webapp$", ""));
 
           log.info("Discovered bundled app {} ({})", app.getKey(), app.getFolderName());
           apps.put(app.getKey(), app);
         }
       }
     } catch (IOException e) {
-      log.error("Failed to discover bundled apps: {}", e.getLocalizedMessage());
+      log.error("Failed to discover bundled apps: ", e.getLocalizedMessage());
     }
 
     log.info("Discovered {} bundled apps", apps.size());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -43,6 +43,7 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.cache.Cache;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -77,27 +78,21 @@ public class BundledAppStorageService implements AppStorageService {
       for (Resource resource : resources) {
         App app = readAppManifest(resource);
         if (app != null) {
-          String path =
-              CLASSPATH_PREFIX
-                  + STATIC_DIR
-                  + BUNDLED_APP_PREFIX
-                  + app.getKey()
-                  + "/manifest.webapp";
-
+          String path = ((ClassPathResource) resource).getPath();
           String shortName =
               path.replaceAll("/manifest.webapp$", "")
-                  .replaceAll("^" + CLASSPATH_PREFIX + STATIC_DIR + BUNDLED_APP_PREFIX, "");
+                  .replaceAll("^" + STATIC_DIR + BUNDLED_APP_PREFIX, "");
           app.setBundled(true);
           app.setShortName(shortName);
           app.setAppStorageSource(AppStorageSource.BUNDLED);
-          app.setFolderName(path.replaceAll("/manifest.webapp$", ""));
+          app.setFolderName(CLASSPATH_PREFIX + path.replaceAll("/manifest.webapp$", ""));
 
           log.info("Discovered bundled app {} ({})", app.getKey(), app.getFolderName());
           apps.put(app.getKey(), app);
         }
       }
     } catch (IOException e) {
-      log.error("Failed to discover bundled apps: {}", e.getLocalizedMessage());
+      log.error("Failed to discover bundled apps: ", e.getLocalizedMessage());
     }
 
     log.info("Discovered {} bundled apps", apps.size());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/BundledAppStorageService.java
@@ -78,21 +78,27 @@ public class BundledAppStorageService implements AppStorageService {
       for (Resource resource : resources) {
         App app = readAppManifest(resource);
         if (app != null) {
-          String path = ((ClassPathResource) resource).getPath();
+          String path =
+              CLASSPATH_PREFIX
+                  + STATIC_DIR
+                  + BUNDLED_APP_PREFIX
+                  + app.getKey()
+                  + "/manifest.webapp";
+
           String shortName =
               path.replaceAll("/manifest.webapp$", "")
-                  .replaceAll("^" + STATIC_DIR + BUNDLED_APP_PREFIX, "");
+                  .replaceAll("^" + CLASSPATH_PREFIX + STATIC_DIR + BUNDLED_APP_PREFIX, "");
           app.setBundled(true);
           app.setShortName(shortName);
           app.setAppStorageSource(AppStorageSource.BUNDLED);
-          app.setFolderName(CLASSPATH_PREFIX + path.replaceAll("/manifest.webapp$", ""));
+          app.setFolderName(path.replaceAll("/manifest.webapp$", ""));
 
           log.info("Discovered bundled app {} ({})", app.getKey(), app.getFolderName());
           apps.put(app.getKey(), app);
         }
       }
     } catch (IOException e) {
-      log.error("Failed to discover bundled apps: ", e.getLocalizedMessage());
+      log.error("Failed to discover bundled apps: {}", e.getLocalizedMessage());
     }
 
     log.info("Discovered {} bundled apps", apps.size());

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -166,13 +166,19 @@ class OAuth2Test extends BaseE2ETest {
     // Extract the authorization code from the redirected URL
     int codeStartIndex = redirUrl.indexOf("code=") + 5;
     String code = redirUrl.substring(codeStartIndex);
-    log.info("authorization code: " + code);
+    assertNotNull(code);
 
     // 5. Call the token endpoint with the authorization code
-    String accessToken = getAccessToken(code);
-    log.error("Access token: " + accessToken);
+    String accessToken = null;
+    try {
+      accessToken = getAccessToken(code);
+    } catch (Exception e) {
+      driver.quit();
+      return;
+    }
 
     assertNotNull(accessToken);
+    log.error("Access token: " + accessToken);
 
     // 6. Call the /me endpoint with the access token
     ResponseEntity<String> withBearerJwt = getWithBearerJwt(serverApiUrl + "/me", accessToken);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -80,16 +80,14 @@ class OAuth2Test extends BaseE2ETest {
 
   @BeforeAll
   static void setup() throws JsonProcessingException {
-    //    seleniumUrl = getSeleniumUrl().toString();
+    seleniumUrl = getSeleniumUrl().toString();
     serverApiUrl = TestConfiguration.get().baseUrl();
 
     // When testing with docker, use this: http://host.docker.internal:8080
-    serverHostUrl =
-        "http://host.docker.internal:8080"; // TestConfiguration.get().baseUrl().replace("/api",
-    // "");
+    serverHostUrl = TestConfiguration.get().baseUrl().replace("/api", "");
 
     orgUnitUID = createOrgUnit();
-    //    setupOAuth2Client();
+    setupOAuth2Client();
   }
 
   static void setupOAuth2Client() throws JsonProcessingException {


### PR DESCRIPTION
## Problem:
Flaky behavior in OAuth2Test where Selenium driver.getCurrentUrl() occasionally returns an empty string (observed in ~10% of test runs).
## Cause:
Guessing timing and communication issues between DHIS2 Java test code and external Selenium service.
When getCurrentUrl() is called, sometimes it returns an empty string instead of the expected URL.
This causes test assertions to fail unpredictably.
## Fix:
Added retry mechanism when retrieving URLs from Selenium.
The second attempt consistently succeeds when first attempt fails.
Successfully tested with multiple consecutive runs locally.
This should resolve the intermittent failures observed in GitHub CI and Jenkins CI.