### PR TITLE
fix: Shortname in dataItems API [DHIS2-19323]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ResultProcessor.java
@@ -178,7 +178,7 @@ class ResultProcessor {
           "%s (%s, %s)",
           trimToEmpty(rowSet.getString(I18N_THIRD_NAME)),
           trimToEmpty(rowSet.getString(I18N_SECOND_NAME)),
-          trimToEmpty(rowSet.getString(I18N_FIRST_NAME)));
+          trimToEmpty(rowSet.getString(I18N_FIRST_SHORTNAME)));
     } else if (isNotBlank(rowSet.getString(PROGRAM_NAME))) {
       return trimToEmpty(rowSet.getString(I18N_FIRST_SHORTNAME))
           + SPACE

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/dataitems/DataItemsAnalyticsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/dataitems/DataItemsAnalyticsTest.java
@@ -417,4 +417,30 @@ public class DataItemsAnalyticsTest {
         .body("dataItems.optionSetId", allOf(hasItem("iDFPKpFTiVw")))
         .body("dataItems.programId", allOf(hasItem("eBAyeGv0exc")));
   }
+
+  @Test
+  void testDataItemsShortNameOption_PROGRAM_DATA_ELEMENT_OPTION() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("paging=truec")
+            .add("page=1")
+            .add("fields=id1,displayShortName~rename(name),dimensionItemType")
+            .add("order=displayName:asc")
+            .add("filter=dimensionItemType:eq:PROGRAM_DATA_ELEMENT_OPTION")
+            .add("filter=programDataElementId:eq:qDkgAbB5Jlk.XCMLePzaZiL");
+
+    // When
+    ApiResponse response = dataItemsActions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(equalTo(200))
+        .body("dataItems", is(not(empty())))
+        .body("dataItems", hasSize(2))
+        .body("dataItems.dimensionItemType", allOf(hasItem("PROGRAM_DATA_ELEMENT_OPTION")))
+        .body("dataItems.name", hasItem("No (Symptoms, Case)"))
+        .body("dataItems.name", hasItem("Yes (Symptoms, Case)"));
+  }
 }


### PR DESCRIPTION
The shortname in `dataItems` API returns the regular `name` in cases where it should return the `shortname`.