### PR TITLE
chore: update google formatter version

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -585,7 +585,7 @@ class JdbcEventStore {
     if (TrackerIdScheme.UID
         != queryParams.getIdSchemeParams().getDataElementIdScheme().getIdScheme()) {
       sqlBuilder.append(
-          """
+"""
 left join
     lateral jsonb_each(
         coalesce(event.ev_eventdatavalues, '{}')
@@ -1431,7 +1431,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
    */
   private String getCategoryOptionComboQuery(User user) {
     String joinCondition =
-        """
+"""
  inner join (select coc.uid, coc.code, coc.name, coc.attributevalues, coc.categoryoptioncomboid as id,\
     jsonb_object_agg(
         co.uid,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -331,9 +331,9 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     ValueType valueType =
         switch (programRuleVariable.getSourceType()) {
           case DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE,
-                  DATAELEMENT_PREVIOUS_EVENT,
-                  DATAELEMENT_NEWEST_EVENT_PROGRAM,
-                  DATAELEMENT_CURRENT_EVENT ->
+              DATAELEMENT_PREVIOUS_EVENT,
+              DATAELEMENT_NEWEST_EVENT_PROGRAM,
+              DATAELEMENT_CURRENT_EVENT ->
               programRuleVariable.getDataElement().getValueType();
           case CALCULATED_VALUE -> programRuleVariable.getValueType();
           case TEI_ATTRIBUTE -> programRuleVariable.getAttribute().getValueType();
@@ -369,9 +369,9 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
   private DataItem getDescription(ProgramRuleVariable prv) {
     return switch (prv.getSourceType()) {
       case DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE,
-              DATAELEMENT_PREVIOUS_EVENT,
-              DATAELEMENT_NEWEST_EVENT_PROGRAM,
-              DATAELEMENT_CURRENT_EVENT ->
+          DATAELEMENT_PREVIOUS_EVENT,
+          DATAELEMENT_NEWEST_EVENT_PROGRAM,
+          DATAELEMENT_CURRENT_EVENT ->
           new DataItem(
               ObjectUtils.firstNonNull(
                   prv.getDataElement().getDisplayFormName(),

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -253,7 +253,10 @@
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
-              <googleJavaFormat/>
+              <googleJavaFormat>
+                <version>1.26.0</version>
+                <style>GOOGLE</style>
+              </googleJavaFormat>
               <trimTrailingWhitespace/>
               <licenseHeader>
                 <file>${rootDir}/license-header</file>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -761,7 +761,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         response.get("trackedEntityType").node().value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"nEenWmSyUEp"}""")));
 
     JsonNode simpleDimensionNode0 = response.get("simpleDimensions").node().element(0);
@@ -772,7 +772,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         simpleDimensionNode0.get("values").value().toString(),
         is(
             equalTo(
-                """
+"""
 ["2023-07-21_2023-08-01","2023-01-21_2023-02-01"]""")));
     assertThat(simpleDimensionNode0.get("parent").value().toString(), is(equalTo("COLUMN")));
 
@@ -794,14 +794,14 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         response.get("columnDimensions").node().value().toString(),
         is(
             equalTo(
-                """
+"""
 ["deabcdefghP.deabcdefghB","deabcdefghC","deabcdefghP.eventDate","created"]""")));
 
     assertThat(
         response.get("filterDimensions").node().value().toString(),
         is(
             equalTo(
-                """
+"""
 ["deabcdefghP.deabcdefghS.ou","deabcdefghE"]""")));
 
     JsonNode dataElementDimensionsNode0 = response.get("dataElementDimensions").node().element(0);
@@ -809,7 +809,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         dataElementDimensionsNode0.get("dataElement").value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"deabcdefghC"}""")));
     assertThat(
         dataElementDimensionsNode0.get("filter").value().toString(), is(equalTo("IN:Female")));
@@ -819,7 +819,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         dataElementDimensionsNode1.get("dataElement").value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"deabcdefghE"}""")));
     assertFalse(dataElementDimensionsNode1.isMember("filter"));
 
@@ -827,14 +827,14 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         response.get("programIndicatorDimensions").node().value().toString(),
         is(
             equalTo(
-                """
+"""
 [{"programIndicator":{"id":"deabcdefghB"}}]""")));
 
     assertThat(
         response.get("organisationUnits").node().value().toString(),
         is(
             equalTo(
-                """
+"""
 [{"id":"ImspTQPwCqd"}]""")));
 
     JsonNode repetitionsNode0 = response.get("repetitions").node().element(0);
@@ -857,7 +857,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         columnsNode0.get("program").value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"deabcdefghP"}""")));
     assertThat(columnsNode0.get("dimension").value().toString(), is(equalTo("deabcdefghB")));
 
@@ -871,13 +871,13 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         columnsNode2.get("items").value().toString(),
         is(
             equalTo(
-                """
+"""
 [{"id":"2023-07-21_2023-08-01"},{"id":"2023-01-21_2023-02-01"}]""")));
     assertThat(
         columnsNode2.get("program").value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"deabcdefghP"}""")));
     assertThat(columnsNode2.get("dimension").value().toString(), is(equalTo("eventDate")));
 
@@ -886,7 +886,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         columnsNode3.get("items").value().toString(),
         is(
             equalTo(
-                """
+"""
 [{"id":"2021-01-21_2021-02-01"}]""")));
     assertThat(columnsNode3.get("dimension").value().toString(), is(equalTo("created")));
 
@@ -901,7 +901,7 @@ class EventVisualizationControllerTest extends H2ControllerIntegrationTestBase {
         filtersNode0.get("programStage").value().toString(),
         is(
             equalTo(
-                """
+"""
 {"id":"deabcdefghS"}""")));
     assertThat(filtersNode0.get("dimension").value().toString(), is(equalTo("ou")));
     assertThat(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -517,7 +517,7 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
   void testDeleteWithException() {
     POST(
             "/metadata",
-            """
+"""
 {'optionSets':
     [{'name': 'Device category','id': 'RHqFlB1Wm4d','version': 2,'valueType': 'TEXT'}]
 ,'dataElements':

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -333,7 +333,7 @@ class VisualizationControllerTest extends H2ControllerIntegrationTestBase {
     String optionUid = option.getUid();
     String dimUid = programUid + "." + attributeUid + "." + optionUid;
     String jsonBody =
-        """
+"""
 {
     "type": "PIE",
     "columns": [
@@ -385,7 +385,7 @@ class VisualizationControllerTest extends H2ControllerIntegrationTestBase {
     String optionUid = option.getUid();
     String dimUid = programUid + "." + dataElementUid + "." + optionUid;
     String jsonBody =
-        """
+"""
 {
     "type": "PIE",
     "columns": [

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationControllerTest.java
@@ -141,7 +141,7 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
         "required input property 'duplicate'",
         POST(
                 "/potentialDuplicates",
-                """
+"""
 {
   "original": "%s"
 }
@@ -157,7 +157,7 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
         "required input property 'original'",
         POST(
                 "/potentialDuplicates",
-                """
+"""
 {
 "duplicate": "%s"
 }
@@ -171,7 +171,7 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
   void shouldThrowNotFoundExceptionWhenTeDoesNotExist() {
     POST(
             "/potentialDuplicates",
-            """
+"""
 {
   "original": "%s",
   "duplicate": "%s"
@@ -192,7 +192,7 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
 
     POST(
             "/potentialDuplicates",
-            """
+"""
 {
   "original": "%s",
   "duplicate": "%s"
@@ -326,7 +326,7 @@ class DeduplicationControllerTest extends PostgresControllerIntegrationTestBase 
             .asA(JsonPage.class);
 
     assertEquals(
-        """
+"""
 {"status":"OPEN"}""",
         page.getList("potentialDuplicates", JsonPotentialDuplicate.class).get(0).toMinimizedJson());
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEnrollmentSMSTest.java
@@ -252,7 +252,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "%s",
 "originator": "%s"
@@ -425,7 +425,7 @@ class TrackerEnrollmentSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "register a=hello|c=there|x=codeIsNotFoundOnCommand",
 "originator": "%s"

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -500,7 +500,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "%s",
 "originator": "%s"
@@ -570,7 +570,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "%s",
 "originator": "%s"
@@ -634,7 +634,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "visit a=hello",
 "originator": "%s"
@@ -701,7 +701,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "birth a=hello",
 "originator": "%s"
@@ -787,7 +787,7 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
         POST(
                 "/sms/inbound",
                 format(
-                    """
+"""
 {
 "text": "birth a=hello",
 "originator": "%s"

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -110,7 +110,7 @@ class TrackerImportControllerTest extends PostgresControllerIntegrationTestBase 
             .content(HttpStatus.OK);
 
     assertNoDiff(
-        """
+"""
 {
   "status": "OK",
   "validationReport": {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/message/ProgramMessageRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/message/ProgramMessageRequestParams.java
@@ -61,14 +61,14 @@ public class ProgramMessageRequestParams {
   private Date beforeDate;
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationInstanceRequestParams.java
@@ -42,21 +42,21 @@ import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 @NoArgsConstructor
 public class ProgramNotificationInstanceRequestParams implements PageRequestParams {
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
   @OpenApi.Description(
-      """
+"""
 Get the total number of items and pages in the pager.
 
 **Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
@@ -65,7 +65,7 @@ Get the total number of items and pages in the pager.
   private boolean totalPages = false;
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/notification/ProgramNotificationTemplateRequestParams.java
@@ -46,14 +46,14 @@ public class ProgramNotificationTemplateRequestParams implements PageRequestPara
   private UID programStage;
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
@@ -69,7 +69,7 @@ Get given number of items per page.
   }
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
@@ -51,14 +51,14 @@ public class PotentialDuplicateRequestParams implements PageRequestParams, Field
       "id,created,lastUpdated,original,duplicate,status";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
@@ -72,7 +72,7 @@ Get given number of items per page.
   }
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages
@@ -81,13 +81,13 @@ will take more time to return.**
   private boolean paging = true;
 
   @OpenApi.Description(
-      """
+"""
 Get potential duplicates that are in given status.
 """)
   private DeduplicationStatus status = DeduplicationStatus.OPEN;
 
   @OpenApi.Description(
-      """
+"""
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
 Get potential duplicates in given order.
@@ -97,7 +97,7 @@ Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive
   private List<OrderCriteria> order = new ArrayList<>();
 
   @OpenApi.Description(
-      """
+"""
 `<uid1>[,<uid2>...]`
 
 Get potential duplicates for given tracked entities.
@@ -105,7 +105,7 @@ Get potential duplicates for given tracked entities.
   private List<UID> trackedEntities = new ArrayList<>();
 
   @OpenApi.Description(
-      """
+"""
 Get only the given fields in the JSON response. This query parameter allows you to remove
 unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
 [metadata field filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
@@ -49,14 +49,14 @@ public class ChangeLogRequestParams implements PageRequestParams, FieldsRequestP
   private static final String DEFAULT_FIELDS_PARAM = "change,createdAt,createdBy,type";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
@@ -77,7 +77,7 @@ Get given number of items per page.
   }
 
   @OpenApi.Description(
-      """
+"""
 Get only the given fields in the JSON response. This query parameter allows you to remove
 unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
 [metadata field filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter)
@@ -86,7 +86,7 @@ on how to use it.
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
-      """
+"""
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
 Get items in given order.

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrors.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/MappingErrors.java
@@ -104,7 +104,7 @@ public class MappingErrors {
     // values
     if (hasDefaultCategory) {
       result.append(
-          """
+"""
 
 
 Data linked to default category option (combo)s cannot be exported using\

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -61,21 +61,21 @@ public class EnrollmentRequestParams implements PageRequestParams, FieldsRequest
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!events,!attributes";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
   @OpenApi.Description(
-      """
+"""
 Get the total number of items and pages in the pager.
 
 **Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
@@ -84,7 +84,7 @@ Get the total number of items and pages in the pager.
   private boolean totalPages = false;
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -71,21 +71,21 @@ public class EventRequestParams implements PageRequestParams, FieldsRequestParam
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
   @OpenApi.Description(
-      """
+"""
 Get the total number of items and pages in the pager.
 
 **Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
@@ -94,7 +94,7 @@ Get the total number of items and pages in the pager.
   private boolean totalPages = false;
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
@@ -53,21 +53,21 @@ public class RelationshipRequestParams implements PageRequestParams, FieldsReque
       "relationship,relationshipType,createdAtClient,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
   @OpenApi.Description(
-      """
+"""
 Get the total number of items and pages in the pager.
 
 **Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
@@ -76,7 +76,7 @@ Get the total number of items and pages in the pager.
   private boolean totalPages = false;
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
@@ -68,21 +68,21 @@ public class TrackedEntityRequestParams implements PageRequestParams, FieldsRequ
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
 
   @OpenApi.Description(
-      """
+"""
 Get the given page.
 """)
   @OpenApi.Property(defaultValue = "1")
   private Integer page;
 
   @OpenApi.Description(
-      """
+"""
 Get given number of items per page.
 """)
   @OpenApi.Property(defaultValue = "50")
   private Integer pageSize;
 
   @OpenApi.Description(
-      """
+"""
 Get the total number of items and pages in the pager.
 
 **Only enable this if absolutely necessary as this is resource intensive.** Use the pagers
@@ -91,7 +91,7 @@ Get the total number of items and pages in the pager.
   private boolean totalPages = false;
 
   @OpenApi.Description(
-      """
+"""
 Get all items by specifying `paging=false`. Requests are paginated by default.
 
 **Be aware that the performance is directly related to the amount of data requested. Larger pages

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/ImportRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/ImportRequestParams.java
@@ -52,7 +52,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundleMode;
 @Builder
 public class ImportRequestParams {
   public static final String OPENAPI_DESCRIPTION_ASYNC =
-      """
+"""
 Tracker data is imported asynchronously by default (as with `async=true`). Asynchronous imports get a `WebMessage` response with a URL to the job executing the import. Check the job status by following the `response.location` URL. Set `async=true` to import synchronously in which case the response will be the `ImportReport`. Prefer asynchronous imports for large data sets.
 """;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -102,7 +102,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 public class TrackerImportController {
   static final String TRACKER_JOB_ADDED = "Tracker job added";
   public static final String OPENAPI_IMPORT_DESCRIPTION =
-      """
+"""
 Import tracker data.
 """
           + ImportRequestParams.OPENAPI_DESCRIPTION_ASYNC;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventServiceTest.java
@@ -276,7 +276,7 @@ class CsvEventServiceTest {
     }
 
     assertEquals(
-        """
+"""
 FRM97UKN8te,COMPLETED,programId,programStageId,PSeMWi7rBgb,orgUnitId,2020-02-26T23:01:00Z,2020-02-26T23:02:00Z,,,,false,false,2020-02-26T23:03:00Z,,2020-02-26T23:05:00Z,,admin,2020-02-26T23:07:00Z,,attributeOptionCombo,attributeCategoryOptions,,dataElement,value,admin,false,,2020-02-26T23:08:00Z,2020-02-26T23:09:00Z
 """,
         csvStream.toString(),
@@ -306,7 +306,7 @@ FRM97UKN8te,COMPLETED,programId,programStageId,PSeMWi7rBgb,orgUnitId,2020-02-26T
     }
 
     assertEquals(
-        """
+"""
 FRM97UKN8te,COMPLETED,programId,programStageId,PSeMWi7rBgb,orgUnitId,2020-02-26T23:01:00Z,2020-02-26T23:02:00Z,,,,false,false,2020-02-26T23:03:00Z,,2020-02-26T23:05:00Z,,admin,2020-02-26T23:07:00Z,,attributeOptionCombo,attributeCategoryOptions,,dataElement,value,admin,false,,2020-02-26T23:08:00Z,2020-02-26T23:09:00Z
 """,
         csvStream.toString(),

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/CsvTrackedEntityServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/CsvTrackedEntityServiceTest.java
@@ -181,7 +181,7 @@ class CsvTrackedEntityServiceTest {
     }
 
     assertEquals(
-        """
+"""
 h4w96yEMlzO,,2022-09-29T15:15:30Z,,,,"Test org unit",false,false,false,"POINT (40 5)",5.0,40.0,,,,,,"attribute 1",,"Age test",AGE
 h4w96yEMlzO,,2022-09-29T15:15:30Z,,,,"Test org unit",false,false,false,"POINT (40 5)",5.0,40.0,,,,,,"attribute 2",,"Text test",TEXT
 """,
@@ -210,7 +210,7 @@ h4w96yEMlzO,,2022-09-29T15:15:30Z,,,,"Test org unit",false,false,false,"POINT (4
     }
 
     assertEquals(
-        """
+"""
 h4w96yEMlzO,,2022-09-29T15:15:30Z,,,,"Test org unit",false,false,false,"POINT (40 5)",5.0,40.0,,,,,,"attribute 1",,"Age test",AGE
 h4w96yEMlzO,,2022-09-29T15:15:30Z,,,,"Test org unit",false,false,false,"POINT (40 5)",5.0,40.0,,,,,,"attribute 2",,"Text test",TEXT
 """,

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2061,7 +2061,7 @@ jasperreports.version=${jasperreports.version}
             </upToDateChecking>
             <java>
               <googleJavaFormat>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
                 <style>GOOGLE</style>
               </googleJavaFormat>
               <trimTrailingWhitespace/>


### PR DESCRIPTION
to benefit from improved textblock handling

see
https://github.com/google/google-java-format/releases/tag/v1.26.0

```java
  private static final String yes =
        """
hello
""";
```

turns to

```java
  private static final String yes =
"""
hello
""";
```

while this is left alone

```java
  private static final String no =
      """
        hello
        """;
```


