### PR TITLE
fix: invalid offset calculation for rowcontext [DHIS2-19352]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -67,6 +67,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
 
 /**
  * @author Luciano Fiandesio
@@ -81,6 +82,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
   @Mock private ExecutionPlanStore executionPlanStore;
 
   @Mock private SqlRowSet rowSet;
+
+  @Mock private SqlRowSetMetaData rowSetMetaData;
 
   @Mock private ProgramIndicatorService programIndicatorService;
 
@@ -113,6 +116,7 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     when(systemSettingsService.getCurrentSettings()).thenReturn(systemSettings);
     when(systemSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
     when(config.getPropertyOrDefault(ANALYTICS_DATABASE, "")).thenReturn("postgresql");
+    when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
     DefaultProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder =
         new DefaultProgramIndicatorSubqueryBuilder(programIndicatorService, systemSettingsService);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -100,6 +100,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
 
 /**
  * @author Luciano Fiandesio
@@ -114,6 +115,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
   @Mock private ExecutionPlanStore executionPlanStore;
 
   @Mock private SqlRowSet rowSet;
+
+  @Mock private SqlRowSetMetaData rowSetMetaData;
 
   @Mock private ProgramIndicatorService programIndicatorService;
 
@@ -156,6 +159,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     when(config.getPropertyOrDefault(ANALYTICS_DATABASE, "")).thenReturn("postgresql");
     DefaultProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder =
         new DefaultProgramIndicatorSubqueryBuilder(programIndicatorService, systemSettingsService);
+    when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
 
     subject =
         new JdbcEnrollmentAnalyticsManager(


### PR DESCRIPTION
## Summary

See https://dhis2.atlassian.net/browse/DHIS2-19352 for a detailed description of the problem fixed in this PR.

## Details

Use `getColumnLabel` instead of `getColumnName` when calculating the row context offset in Enrollment queries.

 

