### PR TITLE
fix: Correct ignored stats when import validation [DHIS2-15604](2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -68,7 +68,7 @@ public class TranslationsCheck implements ObjectValidationCheck {
     Schema schema = context.getSchemaService().getDynamicSchema(klass);
 
     for (int i = 0; i < objects.size(); i++) {
-      run(objects.get(i), klass, addReports, schema, i);
+      run(objects.get(i), klass, addReports, schema, i, context);
     }
   }
 
@@ -77,7 +77,8 @@ public class TranslationsCheck implements ObjectValidationCheck {
       Class<T> klass,
       Consumer<ObjectReport> addReports,
       Schema schema,
-      int index) {
+      int index,
+      ValidationContext context) {
     Set<Translation> translations = object.getTranslations();
 
     if (CollectionUtils.isEmpty(translations)) {
@@ -129,6 +130,9 @@ public class TranslationsCheck implements ObjectValidationCheck {
 
     if (objectReport.hasErrorReports()) {
       addReports.accept(objectReport);
+      if (context != null) {
+        context.markForRemoval(object);
+      }
     }
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataElementControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataElementControllerTest.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.web.HttpStatus.CONFLICT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -37,12 +39,15 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonDataElement;
+import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
+import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -132,5 +137,43 @@ class DataElementControllerTest extends DhisControllerConvenienceTest {
             .map(JsonIdentifiableObject::getId)
             .collect(Collectors.toSet()),
         "Returned cat combo IDs equal custom cat combos Ids only");
+  }
+
+  @Test
+  @DisplayName(
+      "Creating a data element with missing locale should show correct ignored stats value")
+  void dataElementValidationIgnoredValueTest() {
+    JsonImportSummary summary =
+        POST(
+                "/metadata",
+                "{"
+                    + "\"dataElements\": ["
+                    + "{"
+                    + "\"id\": \"DeUid000015\","
+                    + "\"aggregationType\": \"DEFAULT\","
+                    + "\"domainType\": \"AGGREGATE\","
+                    + "\"name\": \"test de 1\","
+                    + "\"shortName\": \"test DE 1\","
+                    + "\"valueType\": \"NUMBER\","
+                    + "\"translations\": ["
+                    + "{"
+                    + "\"property\": \"name\","
+                    + "\"value\": \"french name\""
+                    + "}"
+                    + "]"
+                    + "}"
+                    + "]"
+                    + "}")
+            .content(CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    assertEquals(1, summary.getStats().getIgnored());
+    assertEquals(0, summary.getStats().getCreated());
+
+    JsonErrorReport errorReport =
+        summary.find(JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4000);
+    assertNotNull(errorReport);
+    assertEquals("Missing required property `locale`", errorReport.getMessage());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -681,7 +681,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject>
 
     persistedObject.setTranslations(translations);
     List<ObjectReport> objectReports = new ArrayList<>();
-    translationsCheck.run(persistedObject, getEntityClass(), objectReports::add, getSchema(), 0);
+    translationsCheck.run(
+        persistedObject, getEntityClass(), objectReports::add, getSchema(), 0, null);
 
     if (objectReports.isEmpty()) {
       manager.update(persistedObject, currentUser);


### PR DESCRIPTION
port of #20373 
The specific Dashboard check & tests are not in earlier versions (omitted from this change)