### PR TITLE
chore: improve error message for invalid value type on /tracker/events filter DHIS2-19347

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -38,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.apache.commons.collections4.SetUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -47,6 +50,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -457,18 +461,21 @@ class EventQueryParams {
     return this.dataElements;
   }
 
-  public EventQueryParams filterBy(TrackedEntityAttribute tea, QueryFilter filter) {
+  public EventQueryParams filterBy(
+      @Nonnull TrackedEntityAttribute tea, @Nonnull QueryFilter filter) {
+    validateNumericFilter(tea, filter.getFilter());
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     this.attributes.get(tea).add(filter);
     return this;
   }
 
-  public EventQueryParams filterBy(TrackedEntityAttribute tea) {
+  public EventQueryParams filterBy(@Nonnull TrackedEntityAttribute tea) {
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     return this;
   }
 
-  public EventQueryParams filterBy(DataElement de, QueryFilter filter) {
+  public EventQueryParams filterBy(@Nonnull DataElement de, @Nonnull QueryFilter filter) {
+    validateNumericFilter(de, filter.getFilter());
     this.dataElements.putIfAbsent(de, new ArrayList<>());
     this.dataElements.get(de).add(filter);
     this.hasDataElementFilter = true;
@@ -478,6 +485,32 @@ class EventQueryParams {
   public EventQueryParams filterBy(DataElement de) {
     this.dataElements.putIfAbsent(de, List.of(new QueryFilter(QueryOperator.NNULL)));
     return this;
+  }
+
+  /**
+   * Validates that a filter value for a numeric value type is numeric.
+   *
+   * <p>Uses BigDecimal as we use <code>cast(column as numeric)</code> in the SQL query. BigDecimal
+   * matches PostgreSQL's numeric type behavior.
+   *
+   * @see <a href="https://www.postgresql.org/docs/current/datatype-numeric.html">PostgreSQL Numeric
+   *     Type</a>
+   */
+  private void validateNumericFilter(
+      ValueTypedDimensionalItemObject item, @CheckForNull String filterValue) {
+    if (!item.getValueType().isNumeric() || filterValue == null) {
+      return;
+    }
+
+    try {
+      new BigDecimal(filterValue);
+    } catch (NumberFormatException e) {
+      String name = item instanceof TrackedEntityAttribute ? "attribute" : "data element";
+      throw new IllegalArgumentException(
+          String.format(
+              "Filter for %s %s is invalid. The %s value type is numeric but the value `%s` is not.",
+              name, item.getUid(), name, filterValue));
+    }
   }
 
   public EventQueryParams setIncludeDeleted(boolean includeDeleted) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -659,7 +659,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
               mapSqlParameterSource.addValue(
                   parameterKey,
                   isNumericTea
-                      ? parseNumericFilterValue("attribute", teaUid, filter.getSqlBindFilter())
+                      ? new BigDecimal(filter.getSqlBindFilter())
                       : StringUtils.lowerCase(filter.getSqlBindFilter()),
                   itemType);
               yield new StringBuilder()
@@ -676,25 +676,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
     query.append(String.join(AND, filterStrings));
 
     return query.toString();
-  }
-
-  /**
-   * Validates and parses numeric filter values. Uses BigDecimal to match PostgreSQL's numeric type
-   * behavior. PostgreSQL's numeric type is an exact decimal type that can store numbers of up to
-   * 131072 digits before the decimal point and up to 16383 digits after the decimal point.
-   *
-   * @see <a href="https://www.postgresql.org/docs/current/datatype-numeric.html">PostgreSQL Numeric
-   *     Type</a>
-   */
-  private BigDecimal parseNumericFilterValue(String context, String uid, String filterValue) {
-    try {
-      return new BigDecimal(filterValue);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Filter for %s %s is invalid. The %s value type is numeric but the value '%s' is not.",
-              context, uid, context, filterValue));
-    }
   }
 
   /**
@@ -1303,7 +1284,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
           mapSqlParameterSource.addValue(
               bindParameter,
               de.getValueType().isNumeric()
-                  ? parseNumericFilterValue("data element", deUid, filter.getSqlBindFilter())
+                  ? new BigDecimal(filter.getSqlBindFilter())
                   : StringUtils.lowerCase(filter.getSqlBindFilter()),
               itemValueType);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -243,8 +244,10 @@ class EventOperationParamsMapperTest {
   void shouldMapAttributeFilters() throws BadRequestException, ForbiddenException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
+    tea1.setValueType(ValueType.INTEGER);
     TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
     tea2.setUid(TEA_2_UID);
+    tea2.setValueType(ValueType.TEXT);
     when(trackedEntityAttributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
     when(trackedEntityAttributeService.getTrackedEntityAttribute(TEA_2_UID)).thenReturn(tea2);
 
@@ -352,9 +355,11 @@ class EventOperationParamsMapperTest {
   void shouldMapDataElementFilters() throws BadRequestException, ForbiddenException {
     DataElement de1 = new DataElement();
     de1.setUid(DE_1_UID);
+    de1.setValueType(ValueType.INTEGER);
     when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
     DataElement de2 = new DataElement();
     de2.setUid(DE_2_UID);
+    de2.setValueType(ValueType.TEXT);
     when(dataElementService.getDataElement(DE_2_UID)).thenReturn(de2);
 
     EventOperationParams operationParams =


### PR DESCRIPTION
```http
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=VBqh0ynB2wv&
  fields=dataValues[dataElement,value]&
  filter=qrur9Dvnyt5:gt:foo
```

lead to `409 Query failed because of a syntax error (SqlState: 07006)` if the data element value type is numeric. We did cast the user provided value for data elements to numeric in the SQL. This lead to

```sh
 org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [...]
 ...
  Caused by: org.postgresql.util.PSQLException: Cannot convert an instance of java.lang.String to type BigDecimal
       at org.postgresql.jdbc.PgPreparedStatement.cannotCastException(PgPreparedStatement.java:980) ~[postgresql-42.7.5.jar:42.7.5]
       at org.postgresql.jdbc.PgPreparedStatement.castToBigDecimal(PgPreparedStatement.java:952) ~[postgresql-42.7.5.jar:42.7.5]
       at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:611) ~[postgresql-42.7.5.jar:42.7.5]
       at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:987) ~[postgresql-42.7.5.jar:42.7.5]
       at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.setObject(NewProxyPreparedStatement.java:249) ~[c3p0-0.11.0-pre2.jar:?]
       at org.springframework.jdbc.core.StatementCreatorUtils.setValue(StatementCreatorUtils.java:378) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValueInternal(StatementCreatorUtils.java:247) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(StatementCreatorUtils.java:163) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.PreparedStatementCreatorFactory$PreparedStatementCreatorImpl.setValues(PreparedStatementCreatorFactory.java:287) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.PreparedStatementCreatorFactory$PreparedStatementCreatorImpl.createPreparedStatement(PreparedStatementCreatorFactory.java:245) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:656) ~[spring-jdbc-6.2.3.jar:6.2.3]
       ... 174 more
 Caused by: java.lang.NumberFormatException: Character f is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
       at java.base/java.math.BigDecimal.<init>(Unknown Source) ~[?:?]
       at java.base/java.math.BigDecimal.<init>(Unknown Source) ~[?:?]
       at java.base/java.math.BigDecimal.<init>(Unknown Source) ~[?:?]
       at org.postgresql.jdbc.PgPreparedStatement.castToBigDecimal(PgPreparedStatement.java:926) ~[postgresql-42.7.5.jar:42.7.5]
       at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:611) ~[postgresql-42.7.5.jar:42.7.5]
       at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:987) ~[postgresql-42.7.5.jar:42.7.5]
       at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.setObject(NewProxyPreparedStatement.java:249) ~[c3p0-0.11.0-pre2.jar:?]
       at org.springframework.jdbc.core.StatementCreatorUtils.setValue(StatementCreatorUtils.java:378) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValueInternal(StatementCreatorUtils.java:247) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(StatementCreatorUtils.java:163) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.PreparedStatementCreatorFactory$PreparedStatementCreatorImpl.setValues(PreparedStatementCreatorFactory.java:287) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.PreparedStatementCreatorFactory$PreparedStatementCreatorImpl.createPreparedStatement(PreparedStatementCreatorFactory.java:245) ~[spring-jdbc-6.2.3.jar:6.2.3]
       at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:656) ~[spring-jdbc-6.2.3.jar:6.2.3]
```

Interestingly, we did parse the user provided attribute value for `filterAttributes`.

Validate `filter` values for numeric attributes/data elements are indeed numeric. Use the same data type the postgres jdbc driver uses when using `cast(... as numeric)` (see stack trace).

We now return a 400 for the same request with message

`Filter for data element qrur9Dvnyt5 is invalid. The data element value type is numeric but the value `foo` is not.`

(or `attribute` instead of `data element`).

## Out of scope

`/tracker/trackedEntities?filter`: turns out we are not treating numeric attribute values on `/tracker/trackedEntities?filter` as we do `/tracker/events?filterAttributes`. The former are treated as strings (which they are in the DB). 

The endpoints likely diverged in how the handle different value types in

https://dhis2.atlassian.net/browse/DHIS2-13676

This

https://dhis2.atlassian.net/browse/DHIS2-19364

will align `/tracker/trackedEntities?filter` and ensure we return the same error message in this case.