### PR TITLE
fix: duplicate entries in the authorities endpoint (#20324)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
@@ -29,9 +29,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -84,5 +87,22 @@ class AuthoritiesControllerTest extends H2ControllerIntegrationTestBase {
 
     // System authorities fom Authorities enum
     assertTrue(listIds.contains("ALL"));
+  }
+
+  @Test
+  void testNoDuplicateAuthorities() {
+    JsonArray systemAuthorities = GET("/authorities").content().getArray("systemAuthorities");
+    List<String> listIds =
+        systemAuthorities.asList(JsonObject.class).stream()
+            .map(o -> o.getString("id").string())
+            .toList();
+    Set<String> uniqueIds = new HashSet<>(listIds);
+    assertEquals(
+        uniqueIds.size(),
+        listIds.size(),
+        "Found duplicate authorities in response: List size="
+            + listIds.size()
+            + ", Unique size="
+            + uniqueIds.size());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.appmanager.AndroidSettingsApp;
 import org.hisp.dhis.appmanager.App;
@@ -79,7 +80,7 @@ public class AuthoritiesController {
   public Map<String, List<Map<String, String>>> getAuthorities(HttpServletResponse response) {
     I18n i18n = i18nManager.getI18n();
 
-    List<String> authorities = new ArrayList<>();
+    TreeSet<String> authorities = new TreeSet<>();
 
     Collection<String> systemAuthorities = authoritiesProvider.getSystemAuthorities();
     authorities.addAll(systemAuthorities);


### PR DESCRIPTION
* fix: duplicate authorities in the authority endpoint

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: dbd85b6ea75da652adc0b6020531e97af3676977