### PR TITLE
fix: correctly return apps in the order set in menu management [DHIS2-19124]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -79,6 +79,8 @@ import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.AppHtmlTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -96,7 +98,7 @@ public class DefaultAppManager implements AppManager {
   public static final String INVALID_FILTER_MSG = "Invalid filter: ";
 
   private static final Set<String> EXCLUSION_APPS = Set.of("Line Listing");
-
+  
   private final DhisConfigurationProvider dhisConfigurationProvider;
   private final AppHubService appHubService;
   private final AppStorageService localAppStorageService;
@@ -106,6 +108,7 @@ public class DefaultAppManager implements AppManager {
 
   private final I18nManager i18nManager;
 
+  @Autowired private UserService userService;
   @Autowired private ObjectMapper jsonMapper;
 
   /**
@@ -242,7 +245,27 @@ public class DefaultAppManager implements AppManager {
 
   @Override
   public List<WebModule> getMenu(String contextPath) {
-    return getAccessibleAppMenu(contextPath);
+    List<WebModule> modules = getAccessibleAppMenu(contextPath);
+
+    // Apply user-defined favorite apps order
+    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+
+    if (currentUser != null && currentUser.getApps() != null && !currentUser.getApps().isEmpty()) {
+      final List<String> userApps = new ArrayList<>(currentUser.getApps());
+
+      modules.sort(
+          (m1, m2) -> {
+            int i1 = userApps.indexOf(m1.getName());
+            int i2 = userApps.indexOf(m2.getName());
+
+            i1 = i1 == -1 ? 9999 : i1;
+            i2 = i2 == -1 ? 9999 : i2;
+
+            return Integer.compare(i1, i2);
+          });
+    }
+
+    return modules;
   }
 
   private List<WebModule> getAccessibleAppMenu(String contextPath) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -98,7 +98,7 @@ public class DefaultAppManager implements AppManager {
   public static final String INVALID_FILTER_MSG = "Invalid filter: ";
 
   private static final Set<String> EXCLUSION_APPS = Set.of("Line Listing");
-  
+
   private final DhisConfigurationProvider dhisConfigurationProvider;
   private final AppHubService appHubService;
   private final AppStorageService localAppStorageService;


### PR DESCRIPTION
Prior to Struts removal the `getModules.action` endpoint returned apps in the order set in the Menu Management app (see https://github.com/dhis2/dhis2-core/blob/2.41/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/webportal/menu/action/GetModulesAction.java#L61-L74)

This ordering wasn't supported in the `/api/apps/menu` endpoint, which is now serving the `getModules.action` path.

Ordering is preserved in the User object in the database, however if someone tries to re-order their favorite apps without this fix in place, then new order will be preserved (just not shown in the menu until this fix in merged)

Candidate for 2.42.0 but not yet approved by RCB