### PR TITLE
fix: migrate old ehcache 2 config to 3

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -745,7 +745,9 @@ public enum ConfigurationKey {
       "oauth2.server.jwt.keystore.generate-if-missing", "true", false),
 
   /** Ehcache monitoring. (default: off) */
-  MONITORING_EHCACHE_ENABLED("monitoring.ehcache.enabled", Constants.OFF, false);
+  MONITORING_EHCACHE_ENABLED("monitoring.ehcache.enabled", Constants.OFF, false),
+
+  CACHE_EHCACHE_CONFIG_FILE("cache.ehcache.config.file", "classpath:ehcache.xml", false);
 
   private final String key;
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -176,9 +176,6 @@ public class HibernateConfig {
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
-    properties.put(AvailableSettings.JMX_ENABLED, "true");
-    properties.put(AvailableSettings.GENERATE_STATISTICS, "true");
-
     // TODO: this is anti-pattern and should be turn off
     properties.put("hibernate.allow_update_outside_transaction", "true");
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -170,9 +170,14 @@ public class HibernateConfig {
       properties.put(
           ConfigSettings.MISSING_CACHE_STRATEGY,
           MissingCacheStrategy.CREATE.getExternalRepresentation());
+      // Specify the location of the Ehcache 3 configuration file
+      properties.put(ConfigSettings.CONFIG_URI, "classpath:ehcache.xml");
     }
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
+
+    properties.put(AvailableSettings.JMX_ENABLED, "true");
+    properties.put(AvailableSettings.GENERATE_STATISTICS, "true");
 
     // TODO: this is anti-pattern and should be turn off
     properties.put("hibernate.allow_update_outside_transaction", "true");

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.config;
 
+import static org.hisp.dhis.external.conf.ConfigurationKey.CACHE_EHCACHE_CONFIG_FILE;
 import static org.hisp.dhis.external.conf.ConfigurationKey.USE_QUERY_CACHE;
 import static org.hisp.dhis.external.conf.ConfigurationKey.USE_SECOND_LEVEL_CACHE;
 
@@ -166,15 +167,16 @@ public class HibernateConfig {
     if ("true".equals(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE))) {
       properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
       properties.put(AvailableSettings.CACHE_REGION_FACTORY, JCacheRegionFactory.class.getName());
-
+      properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
       properties.put(
           ConfigSettings.MISSING_CACHE_STRATEGY,
           MissingCacheStrategy.CREATE.getExternalRepresentation());
       // Specify the location of the Ehcache 3 configuration file
-      properties.put(ConfigSettings.CONFIG_URI, "classpath:ehcache.xml");
+      String configFile = dhisConfig.getProperty(CACHE_EHCACHE_CONFIG_FILE);
+      if (!configFile.isBlank()) {
+        properties.put(ConfigSettings.CONFIG_URI, configFile);
+      }
     }
-
-    properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -166,13 +166,15 @@ public class HibernateConfig {
     if ("true".equals(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE))) {
       properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
       properties.put(AvailableSettings.CACHE_REGION_FACTORY, JCacheRegionFactory.class.getName());
-      properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
+
       properties.put(
           ConfigSettings.MISSING_CACHE_STRATEGY,
           MissingCacheStrategy.CREATE.getExternalRepresentation());
       // Specify the location of the Ehcache 3 configuration file
       properties.put(ConfigSettings.CONFIG_URI, "classpath:ehcache.xml");
     }
+
+    properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -18,11 +18,11 @@
     <expiry>
       <!-- Time-to-live: 6 hours (Chosen as primary expiry from old config) -->
       <!-- TTI (Time-to-idle) was also 6 hours, but only one can be specified directly here. -->
-      <ttl unit="seconds">9999</ttl>
+      <ttl unit="seconds">21600</ttl>
     </expiry>
     <resources>
       <!-- Max 1,000,000 entries on heap -->
-      <heap unit="entries">777777</heap>
+      <heap unit="entries">1000000</heap>
     </resources>
   </cache-template>
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -1,31 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ehcache>
+<!-- Add jsr107 namespace -->
+<config xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns='http://www.ehcache.org/v3'
+  xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+  xsi:schemaLocation="
+            http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.10.xsd
+            http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.10.xsd">
 
-<!-- Default cache -->
-  <!-- 
-    Ensure that default cache has less frequent expiration than query cache
-    to avoid individual select queries per entity.
+  <!-- Service definition to specify the default template for JSR-107 created caches -->
+  <service>
+    <jsr107:defaults default-template="defaultCacheTemplate"/>
+  </service>
+
+  <!-- Cache template definition (referenced by jsr107:defaults and potentially explicit caches) -->
+  <!-- Based on old defaultCache settings -->
+  <cache-template name="defaultCacheTemplate">
+    <expiry>
+      <!-- Time-to-live: 6 hours (Chosen as primary expiry from old config) -->
+      <!-- TTI (Time-to-idle) was also 6 hours, but only one can be specified directly here. -->
+      <ttl unit="seconds">9999</ttl>
+    </expiry>
+    <resources>
+      <!-- Max 1,000,000 entries on heap -->
+      <heap unit="entries">777777</heap>
+    </resources>
+  </cache-template>
+
+  <!-- Hibernate Default Query Cache (mapped from old 'default-query-results-region') -->
+  <!-- Uses settings from defaultCacheTemplate -->
+<!--  <cache alias="default-query-cache" uses-template="defaultCacheTemplate">-->
+<!--    &lt;!&ndash; No overrides needed as it matches the old defaultCache settings &ndash;&gt;-->
+<!--  </cache>-->
+
+  <!-- Hibernate Default Entity Cache for Update Timestamps -->
+  <cache alias="default-update-timestamps-region">
+    <expiry>
+      <none/> <!-- Timestamps should not expire -->
+    </expiry>
+    <resources>
+      <!-- Max 5,000 entries on heap (from old config) -->
+      <heap unit="entries">5000</heap>
+    </resources>
+  </cache>
+
+  <!--
+    NOTE: The old configuration did not define specific caches for entities.
+    Entities will use the 'defaultCacheTemplate' settings unless you define
+    specific <cache> elements for them below using their fully qualified class name as the alias.
+    Example:
+    <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit" uses-template="defaultCacheTemplate">
+      <resources>
+        <heap unit="entries">50000</heap> <!- More specific size ->
+      </resources>
+    </cache>
   -->
 
-  <defaultCache
-    maxElementsInMemory="1000000" 
-    eternal="false" 
-    timeToIdleSeconds="21600" 
-    timeToLiveSeconds="21600"
-    overflowToDisk="false"
-    diskPersistent="false" />
-
-  <!-- Hibernate query cache -->
-
-  <cache name="default-query-results-region"
-    maxElementsInMemory="1000000" 
-    eternal="false" 
-    timeToIdleSeconds="21600" 
-    timeToLiveSeconds="21600"
-    overflowToDisk="false" 
-    diskPersistent="false" />
-
-  <cache name="default-update-timestamps-region" 
-    maxElementsInMemory="5000" />
-
-</ehcache>
+</config>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -26,11 +26,10 @@
     </resources>
   </cache-template>
 
-  <!-- Hibernate Default Query Cache (mapped from old 'default-query-results-region') -->
-  <!-- Uses settings from defaultCacheTemplate -->
-<!--  <cache alias="default-query-cache" uses-template="defaultCacheTemplate">-->
-<!--    &lt;!&ndash; No overrides needed as it matches the old defaultCache settings &ndash;&gt;-->
-<!--  </cache>-->
+  <!--   Hibernate Default Query Cache -->
+  <cache alias="default-query-results-region" uses-template="defaultCacheTemplate">
+    <!-- No overrides needed as it matches the old defaultCache settings -->
+  </cache>
 
   <!-- Hibernate Default Entity Cache for Update Timestamps -->
   <cache alias="default-update-timestamps-region">

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
@@ -7,7 +7,7 @@
 #   1) The classpath (src/main/resources)
 #   2) $DHIS2_HOME
 
-hibernate.jmx.enabled=true
+
 # Flush mode
 #org.hibernate.flushMode=ALWAYS
 
@@ -27,7 +27,6 @@ hibernate.cache.ehcache.missing_cache_strategy=create # Verify if relevant with 
 # hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory # Deprecated: Overridden by HibernateConfig.java
 hibernate.cache.use_second_level_cache=true # Ensure this matches DhisConfigurationProvider setting used in HibernateConfig.java
 hibernate.cache.use_query_cache=true # Ensure this matches DhisConfigurationProvider setting used in HibernateConfig.java
-#hibernate.cache.region.factory_class = com.hazelcast.hibernate.HazelcastLocalCacheRegionFactory
 
 # Statistics
 #hibernate.generate_statistics = true

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
@@ -7,7 +7,7 @@
 #   1) The classpath (src/main/resources)
 #   2) $DHIS2_HOME
 
-
+hibernate.jmx.enabled=true
 # Flush mode
 #org.hibernate.flushMode=ALWAYS
 
@@ -22,10 +22,11 @@ hibernate.bytecode.provider=bytebuddy
 #hibernate.bytecode.enforce_legacy_proxy_classnames=true
 
 # Caching
-hibernate.cache.ehcache.missing_cache_strategy=create
-hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
-hibernate.cache.use_second_level_cache=true
-hibernate.cache.use_query_cache=true
+# Note: L2 Cache settings are primarily configured programmatically in HibernateConfig.java
+hibernate.cache.ehcache.missing_cache_strategy=create # Verify if relevant with JSR-107/Ehcache3
+# hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory # Deprecated: Overridden by HibernateConfig.java
+hibernate.cache.use_second_level_cache=true # Ensure this matches DhisConfigurationProvider setting used in HibernateConfig.java
+hibernate.cache.use_query_cache=true # Ensure this matches DhisConfigurationProvider setting used in HibernateConfig.java
 #hibernate.cache.region.factory_class = com.hazelcast.hibernate.HazelcastLocalCacheRegionFactory
 
 # Statistics

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresDhisConfigurationProvider.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.test.config;
 
 import java.util.Map;
 import java.util.Properties;
+import javax.annotation.CheckForNull;
 import org.springframework.core.io.ClassPathResource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -108,10 +109,13 @@ public class PostgresDhisConfigurationProvider extends TestDhisConfigurationProv
     return resource.exists();
   }
 
-  public PostgresDhisConfigurationProvider() {
+  public PostgresDhisConfigurationProvider(@CheckForNull Properties overrides) {
     Properties dhisConfig = new Properties();
     dhisConfig.putAll(getPropertiesFromFile(DEFAULT_CONFIGURATION_FILE_NAME));
     dhisConfig.putAll(getConnectionProperties());
+
+    if (overrides != null) dhisConfig.putAll(overrides);
+
     this.properties = dhisConfig;
   }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresTestConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresTestConfig.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.test.config;
 
+import javax.annotation.Nullable;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,8 +41,10 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class PostgresTestConfig {
+
   @Bean
-  public DhisConfigurationProvider dhisConfigurationProvider(PostgresTestConfigOverride overrides) {
+  public DhisConfigurationProvider dhisConfigurationProvider(
+      @Nullable PostgresTestConfigOverride overrides) {
     return new PostgresDhisConfigurationProvider(overrides);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresTestConfigOverride.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/PostgresTestConfigOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,19 +29,6 @@
  */
 package org.hisp.dhis.test.config;
 
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import java.util.Properties;
 
-/**
- * Use this Spring configuration for tests relying on the Postgres DB running in a Docker container.
- *
- * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
- */
-@Configuration
-public class PostgresTestConfig {
-  @Bean
-  public DhisConfigurationProvider dhisConfigurationProvider(PostgresTestConfigOverride overrides) {
-    return new PostgresDhisConfigurationProvider(overrides);
-  }
-}
+public class PostgresTestConfigOverride extends Properties {}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/junit/MinIOTestExtension.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/junit/MinIOTestExtension.java
@@ -78,7 +78,7 @@ public class MinIOTestExtension implements AfterAllCallback {
       properties.put("filestore.identity", MINIO_USER);
       properties.put("filestore.secret", MINIO_PASSWORD);
 
-      PostgresDhisConfigurationProvider pgDhisConfig = new PostgresDhisConfigurationProvider();
+      PostgresDhisConfigurationProvider pgDhisConfig = new PostgresDhisConfigurationProvider(null);
       pgDhisConfig.addProperties(properties);
       return pgDhisConfig;
     }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -3,7 +3,7 @@ filestore.container = files
 connection.pool.max_size=50
 encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 
-hibernate.cache.use_query_cache=false
+hibernate.cache.use_query_cache=true
 hibernate.cache.use_second_level_cache=false
 
 enable.api_token.authentication = on

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
@@ -95,7 +95,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
       override.put("audit.tracker", "CREATE");
       override.put("audit.aggregate", "CREATE");
       PostgresDhisConfigurationProvider postgresDhisConfigurationProvider =
-          new PostgresDhisConfigurationProvider();
+          new PostgresDhisConfigurationProvider(null);
       postgresDhisConfigurationProvider.addProperties(override);
       return postgresDhisConfigurationProvider;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -63,6 +63,8 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
     public PostgresTestConfigOverride postgresTestConfigOverride() {
       PostgresTestConfigOverride override = new PostgresTestConfigOverride();
       override.put(AvailableSettings.USE_QUERY_CACHE, "true");
+      override.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
+      override.put("cache.ehcache.config.file", "");
       return override;
     }
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -35,17 +35,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.TypedQuery;
-import java.util.Properties;
 import org.hibernate.FlushMode;
 import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.QueryHints;
+import org.hibernate.stat.Statistics;
 import org.hisp.dhis.cache.HibernateQueryCacheTest.DhisConfig;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.scheduling.HousekeepingJob;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.test.config.PostgresDhisConfigurationProvider;
+import org.hisp.dhis.test.config.PostgresTestConfigOverride;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,14 +60,10 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
 
   static class DhisConfig {
     @Bean
-    public DhisConfigurationProvider dhisConfigurationProvider() {
-      Properties override = new Properties();
-      override.put("hibernate.cache.use_query_cache", "true");
-      override.put("hibernate.cache.use_second_level_cache", "true");
-      PostgresDhisConfigurationProvider postgresDhisConfigurationProvider =
-          new PostgresDhisConfigurationProvider();
-      postgresDhisConfigurationProvider.addProperties(override);
-      return postgresDhisConfigurationProvider;
+    public PostgresTestConfigOverride postgresTestConfigOverride() {
+      PostgresTestConfigOverride override = new PostgresTestConfigOverride();
+      override.put(AvailableSettings.USE_QUERY_CACHE, "true");
+      return override;
     }
   }
 
@@ -79,9 +75,7 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
   @BeforeEach
   void setUp() {
     this.sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-
     this.entityManager.setProperty(org.hibernate.annotations.QueryHints.FLUSH_MODE, FlushMode.AUTO);
-
     sessionFactory.getStatistics().setStatisticsEnabled(true);
     sessionFactory.getStatistics().clear();
   }
@@ -89,6 +83,18 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
   @AfterEach
   public final void afterEach() {
     entityManager.close();
+  }
+
+  private void setUpData() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setAutoFields();
+    optionSet.setName("OptionSetA");
+    optionSet.setCode("OptionSetCodeA");
+    optionSet.setValueType(ValueType.TEXT);
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(optionSet);
+    entityManager.getTransaction().commit();
   }
 
   @Test
@@ -103,8 +109,9 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
       entityManager.getTransaction().commit();
     }
 
-    assertEquals(1, sessionFactory.getStatistics().getQueryCacheMissCount());
-    assertEquals(9, sessionFactory.getStatistics().getQueryCacheHitCount());
+    Statistics statistics = sessionFactory.getStatistics();
+    assertEquals(1, statistics.getQueryCacheMissCount());
+    assertEquals(9, statistics.getQueryCacheHitCount());
   }
 
   @Test
@@ -122,18 +129,6 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
             .getCacheRegionStatistics(OptionSet.class.getName())
             .getHitCount());
     assertTrue(sessionFactory.getStatistics().getQueryCacheHitCount() > 10);
-  }
-
-  private void setUpData() {
-    OptionSet optionSet = new OptionSet();
-    optionSet.setAutoFields();
-    optionSet.setName("OptionSetA");
-    optionSet.setCode("OptionSetCodeA");
-    optionSet.setValueType(ValueType.TEXT);
-
-    entityManager.getTransaction().begin();
-    entityManager.persist(optionSet);
-    entityManager.getTransaction().commit();
   }
 
   private void createSelectQuery(int numberOfQueries) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
@@ -108,7 +108,7 @@ class RouteControllerTest extends PostgresControllerIntegrationTestBase {
           "http://localhost:*,https://stub");
 
       PostgresDhisConfigurationProvider postgresDhisConfigurationProvider =
-          new PostgresDhisConfigurationProvider();
+          new PostgresDhisConfigurationProvider(null);
       postgresDhisConfigurationProvider.addProperties(override);
       return postgresDhisConfigurationProvider;
     }


### PR DESCRIPTION
## Description

This PR addresses an issue where the Hibernate L2 cache was not being configured correctly after the upgrade to Ehcache 3. Although the necessary dependencies (`ehcache`, `hibernate-jcache`) were present, the cache was operating with Ehcache's internal default settings instead of the intended project-specific configuration.

**Problem:**

*   The `hibernate-default.properties` file contained outdated settings pointing to the Ehcache 2 region factory (`org.hibernate.cache.ehcache.EhCacheRegionFactory`).
*   The actual Hibernate configuration was being applied programmatically in `HibernateConfig.java`, correctly setting the JSR-107 factory (`org.hibernate.cache.jcache.JCacheRegionFactory`).
*   However, the programmatic configuration was missing the crucial `hibernate.javax.cache.uri` property, preventing the JSR-107 provider from loading the intended `ehcache.xml` configuration file.
*   As a result, Ehcache 3 fell back to its default settings for all L2 cache regions (entities, collections, queries), ignoring any project-specific tuning defined previously (in the old Ehcache 2 format) or intended for Ehcache 3.

**Investigation:**

*   Confirmed dependencies were correctly set for Ehcache 3 / JSR-107.
*   Identified the outdated configuration in `hibernate-default.properties`.
*   Confirmed via debugging that the `JCacheRegionFactory` was active but using Ehcache defaults (`urn:X-ehcache:jsr107-default-config`).
*   Verified via JMX and debugging that L2 cache regions were being created but not necessarily configured as intended initially.

**Solution:**

1.  **Updated `HibernateConfig.java`:** Added the `hibernate.javax.cache.uri` property (using `ConfigSettings.CONFIG_URI`) within the `getAdditionalProperties` method, pointing it to `classpath:ehcache.xml`.
2.  **Created a new `ehcache.xml`:** Replaced configuration file at `dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml`.
3.  **Translated Configuration:** Populated `ehcache.xml` with settings translated from the previous Ehcache 2 configuration, using the correct Ehcache 3 XML schema and the JSR-107 `<service>/<jsr107:defaults>` structure to apply default settings to Hibernate-managed caches.
4.  **Cleaned up `hibernate-default.properties`:** Commented out the outdated and misleading Ehcache 2 factory setting.

**Outcome:**

Hibernate now correctly initializes the Ehcache 3 L2 cache, loading its configuration from `ehcache.xml`. Cache regions for entities and collections inherit settings from the defined `defaultCacheTemplate` as intended, restoring the previously configured cache behavior (e.g., TTL, heap sizes).

**Verification:**

*   Debugging the `JCacheRegionFactory` confirmed that the runtime configuration for cache regions now matches the settings defined in `ehcache.xml`.

This ensures the L2 cache operates efficiently and according to the project's specific requirements.

## See attached screenshots for proof of config state pre- and post-change (the new values in the second screenshot don't reflect the real values, they are just used for easier debugging, the real values are 6H expiry and 1 million entries):
![Screenshot 2025-04-02 at 18 40 29](https://github.com/user-attachments/assets/c5366e1e-6fb0-4af7-ba68-b0ebd008a574)
![Screenshot 2025-04-02 at 18 42 54](https://github.com/user-attachments/assets/c66d96ff-9129-40fd-8660-bb334440c885)

## Bonus feature:
* Added a new config key: `cache.ehcache.config.file` for setting the ehcache.xml file location.