### PR TITLE
fix: Assign null to data element representing option set [DHIS2-19396]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
@@ -59,7 +58,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 class RuleActionEventMapper {
   private final SystemSettingsProvider settingsProvider;
-  private final OptionService optionService;
 
   public Map<Event, List<RuleActionExecutor<Event>>> mapRuleEffects(
       Map<UID, List<ValidationEffect>> eventValidationEffects, TrackerBundle bundle) {
@@ -91,7 +89,6 @@ class RuleActionEventMapper {
       case ASSIGN ->
           new AssignDataValueExecutor(
               settingsProvider,
-              optionService,
               validationEffect.rule(),
               validationEffect.data(),
               validationEffect.field(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutorTest.java
@@ -31,11 +31,8 @@ package org.hisp.dhis.tracker.imports.programrule.executor.event;
 
 import static org.hisp.dhis.tracker.imports.programrule.IssueType.ERROR;
 import static org.hisp.dhis.tracker.imports.programrule.IssueType.WARNING;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -165,7 +162,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             INVALID_OPTION_VALUE,
             OPTION_SET_DATA_ELEMENT_UID,
@@ -181,65 +177,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   @Test
-  void shouldAssignDataValueWhenAssignedValueIsValidOptionAndDataValueIsEmpty() {
-    when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
-    when(optionService.existsAllOptions(any(), anyList())).thenReturn(true);
-
-    Event eventWithOptionDataValue = getEventWithOptionSetDataValueWithValidValue();
-    List<Event> events = List.of(eventWithOptionDataValue);
-    bundle.setEvents(events);
-
-    AssignDataValueExecutor executor =
-        new AssignDataValueExecutor(
-            settingsProvider,
-            optionService,
-            RULE_UID,
-            VALID_OPTION_VALUE,
-            OPTION_SET_DATA_ELEMENT_UID,
-            eventWithOptionDataValue.getDataValues());
-
-    Optional<ProgramRuleIssue> warning =
-        executor.executeRuleAction(bundle, eventWithOptionDataValue);
-
-    Optional<DataValue> dataValue =
-        findDataValueByUid(bundle, EVENT_UID, OPTION_SET_DATA_ELEMENT_UID);
-
-    assertTrue(dataValue.isPresent());
-    assertEquals(VALID_OPTION_VALUE, dataValue.get().getValue());
-    assertTrue(warning.isPresent());
-    assertEquals(WARNING, warning.get().getIssueType());
-  }
-
-  @Test
-  void shouldAssignDataValueWhenAssignedValueIsInvalidOptionAndDataValueIsEmpty() {
-    when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
-    Event eventWithOptionDataValue = getEventWithDataValueNOTSet();
-    List<Event> events = List.of(eventWithOptionDataValue);
-    bundle.setEvents(events);
-
-    AssignDataValueExecutor executor =
-        new AssignDataValueExecutor(
-            settingsProvider,
-            optionService,
-            RULE_UID,
-            INVALID_OPTION_VALUE,
-            OPTION_SET_DATA_ELEMENT_UID,
-            eventWithOptionDataValue.getDataValues());
-
-    Optional<ProgramRuleIssue> warning =
-        executor.executeRuleAction(bundle, eventWithOptionDataValue);
-
-    Optional<DataValue> dataValue =
-        findDataValueByUid(bundle, SECOND_EVENT_UID, OPTION_SET_DATA_ELEMENT_UID);
-
-    assertAll(
-        () -> assertTrue(dataValue.isEmpty()),
-        () -> assertTrue(warning.isPresent()),
-        () -> assertEquals(WARNING, warning.get().getIssueType()));
-  }
-
-  @Test
-  void shouldAssignNullDataValueWhenAssignedValueIsInvalidOptionAndOverwriteIsTrue() {
+  void shouldAssignDataValueWhenAssignedValueIsInvalidOptionAndOverwriteIsTrue() {
     when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
     when(settings.getRuleEngineAssignOverwrite()).thenReturn(true);
     Event eventWithOptionDataValue = getEventWithOptionSetDataValueWithValidValue();
@@ -249,7 +187,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             INVALID_OPTION_VALUE,
             OPTION_SET_DATA_ELEMENT_UID,
@@ -261,7 +198,7 @@ class AssignDataValueExecutorTest extends TestBase {
     Optional<DataValue> dataValue =
         findDataValueByUid(bundle, EVENT_UID, OPTION_SET_DATA_ELEMENT_UID);
 
-    assertDataValueWasAssignedAndWarningIsPresent(null, dataValue, warning);
+    assertDataValueWasAssignedAndWarningIsPresent(INVALID_OPTION_VALUE, dataValue, warning);
   }
 
   @Test
@@ -274,7 +211,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             DATAELEMENT_NEW_VALUE,
             DATA_ELEMENT_UID,
@@ -297,7 +233,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             DATAELEMENT_NEW_VALUE,
             DATA_ELEMENT_UID,
@@ -322,7 +257,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             DATAELEMENT_NEW_VALUE,
             DATA_ELEMENT_UID,
@@ -344,7 +278,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             DATAELEMENT_NEW_VALUE,
             DATA_ELEMENT_UID,
@@ -369,7 +302,6 @@ class AssignDataValueExecutorTest extends TestBase {
     AssignDataValueExecutor executor =
         new AssignDataValueExecutor(
             settingsProvider,
-            optionService,
             RULE_UID,
             DATAELEMENT_NEW_VALUE,
             DATA_ELEMENT_UID,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -35,12 +35,14 @@ import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertHasOnlyWarnings;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1125;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1307;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1308;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1310;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
@@ -75,7 +77,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,6 +106,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
 
   private DataElement dataElement2;
 
+  private DataElement optionDataElement;
+
   private TrackedEntityAttribute attribute1;
 
   @BeforeAll
@@ -114,6 +120,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     program = bundle.getPreheat().get(PreheatIdentifier.UID, Program.class, "BFcipDERJnf");
     dataElement1 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00001");
     dataElement2 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00002");
+    optionDataElement =
+        bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00005");
     attribute1 =
         bundle.getPreheat().get(PreheatIdentifier.UID, TrackedEntityAttribute.class, "dIVt4l5vIOa");
     TrackedEntityAttribute attribute2 =
@@ -282,6 +290,23 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assertHasOnlyWarnings(importReport, E1308);
   }
 
+  @ParameterizedTest
+  @MethodSource("getOptions")
+  void shouldImportWithWarningWhenDataElementOfTypeOptionWithValidValueIsAssignedByAssignRule(
+      String option, boolean hasValidValue) throws IOException {
+    assignOptionProgramRule(option);
+    TrackerObjects trackerObjects =
+        testSetup.fromJson("tracker/programrule/event_update_datavalue_different_value.json");
+
+    ImportReport importReport =
+        trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
+
+    assertHasOnlyWarnings(importReport, E1308);
+    if (!hasValidValue) {
+      assertHasOnlyErrors(importReport, E1125);
+    }
+  }
+
   @Test
   void
       shouldImportWithWarningWhenDataElementWithDifferentAndEmptyValueIsAssignedByAssignRuleAndOverwriteKeyIsTrue()
@@ -347,6 +372,16 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     programRuleService.updateProgramRule(programRule);
   }
 
+  private void assignOptionProgramRule(String option) {
+    ProgramRule programRule = createProgramRule('O', program, null, "true");
+    programRuleService.addProgramRule(programRule);
+    ProgramRuleAction programRuleAction =
+        createProgramRuleAction(programRule, ASSIGN, optionDataElement, option);
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
+  }
+
   private void assignToCalculatedValueProgramRule() {
     ProgramRule programRule = createProgramRule('I', program, null, "true");
     programRuleService.addProgramRule(programRule);
@@ -407,5 +442,12 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     programRuleAction.setData(data);
 
     return programRuleAction;
+  }
+
+  public Stream<Arguments> getOptions() {
+    return Stream.of(
+        Arguments.of("\"option1\"", true),
+        Arguments.of(null, true),
+        Arguments.of("\"invalidOption\"", false));
   }
 }


### PR DESCRIPTION
This PR is fixing a NPE that was introduced in this PR https://github.com/dhis2/dhis2-core/pull/20396. When trying to assign a `null` value to an option set using a program rule, a 500 is returned by the importer.

While at it, I noticed that we needed to check if the option was valid in the action executor only because `rule-engine` library was not able to assign `null`. 
Last version of `rule-engine` allows to assign `null`, so we do not need any special treatment for option sets, we can assign any value, and if it is invalid it will be caught by the validators.

To resume:
- Fixing NPE when assigning `null` to an option set.
- Do not transform an invalid option to `null` as implemented [here](https://dhis2.atlassian.net/browse/DHIS2-14190)