### PR TITLE
fix: metadata icons now showing due to broken redirect

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -273,6 +273,12 @@ public class LoginTest extends BaseE2ETest {
   }
 
   @Test
+  void testRedirectIcon() {
+    testRedirectAsUser(
+        "/api/icons/medicines_positive/icon.svg", "api/icons/medicines_positive/icon");
+  }
+
+  @Test
   void testJsonResponseForFailedLogin() {
     try {
       getWithWrongAuth("/me", Map.of());
@@ -480,6 +486,35 @@ public class LoginTest extends BaseE2ETest {
     ResponseEntity<String> redirResp =
         restTemplateNoRedirects.exchange(
             serverHostUrl + "dhis-web-dashboard", HttpMethod.GET, entity, String.class);
+    List<String> location = redirResp.getHeaders().get("Location");
+    assertNotNull(location);
+    assertEquals(1, location.size());
+    String actual = location.get(0);
+    assertEquals(redirectUrl, actual.replaceAll(serverHostUrl, ""));
+  }
+
+  public static void testRedirectAsUser(String url, String redirectUrl) {
+    // Disable auto-redirects
+    RestTemplate restTemplateNoRedirects = getRestTemplateNoRedirects();
+
+    // Do a valid login
+    HttpHeaders cookieHeaders = jsonHeaders();
+    ResponseEntity<LoginResponse> secondResponse =
+        restTemplateNoRedirects.postForEntity(
+            serverApiUrl + LOGIN_API_PATH,
+            new HttpEntity<>(
+                LoginRequest.builder().username("admin").password("district").build(),
+                cookieHeaders),
+            LoginResponse.class);
+    String cookie = extractSessionCookie(secondResponse);
+
+    // Test the redirect
+    HttpHeaders headers = jsonHeaders();
+    headers.set("Cookie", cookie);
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+    ResponseEntity<String> redirResp =
+        restTemplateNoRedirects.exchange(serverHostUrl + url, HttpMethod.GET, entity, String.class);
+
     List<String> location = redirResp.getHeaders().get("Location");
     assertNotNull(location);
     assertEquals(1, location.size());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
@@ -149,7 +149,7 @@ public class IconController {
       throws IOException, NotFoundException {
     if (!iconService.iconExists(key)) throw new NotFoundException(Icon.class, key);
 
-    String location = response.encodeRedirectURL("/icons/" + key + "/icon");
+    String location = response.encodeRedirectURL("/api/icons/" + key + "/icon");
     response.sendRedirect(ContextUtils.getRootPath(request) + location);
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -376,9 +376,6 @@ public class DhisWebApiWebSecurityConfig {
                       new AntPathRequestMatcher(apiContextPath + "/**/externalFileResources/**"))
                   .permitAll()
                   .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/icons/*/icon.svg"))
-                  .permitAll()
-                  .requestMatchers(
                       new AntPathRequestMatcher(apiContextPath + "/**/files/style/external"))
                   .permitAll()
                   .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/publicKeys/**"))


### PR DESCRIPTION
## Problem
* Metadata icons is not showing, but giving a 404. 
* URLs looking like this: `http://localhost:8080/api/icons/medicines_positive/icon.svg` will be redirected to `http://localhost:8080/icons/medicines_positive/icon.svg`
## Cause
The `getIconData()` in the `IconController.java` was missing the `api` part in the redirect.
This was a regression from the big refactoring of all endpoints base path. 
## Fix
Add the `api` part to the URL

## Test
* E2E test in LoginTest.testRedirectIcon()
