### PR TITLE
fix: transactional scopes/slower response [DHIS2-19359]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/OutliersCache.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/OutliersCache.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Slf4j
 @Component
+@Transactional(readOnly = true)
 public class OutliersCache {
   private final AnalyticsCacheSettings analyticsCacheSettings;
 
@@ -78,7 +79,6 @@ public class OutliersCache {
    * @return the cached or fetched list of {@link Outlier}.
    * @throws NullPointerException if any argument is null.
    */
-  @Transactional(readOnly = true)
   public List<Outlier> getOrFetch(
       OutlierRequest params, Function<OutlierRequest, List<Outlier>> function) {
     Optional<List<Outlier>> cachedOutliers = get(params.getQueryKey());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/OutliersCache.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/OutliersCache.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * This is a wrapper class responsible for keeping and isolating all cache definitions related to
@@ -77,6 +78,7 @@ public class OutliersCache {
    * @return the cached or fetched list of {@link Outlier}.
    * @throws NullPointerException if any argument is null.
    */
+  @Transactional(readOnly = true)
   public List<Outlier> getOrFetch(
       OutlierRequest params, Function<OutlierRequest, List<Outlier>> function) {
     Optional<List<Outlier>> cachedOutliers = get(params.getQueryKey());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @AllArgsConstructor
+@Transactional(readOnly = true)
 public class TableInfoReader {
 
   @Qualifier("analyticsJdbcTemplate")
@@ -61,7 +62,6 @@ public class TableInfoReader {
    * @return the populated {@link TableInfo} object.
    * @throws IllegalArgumentException if the argument 'tableName' is null or blank.
    */
-  @Transactional(readOnly = true)
   public TableInfo getInfo(@Nonnull String tableName) {
     hasText(tableName, "Param 'tableName' cannot be null/blank");
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
@@ -39,6 +39,7 @@ import lombok.Data;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Component responsible for querying meta information related to DB tables, as well as providing
@@ -60,6 +61,7 @@ public class TableInfoReader {
    * @return the populated {@link TableInfo} object.
    * @throws IllegalArgumentException if the argument 'tableName' is null or blank.
    */
+  @Transactional(readOnly = true)
   public TableInfo getInfo(@Nonnull String tableName) {
     hasText(tableName, "Param 'tableName' cannot be null/blank");
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
@@ -110,6 +110,7 @@ import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Component that focus on the production of dimensional objects of different types.
@@ -190,6 +191,7 @@ public class DimensionalObjectProvider {
    * @param relativePeriodDate date that relative periods will be generated based on.
    * @return a period based instance of {@link BaseDimensionalObject}.
    */
+  @Transactional(readOnly = true)
   public BaseDimensionalObject getPeriodDimension(List<String> items, Date relativePeriodDate) {
     List<Period> periods = new ArrayList<>();
     DimensionItemKeywords dimensionalKeywords = new DimensionItemKeywords();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
@@ -119,6 +119,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DimensionalObjectProvider {
   private final IdentifiableObjectManager idObjectManager;
 
@@ -191,7 +192,6 @@ public class DimensionalObjectProvider {
    * @param relativePeriodDate date that relative periods will be generated based on.
    * @return a period based instance of {@link BaseDimensionalObject}.
    */
-  @Transactional(readOnly = true)
   public BaseDimensionalObject getPeriodDimension(List<String> items, Date relativePeriodDate) {
     List<Period> periods = new ArrayList<>();
     DimensionItemKeywords dimensionalKeywords = new DimensionItemKeywords();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -61,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 /** Parse and transform the incoming query params into the OutlierDetectionRequest. */
 @Component
 @AllArgsConstructor
+@Transactional(readOnly = true)
 public class OutlierQueryParser {
   private final IdentifiableObjectManager idObjectManager;
   private final DimensionalObjectProvider dimensionalObjectProducer;
@@ -72,7 +73,6 @@ public class OutlierQueryParser {
    * @param queryParams the {@link OutlierQueryParams}.
    * @return a {@link OutlierRequest}.
    */
-  @Transactional(readOnly = true)
   public OutlierRequest getFromQuery(OutlierQueryParams queryParams, boolean analyzeOnly) {
     List<DataDimension> dimensions = getDataDimensions(queryParams);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Parse and transform the incoming query params into the OutlierDetectionRequest. */
 @Component
@@ -71,6 +72,7 @@ public class OutlierQueryParser {
    * @param queryParams the {@link OutlierQueryParams}.
    * @return a {@link OutlierRequest}.
    */
+  @Transactional(readOnly = true)
   public OutlierRequest getFromQuery(OutlierQueryParams queryParams, boolean analyzeOnly) {
     List<DataDimension> dimensions = getDataDimensions(queryParams);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
@@ -57,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @AllArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class OutlierRequestValidator {
 
   public static final int DEFAULT_LIMIT = 500;
@@ -69,7 +70,6 @@ public class OutlierRequestValidator {
    * @param request the {@link OutlierRequest}.
    * @throws IllegalQueryException if request is invalid.
    */
-  @Transactional(readOnly = true)
   public void validate(OutlierRequest request, boolean isAnalytics) throws IllegalQueryException {
     ErrorMessage errorMessage = validateForErrorMessage(request, isAnalytics);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /** OutlierDetectionRequest validator. */
 @Component
@@ -68,6 +69,7 @@ public class OutlierRequestValidator {
    * @param request the {@link OutlierRequest}.
    * @throws IllegalQueryException if request is invalid.
    */
+  @Transactional(readOnly = true)
   public void validate(OutlierRequest request, boolean isAnalytics) throws IllegalQueryException {
     ErrorMessage errorMessage = validateForErrorMessage(request, isAnalytics);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -89,6 +89,7 @@ import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @AllArgsConstructor
 @Service
@@ -114,6 +115,7 @@ public class AnalyticsOutlierService {
    * @param request the {@link OutlierRequest}.
    * @return the {@link Grid}.
    */
+  @Transactional(readOnly = true)
   public Grid getOutliers(OutlierRequest request) throws IllegalQueryException {
     List<Outlier> outliers =
         outliersCache.getOrFetch(request, p -> zScoreOutlierDetector.getOutliers(request));
@@ -201,6 +203,7 @@ public class AnalyticsOutlierService {
    * table. The 'sourceid' column serves as a reliable indicator for successful outliers export. Its
    * absence implies that the outliers were not exported.
    */
+  @Transactional(readOnly = true)
   public void checkAnalyticsTableForOutliers() {
     if (tableInfoReader.getInfo("analytics").getColumns().stream()
         .noneMatch("sourceid"::equalsIgnoreCase)) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -93,6 +93,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @AllArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class AnalyticsOutlierService {
 
   private final AnalyticsZScoreOutlierDetector zScoreOutlierDetector;
@@ -115,7 +116,6 @@ public class AnalyticsOutlierService {
    * @param request the {@link OutlierRequest}.
    * @return the {@link Grid}.
    */
-  @Transactional(readOnly = true)
   public Grid getOutliers(OutlierRequest request) throws IllegalQueryException {
     List<Outlier> outliers =
         outliersCache.getOrFetch(request, p -> zScoreOutlierDetector.getOutliers(request));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
@@ -65,6 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Repository
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AnalyticsZScoreOutlierDetector {
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -79,7 +80,6 @@ public class AnalyticsZScoreOutlierDetector {
    * @param request the {@link OutlierRequest}.
    * @return list of the {@link Outlier} instances for api response.
    */
-  @Transactional(readOnly = true)
   public List<Outlier> getOutliers(OutlierRequest request) {
     String sql = sqlStatementProcessor.getSqlStatement(request);
     SqlParameterSource params = sqlStatementProcessor.getSqlParameterSource(request);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
@@ -52,6 +52,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Manager for database queries related to outlier data detection based on z-score and modified
@@ -78,6 +79,7 @@ public class AnalyticsZScoreOutlierDetector {
    * @param request the {@link OutlierRequest}.
    * @return list of the {@link Outlier} instances for api response.
    */
+  @Transactional(readOnly = true)
   public List<Outlier> getOutliers(OutlierRequest request) {
     String sql = sqlStatementProcessor.getSqlStatement(request);
     SqlParameterSource params = sqlStatementProcessor.getSqlParameterSource(request);


### PR DESCRIPTION
Adding read-only transactional annotations, so we can avoid the overhead of unnecessary commits, causing slower response times for the outliers API.
