### PR TITLE
fix: Save event data value after logging change [DHIS2-19092][2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueChangeLogStore.java
@@ -64,7 +64,7 @@ public class HibernateTrackedEntityDataValueChangeLogStore
   // Dependencies
   // -------------------------------------------------------------------------
 
-  private EntityManager entityManager;
+  private final EntityManager entityManager;
 
   public HibernateTrackedEntityDataValueChangeLogStore(EntityManager entityManager) {
     this.entityManager = entityManager;
@@ -77,7 +77,9 @@ public class HibernateTrackedEntityDataValueChangeLogStore
   @Override
   public void addTrackedEntityDataValueChangeLog(
       TrackedEntityDataValueChangeLog trackedEntityDataValueChangeLog) {
-    entityManager.unwrap(Session.class).save(trackedEntityDataValueChangeLog);
+    try (Session session = entityManager.unwrap(Session.class)) {
+      session.save(trackedEntityDataValueChangeLog);
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -200,9 +200,11 @@ public class EventPersister
           EventDataValue eventDataValue = dataValueDBMap.get(dataElement.getUid());
 
           ValuesHolder valuesHolder = getAuditAndDateParameters(eventDataValue, dv);
+          if (valuesHolder.getChangeLogType() == null) {
+            return;
+          }
 
           eventDataValue = valuesHolder.getEventDataValue();
-
           eventDataValue.setDataElement(dataElement.getUid());
           eventDataValue.setStoredBy(dv.getStoredBy());
 
@@ -265,16 +267,17 @@ public class EventPersister
   }
 
   private boolean isNewDataValue(EventDataValue eventDataValue, DataValue dv) {
-    return eventDataValue == null
-        || (eventDataValue.getCreated() == null && StringUtils.isNotBlank(dv.getValue()));
+    return StringUtils.isNotBlank(dv.getValue()) && eventDataValue == null;
   }
 
   private boolean isDeletion(EventDataValue eventDataValue, DataValue dv) {
-    return StringUtils.isNotBlank(eventDataValue.getValue()) && StringUtils.isBlank(dv.getValue());
+    return eventDataValue != null
+        && StringUtils.isNotBlank(eventDataValue.getValue())
+        && StringUtils.isBlank(dv.getValue());
   }
 
   private boolean isUpdate(EventDataValue eventDataValue, DataValue dv) {
-    return !StringUtils.equals(dv.getValue(), eventDataValue.getValue());
+    return eventDataValue != null && !StringUtils.equals(dv.getValue(), eventDataValue.getValue());
   }
 
   private ValuesHolder getAuditAndDateParameters(EventDataValue eventDataValue, DataValue dv) {
@@ -289,7 +292,7 @@ public class EventPersister
       persistedValue = dv.getValue();
       changeLogType = ChangeLogType.CREATE;
     } else {
-      persistedValue = eventDataValue.getValue();
+      persistedValue = eventDataValue != null ? eventDataValue.getValue() : null;
 
       if (isUpdate(eventDataValue, dv)) {
         changeLogType = ChangeLogType.UPDATE;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
@@ -132,8 +132,6 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest {
 
     DataElement dataElement = new DataElement();
     dataElement.setUid(CodeGenerator.generateUid());
-    when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElement.getUid())))
-        .thenReturn(dataElement);
 
     org.hisp.dhis.tracker.imports.domain.Event event =
         event(dataValue(MetadataIdentifier.ofUid(dataElement.getUid()), "value"));
@@ -163,8 +161,6 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest {
 
     DataElement dataElement = new DataElement();
     dataElement.setUid(CodeGenerator.generateUid());
-    when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElement.getUid())))
-        .thenReturn(dataElement);
     when(preheat.getUsername()).thenReturn(USERNAME);
 
     org.hisp.dhis.tracker.imports.domain.Event event =
@@ -197,8 +193,6 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest {
     DataElement dataElement = new DataElement();
     dataElement.setUid(CodeGenerator.generateUid());
     String eventUid = CodeGenerator.generateUid();
-    when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElement.getUid())))
-        .thenReturn(dataElement);
     dbEvent.setStatus(EventStatus.COMPLETED);
     when(preheat.getEvent(eventUid)).thenReturn(dbEvent);
 
@@ -231,8 +225,6 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest {
     DataElement dataElement = new DataElement();
     dataElement.setUid(CodeGenerator.generateUid());
     String eventUid = CodeGenerator.generateUid();
-    when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElement.getUid())))
-        .thenReturn(dataElement);
     when(preheat.getUsername()).thenReturn(USERNAME);
     dbEvent.setStatus(EventStatus.ACTIVE);
     when(preheat.getEvent(eventUid)).thenReturn(dbEvent);


### PR DESCRIPTION
When an event data value was created in an existing event, we were persisting those values to the database before computing the change logs. 
This was a problem because, at the moment we had to validate whether or not to log changes, the event data value in the payload and the one in the database were the same, so we didn't log anything. 
Now, we will persist the event data values after logging the changes, so we can keep track of them.

However, when it comes to the rule engine, we still need to persist the data values in order to calculate the rule effects correctly. That's why I've created the method `getPayloadDataValues`, which gets all data values from the payload, as it did in the mapper before this fix.

