### PR TITLE
Backport: fix: metadata icons now showing due to broken redirect (#20515)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
@@ -149,7 +149,7 @@ public class IconController {
       throws IOException, NotFoundException {
     if (!iconService.iconExists(key)) throw new NotFoundException(Icon.class, key);
 
-    String location = response.encodeRedirectURL("/icons/" + key + "/icon");
+    String location = response.encodeRedirectURL("/api/icons/" + key + "/icon");
     response.sendRedirect(ContextUtils.getRootPath(request) + location);
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -376,9 +376,6 @@ public class DhisWebApiWebSecurityConfig {
                       new AntPathRequestMatcher(apiContextPath + "/**/externalFileResources/**"))
                   .permitAll()
                   .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/icons/*/icon.svg"))
-                  .permitAll()
-                  .requestMatchers(
                       new AntPathRequestMatcher(apiContextPath + "/**/files/style/external"))
                   .permitAll()
                   .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/publicKeys/**"))


### PR DESCRIPTION
* fix: metadata icons now showing due to broken redirect

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: 429d00e0ecf6f15e28fc67ba6b4cbe75c94e695f