### PR TITLE
Backport: fix: metadata icons now showing due to broken redirect (#20515)

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -273,6 +273,12 @@ public class LoginTest extends BaseE2ETest {
   }
 
   @Test
+  void testRedirectIcon() {
+    testRedirectAsUser(
+        "/api/icons/medicines_positive/icon.svg", "api/icons/medicines_positive/icon");
+  }
+
+  @Test
   void testJsonResponseForFailedLogin() {
     try {
       getWithWrongAuth("/me", Map.of());
@@ -480,6 +486,35 @@ public class LoginTest extends BaseE2ETest {
     ResponseEntity<String> redirResp =
         restTemplateNoRedirects.exchange(
             serverHostUrl + "dhis-web-dashboard", HttpMethod.GET, entity, String.class);
+    List<String> location = redirResp.getHeaders().get("Location");
+    assertNotNull(location);
+    assertEquals(1, location.size());
+    String actual = location.get(0);
+    assertEquals(redirectUrl, actual.replaceAll(serverHostUrl, ""));
+  }
+
+  public static void testRedirectAsUser(String url, String redirectUrl) {
+    // Disable auto-redirects
+    RestTemplate restTemplateNoRedirects = getRestTemplateNoRedirects();
+
+    // Do a valid login
+    HttpHeaders cookieHeaders = jsonHeaders();
+    ResponseEntity<LoginResponse> secondResponse =
+        restTemplateNoRedirects.postForEntity(
+            serverApiUrl + LOGIN_API_PATH,
+            new HttpEntity<>(
+                LoginRequest.builder().username("admin").password("district").build(),
+                cookieHeaders),
+            LoginResponse.class);
+    String cookie = extractSessionCookie(secondResponse);
+
+    // Test the redirect
+    HttpHeaders headers = jsonHeaders();
+    headers.set("Cookie", cookie);
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+    ResponseEntity<String> redirResp =
+        restTemplateNoRedirects.exchange(serverHostUrl + url, HttpMethod.GET, entity, String.class);
+
     List<String> location = redirResp.getHeaders().get("Location");
     assertNotNull(location);
     assertEquals(1, location.size());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
@@ -149,7 +149,7 @@ public class IconController {
       throws IOException, NotFoundException {
     if (!iconService.iconExists(key)) throw new NotFoundException(Icon.class, key);
 
-    String location = response.encodeRedirectURL("/icons/" + key + "/icon");
+    String location = response.encodeRedirectURL("/api/icons/" + key + "/icon");
     response.sendRedirect(ContextUtils.getRootPath(request) + location);
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -376,9 +376,6 @@ public class DhisWebApiWebSecurityConfig {
                       new AntPathRequestMatcher(apiContextPath + "/**/externalFileResources/**"))
                   .permitAll()
                   .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/icons/*/icon.svg"))
-                  .permitAll()
-                  .requestMatchers(
                       new AntPathRequestMatcher(apiContextPath + "/**/files/style/external"))
                   .permitAll()
                   .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/publicKeys/**"))


### PR DESCRIPTION
* fix: metadata icons now showing due to broken redirect

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: 429d00e0ecf6f15e28fc67ba6b4cbe75c94e695f