### PR TITLE
fix: bump login version to handle empty templates [DHIS2-19395]

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -25,7 +25,7 @@
   "https://github.com/d2-ci/usage-analytics-app#v101.1.0",
   "https://github.com/d2-ci/user-app#v100.7.1",
   "https://github.com/d2-ci/user-profile-app#v100.7.2",
-  "https://github.com/d2-ci/login-app#v100.4.3",
+  "https://github.com/d2-ci/login-app#v100.4.4",
   "https://github.com/d2-ci/global-shell-app#v1.7.3",
   "https://github.com/d2-ci/line-listing-app#v102.1.1"
 ]


### PR DESCRIPTION
Bumps login app to pick up change in login app whereby app will use standard login page HTML if `loginPageLayout ` is `CUSTOM` but `loginPageTemplate` is an empty string (`""`) (as returned by api/loginConfig).

See ticket: https://dhis2.atlassian.net/browse/DHIS2-19395