### PR TITLE
fix: Revert try/resources hibernate session [DHIS2-19092][2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueChangeLogStore.java
@@ -77,9 +77,7 @@ public class HibernateTrackedEntityDataValueChangeLogStore
   @Override
   public void addTrackedEntityDataValueChangeLog(
       TrackedEntityDataValueChangeLog trackedEntityDataValueChangeLog) {
-    try (Session session = entityManager.unwrap(Session.class)) {
-      session.save(trackedEntityDataValueChangeLog);
-    }
+    entityManager.unwrap(Session.class).save(trackedEntityDataValueChangeLog);
   }
 
   @Override


### PR DESCRIPTION
Reverting Sonar's suggestion of using try with resources when getting the Session.
It should be Hibernate the one who manages it. Manually closing it could lead to undesired issues.