### PR TITLE
feat: Gist API DB filters on JSONB backed collections [DHIS2-19439]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.schema;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -446,6 +447,16 @@ public class Property implements Ordered, Klass {
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isManyToOne() {
     return manyToOne;
+  }
+
+  /**
+   * @return true only, if this property reflects a relation to another table in the DB. There might
+   *     be collections which are not actually relations since they store their data in a JSONB
+   *     column.
+   */
+  @JsonIgnore
+  public boolean isRelation() {
+    return oneToOne || oneToMany || manyToOne || manyToMany;
   }
 
   @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -41,6 +41,7 @@ import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPat
 import static org.hisp.dhis.gist.GistLogic.isAttributeValuesProperty;
 import static org.hisp.dhis.gist.GistLogic.isCollectionSizeFilter;
 import static org.hisp.dhis.gist.GistLogic.isHrefProperty;
+import static org.hisp.dhis.gist.GistLogic.isJsonCollectionFilter;
 import static org.hisp.dhis.gist.GistLogic.isNonNestedPath;
 import static org.hisp.dhis.gist.GistLogic.isPersistentCollectionField;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
@@ -883,6 +884,8 @@ final class GistBuilder {
         fieldTemplate = "length(%s)";
       } else if (isCollectionSizeFilter(filter, property)) {
         fieldTemplate = "size(%s)";
+      } else if (isJsonCollectionFilter(filter, property)) {
+        return createJsonFilterHQL(index, filter, field);
       } else if (operator.isCaseInsensitive()) {
         fieldTemplate = "lower(%s)";
       }
@@ -893,6 +896,22 @@ final class GistBuilder {
       str.append(" :f_").append(index).append(createOperatorRightSideHQL(operator));
     }
     return str.toString();
+  }
+
+  private String createJsonFilterHQL(int index, Filter filter, String field) {
+    return switch (filter.getOperator()) {
+      case EQ -> "%s = :f_%d".formatted(field, index);
+      case NE -> "%s != :f_%d".formatted(field, index);
+      case EMPTY ->
+          "(%1$s is null or %1$s = '{}' or %1$s = '[]' or %1$s = 'null')".formatted(field);
+      case NOT_EMPTY ->
+          "(%1$s is not null and %1$s != 'null' and not (%1$s = '[]' or %1$s = '{}'))"
+              .formatted(field);
+      default ->
+          throw new UnsupportedOperationException(
+              "Filter %s not supported for property %s since it is stored as JSONB"
+                  .formatted(filter.getOperator(), filter.getPropertyPath()));
+    };
   }
 
   private String createAccessFilterHQL(int index, Filter filter, String field) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -900,8 +900,6 @@ final class GistBuilder {
 
   private String createJsonFilterHQL(int index, Filter filter, String field) {
     return switch (filter.getOperator()) {
-      case EQ -> "%s = :f_%d".formatted(field, index);
-      case NE -> "%s != :f_%d".formatted(field, index);
       case EMPTY ->
           "(%1$s is null or %1$s = '{}' or %1$s = '[]' or %1$s = 'null')".formatted(field);
       case NOT_EMPTY ->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -119,8 +119,12 @@ final class GistLogic {
   }
 
   static boolean isCollectionSizeFilter(Filter filter, Property property) {
-    return filter.getOperator().isEmptinessCompare()
+    return property.isRelation() && filter.getOperator().isEmptinessCompare()
         || (filter.getOperator().isNumericCompare() && property.isCollection());
+  }
+
+  static boolean isJsonCollectionFilter(Filter filter, Property property) {
+    return property.isCollection() && !property.isRelation();
   }
 
   static boolean isStringLengthFilter(Filter filter, Property property) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationsStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
@@ -90,6 +91,14 @@ class ProgramControllerIntegrationTest extends PostgresControllerIntegrationTest
         .content(HttpStatus.CREATED);
 
     POST("/metadata", Path.of("program/create_program.json")).content(HttpStatus.OK);
+  }
+
+  @Test
+  void testGistFilterCategoryMappings() {
+    JsonObject noMapping = GET("/programs/gist?filter=categoryMappings:empty").content();
+    JsonObject withMapping = GET("/programs/gist?filter=categoryMappings:!empty").content();
+    assertEquals(0, withMapping.getArray("programs").size());
+    assertEquals(1, noMapping.getArray("programs").size());
   }
 
   @Test


### PR DESCRIPTION
### Summary
When a collection property is backed by a JSONB column instead of a separate database table the filters need a dedicated implementation to take that into account. 

This PR adds support for 4 filters for JSONB backed collections: `empty` and `!empty`.

### Automatic Testing
Added a new test case for the filter case that spawned the issue

### Manual Testing 
* check `/api/programs/gist?filter=categoryMappings:empty` works
* check `/api/programs/gist?filter=categoryMappings:!empty` works