### PR TITLE
fix: bump capture version 101.33.3

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -3,7 +3,7 @@
   "https://github.com/d2-ci/approval-app#v100.0.17",
   "https://github.com/d2-ci/app-management-app#v100.4.4",
   "https://github.com/d2-ci/cache-cleaner-app#v100.1.18",
-  "https://github.com/d2-ci/capture-app#v101.33.2",
+  "https://github.com/d2-ci/capture-app#v101.33.3",
   "https://github.com/d2-ci/dashboard-app#v101.1.6",
   "https://github.com/d2-ci/data-administration-app#v100.0.14",
   "https://github.com/d2-ci/data-visualizer-app#v101.1.2",


### PR DESCRIPTION
This has been approved by RCB

Capture: [DHIS2-19415](https://dhis2.atlassian.net/browse/DHIS2-19415)

[DHIS2-19415]: https://dhis2.atlassian.net/browse/DHIS2-19415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ