### PR TITLE
chore: Revert custom request mapping condition

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/CustomRequestMappingHandlerMapping.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/CustomRequestMappingHandlerMapping.java
@@ -55,7 +55,7 @@ public class CustomRequestMappingHandlerMapping extends RequestMappingHandlerMap
   protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
     RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
 
-    if (info == null || info.getPatternValues().stream().noneMatch(s -> s.startsWith("/api/"))) {
+    if (info == null) {
       return null;
     }
 


### PR DESCRIPTION
Revert a condition check in the custom request mapping that was recently changed in #20523.
If a mapping doesn't contain `/api`, it should still get through to have its base mapping added.

Versioned mappings are only added if they contain `/api/`.

This change should be pushed through even while we look at implementing a servlet filter instead of using these custom mappings.