### PR TITLE
chore: update global-shell in apps-to-bundle.json (DHIS2-19404) (DHIS2-19285)

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -26,6 +26,6 @@
   "https://github.com/d2-ci/user-app#v100.7.1",
   "https://github.com/d2-ci/user-profile-app#v100.7.2",
   "https://github.com/d2-ci/login-app#v100.4.4",
-  "https://github.com/d2-ci/global-shell-app#v1.7.3",
+  "https://github.com/d2-ci/global-shell-app#v1.7.5",
   "https://github.com/d2-ci/line-listing-app#v102.1.2"
 ]

--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -26,6 +26,6 @@
   "https://github.com/d2-ci/user-app#v100.7.1",
   "https://github.com/d2-ci/user-profile-app#v100.7.2",
   "https://github.com/d2-ci/login-app#v100.4.4",
-  "https://github.com/d2-ci/global-shell-app#v1.7.5",
+  "https://github.com/d2-ci/global-shell-app#v1.7.6",
   "https://github.com/d2-ci/line-listing-app#v102.1.2"
 ]


### PR DESCRIPTION
bump global shell in RC to include the fixes for: https://dhis2.atlassian.net/browse/DHIS2-19285 and https://dhis2.atlassian.net/browse/DHIS2-19404 (approved by RCB)