### PR TITLE
perf: Gist API - use sub-select exists for filter when possible [DHIS2-19410]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -77,8 +77,8 @@ final class GistLogic {
     return p.isCollection() ? p.getItemKlass() : p.getKlass();
   }
 
-  static boolean isNonNestedPath(String path) {
-    return path.indexOf('.') < 0;
+  static boolean isNestedPath(String path) {
+    return path.indexOf('.') >= 0;
   }
 
   static boolean isAttributePath(String path) {
@@ -94,11 +94,11 @@ final class GistLogic {
   }
 
   static String parentPath(String path) {
-    return isNonNestedPath(path) ? "" : path.substring(0, path.lastIndexOf('.'));
+    return !isNestedPath(path) ? "" : path.substring(0, path.lastIndexOf('.'));
   }
 
   static String pathOnSameParent(String path, String property) {
-    return isNonNestedPath(path) ? property : parentPath(path) + '.' + property;
+    return !isNestedPath(path) ? property : parentPath(path) + '.' + property;
   }
 
   static boolean isHrefProperty(Property p) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -38,7 +38,7 @@ import static org.hisp.dhis.gist.GistLogic.isAttributePath;
 import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPath;
 import static org.hisp.dhis.gist.GistLogic.isCollectionSizeFilter;
 import static org.hisp.dhis.gist.GistLogic.isIncludedField;
-import static org.hisp.dhis.gist.GistLogic.isNonNestedPath;
+import static org.hisp.dhis.gist.GistLogic.isNestedPath;
 import static org.hisp.dhis.gist.GistLogic.isPersistentCollectionField;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
 import static org.hisp.dhis.gist.GistLogic.parentPath;
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -73,15 +74,15 @@ import org.hisp.dhis.schema.annotation.Gist.Transform;
  * @author Jan Bernitt
  */
 @AllArgsConstructor
-class GistPlanner {
+final class GistPlanner {
+
   private final GistQuery query;
-
   private final RelativePropertyContext context;
-
   private final GistAccessControl access;
 
   public GistQuery plan() {
-    return query.withFields(planFields()).withFilters(planFilters());
+    List<Field> fields = planFields();
+    return query.withFields(fields).withFilters(planFilters(fields));
   }
 
   private List<Field> planFields() {
@@ -99,13 +100,37 @@ class GistPlanner {
     return fields;
   }
 
-  private List<Filter> planFilters() {
+  private List<Filter> planFilters(List<Field> fields) {
     List<Filter> filters = query.getFilters();
     filters = withAttributeIdAsPropertyFilters(filters); // 1:1
     filters = withAttributeIdEqAsNotNullFilters(filters); // 1:1
     filters = withIdentifiableCollectionAutoIdFilters(filters); // 1:1
     filters = withCurrentUserDefaultForAccessFilters(filters); // 1:1
+    filters = withSubSelectForUnboundRelationFilters(filters, fields); // 1:1
     return filters;
+  }
+
+  /**
+   * Any filter that targets another table than the main table but which (table) is not used in the
+   * fields is turned into a sub-select filter.
+   */
+  private List<Filter> withSubSelectForUnboundRelationFilters(
+      List<Filter> filters, List<Field> fields) {
+    return map1to1(filters, f -> isUnboundSubSelect(f, fields), Filter::asSubSelect);
+  }
+
+  private boolean isUnboundSubSelect(@Nonnull Filter f, List<Field> fields) {
+    String path = f.getPropertyPath();
+    if (!path.contains(".")) return false;
+    if (context.resolve(path) == null) return false;
+    List<Property> segments = context.resolvePath(path);
+    if (segments.size() != 2 || !segments.get(0).isRelation()) return false;
+    String property = segments.get(0).getName();
+    return fields.stream()
+        .noneMatch(
+            field ->
+                field.getPropertyPath().equals(property)
+                    || field.getPropertyPath().startsWith(property + "."));
   }
 
   private List<Filter> withAttributeIdAsPropertyFilters(List<Filter> filters) {
@@ -316,7 +341,7 @@ class GistPlanner {
     List<Field> mapped = new ArrayList<>();
     for (Field f : fields) {
       String path = f.getPropertyPath();
-      if (!isNonNestedPath(path) && context.resolveMandatory(parentPath(path)).isCollection()) {
+      if (isNestedPath(path) && context.resolveMandatory(parentPath(path)).isCollection()) {
         String parentPath = parentPath(path);
         String propertyName = path.substring(path.lastIndexOf('.') + 1);
         Property collection = context.resolveMandatory(parentPath);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -106,7 +106,7 @@ final class GistPlanner {
     filters = withAttributeIdEqAsNotNullFilters(filters); // 1:1
     filters = withIdentifiableCollectionAutoIdFilters(filters); // 1:1
     filters = withCurrentUserDefaultForAccessFilters(filters); // 1:1
-    filters = withSubSelectForUnboundRelationFilters(filters, fields); // 1:1
+    filters = withSubSelectForUnboundRelationFilters(filters); // 1:1
     return filters;
   }
 
@@ -114,19 +114,17 @@ final class GistPlanner {
    * Any filter that targets another table than the main table but which (table) is not used in the
    * fields is turned into a sub-select filter.
    */
-  private List<Filter> withSubSelectForUnboundRelationFilters(
-      List<Filter> filters, List<Field> fields) {
-    return map1to1(filters, f -> isUnboundSubSelect(f, fields), Filter::asSubSelect);
+  private List<Filter> withSubSelectForUnboundRelationFilters(List<Filter> filters) {
+    return map1to1(filters, this::isUnboundSubSelect, Filter::asSubSelect);
   }
 
-  private boolean isUnboundSubSelect(@Nonnull Filter f, List<Field> fields) {
+  private boolean isUnboundSubSelect(@Nonnull Filter f) {
     String path = f.getPropertyPath();
     if (!path.contains(".")) return false;
     if (context.resolve(path) == null) return false;
     List<Property> segments = context.resolvePath(path);
     if (segments.size() != 2) return false;
-    Property relation = segments.get(0);
-    return relation.isRelation();
+    return segments.get(0).isRelation();
   }
 
   private List<Filter> withAttributeIdAsPropertyFilters(List<Filter> filters) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -124,13 +124,9 @@ final class GistPlanner {
     if (!path.contains(".")) return false;
     if (context.resolve(path) == null) return false;
     List<Property> segments = context.resolvePath(path);
-    if (segments.size() != 2 || !segments.get(0).isRelation()) return false;
-    String property = segments.get(0).getName();
-    return fields.stream()
-        .noneMatch(
-            field ->
-                field.getPropertyPath().equals(property)
-                    || field.getPropertyPath().startsWith(property + "."));
+    if (segments.size() != 2) return false;
+    Property relation = segments.get(0);
+    return relation.isRelation();
   }
 
   private List<Filter> withAttributeIdAsPropertyFilters(List<Filter> filters) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -459,18 +459,16 @@ public final class GistQuery {
   @Getter
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   public static final class Filter {
+
     @JsonProperty private final int group;
-
     @JsonProperty private final String propertyPath;
-
     @JsonProperty private final Comparison operator;
-
     @JsonProperty private final String[] value;
-
     @JsonProperty private final boolean attribute;
+    @JsonProperty private final boolean subSelect;
 
     public Filter(String propertyPath, Comparison operator, String... value) {
-      this(0, propertyPath, operator, value, false);
+      this(0, propertyPath, operator, value, false, false);
     }
 
     public Filter withPropertyPath(String path) {
@@ -481,14 +479,25 @@ public final class GistQuery {
       return new Filter(propertyPath, operator, value);
     }
 
+    /**
+     * @return A new filter modified to be considered an attribute value match for the UID given by
+     *     the path
+     */
     public Filter asAttribute() {
-      return new Filter(group, propertyPath, operator, value, true);
+      return new Filter(group, propertyPath, operator, value, true, subSelect);
+    }
+
+    /**
+     * @return a new filter modified to use a sub-select query to match
+     */
+    public Filter asSubSelect() {
+      return new Filter(group, propertyPath, operator, value, attribute, true);
     }
 
     public Filter inGroup(int group) {
       return group == this.group
           ? this
-          : new Filter(group, propertyPath, operator, value, attribute);
+          : new Filter(group, propertyPath, operator, value, attribute, subSelect);
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -33,7 +33,7 @@ import static java.util.Arrays.stream;
 import static org.hisp.dhis.gist.GistLogic.attributePath;
 import static org.hisp.dhis.gist.GistLogic.getBaseType;
 import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPath;
-import static org.hisp.dhis.gist.GistLogic.isNonNestedPath;
+import static org.hisp.dhis.gist.GistLogic.isNestedPath;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -104,7 +104,7 @@ final class GistValidator {
       return;
     }
     Property field = context.resolveMandatory(path);
-    if (!isNonNestedPath(path)) {
+    if (isNestedPath(path)) {
       List<Property> pathElements = context.resolvePath(path);
       Property head = pathElements.get(0);
       if (head.isCollection() && head.isPersisted()) {
@@ -174,7 +174,7 @@ final class GistValidator {
     if (!access.canRead(query.getElementType(), path)) {
       throw createNoReadAccess(f, query.getElementType());
     }
-    if (!isNonNestedPath(path)) {
+    if (isNestedPath(path)) {
       Schema fieldOwner = context.switchedTo(path).getHome();
       @SuppressWarnings("unchecked")
       Class<? extends PrimaryKeyObject> ownerType =

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * A utility to resolve the {@link Property} for a given path.
@@ -109,7 +109,7 @@ public final class RelativePropertyContext {
     return property;
   }
 
-  @Nullable
+  @CheckForNull
   public Property resolve(String path) {
     if (path.indexOf('.') < 0) {
       // just for performance do simple and common case first

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -34,9 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
+import org.hisp.dhis.test.webapi.json.domain.JsonOption;
 import org.hisp.dhis.test.webapi.json.domain.JsonOptionSet;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -141,5 +143,12 @@ class OptionControllerTest extends H2ControllerIntegrationTestBase {
     assertEquals(
         List.of("this-is-a", "this-is-b"),
         set.getOptions().toList(JsonIdentifiableObject::getDescription));
+
+    JsonList<JsonOption> options =
+        GET("/options/gist?headless=true&filter=optionSet.id:eq:{id}", id)
+            .content()
+            .asList(JsonOption.class);
+    assertEquals(2, options.size());
+    assertEquals(List.of("Anna", "Betta"), options.toList(JsonIdentifiableObject::getName));
   }
 }


### PR DESCRIPTION
### Summary
HQL allows to write filters on relations in object notation, e.g. `root.groups.id = id`. However, such filter would result in a `cross join`. Some manual testing has shown that using sub-selects can be beneficial making it 1-10x faster but never worse. 
With that in mind we use sub-selects for filters on relations. In a simple case that would translate to `root.groups.fk = (select fk from Groups g where g.id = id)`. But even better is to also use `exists` making it `exists (select 1 from root.groups g where g.id = id)`. This will result in the equivalent SQL exists query.

### Automatic Testing
I added a query with some basic asserts to make sure that an exists type query is at least triggered. There is a very high chance that lots of other tests indirectly cover similar scenarios but I don't know of any particular one.

### Manual Testing
Some URL examples:
* http://localhost:8080/api/options/gist?fields=id,code,name,displayName,created,lastUpdated,sortOrder,style&page=1&pageSize=5000&total=true&filter=optionSet.id:in:[eUZ79clX7y1,eUZ79clX7y2]
* http://localhost:8080/api/options/gist?fields=id,code,name,displayName,created,lastUpdated,sortOrder,style,optionSet&page=1&pageSize=5000&total=true&filter=optionSet.id:in:[eUZ79clX7y1,eUZ79clX7y2] (with selecting the option-set)
* http://localhost:8080/api/dataElements/gist?fields=id,name,dataElementGroups::ids&filter=dataElementGroups.id:eq:nb3rBNvVHtp (a 1:* relation)
* http://localhost:8080/api/dataElements/gist?fields=id,name,categoryCombo&filter=categoryCombo.id:eq:dzjKKQq0cSO  (another 1:1 relation)

