### PR TITLE
fix: /tracker/events?filterAttributes operator in and like based ones [41]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -177,10 +178,31 @@ public class QueryFilter {
     } else if (SW == operator) {
       return this.filter + "%";
     } else if (EW == operator) {
-      return "%" + this.filter + "";
+      return "%" + this.filter;
     }
 
     return this.filter;
+  }
+
+  /**
+   * Returns the query filter with pre-/suffixed (affixed) '%' wildcards if the operator is based on
+   * SQL <a
+   * href="https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE">like</a>
+   * (see {@link #OPERATOR_MAP}). Filters for non-like based operators are returned as is.
+   *
+   * <p>Make sure to escape like wildcards in user input before calling this method!
+   */
+  @Nonnull
+  public static String affixLikeWildcards(@Nonnull QueryOperator operator, @Nonnull String filter) {
+    if (operator.isLike()) {
+      return "%" + filter + "%";
+    } else if (operator == SW) {
+      return filter + "%";
+    } else if (operator == EW) {
+      return "%" + filter;
+    }
+
+    return filter;
   }
 
   public String getSqlFilter(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -65,6 +65,15 @@ public enum QueryOperator {
 
   private static final Set<QueryOperator> LIKE_OPERATORS = EnumSet.of(LIKE, NLIKE, ILIKE, NILIKE);
 
+  /**
+   * All query operators that are implemented using the SQL {@code like} operator (see {@link
+   * #value}).
+   *
+   * <p>This is a union of {@link #LIKE_OPERATORS} and SW, EW. So keep it in sync!
+   */
+  private static final Set<QueryOperator> LIKE_BASED_OPERATORS =
+      EnumSet.of(LIKE, NLIKE, ILIKE, NILIKE, SW, EW);
+
   private static final Set<QueryOperator> COMPARISON_OPERATORS = EnumSet.of(GT, GE, LT, LE);
 
   private final String value;
@@ -99,6 +108,11 @@ public enum QueryOperator {
 
   public boolean isLike() {
     return LIKE_OPERATORS.contains(this);
+  }
+
+  /** Returns true if this query operator is implemented using the SQL {@code like} operator. */
+  public boolean isLikeBased() {
+    return LIKE_BASED_OPERATORS.contains(this);
   }
 
   public boolean isIn() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -52,7 +52,7 @@ import static org.hisp.dhis.commons.collection.CollectionUtils.addUnique;
 import static org.hisp.dhis.parser.expression.ParserUtils.castSql;
 import static org.hisp.dhis.subexpression.SubexpressionDimensionItem.getItemColumnName;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.system.util.SqlUtils.singleQuote;
+import static org.hisp.dhis.system.util.SqlUtils.singleQuoteAndEscape;
 
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;
@@ -186,7 +186,8 @@ public class JdbcSubexpressionQueryGenerator {
     String dimensions =
         jam.getCommaDelimitedQuotedDimensionColumns(paramsWithoutData.getDimensions());
 
-    String data = singleQuote(subex.getDimensionItemWithQueryModsId()) + " as " + quote(DX);
+    String data =
+        singleQuoteAndEscape(subex.getDimensionItemWithQueryModsId()) + " as " + quote(DX);
 
     String aggregate = getHighLevelAggregateFunction();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/AbstractOrganisationUnitAssociationsQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/AbstractOrganisationUnitAssociationsQueryBuilder.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions.EXTRACT_PATH_TEX
 import static org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions.HAS_USER_GROUP_IDS;
 import static org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions.HAS_USER_ID;
 import static org.hisp.dhis.security.acl.AclService.LIKE_READ_METADATA;
-import static org.hisp.dhis.system.util.SqlUtils.singleQuote;
+import static org.hisp.dhis.system.util.SqlUtils.singleQuoteAndEscape;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -153,14 +153,14 @@ public abstract class AbstractOrganisationUnitAssociationsQueryBuilder {
   private String getOwnerCondition(String userUid) {
     return String.join(
         " or ",
-        jsonbFunction(EXTRACT_PATH_TEXT, "owner") + " = " + singleQuote(userUid),
+        jsonbFunction(EXTRACT_PATH_TEXT, "owner") + " = " + singleQuoteAndEscape(userUid),
         jsonbFunction(EXTRACT_PATH_TEXT, "owner") + " is null");
   }
 
   private String getPublicSharingCondition(String access) {
     return String.join(
         " or ",
-        jsonbFunction(EXTRACT_PATH_TEXT, "public") + " like " + singleQuote(access),
+        jsonbFunction(EXTRACT_PATH_TEXT, "public") + " like " + singleQuoteAndEscape(access),
         jsonbFunction(EXTRACT_PATH_TEXT, "public") + " is null");
   }
 
@@ -189,7 +189,7 @@ public abstract class AbstractOrganisationUnitAssociationsQueryBuilder {
         String.join(
             ",",
             "inner_query_alias.sharing",
-            Arrays.stream(params).map(SqlUtils::singleQuote).collect(joining(","))),
+            Arrays.stream(params).map(SqlUtils::singleQuoteAndEscape).collect(joining(","))),
         ")");
   }
 
@@ -200,7 +200,7 @@ public abstract class AbstractOrganisationUnitAssociationsQueryBuilder {
   private String getUidsFilter(Set<String> uids) {
     return T_ALIAS
         + ".uid in ("
-        + uids.stream().map(SqlUtils::singleQuote).collect(joining(","))
+        + uids.stream().map(SqlUtils::singleQuoteAndEscape).collect(joining(","))
         + ")";
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
@@ -330,7 +330,7 @@ public class DatastoreQueryBuilder {
    */
   private static String toPathSegments(String path) {
     return Arrays.stream(path.split("\\."))
-        .map(SqlUtils::singleQuote)
+        .map(SqlUtils::singleQuoteAndEscape)
         .collect(Collectors.joining(", "));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.util.DateUtils;
 public class vAnalyticsPeriodEnd extends ProgramDateVariable {
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    return SqlUtils.singleQuote(
+    return SqlUtils.singleQuoteAndEscape(
         DateUtils.getSqlDateString(visitor.getProgParams().getReportingEndDate()));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.util.DateUtils;
 public class vAnalyticsPeriodStart extends ProgramDateVariable {
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    return SqlUtils.singleQuote(
+    return SqlUtils.singleQuoteAndEscape(
         DateUtils.getSqlDateString(visitor.getProgParams().getReportingStartDate()));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCurrentDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCurrentDate.java
@@ -39,6 +39,6 @@ import org.hisp.dhis.util.DateUtils;
 public class vCurrentDate extends ProgramDateVariable {
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    return SqlUtils.singleQuote(DateUtils.getLongDate());
+    return SqlUtils.singleQuoteAndEscape(DateUtils.getLongDate());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityChangeLogStore.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.trackedentity.hibernate;
 
-import static org.hisp.dhis.system.util.SqlUtils.singleQuote;
+import static org.hisp.dhis.system.util.SqlUtils.singleQuoteAndEscape;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,13 +85,13 @@ public class HibernateTrackedEntityChangeLogStore
           StringBuilder sb = new StringBuilder();
           sb.append("(");
           sb.append("nextval('trackedentityinstanceaudit_sequence'), ");
-          sb.append(singleQuote(audit.getTrackedEntity())).append(",");
+          sb.append(singleQuoteAndEscape(audit.getTrackedEntity())).append(",");
           sb.append("now()").append(",");
-          sb.append(singleQuote(audit.getAccessedBy())).append(",");
-          sb.append(singleQuote(audit.getAuditType().name())).append(",");
+          sb.append(singleQuoteAndEscape(audit.getAccessedBy())).append(",");
+          sb.append(singleQuoteAndEscape(audit.getAuditType().name())).append(",");
           sb.append(
               StringUtils.isNotEmpty(audit.getComment())
-                  ? SqlUtils.singleQuote(audit.getComment())
+                  ? SqlUtils.singleQuoteAndEscape(audit.getComment())
                   : "''");
           sb.append(")");
           return sb.toString();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -952,7 +952,7 @@ public class JdbcEventStore implements EventStore {
           .append(AND)
           .append(teaCol + ".UID")
           .append(EQUALS)
-          .append(SqlUtils.singleQuote(queryItem.getItem().getUid()));
+          .append(SqlUtils.singleQuoteAndEscape(queryItem.getItem().getUid()));
 
       attributes.append(getAttributeFilterQuery(queryItem, teaCol, teaValueCol));
     }
@@ -977,7 +977,7 @@ public class JdbcEventStore implements EventStore {
                 NUMERIC_TYPES.stream()
                     .map(Enum::name)
                     .map(StringUtils::lowerCase)
-                    .map(SqlUtils::singleQuote)
+                    .map(SqlUtils::singleQuoteAndEscape)
                     .collect(Collectors.joining(",")))
             .append(")")
             .append(" then ");

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
@@ -45,6 +45,10 @@ public class SqlUtils {
 
   public static final String SINGLE_QUOTE = "'";
 
+  public static final String PERCENT = "%";
+
+  public static final String UNDERSCORE = "_";
+
   public static final String SEPARATOR = ".";
 
   public static final String OPTION_SEP = ".";
@@ -80,14 +84,19 @@ public class SqlUtils {
   }
 
   /**
-   * Single quotes the given relation (typically a value). Escapes characters including single quote
-   * and backslash.
+   * Single quotes the given relation (typically a value) and escapes characters including single
+   * quote and backslash.
    *
    * @param value the value.
    * @return the single quoted relation.
    */
+  public static String singleQuoteAndEscape(String value) {
+    return singleQuote(escape(value));
+  }
+
+  /** Single quotes the given value. */
   public static String singleQuote(String value) {
-    return SINGLE_QUOTE + escape(value) + SINGLE_QUOTE;
+    return SINGLE_QUOTE + value + SINGLE_QUOTE;
   }
 
   /**
@@ -101,6 +110,30 @@ public class SqlUtils {
     return value
         .replace(SINGLE_QUOTE, (SINGLE_QUOTE + SINGLE_QUOTE))
         .replace(BACKSLASH, (BACKSLASH + BACKSLASH));
+  }
+
+  /**
+   * Only escapes single quotes in given value. This is needed for SQL text literals containing
+   * single-quotes as text literals use single-quotes as the literal delimiter.
+   */
+  public static String escapeSingleQuotes(String value) {
+    return value.replace(SINGLE_QUOTE, (SINGLE_QUOTE + SINGLE_QUOTE));
+  }
+
+  /**
+   * Escapes {@code like} wildcards '%' and '_' and the default escape character '\' in a given
+   * string using the default escape character. This expects you to use the default escape
+   * character. Make sure to call this before inserting any like wildcard characters!
+   *
+   * <p>See <a
+   * href="https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE">PostgreSQL
+   * like</a>
+   */
+  public static String escapeLikeWildcards(String value) {
+    return value
+        .replace(BACKSLASH, (BACKSLASH + BACKSLASH))
+        .replace(PERCENT, (BACKSLASH + PERCENT))
+        .replace(UNDERSCORE, (BACKSLASH + UNDERSCORE));
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SqlUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/SqlUtilsTest.java
@@ -53,14 +53,17 @@ class SqlUtilsTest {
 
   @Test
   void testSingleQuote() {
-    assertEquals("'jkhYg65ThbF'", SqlUtils.singleQuote("jkhYg65ThbF"));
-    assertEquals("'Some ''special'' value'", SqlUtils.singleQuote("Some 'special' value"));
-    assertEquals("'Another \"strange\" value'", SqlUtils.singleQuote("Another \"strange\" value"));
-    assertEquals("'John White'", SqlUtils.singleQuote("John White"));
+    assertEquals("'jkhYg65ThbF'", SqlUtils.singleQuoteAndEscape("jkhYg65ThbF"));
+    assertEquals("'Some ''special'' value'", SqlUtils.singleQuoteAndEscape("Some 'special' value"));
     assertEquals(
-        "'Main St 1\\\\nSmallwille\\\\n'", SqlUtils.singleQuote("Main St 1\\nSmallwille\\n"));
+        "'Another \"strange\" value'", SqlUtils.singleQuoteAndEscape("Another \"strange\" value"));
+    assertEquals("'John White'", SqlUtils.singleQuoteAndEscape("John White"));
     assertEquals(
-        "'Provided ''Rx01'' to patient'", SqlUtils.singleQuote("Provided 'Rx01' to patient"));
+        "'Main St 1\\\\nSmallwille\\\\n'",
+        SqlUtils.singleQuoteAndEscape("Main St 1\\nSmallwille\\n"));
+    assertEquals(
+        "'Provided ''Rx01'' to patient'",
+        SqlUtils.singleQuoteAndEscape("Provided 'Rx01' to patient"));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -346,7 +346,7 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .dataElementFilters(
-                Map.of("DATAEL00001", List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of("DATAEL00001", List.of(new QueryFilter(QueryOperator.LIKE, "val"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -367,7 +367,7 @@ class EventExporterTest extends TrackerTest {
             .programStageUid(programStage.getUid())
             .programStatus(ProgramStatus.ACTIVE)
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "val"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -386,7 +386,7 @@ class EventExporterTest extends TrackerTest {
             .programStageUid(programStage.getUid())
             .programType(ProgramType.WITH_REGISTRATION)
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "val"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -406,7 +406,7 @@ class EventExporterTest extends TrackerTest {
             .dataElementFilters(
                 Map.of(
                     dataElement.getUid(),
-                    List.of(new QueryFilter(QueryOperator.LIKE, "%value00001%"))))
+                    List.of(new QueryFilter(QueryOperator.LIKE, "value00001"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -685,7 +685,7 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .dataElementFilters(
-                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "opt"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -944,6 +944,43 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
+  void testEnrollmentFilterTextAttributesUsingIn() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder
+            .orgUnitUid(orgUnit.getUid())
+            .attributeFilters(
+                Map.of(
+                    "toUpdate000",
+                    List.of(new QueryFilter(QueryOperator.IN, "Rainy day;summer Day"))))
+            .build();
+
+    Set<String> trackedEntities =
+        eventService.getEvents(params).stream()
+            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
+            .collect(Collectors.toSet());
+
+    assertContainsOnly(Set.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+  }
+
+  @Test
+  void testEnrollmentFilterNumericAttributesUsingIn()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder
+            .orgUnitUid(orgUnit.getUid())
+            .attributeFilters(
+                Map.of("numericAttr", List.of(new QueryFilter(QueryOperator.IN, "70;88"))))
+            .build();
+
+    Set<String> trackedEntities =
+        eventService.getEvents(params).stream()
+            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
+            .collect(Collectors.toSet());
+
+    assertContainsOnly(Set.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+  }
+
+  @Test
   void testEnrollmentFilterAttributes() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         operationParamsBuilder
@@ -961,6 +998,53 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldExportEventsWhenFilteringByTextAttributesUsingSW()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder
+            .orgUnitMode(ACCESSIBLE)
+            .attributeFilters(
+                Map.of("notUpdated0", List.of(new QueryFilter(QueryOperator.SW, "20% \\Winter'"))))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
+  void shouldExportEventsWhenFilteringByTextAttributesUsingEW()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder
+            .orgUnitMode(ACCESSIBLE)
+            .attributeFilters(
+                Map.of(
+                    "notUpdated0", List.of(new QueryFilter(QueryOperator.EW, "% \\Winter's day"))))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
+  void shouldExportEventsWhenFilteringByTextAttributesUsingLike()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        operationParamsBuilder
+            .orgUnitMode(ACCESSIBLE)
+            .attributeFilters(
+                Map.of(
+                    "notUpdated0", List.of(new QueryFilter(QueryOperator.LIKE, "0% \\Winter's"))))
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertContainsOnly(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
   void testEnrollmentFilterAttributesWithMultipleFiltersOnDifferentAttributes()
       throws ForbiddenException, BadRequestException {
     EventOperationParams params =
@@ -971,7 +1055,7 @@ class EventExporterTest extends TrackerTest {
                     "toUpdate000",
                     List.of(new QueryFilter(QueryOperator.EQ, "rainy day")),
                     "notUpdated0",
-                    List.of(new QueryFilter(QueryOperator.EQ, "winter day"))))
+                    List.of(new QueryFilter(QueryOperator.EQ, "20% \\winter's day"))))
             .build();
 
     List<String> trackedEntities =

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -112,7 +112,7 @@
             "idScheme": "UID",
             "identifier": "notUpdated0"
           },
-          "value": "winter day"
+          "value": "20% \\winter's day"
         },
         {
           "valueType": "INTEGER",


### PR DESCRIPTION
This is the simplest way to fix the issues. We are not going to bring in all the improvements 
from https://dhis2.atlassian.net/browse/DHIS2-19347.

# 1. operator in

```http
### operator: in on NUMBER
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=uy2gU8kT1jF&
  fields=event,enrollment,trackedEntity&
  pageSize=15&
  filterAttributes=lw1SqmMlnfh:in:167.0;168

{
  "httpStatus": "Bad Request",
  "httpStatusCode": 400,
  "status": "ERROR",
  "message": "For input string: \"167.7;168\""
}
```

failed for numeric value types as we did not split the input `167.0;168` on `;` (which we do for non-numeric value types).

# 2. like based operators

Like wildcards were not escaped (https://github.com/dhis2/dhis2-core/pull/20586, https://github.com/dhis2/dhis2-core/pull/20705) for `filterAttributes`.

```json
{
  "attribute": "w75KJ2mc4zz",
  "displayName": "First name",
  "valueType": "TEXT",
  "value": "Sarah % ' \\ what"
}
```

```http
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=uy2gU8kT1jF&
  fields=trackedEntity,attributes&
  pageSize=12&
  filterAttributes=w75KJ2mc4zz:like:% ' \ what

{
  "httpStatus": "Conflict",
  "httpStatusCode": 409,
  "status": "ERROR",
  "message": "Query failed because of a syntax error (SqlState: 42601)",
  "devMessage": "SqlState: 42601",
  "errorCode": "E7145"
}
```
