### PR TITLE
perf: adds index used to find programs by OU [DHIS2-11105]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_4__create_ou_index_for_ou_program_mapping.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_4__create_ou_index_for_ou_program_mapping.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS in_program_organisationunits_organisationunitid ON program_organisationunits (organisationunitid);


### PR DESCRIPTION
### Summary
A query like https://play.im.dhis2.org/dev/api/organisationUnits/gist?filter=programs:gt:5 wants to find programs belonging to an OU. A similar query would happen when selecting OUs and accessing their `Program`s. ATM there is no index on the mapping table causing this having to use the PK/UNIQUE index of the mapping table which is sorted by program first, OU second. Thus to find all programs of an OU it has to look in each of the OU groups within a program to see if the OU is contained. That is far from optimal. To cover both directions another index is needed which is added by this PR.