### PR TITLE
feat: enable translation for DashboardItem.text

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/DashboardItem.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.report.Report;
 import org.hisp.dhis.schema.annotation.PropertyTransformer;
 import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
+import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.Visualization;
 
@@ -313,6 +314,13 @@ public class DashboardItem extends BaseIdentifiableObject implements EmbeddedObj
   @JacksonXmlProperty(namespace = DXF_2_0)
   public String getText() {
     return text;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @Translatable(propertyName = "text")
+  public String getDisplayText() {
+    return getTranslation("TEXT", getText());
   }
 
   public void setText(String text) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -149,5 +150,12 @@ class SchemaServiceTest extends PostgresIntegrationTestBase {
     assertEquals(PropertyType.BOOLEAN, isDefault.getPropertyType());
     assertNotNull(isDefault.getGetterMethod(), "getter is null");
     assertNotNull(isDefault.getSetterMethod(), "setter is null");
+  }
+
+  @Test
+  void testDashboardItemTextTranslatable() {
+    Schema schema = schemaService.getDynamicSchema(DashboardItem.class);
+    Property text = schema.getProperty("text");
+    assertTrue(text.isTranslatable());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -332,14 +332,14 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  public void testDisplayNameWithNoTranslation() {
+  void testDisplayNameWithNoTranslation() {
     DataElement dataElementA = createDataElement('A');
     manager.save(dataElementA);
     assertEquals("DataElementA", dataElementA.getDisplayName());
   }
 
   @Test
-  public void testDashboardItemTextTranslation() {
+  void testDashboardItemTextTranslation() {
     DashboardItem dashboardItem = new DashboardItem();
     dashboardItem.setText("Dashboard Item");
     dashboardItem.setAutoFields();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationType;
@@ -335,5 +336,20 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     DataElement dataElementA = createDataElement('A');
     manager.save(dataElementA);
     assertEquals("DataElementA", dataElementA.getDisplayName());
+  }
+
+  @Test
+  public void testDashboardItemTextTranslation() {
+    DashboardItem dashboardItem = new DashboardItem();
+    dashboardItem.setText("Dashboard Item");
+    dashboardItem.setAutoFields();
+    manager.save(dashboardItem);
+
+    String translatedText = "Translated Dashboard Item";
+    Set<Translation> translations = new HashSet<>();
+    translations.add(new Translation(locale.getLanguage(), "TEXT", translatedText));
+    manager.updateTranslations(dashboardItem, translations);
+    dashboardItem = manager.get(DashboardItem.class, dashboardItem.getUid());
+    assertEquals(translatedText, dashboardItem.getDisplayText());
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-12012

This PR makes `text` property in `DashboardItem` class translatable.