### PR TITLE
chore: Remove unused methods from TrackedEntityAttributeValueService [DHIS2-17679]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
@@ -80,23 +80,9 @@ public class DefaultTrackedEntityAttributeValueService
 
   @Override
   @Transactional(readOnly = true)
-  public TrackedEntityAttributeValue getTrackedEntityAttributeValue(
-      TrackedEntity trackedEntity, TrackedEntityAttribute attribute) {
-    return attributeValueStore.get(trackedEntity, attribute);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public List<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
       TrackedEntity trackedEntity) {
     return attributeValueStore.get(trackedEntity);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
-      TrackedEntityAttribute attribute) {
-    return attributeValueStore.get(attribute);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/HibernateTrackedEntityAttributeValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/HibernateTrackedEntityAttributeValueStore.java
@@ -35,7 +35,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.query.Query;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
@@ -61,40 +60,11 @@ class HibernateTrackedEntityAttributeValueStore
     getSession().save(attributeValue);
   }
 
-  public int deleteByTrackedEntity(TrackedEntity trackedEntity) {
-    Query<TrackedEntityAttributeValue> query =
-        getQuery("delete from TrackedEntityAttributeValue where trackedEntity = :trackedEntity");
-    query.setParameter("trackedEntity", trackedEntity);
-    return query.executeUpdate();
-  }
-
-  public TrackedEntityAttributeValue get(
-      TrackedEntity trackedEntity, TrackedEntityAttribute attribute) {
-    String query =
-        " from TrackedEntityAttributeValue v where v.trackedEntity =:trackedEntity and attribute =:attribute";
-
-    Query<TrackedEntityAttributeValue> typedQuery =
-        getQuery(query)
-            .setParameter("trackedEntity", trackedEntity)
-            .setParameter("attribute", attribute);
-
-    return getSingleResult(typedQuery);
-  }
-
   public List<TrackedEntityAttributeValue> get(TrackedEntity trackedEntity) {
     String query = " from TrackedEntityAttributeValue v where v.trackedEntity =:trackedEntity";
 
     Query<TrackedEntityAttributeValue> typedQuery =
         getQuery(query).setParameter("trackedEntity", trackedEntity);
-
-    return getList(typedQuery);
-  }
-
-  public List<TrackedEntityAttributeValue> get(TrackedEntityAttribute attribute) {
-    String query = " from TrackedEntityAttributeValue v where v.attribute =:attribute";
-
-    Query<TrackedEntityAttributeValue> typedQuery =
-        getQuery(query).setParameter("attribute", attribute);
 
     return getList(typedQuery);
   }
@@ -108,29 +78,6 @@ class HibernateTrackedEntityAttributeValueStore
         getQuery(query)
             .setParameter("attribute", attribute)
             .setParameter("values", values.stream().map(StringUtils::lowerCase).toList());
-
-    return getList(typedQuery);
-  }
-
-  public List<TrackedEntityAttributeValue> get(TrackedEntityAttribute attribute, String value) {
-    String query =
-        " from TrackedEntityAttributeValue v where v.attribute =:attribute and lower(v.plainValue) like :value";
-
-    Query<TrackedEntityAttributeValue> typedQuery =
-        getQuery(query)
-            .setParameter("attribute", attribute)
-            .setParameter("value", StringUtils.lowerCase(value));
-
-    return getList(typedQuery);
-  }
-
-  public List<TrackedEntityAttributeValue> get(TrackedEntity trackedEntity, Program program) {
-    String query =
-        " from TrackedEntityAttributeValue v where v.trackedEntity =:trackedEntity and v.attribute.program =:program";
-
-    Query<TrackedEntityAttributeValue> typedQuery = getQuery(query);
-    typedQuery.setParameter("trackedEntity", trackedEntity);
-    typedQuery.setParameter("program", program);
 
     return getList(typedQuery);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/TrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentityattributevalue/TrackedEntityAttributeValueService.java
@@ -54,31 +54,12 @@ public interface TrackedEntityAttributeValueService {
   void deleteTrackedEntityAttributeValue(TrackedEntityAttributeValue attributeValue);
 
   /**
-   * Retrieve a {@link TrackedEntityAttributeValue} on a {@link TrackedEntity} and {@link
-   * TrackedEntityAttribute}
-   *
-   * @param attribute {@link TrackedEntityAttribute}
-   * @return TrackedEntityAttributeValue
-   */
-  TrackedEntityAttributeValue getTrackedEntityAttributeValue(
-      TrackedEntity instance, TrackedEntityAttribute attribute);
-
-  /**
    * Retrieve {@link TrackedEntityAttributeValue} of a {@link TrackedEntity}
    *
    * @param instance TrackedEntityAttributeValue
    * @return TrackedEntityAttributeValue list
    */
   List<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(TrackedEntity instance);
-
-  /**
-   * Retrieve {@link TrackedEntityAttributeValue} of a {@link TrackedEntityAttribute}
-   *
-   * @param attribute {@link TrackedEntityAttribute}
-   * @return TrackedEntityAttributeValue list
-   */
-  List<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
-      TrackedEntityAttribute attribute);
 
   /**
    * Retrieve a list of {@link TrackedEntityAttributeValue} that matches the values and the tea

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -30,8 +30,8 @@
 package org.hisp.dhis.tracker.deduplication;
 
 import static org.hisp.dhis.security.Authorities.ALL;
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -138,9 +138,8 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     assertTrue(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
     removeTrackedEntity(trackedEntity);
     assertFalse(trackedEntityService.findTrackedEntity(UID.of(trackedEntity)).isPresent());
-    assertNull(
-        trackedEntityAttributeValueService.getTrackedEntityAttributeValue(
-            trackedEntity, trackedEntityAttribute));
+    assertIsEmpty(
+        trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentityattributevalue/TrackedEntityAttributeValueServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentityattributevalue/TrackedEntityAttributeValueServiceTest.java
@@ -29,12 +29,13 @@
  */
 package org.hisp.dhis.tracker.trackedentityattributevalue;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
@@ -72,15 +73,9 @@ class TrackedEntityAttributeValueServiceTest extends PostgresIntegrationTestBase
 
   private TrackedEntityAttribute attributeB;
 
-  private TrackedEntityAttribute attributeC;
-
   private TrackedEntity trackedEntityA;
 
   private TrackedEntity trackedEntityB;
-
-  private TrackedEntity trackedEntityC;
-
-  private TrackedEntity trackedEntityD;
 
   private TrackedEntityAttributeValue attributeValueA;
 
@@ -97,18 +92,12 @@ class TrackedEntityAttributeValueServiceTest extends PostgresIntegrationTestBase
     manager.save(trackedEntityType);
     trackedEntityA = createTrackedEntity(organisationUnit, trackedEntityType);
     trackedEntityB = createTrackedEntity(organisationUnit, trackedEntityType);
-    trackedEntityC = createTrackedEntity(organisationUnit, trackedEntityType);
-    trackedEntityD = createTrackedEntity(organisationUnit, trackedEntityType);
     manager.save(trackedEntityA);
     manager.save(trackedEntityB);
-    manager.save(trackedEntityC);
-    manager.save(trackedEntityD);
     attributeA = createTrackedEntityAttribute('A');
     attributeB = createTrackedEntityAttribute('B');
-    attributeC = createTrackedEntityAttribute('C');
     attributeService.addTrackedEntityAttribute(attributeA);
     attributeService.addTrackedEntityAttribute(attributeB);
-    attributeService.addTrackedEntityAttribute(attributeC);
     attributeValueA = new TrackedEntityAttributeValue(attributeA, trackedEntityA, "A");
     attributeValueB = new TrackedEntityAttributeValue(attributeB, trackedEntityA, "B");
     attributeValueC = new TrackedEntityAttributeValue(attributeA, trackedEntityB, "C");
@@ -118,34 +107,36 @@ class TrackedEntityAttributeValueServiceTest extends PostgresIntegrationTestBase
   void testSaveTrackedEntityAttributeValue() {
     attributeValueService.addTrackedEntityAttributeValue(attributeValueA);
     attributeValueService.addTrackedEntityAttributeValue(attributeValueB);
-    assertNotNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
-    assertNotNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
+    assertContainsOnly(
+        Set.of(attributeValueA, attributeValueB),
+        attributeValueService.getTrackedEntityAttributeValues(trackedEntityA));
   }
 
   @Test
   void testDeleteTrackedEntityAttributeValue() {
     attributeValueService.addTrackedEntityAttributeValue(attributeValueA);
     attributeValueService.addTrackedEntityAttributeValue(attributeValueB);
-    assertNotNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
-    assertNotNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeB));
+    assertContainsOnly(
+        Set.of(attributeValueA, attributeValueB),
+        attributeValueService.getTrackedEntityAttributeValues(trackedEntityA));
     attributeValueService.deleteTrackedEntityAttributeValue(attributeValueA);
-    assertNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
-    assertNotNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeB));
+    assertContainsOnly(
+        Set.of(attributeValueB),
+        attributeValueService.getTrackedEntityAttributeValues(trackedEntityA));
     attributeValueService.deleteTrackedEntityAttributeValue(attributeValueB);
-    assertNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
-    assertNull(attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeB));
+    assertIsEmpty(attributeValueService.getTrackedEntityAttributeValues(trackedEntityA));
   }
 
   @Test
   void testGetTrackedEntityAttributeValue() {
     attributeValueService.addTrackedEntityAttributeValue(attributeValueA);
     attributeValueService.addTrackedEntityAttributeValue(attributeValueC);
-    assertEquals(
-        attributeValueA,
-        attributeValueService.getTrackedEntityAttributeValue(trackedEntityA, attributeA));
-    assertEquals(
-        attributeValueC,
-        attributeValueService.getTrackedEntityAttributeValue(trackedEntityB, attributeA));
+    assertContainsOnly(
+        Set.of(attributeValueA),
+        attributeValueService.getTrackedEntityAttributeValues(trackedEntityA));
+    assertContainsOnly(
+        Set.of(attributeValueC),
+        attributeValueService.getTrackedEntityAttributeValues(trackedEntityB));
   }
 
   @Test
@@ -160,21 +151,6 @@ class TrackedEntityAttributeValueServiceTest extends PostgresIntegrationTestBase
     attributeValues = attributeValueService.getTrackedEntityAttributeValues(trackedEntityB);
     assertEquals(1, attributeValues.size());
     assertTrue(equals(attributeValues, attributeValueC));
-  }
-
-  @Test
-  void testGetTrackedEntityAttributeValuesbyAttribute() {
-    attributeValueService.addTrackedEntityAttributeValue(attributeValueA);
-    attributeValueService.addTrackedEntityAttributeValue(attributeValueB);
-    attributeValueService.addTrackedEntityAttributeValue(attributeValueC);
-    List<TrackedEntityAttributeValue> attributeValues =
-        attributeValueService.getTrackedEntityAttributeValues(attributeA);
-    assertEquals(2, attributeValues.size());
-    assertTrue(attributeValues.contains(attributeValueA));
-    assertTrue(attributeValues.contains(attributeValueC));
-    attributeValues = attributeValueService.getTrackedEntityAttributeValues(attributeB);
-    assertEquals(1, attributeValues.size());
-    assertTrue(attributeValues.contains(attributeValueB));
   }
 
   @Test


### PR DESCRIPTION
Remove `getTrackedEntityAttributeValue` methods only used in tests