### PR TITLE
fix: escape default escape in like based operator input DHIS2-19347

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
@@ -114,8 +114,9 @@ public class SqlUtils {
   }
 
   /**
-   * Escapes {@code like} wildcards '%' and '_' in a given string using the default '\' escape
-   * character. Make sure to call this before inserting any like wildcard characters!
+   * Escapes {@code like} wildcards '%' and '_' and the default escape character '\' in a given
+   * string using the default escape character. This expects you to use the default escape character
+   * '\' in your SQL. Make sure to call this before inserting any like wildcard characters!
    *
    * <p>See <a
    * href="https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE">PostgreSQL
@@ -123,6 +124,7 @@ public class SqlUtils {
    */
   public static String escapeLikeWildcards(String value) {
     return value
+        .replace(BACKSLASH, (BACKSLASH + BACKSLASH))
         .replace(PERCENT, (BACKSLASH + PERCENT))
         .replace(UNDERSCORE, (BACKSLASH + UNDERSCORE));
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_data.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_data.json
@@ -113,7 +113,7 @@
             "idScheme": "UID",
             "identifier": "notUpdated0"
           },
-          "value": "20% winter's day"
+          "value": "20% \\winter's day"
         },
         {
           "valueType": "INTEGER",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/FilterExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/FilterExporterTest.java
@@ -252,7 +252,7 @@ class FilterExporterTest extends PostgresIntegrationTestBase {
         TrackedEntityOperationParams.builder()
             .organisationUnits(orgUnit)
             .orgUnitMode(SELECTED)
-            .filterBy(UID.of(attr), List.of(new QueryFilter(QueryOperator.LIKE, "0% Winter's")))
+            .filterBy(UID.of(attr), List.of(new QueryFilter(QueryOperator.LIKE, "0% \\Winter's")))
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -575,7 +575,7 @@ class FilterExporterTest extends PostgresIntegrationTestBase {
         operationParamsBuilder
             .orgUnitMode(ACCESSIBLE)
             .filterByAttribute(
-                UID.of(attr), List.of(new QueryFilter(QueryOperator.LIKE, "0% Winter's")))
+                UID.of(attr), List.of(new QueryFilter(QueryOperator.LIKE, "0% \\Winter's")))
             .build();
 
     List<String> events = getEvents(params);


### PR DESCRIPTION
We [previously fixed](https://github.com/dhis2/dhis2-core/pull/20586) escaping `like` wildcards `%` and `_` with `\` but did not escape the escape itself 😬

Users could not find TE/EV using attribute/data values with `\` using like based DHIS2 filter operators `like`, `sw` and `ew`.

For example

```json
{
  "dataElement": "Da03a96443r",
  "value": "Mixed' \\ %Case"
}
```

could be found using `eq`

```http
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=q04UBOqq3rp&
  fields=dataValues[dataElement,value]&
  filter=Da03a96443r:eq:miXed' \ %case
```

since `\` has no special meaning outside of `like`.

```http
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=q04UBOqq3rp&
  fields=dataValues[dataElement,value]&
  filter=Da03a96443r:ew:' \ %case
```

did not return any result.

Note: when looking at the changes you need to remember that `\` is also an escape character that needs to be escaped in [JSON](https://www.json.org/json-en.html) and Java string literals 😅 So it will end up as a single `\` in the DB varchar.

## Docs

* https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE