### PR TITLE
fix: skip doris subquery on event table population [DHIS2-19489]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -185,7 +185,7 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
 
   @Override
   public boolean supportsCorrelatedSubquery() {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
## Summary  

This PR addresses and resolves an issue related to the population of Analytics tables when using `doris` as the analytics database.  

## Context  

The problem arises in scenarios where Event tables are populated with Tracked Entities that have the following attributes:  

- Non-confidential  
- Associated with a legend set  
- Numeric type  

In such cases, the generated SQL queries fail to execute because Apache Doris does not support this type of SQL query (the error specifically means that the column referenced in the ON clause belongs to a higher (outer) query block, but the join itself is being planned inside an inner block. Doris’ current optimiser cannot correlate a JOIN that way, so it aborts.)


## Fix  

- Implemented a solution to skip the generation of unsupported SQL queries, similar to the approach used for `Clickhouse`.
