### PR TITLE
chore: remove unused setting multiOrganisationUnitForms [DHIS2-19399]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -242,10 +242,6 @@ public non-sealed interface SystemSettings extends Settings {
     return asString("phoneNumberAreaCode", "");
   }
 
-  default boolean getMultiOrganisationUnitForms() {
-    return asBoolean("multiOrganisationUnitForms", false);
-  }
-
   default boolean getAccountRecoveryEnabled() {
     return asBoolean("keyAccountRecovery", false);
   }

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -95,7 +95,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(145, keys.size());
+    assertEquals(144, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));


### PR DESCRIPTION
The new data entry app no longer supports `multiOrganisationUnitForms` so the setting is obsolete and therefore gets removed.