### PR TITLE
test: do not promote test order annotations

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 junit.jupiter.extensions.autodetection.enabled=true
 # Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
 # see https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+# junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 junit.jupiter.execution.timeout.default=1m

--- a/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
@@ -1,4 +1,6 @@
 # Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
 # see https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order
-# junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+# TODO(analytics) analytics tests fail if I comment this, please investigate as we should not rely
+# on test order
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 junit.jupiter.execution.timeout.default=1m

--- a/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
 # Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
 # see https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+# junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 junit.jupiter.execution.timeout.default=1m

--- a/dhis-2/dhis-test-web-api/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-web-api/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
 # Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
 # see https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+# junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 junit.jupiter.execution.timeout.default=1m


### PR DESCRIPTION
Adding this into the properties was so we could easily remember how to debug test order issues often causing flaky tests. I did comment the config again in the backports for the test timeout https://github.com/dhis2/dhis2-core/pull/20758 apart from the integration test module. That is blocked by analytics tests see below.

https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order

## Analtyics integration tests

@dhis2/analytics-backend please have a look at this test. Also investigate the tests mentioned in the test section of PR description https://github.com/dhis2/dhis2-core/pull/20762.

`EventAnalyticsServiceTest` fails if we comment

`junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation` in
dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties

with these errors

https://github.com/dhis2/dhis2-core/actions/runs/14657993637/job/41136322674?pr=20759#step:4:7962
(logs might be gone by the time someone looks at this)

```
Error:  Failures: 
Error:    EventAnalyticsServiceTest.testDimensionRestrictionSuccessfully:709 Unexpected exception thrown: org.springframework.jdbc.BadSqlGrammarException: StatementCallback; bad SQL grammar [select count(ax."event") as value,ax."uidlevel3" from analytics_event_programb123 as ax where (((ax."occurreddate" >= '2017-01-01' and ax."occurreddate" < '2018-01-01'))) and ax."uidlevel3" in ('ouabcdefghD') and ax."categoryIdB" in ('cataOptionC', 'cataOptionD') and ax."categoryIdA" in ('cataOptionA', 'cataOptionB') and ax."yearly" in ('2017') group by ax."uidlevel3" limit 100001]
Error:    EventAnalyticsServiceTest.testEnrollmentProgramIndicatorWithOrgUnitFieldAtEnd:1237->assertGridContains:1608 Expected 3 rows in grid [
[dy, pe, ou, value]
] ==> expected: <3> but was: <0>
Error:    EventAnalyticsServiceTest.testEnrollmentProgramIndicatorWithOrgUnitFieldAtStart:1206->assertGridContains:1608 Expected 3 rows in grid [
[dy, pe, ou, value]
] ==> expected: <3> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorAverage:1334->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorCustomCountIntegers:1351->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorCustomCountOrgUnits:1368->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorFirstAverageOrgUnit:1286->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorFirstSumOrgUnit:1254->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorLastAverageOrgUnit:1302->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorLastSumOrgUnit:1270->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorSum:1318->assertGridContains:1608 Expected 6 rows in grid [
[dy, pe, ou, value]
] ==> expected: <6> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorWithOrgUnitFieldAtEnd:1175->assertGridContains:1608 Expected 3 rows in grid [
[dy, pe, ou, value]
] ==> expected: <3> but was: <0>
Error:    EventAnalyticsServiceTest.testEventProgramIndicatorWithOrgUnitFieldAtStart:1149->assertGridContains:1608 Expected 3 rows in grid [
[dy, pe, ou, value]
] ==> expected: <3> but was: <0>
Error:    EventAnalyticsServiceTest.testGetAggregatedEventDataWithOwnerAtEnd:839->assertGridContains:1608 Expected 3 rows in grid [
[pe, ou, value]
```