### PR TITLE
fix: Add path segment back into response URL [DHIS2-19516]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/StaticContentControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/StaticContentControllerTest.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.fileresource.FileResourceDomain.DOCUMENT;
 import static org.hisp.dhis.fileresource.FileResourceKeyUtil.makeKey;
 import static org.hisp.dhis.test.webapi.TestUtils.APPLICATION_JSON_UTF8;
 import static org.hisp.dhis.webapi.controller.StaticContentController.LOGO_BANNER;
-import static org.hisp.dhis.webapi.controller.StaticContentController.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.build;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
@@ -115,7 +114,7 @@ class StaticContentControllerTest extends WebSpringTestBase {
   void testGetStaticImagesCustomKey() throws Exception {
     // Given
     final String theExpectedType = "png";
-    final String theExpectedApiUrl = "/api" + RESOURCE_PATH;
+    final String theExpectedApiUrl = "/api/staticContent";
     // a mock file in the content store used during the fetch
     fileResourceContentStore.saveFileResourceContent(
         build(LOGO_BANNER, mockMultipartFile, DOCUMENT), "image".getBytes());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
@@ -92,15 +92,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @RequiredArgsConstructor
 public class StaticContentController {
-  protected static final String RESOURCE_PATH = "";
-
   private final StyleManager styleManager;
   private final FileResourceContentStore contentStore;
-
   static final String LOGO_BANNER = "logo_banner";
-
   static final String LOGO_FRONT = "logo_front";
-
   private static final FileResourceDomain DEFAULT_RESOURCE_DOMAIN = DOCUMENT;
 
   /**
@@ -127,7 +122,7 @@ public class StaticContentController {
       final boolean customFileExists = contentStore.fileResourceContentExists(storageKey);
 
       if (customFileExists) {
-        final String blobEndpoint = getContextPath(request) + "/api" + RESOURCE_PATH + "/" + key;
+        final String blobEndpoint = getContextPath(request) + "/api/staticContent/" + key;
 
         final SimpleImageResource imageResource = new SimpleImageResource();
         imageResource.addImage(IMAGE_PNG.getSubtype(), blobEndpoint);


### PR DESCRIPTION
## Issue
When calling the endpoint `GET` `/api/staticContent/logo_banner` with an Accept header of `*/*` or `application/json` it returns the following response:
```json
{
    "images": {
        "png": "https://play.im.dhis2.org/dev-2-42/api/logo_banner"
    }
}
```

The returned URL (`https://play.im.dhis2.org/dev-2-42/api/logo_banner`) is invalid. It should be:
`https://play.im.dhis2.org/dev-2-42/api/staticContent/logo_banner`

## Cause
[This change](https://github.com/dhis2/dhis2-core/commit/503eaa0e87e65082df97a5bbade5bf64c94d5be8#diff-7b37f48590eee0829b3e859f0af7e133a80eaf4a38005d8d0ce1ea463f986b6e) removed the `staticContent` string value which results in an invalid URL being returned.

## Fix
Add back in the `/staticContent` path segment so a valid URL is returned.
This assumes that the frontend then calls the endpoint `GET` `https://play.im.dhis2.org/dev-2-42/api/staticContent/logo_banner` with an accept header of `image/*` or `image/png` which returns the image.

## Testing
Existing test updated to make sure the returned URL contains `staticContent`
Tested in IM, see screenshots showing custom logo being used & response having correct URL

<img width="1107" alt="Screenshot 2025-04-25 at 15 10 34" src="https://github.com/user-attachments/assets/92375c59-1f16-4bf6-af1a-f6abb40b308b" />
<img width="908" alt="Screenshot 2025-04-25 at 15 11 37" src="https://github.com/user-attachments/assets/cf3f6a6a-0f99-4c2d-ba52-6c987d3653da" />
