### PR TITLE
chore: Disable MinIO hanging integration tests 2.42

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerMinIOTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerMinIOTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.appmanager.ResourceResult.ResourceNotFound;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.test.junit.MinIOTestExtension;
 import org.hisp.dhis.test.junit.MinIOTestExtension.DhisConfig;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,6 +64,7 @@ import org.springframework.test.context.ContextConfiguration;
  * Test class configured for use cases when DHIS2 is configured to use MinIO storage. The default
  * storage is the local filesystem.
  */
+@Disabled("Started failing in some PRs, not clear why.")
 @ExtendWith(MinIOTestExtension.class)
 @ContextConfiguration(classes = {DhisConfig.class})
 class AppManagerMinIOTest extends PostgresIntegrationTestBase {


### PR DESCRIPTION
Disable MinIO integration tests which have recently started hanging at the initialization phase (not even getting to run the tests).

```text
2025-04-25T05:47:45.9644979Z [INFO] Running org.hisp.dhis.app.AppManagerMinIOTest
2025-04-25T05:47:46.8629046Z Exception in thread "C3P0PooledConnectionPoolManager[identityToken->2rxcfkbattcmvg1iz2hv9|6e310162]-HelperThread-#1" java.lang.AssertionError
2025-04-25T05:47:46.8630509Z 	at com.mchange.v2.resourcepool.BasicResourcePool.doAcquire(BasicResourcePool.java:1299)
2025-04-25T05:47:46.8632004Z 	at com.mchange.v2.resourcepool.BasicResourcePool.doAcquireAndDecrementPendingAcquiresWithinLockOnSuccess(BasicResourcePool.java:1288)
2025-04-25T05:47:46.8633439Z 	at com.mchange.v2.resourcepool.BasicResourcePool.access$700(BasicResourcePool.java:12)
2025-04-25T05:47:46.8634713Z 	at com.mchange.v2.resourcepool.BasicResourcePool$ScatteredAcquireTask.run(BasicResourcePool.java:2083)
2025-04-25T05:47:46.8635983Z 	at com.mchange.v2.async.ThreadPoolAsynchronousRunner$PoolThread.run(ThreadPoolAsynchronousRunner.java:696)
2025-04-25T05:47:46.8637362Z 05:47:46.839 [main] ERROR org.hisp.dhis.datasource.DatabasePoolUtils - Connections could not be acquired from the underlying database!
```