### PR TITLE
fix: Analytics e2e tests require Order

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 junit.jupiter.extensions.autodetection.enabled=true
 # Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
 # see https://junit.org/junit5/docs/current/user-guide/index.html#writing-tests-test-execution-order
-# junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 junit.jupiter.execution.timeout.default=1m


### PR DESCRIPTION
A few e2e Analytics tests need “Order”. So, we need to add the configuration back. See:

NoAnalyticsTablesErrorsScenariosTest
DataItemsAnalyticsTest


This setting has been removed as part of this PR:
https://github.com/dhis2/dhis2-core/pull/20759 


It should be reverted, as it causes our Analytics tests to fail.