### PR TITLE
fix: support any installed or bundled app as start module

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -59,16 +59,30 @@ public class IndexController {
 
   private final SchemaService schemaService;
   private final ContextService contextService;
+  private final AppManager appManager;
 
   @GetMapping("/")
   public void getIndexWithSlash(
       HttpServletRequest request, HttpServletResponse response, SystemSettings settings)
       throws IOException {
-    String redirectUrl = request.getContextPath() + "/api/apps/" + settings.getStartModule();
+    
+    String redirectUrl = "/apps"; // By default, redirect to the global shell root
+    String sanitizedStartModule = settings.getStartModule();
+    if (sanitizedStartModule != null) {
+     if ( sanitizedStartModule.startsWith("dhis-web-") ) {
+      sanitizedStartModule = sanitizedStartModule.substring(9);
+     } else if ( sanitizedStartModule.startsWith("app:") ) {
+      sanitizedStartModule = sanitizedStartModule.substring(4);
+     }
 
-    if (!redirectUrl.endsWith("/")) {
-      redirectUrl += "/";
+      App app = appManager.getApp(sanitizedStartModule);
+
+      if (app != null) {
+        redirectUrl = app.getLaunchUrl();
+      }
     }
+
+
     String location = response.encodeRedirectURL(redirectUrl);
     response.sendRedirect(location);
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -68,7 +68,7 @@ public class IndexController {
       HttpServletRequest request, HttpServletResponse response, SystemSettings settings)
       throws IOException {
 
-    String redirectUrl = "/apps"; // By default, redirect to the global shell root
+    String redirectUrl = "/apps/"; // By default, redirect to the global shell root
     String sanitizedStartModule = settings.getStartModule();
     if (sanitizedStartModule != null) {
       if (sanitizedStartModule.startsWith("dhis-web-")) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -65,15 +65,15 @@ public class IndexController {
   public void getIndexWithSlash(
       HttpServletRequest request, HttpServletResponse response, SystemSettings settings)
       throws IOException {
-    
+
     String redirectUrl = "/apps"; // By default, redirect to the global shell root
     String sanitizedStartModule = settings.getStartModule();
     if (sanitizedStartModule != null) {
-     if ( sanitizedStartModule.startsWith("dhis-web-") ) {
-      sanitizedStartModule = sanitizedStartModule.substring(9);
-     } else if ( sanitizedStartModule.startsWith("app:") ) {
-      sanitizedStartModule = sanitizedStartModule.substring(4);
-     }
+      if (sanitizedStartModule.startsWith("dhis-web-")) {
+        sanitizedStartModule = sanitizedStartModule.substring(9);
+      } else if (sanitizedStartModule.startsWith("app:")) {
+        sanitizedStartModule = sanitizedStartModule.substring(4);
+      }
 
       App app = appManager.getApp(sanitizedStartModule);
 
@@ -81,7 +81,6 @@ public class IndexController {
         redirectUrl = app.getLaunchUrl();
       }
     }
-
 
     String location = response.encodeRedirectURL(redirectUrl);
     response.sendRedirect(location);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -34,6 +34,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.appmanager.App;
+import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;


### PR DESCRIPTION
This updates the logic for start module redirects to always look up the configured module in the AppManager cache and return the absolute launch URL for that app.  This means that the redirect will never point to a non-existent URL.  It also is backwards-compatible with older versions of the settings app which set `dhis-web-` or `app:` prefixes.  It does NOT support `apps/` prefix, but could be updated to do so if needed.