### PR TITLE
fix: Gist API link URLs [DHIS2-19531]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -125,10 +125,10 @@ public class DefaultGistService implements GistService, GistBuilder.GistBuilderS
       }
     }
     if (schema.hasApiEndpoint()) {
-      URI baseURL = GistPager.computeBaseURL(query, params, schemaService::getDynamicSchema);
+      URI queryURI = URI.create(query.getRequestURL());
       if (page > 1) {
         prev =
-            UriComponentsBuilder.fromUri(baseURL)
+            UriComponentsBuilder.fromUri(queryURI)
                 .replaceQueryParam("page", page - 1)
                 .build()
                 .toString();
@@ -136,7 +136,7 @@ public class DefaultGistService implements GistService, GistBuilder.GistBuilderS
       if (total != null && query.getPageOffset() + rows.size() < total
           || total == null && query.getPageSize() == rows.size()) {
         next =
-            UriComponentsBuilder.fromUri(baseURL)
+            UriComponentsBuilder.fromUri(queryURI)
                 .replaceQueryParam("page", page + 1)
                 .build()
                 .toString();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPager.java
@@ -30,15 +30,9 @@
 package org.hisp.dhis.gist;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.net.URI;
-import java.util.Map;
-import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hisp.dhis.gist.GistQuery.Owner;
-import org.hisp.dhis.schema.Schema;
-import org.springframework.web.util.UriBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
+import lombok.ToString;
 
 /**
  * Pager POJO for paging gist lists.
@@ -47,42 +41,17 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @Getter
 @AllArgsConstructor
+@ToString
 public final class GistPager {
+
   @JsonProperty private final int page;
-
   @JsonProperty private final int pageSize;
-
   @JsonProperty private final Integer total;
-
   @JsonProperty private final String prevPage;
-
   @JsonProperty private final String nextPage;
 
   @JsonProperty
   public Integer getPageCount() {
     return total == null ? null : (int) Math.ceil(total / (double) pageSize);
-  }
-
-  public String toString() {
-    return "[Page: " + page + " size: " + pageSize + "]";
-  }
-
-  public static URI computeBaseURL(
-      GistQuery query, Map<String, String[]> params, Function<Class<?>, Schema> schemaByType) {
-    UriBuilder url = UriComponentsBuilder.fromUriString(query.getEndpointRoot());
-    Owner owner = query.getOwner();
-    if (owner != null) {
-      Schema o = schemaByType.apply(owner.getType());
-      url.pathSegment(
-          o.getRelativeApiEndpoint().substring(1),
-          owner.getId(),
-          o.getProperty(owner.getCollectionProperty()).key(),
-          "gist");
-    } else {
-      Schema s = schemaByType.apply(query.getElementType());
-      url.pathSegment(s.getRelativeApiEndpoint().substring(1), "gist");
-    }
-    params.forEach(url::queryParam);
-    return url.build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -101,7 +101,7 @@ public final class GistParams {
 
   @OpenApi.Description(
       """
-      Use absolute (`true`) or relative URLs (`false`, default) when linking to other objects.
+      Use absolute (`true`) or relative URLs (`false`, default) when linking to other objects in `apiEndpoints`.
       See [Gist absoluteUrls parameter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata-gist.html#gist_parameters_absoluteUrls).""")
   boolean absoluteUrls = false;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -108,6 +108,7 @@ public final class GistQuery {
   @JsonProperty private final boolean total;
 
   private final String contextRoot;
+  private final String requestURL;
 
   private final Locale translationLocale;
 
@@ -167,7 +168,7 @@ public final class GistQuery {
   }
 
   public String getEndpointRoot() {
-    return isAbsoluteUrls() ? getContextRoot() : "";
+    return isAbsoluteUrls() ? getContextRoot() + "/api" : "/api";
   }
 
   public boolean hasFilterGroups() {
@@ -352,22 +353,16 @@ public final class GistQuery {
   @Builder(toBuilder = true)
   @AllArgsConstructor
   public static final class Field {
+
     public static final String REFS_PATH = "__refs__";
-
     public static final String ALL_PATH = "*";
-
     public static final Field ALL = new Field(ALL_PATH, Transform.NONE);
 
     @JsonProperty private final String propertyPath;
-
     @JsonProperty private final Transform transformation;
-
     @JsonProperty private final String alias;
-
     @JsonProperty private final String transformationArgument;
-
     @JsonProperty private final boolean translate;
-
     @JsonProperty private final boolean attribute;
 
     public Field(String propertyPath, Transform transformation) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -118,7 +118,7 @@ class GistFieldsControllerTest extends AbstractGistControllerTest {
     JsonObject user0 = users.getObject(0);
     assertTrue(user0.has("id", "href"));
     assertEquals(
-        "/users/" + user0.getString("id").string() + "/gist", user0.getString("href").string());
+        "/api/users/" + user0.getString("id").string() + "/gist", user0.getString("href").string());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
@@ -93,11 +93,11 @@ class GistPagerControllerTest extends AbstractGistControllerTest {
     gist = GET(url + "&page=2", orgUnitId).content();
     assertHasPager(gist, 2, 3, 10);
     assertEquals(
-        "/organisationUnits/{id}/dataSets/gist?total=true&pageSize=3&order=name&filter=name:startsWith:extra&page=1"
+        "http://localhost/api/organisationUnits/{id}/dataSets/gist?total=true&pageSize=3&order=name&filter=name:startsWith:extra&page=1"
             .replace("{id}", orgUnitId),
         gist.getObject("pager").getString("prevPage").string());
     assertEquals(
-        "/organisationUnits/{id}/dataSets/gist?total=true&pageSize=3&order=name&filter=name:startsWith:extra&page=3"
+        "http://localhost/api/organisationUnits/{id}/dataSets/gist?total=true&pageSize=3&order=name&filter=name:startsWith:extra&page=3"
             .replace("{id}", orgUnitId),
         gist.getObject("pager").getString("nextPage").string());
     JsonArray dataSets = gist.getArray("dataSets");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -227,6 +227,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
         .elementType(elementType)
         .autoType(params.getAuto(autoDefault))
         .contextRoot(ContextUtils.getRootPath(ContextUtils.getRequest()))
+        .requestURL(ContextUtils.getRequestURL())
         .translationLocale(translationLocale)
         .typedAttributeValues(true)
         .build()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.utils;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.nullToEmpty;
 import static org.hisp.dhis.common.cache.CacheStrategy.RESPECT_SYSTEM_SETTING;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.CheckForNull;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.HashUtils;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -206,6 +208,7 @@ public class ContextUtils {
     return response;
   }
 
+  @CheckForNull
   public static HttpServletRequest getRequest() {
     ServletRequestAttributes attributes =
         (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
@@ -215,6 +218,27 @@ public class ContextUtils {
 
   public static String getRootPath(HttpServletRequest request) {
     return HttpServletRequestPaths.getContextPath(request) + request.getServletPath();
+  }
+
+  /**
+   * Omits the default ports.
+   *
+   * @return The full URL as requested by the client or null of no request context is available
+   */
+  @CheckForNull
+  public static String getRequestURL() {
+    HttpServletRequest request = getRequest();
+    if (request == null) return null;
+    String scheme = request.getScheme();
+    String domain = request.getServerName();
+    String port = ":" + request.getServerPort();
+    if ((":80".equals(port) && "http".equals(scheme))
+        || (":443".equals(port) && "https".equals(scheme))) port = "";
+    String path = request.getRequestURI();
+    String query = "?" + nullToEmpty(request.getQueryString());
+    if ("?".equals(query)) query = "";
+    scheme += "://";
+    return scheme + domain + port + path + query;
   }
 
   /**


### PR DESCRIPTION
### Summary
The change to have `/api` be explicit must have broken the URL composition. 
I added the `/api` to the base URL used for `apiEndpoints`.
For prev/next I decided it would be more robust to simply use the current URL and add/change the `page=x` parameter.
The `absoluteUrls` parameter already was documented on just affecting referenced to other objects. I just made that more clear. So the prev/next in the pager are now never relative. This is also more consistent with the normal metadata API pager.

### Automatic Testing
Existing tests got adjusted. Maybe the expectation wasn't correct or outdated with the changes made to /api.

### Manual Testing
* browse to a gist API list, e.g. `/api/options/gist`
* check that the pager links and `absoluteUrls` links work
* check again for `/api/options/gist?absoluteUrls=true`
* also check that when adding a `filter` or `fields` those are preserved in the prev/next links of the pager