### PR TITLE
fix: use global shell v1.7.7 for startModule fix

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -26,6 +26,6 @@
   "https://github.com/d2-ci/user-app#v100.7.1",
   "https://github.com/d2-ci/user-profile-app#v100.7.2",
   "https://github.com/d2-ci/login-app#v100.4.4",
-  "https://github.com/d2-ci/global-shell-app#v1.7.6",
+  "https://github.com/d2-ci/global-shell-app#v1.7.7",
   "https://github.com/d2-ci/line-listing-app#v102.1.2"
 ]


### PR DESCRIPTION
Part of [DHIS2-19527](https://dhis2.atlassian.net/browse/DHIS2-19527) -- see global shell changes here: https://github.com/dhis2/global-shell-app/pull/49

Relates to #20824 

[DHIS2-19527]: https://dhis2.atlassian.net/browse/DHIS2-19527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ