### PR TITLE
chore: remove error log for job controller tests

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Tests the {@link org.hisp.dhis.webapi.controller.scheduling.JobConfigurationController} that
+ * cannot be tested with H2.
+ *
+ * @author Jan Bernitt
+ */
+@Transactional
+class JobConfigurationControllerIntegrationTest extends PostgresControllerIntegrationTestBase {
+
+  @Test
+  void testRevert() {
+    String json =
+        """
+        {
+        "name": "test",
+        "jobType": "DATA_INTEGRITY",
+        "cronExpression": "0 0 12 ? * MON-FRI"
+        }
+        """;
+    String jobId = assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", json));
+    switchToNewUser("no-auth");
+    assertStatus(HttpStatus.FORBIDDEN, POST("/jobConfigurations/" + jobId + "/revert"));
+    switchToAdminUser();
+    assertStatus(HttpStatus.CONFLICT, POST("/jobConfigurations/" + jobId + "/revert"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -462,16 +462,6 @@ class JobConfigurationControllerTest extends H2ControllerIntegrationTestBase {
     assertStatus(HttpStatus.CONFLICT, POST("/jobConfigurations/" + jobId + "/enable"));
   }
 
-  @Test
-  void testRevert() {
-    JsonJobConfiguration config = createExpectSuccess(Map.of());
-    String jobId = config.getId();
-    switchToNewUser("no-auth");
-    assertStatus(HttpStatus.FORBIDDEN, POST("/jobConfigurations/" + jobId + "/revert"));
-    switchToAdminUser();
-    assertStatus(HttpStatus.CONFLICT, POST("/jobConfigurations/" + jobId + "/revert"));
-  }
-
   private JsonJobConfiguration createExpectSuccess(Map<String, Object> extra) {
     return createExpectSuccess(MINIMAL_CRON_CONFIG, extra);
   }


### PR DESCRIPTION
The revert test needed to be moved to postgres since it otherwise would log an error. This is because the `cancel` column is (intentionally) not mapped in the `JobConfiguration` class and so it is missing in H2's view of the table.

Thanks to J.P. for pointing it out.