### PR TITLE
chore: use named parameters in HibernateTrackedEntityStore DHIS2-19474

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -36,23 +36,21 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
-import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 import static org.hisp.dhis.tracker.export.JdbcPredicate.mapPredicatesToSql;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
-import static org.hisp.dhis.util.DateUtils.toLongDateWithMillis;
-import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
 
 import jakarta.persistence.EntityManager;
+import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -64,7 +62,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.Page;
@@ -74,6 +71,7 @@ import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
@@ -96,21 +94,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   private static final String ENROLLMENT_DATE_KEY = "enrollment.enrollmentDate";
 
-  private static final String EV_OCCURREDDATE = "EV.occurreddate";
-
-  private static final String EV_SCHEDULEDDATE = "EV.scheduleddate";
-
-  private static final String IS_NULL = "IS NULL";
-
-  private static final String IS_NOT_NULL = "IS NOT NULL";
-
   private static final String SPACE = " ";
-
-  private static final String SINGLE_QUOTE = "'";
-
-  private static final String EQUALS = " = ";
-
-  private static final String EV_STATUS = "EV.status";
 
   private static final String SELECT_COUNT_INSTANCE_FROM = "SELECT count(trackedentityid) FROM ( ";
 
@@ -211,10 +195,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   public Set<String> getOrderableFields() {
     return ORDERABLE_FIELDS.keySet();
-  }
-
-  private String encodeAndQuote(Collection<String> elements) {
-    return getQuotedCommaDelimitedString(elements.stream().map(SqlUtils::escape).toList());
   }
 
   private Long getTrackedEntityCount(TrackedEntityQueryParams params) {
@@ -377,33 +357,32 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       boolean isCountQuery,
       PageParams pageParams) {
     SqlHelper whereAnd = new SqlHelper(true);
-    StringBuilder fromSubQuery =
+    StringBuilder sql =
         new StringBuilder()
             .append("(")
             .append(getFromSubQuerySelect(params))
-            .append(" FROM trackedentity " + MAIN_QUERY_ALIAS + " ")
+            .append(" FROM trackedentity " + MAIN_QUERY_ALIAS + " ");
 
-            // INNER JOIN on constraints
-            .append(joinPrograms(params))
-            .append(getFromSubQueryJoinProgramOwnerConditions(params))
-            .append(getFromSubQueryJoinOrgUnitConditions(params, sqlParameters))
-            .append(getFromSubQueryJoinEnrollmentConditions(params))
+    addJoinOnProgram(sql, sqlParameters, params);
+    sql.append(" ");
+    addJoinOnProgramOwner(sql, sqlParameters, params);
+    sql.append(" ")
+        .append(getFromSubQueryJoinOrgUnitConditions(sqlParameters, params))
+        .append(getFromSubQueryJoinEnrollmentConditions(params))
 
-            // LEFT JOIN attributes we need to sort on and/or filter by.
-            .append(getLeftJoinFromAttributes(params))
+        // LEFT JOIN attributes we need to sort on and/or filter by.
+        .append(getLeftJoinFromAttributes(params))
 
-            // WHERE
-            .append(getWhereClauseFromFilterConditions(params, sqlParameters, whereAnd))
-            .append(getFromSubQueryTrackedEntityConditions(whereAnd, params))
-            .append(getFromSubQueryEnrollmentConditions(whereAnd, params));
+        // WHERE
+        .append(getWhereClauseFromFilterConditions(whereAnd, sqlParameters, params))
+        .append(getFromSubQueryTrackedEntityConditions(whereAnd, sqlParameters, params))
+        .append(getFromSubQueryEnrollmentConditions(whereAnd, sqlParameters, params));
 
     if (!isCountQuery) {
-      fromSubQuery
-          .append(getQueryOrderBy(params, true))
-          .append(getFromSubQueryLimitAndOffset(pageParams));
+      sql.append(getQueryOrderBy(params, true)).append(getFromSubQueryLimitAndOffset(pageParams));
     }
 
-    return fromSubQuery.append(") ").append(MAIN_QUERY_ALIAS).append(" ").toString();
+    return sql.append(") ").append(MAIN_QUERY_ALIAS).append(" ").toString();
   }
 
   /**
@@ -454,20 +433,15 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     return "SELECT DISTINCT " + String.join(", ", columns);
   }
 
-  private String joinPrograms(TrackedEntityQueryParams params) {
-    StringBuilder trackedEntity = new StringBuilder();
-
-    trackedEntity.append(" INNER JOIN program P ");
-    trackedEntity.append(" ON P.trackedentitytypeid = TE.trackedentitytypeid ");
+  private void addJoinOnProgram(
+      StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
+    sql.append("inner join program P on P.trackedentitytypeid = TE.trackedentitytypeid");
 
     if (!params.hasEnrolledInTrackerProgram()) {
-      trackedEntity
-          .append("AND P.programid IN (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getAccessibleTrackerPrograms())))
-          .append(")");
+      sql.append(" and P.programid in (:accessiblePrograms)");
+      sqlParameters.addValue(
+          "accessiblePrograms", getIdentifiers(params.getAccessibleTrackerPrograms()));
     }
-
-    return trackedEntity.toString();
   }
 
   /**
@@ -477,50 +451,44 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * @return a SQL segment for the WHERE clause used in the sub-query
    */
   private String getFromSubQueryTrackedEntityConditions(
-      SqlHelper whereAnd, TrackedEntityQueryParams params) {
+      SqlHelper whereAnd, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     StringBuilder trackedEntity = new StringBuilder();
 
     if (params.hasTrackedEntities()) {
-      trackedEntity
-          .append(whereAnd.whereAnd())
-          .append("TE.uid IN (")
-          .append(encodeAndQuote(UID.toValueSet(params.getTrackedEntities())))
-          .append(") ");
+      trackedEntity.append(whereAnd.whereAnd()).append("TE.uid IN (:trackedEntities) ");
+      sqlParameters.addValue("trackedEntities", UID.toValueSet(params.getTrackedEntities()));
     }
 
     if (params.hasTrackedEntityType()) {
       trackedEntity
           .append(whereAnd.whereAnd())
-          .append("TE.trackedentitytypeid = ")
-          .append(params.getTrackedEntityType().getId());
+          .append("TE.trackedentitytypeid = :trackedEntityTypeId ");
+      sqlParameters.addValue("trackedEntityTypeId", params.getTrackedEntityType().getId());
     } else if (!params.hasEnrolledInTrackerProgram()) {
       trackedEntity
           .append(whereAnd.whereAnd())
-          .append("TE.trackedentitytypeid in (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getTrackedEntityTypes())))
-          .append(")");
+          .append("TE.trackedentitytypeid in (:trackedEntityTypeIds) ");
+      sqlParameters.addValue(
+          "trackedEntityTypeIds", getIdentifiers(params.getTrackedEntityTypes()));
     }
 
     if (params.hasLastUpdatedDuration()) {
-      trackedEntity
-          .append(whereAnd.whereAnd())
-          .append(" TE.lastupdated >= '")
-          .append(toLongGmtDate(DateUtils.nowMinusDuration(params.getLastUpdatedDuration())))
-          .append(SINGLE_QUOTE);
+      trackedEntity.append(whereAnd.whereAnd()).append(" TE.lastupdated >= :lastUpdatedDuration ");
+      sqlParameters.addValue(
+          "lastUpdatedDuration",
+          timestampParameter(DateUtils.nowMinusDuration(params.getLastUpdatedDuration())));
     } else {
       if (params.hasLastUpdatedStartDate()) {
         trackedEntity
             .append(whereAnd.whereAnd())
-            .append(" TE.lastupdated >= '")
-            .append(toLongDateWithMillis(params.getLastUpdatedStartDate()))
-            .append(SINGLE_QUOTE);
+            .append(" TE.lastupdated >= :lastUpdatedStartDate ");
+        sqlParameters.addValue(
+            "lastUpdatedStartDate", timestampParameter(params.getLastUpdatedStartDate()));
       }
       if (params.hasLastUpdatedEndDate()) {
-        trackedEntity
-            .append(whereAnd.whereAnd())
-            .append(" TE.lastupdated <= '")
-            .append(toLongDateWithMillis(params.getLastUpdatedEndDate()))
-            .append(SINGLE_QUOTE);
+        trackedEntity.append(whereAnd.whereAnd()).append(" TE.lastupdated <= :lastUpdatedEndDate ");
+        sqlParameters.addValue(
+            "lastUpdatedEndDate", timestampParameter(params.getLastUpdatedEndDate()));
       }
     }
 
@@ -531,9 +499,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     if (params.hasPotentialDuplicateFilter()) {
       trackedEntity
           .append(whereAnd.whereAnd())
-          .append("TE.potentialduplicate=")
-          .append(params.getPotentialDuplicate())
-          .append(SPACE);
+          .append("TE.potentialduplicate = :potentialDuplicate ");
+      sqlParameters.addValue("potentialDuplicate", params.getPotentialDuplicate());
     }
 
     return trackedEntity.toString();
@@ -544,9 +511,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * this LEFT JOIN is used in the subquery projection and for ordering in both the subquery and the
    * main query.
    *
-   * <p>Attribute filtering is handled in {@link
-   * #getWhereClauseFromFilterConditions(TrackedEntityQueryParams, MapSqlParameterSource,
-   * SqlHelper)}.
+   * <p>Attribute filtering is handled in {@link #getWhereClauseFromFilterConditions(SqlHelper,
+   * MapSqlParameterSource, TrackedEntityQueryParams)}.
    *
    * @return a SQL LEFT JOIN for the relevant attributes, or an empty string if none are provided.
    */
@@ -570,24 +536,24 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     return attributes.toString();
   }
 
-  /**
-   * Generates an INNER JOIN for program owner. This segment is only included if program is
-   * specified.
-   *
-   * @return a SQL INNER JOIN for program owner, or a LEFT JOIN if no program is specified.
-   */
-  private String getFromSubQueryJoinProgramOwnerConditions(TrackedEntityQueryParams params) {
+  private void addJoinOnProgramOwner(
+      StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     if (params.hasEnrolledInTrackerProgram()) {
-      return " INNER JOIN trackedentityprogramowner PO "
-          + " ON PO.programid = "
-          + params.getEnrolledInTrackerProgram().getId()
-          + " AND PO.trackedentityid = TE.trackedentityid "
-          + " AND P.programid = PO.programid";
+      sql.append(
+          """
+          inner join trackedentityprogramowner PO \
+           on PO.programid = :enrolledInTrackerProgram\
+           and PO.trackedentityid = TE.trackedentityid \
+           and P.programid = PO.programid""");
+      sqlParameters.addValue(
+          "enrolledInTrackerProgram", params.getEnrolledInTrackerProgram().getId());
+      return;
     }
 
-    return "LEFT JOIN trackedentityprogramowner PO ON "
-        + " PO.trackedentityid = TE.trackedentityid"
-        + " AND P.programid = PO.programid";
+    sql.append(
+        "left join trackedentityprogramowner PO on "
+            + " PO.trackedentityid = TE.trackedentityid"
+            + " and P.programid = PO.programid");
   }
 
   /**
@@ -614,7 +580,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * @return a SQL INNER JOIN clause for organisation units
    */
   private String getFromSubQueryJoinOrgUnitConditions(
-      TrackedEntityQueryParams params, MapSqlParameterSource sqlParams) {
+      MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     StringBuilder orgUnits = new StringBuilder();
 
     UserDetails userDetails = getCurrentUserDetails();
@@ -624,8 +590,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         getOrgUnitsFromUids(userDetails.getUserOrgUnitIds());
 
     orgUnits
-        .append(" INNER JOIN organisationunit OU ")
-        .append("ON OU.organisationunitid = ")
+        .append(" inner join organisationunit OU ")
+        .append("on OU.organisationunitid = ")
         .append(getOwnerOrgUnit(params));
 
     if (params.hasOrganisationUnits()) {
@@ -634,7 +600,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       } else if (params.isOrganisationUnitMode(CHILDREN)) {
         orgUnits.append(getChildrenQuery(params));
       } else if (params.isOrganisationUnitMode(SELECTED)) {
-        orgUnits.append(getSelectedQuery(params));
+        orgUnits.append("and OU.organisationunitid in (:orgUnits) ");
+        sqlParameters.addValue("orgUnits", getIdentifiers(params.getOrgUnits()));
       }
     }
 
@@ -642,13 +609,14 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       return orgUnits.toString();
     }
 
-    sqlParams.addValue("effectiveSearchScopePaths", getOrgUnitsPathArray(effectiveSearchOrgUnits));
-    sqlParams.addValue("captureScopePaths", getOrgUnitsPathArray(captureScopeOrgUnits));
-
     orgUnits.append(
         "and ((P.accesslevel in ('OPEN', 'AUDITED') and (OU.path like any (:effectiveSearchScopePaths))) ");
+    sqlParameters.addValue(
+        "effectiveSearchScopePaths", getOrgUnitsPathArray(effectiveSearchOrgUnits));
+
     orgUnits.append(
         "or (P.accesslevel in ('PROTECTED', 'CLOSED') and (OU.path like any (:captureScopePaths)))) ");
+    sqlParameters.addValue("captureScopePaths", getOrgUnitsPathArray(captureScopeOrgUnits));
 
     return orgUnits.toString();
   }
@@ -666,19 +634,19 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       return "PO.organisationunitid ";
     }
 
-    return "COALESCE(PO.organisationunitid, TE.organisationunitid) ";
+    return "coalesce(PO.organisationunitid, TE.organisationunitid) ";
   }
 
   private String getDescendantsQuery(TrackedEntityQueryParams params) {
     StringBuilder orgUnits = new StringBuilder();
     SqlHelper orHlp = new SqlHelper(true);
 
-    orgUnits.append("AND (");
+    orgUnits.append("and (");
 
     for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
       orgUnits
           .append(orHlp.or())
-          .append("OU.path LIKE '")
+          .append("OU.path like '")
           .append(organisationUnit.getStoredPath())
           .append("%'");
     }
@@ -692,17 +660,17 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     StringBuilder orgUnits = new StringBuilder();
     SqlHelper orHlp = new SqlHelper(true);
 
-    orgUnits.append("AND (");
+    orgUnits.append("and (");
 
     for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
       orgUnits
           .append(orHlp.or())
-          .append(" OU.path LIKE '")
+          .append(" OU.path like '")
           .append(organisationUnit.getStoredPath())
           .append("%'")
-          .append(" AND (ou.hierarchylevel = ")
+          .append(" and (ou.hierarchylevel = ")
           .append(organisationUnit.getHierarchyLevel())
-          .append(" OR ou.hierarchylevel = ")
+          .append(" or ou.hierarchylevel = ")
           .append((organisationUnit.getHierarchyLevel() + 1))
           .append(")");
     }
@@ -710,12 +678,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     orgUnits.append(") ");
 
     return orgUnits.toString();
-  }
-
-  private String getSelectedQuery(TrackedEntityQueryParams params) {
-    return "AND OU.organisationunitid IN ("
-        + getCommaDelimitedString(getIdentifiers(params.getOrgUnits()))
-        + ") ";
   }
 
   /**
@@ -728,21 +690,19 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   private String getFromSubQueryJoinEnrollmentConditions(TrackedEntityQueryParams params) {
     if (params.getOrder().stream()
         .filter(o -> o.getField() instanceof String)
-        .anyMatch(p -> ENROLLMENT_DATE_KEY.equals(p.getField()))) {
-
-      String join =
-          """
-            INNER JOIN enrollment %1$s
-            ON %1$s.trackedentityid = TE.trackedentityid
-            """;
-
-      return !params.hasEnrolledInTrackerProgram()
-          ? join.formatted(ENROLLMENT_ALIAS)
-          : join.concat(" AND %1$s.programid = %2$s")
-              .formatted(ENROLLMENT_ALIAS, params.getEnrolledInTrackerProgram().getId());
+        .noneMatch(p -> ENROLLMENT_DATE_KEY.equals(p.getField()))) {
+      return "";
     }
 
-    return "";
+    String join =
+        """
+          inner join enrollment %1$s
+          on %1$s.trackedentityid = TE.trackedentityid
+          """;
+    return !params.hasEnrolledInTrackerProgram()
+        ? join.formatted(ENROLLMENT_ALIAS)
+        : join.concat(" and %1$s.programid = %2$s")
+            .formatted(ENROLLMENT_ALIAS, params.getEnrolledInTrackerProgram().getId());
   }
 
   /**
@@ -754,72 +714,64 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * @return an SQL EXISTS clause for enrollment, or empty string if not program is specified.
    */
   private String getFromSubQueryEnrollmentConditions(
-      SqlHelper whereAnd, TrackedEntityQueryParams params) {
-    StringBuilder program = new StringBuilder();
-
+      SqlHelper whereAnd, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     if (!params.hasEnrolledInTrackerProgram()) {
       return "";
     }
 
-    program
-        .append(whereAnd.whereAnd())
-        .append("EXISTS (")
-        .append("SELECT EN.trackedentityid ")
-        .append("FROM enrollment EN ");
+    StringBuilder sql = new StringBuilder();
+    sql.append(whereAnd.whereAnd())
+        .append("exists (")
+        .append("select en.trackedentityid ")
+        .append("from enrollment en ");
 
     if (params.hasFilterForEvents()) {
-      program.append(getFromSubQueryEvent(params));
+      sql.append("inner join (");
+      addEventQuery(sql, sqlParameters, params);
+      sql.append(") EV on EV.enrollmentid = en.enrollmentid ");
     }
 
-    program
-        .append("WHERE EN.trackedentityid = TE.trackedentityid ")
-        .append("AND EN.programid = ")
-        .append(params.getEnrolledInTrackerProgram().getId())
-        .append(SPACE);
+    sql.append("where en.trackedentityid = TE.trackedentityid ")
+        .append("and en.programid = :enrolledProgramId ");
+    sqlParameters.addValue("enrolledProgramId", params.getEnrolledInTrackerProgram().getId());
 
     if (params.hasEnrollmentStatus()) {
-      program.append("AND EN.status = '").append(params.getEnrollmentStatus()).append("' ");
+      sql.append("and en.status = :enrollmentStatus ");
+      sqlParameters.addValue("enrollmentStatus", params.getEnrollmentStatus());
     }
 
     if (params.hasFollowUp()) {
-      program.append("AND EN.followup IS ").append(params.getFollowUp()).append(SPACE);
+      sql.append("and en.followup IS :followUp ");
+      sqlParameters.addValue("followUp", params.getFollowUp());
     }
 
     if (params.hasProgramEnrollmentStartDate()) {
-      program
-          .append("AND EN.enrollmentdate >= '")
-          .append(toLongDateWithMillis(params.getProgramEnrollmentStartDate()))
-          .append("' ");
+      sql.append("and en.enrollmentdate >= :enrollmentStartDate ");
+      sqlParameters.addValue("enrollmentStartDate", params.getProgramEnrollmentStartDate());
     }
 
     if (params.hasProgramEnrollmentEndDate()) {
-      program
-          .append("AND EN.enrollmentdate <= '")
-          .append(toLongDateWithMillis(params.getProgramEnrollmentEndDate()))
-          .append("' ");
+      sql.append("and en.enrollmentdate <= :enrollmentEndDate ");
+      sqlParameters.addValue("enrollmentEndDate", params.getProgramEnrollmentEndDate());
     }
 
     if (params.hasProgramIncidentStartDate()) {
-      program
-          .append("AND EN.occurreddate >= '")
-          .append(toLongDateWithMillis(params.getProgramIncidentStartDate()))
-          .append("' ");
+      sql.append("and en.occurreddate >= :occurredStartDate ");
+      sqlParameters.addValue("occurredStartDate", params.getProgramIncidentStartDate());
     }
 
     if (params.hasProgramIncidentEndDate()) {
-      program
-          .append("AND EN.occurreddate <= '")
-          .append(toLongDateWithMillis(params.getProgramIncidentEndDate()))
-          .append("' ");
+      sql.append("and en.occurreddate <= :occurredEndDate ");
+      sqlParameters.addValue("occurredEndDate", params.getProgramIncidentEndDate());
     }
 
     if (!params.isIncludeDeleted()) {
-      program.append("AND EN.deleted is false ");
+      sql.append("and en.deleted is false ");
     }
 
-    program.append(") ");
+    sql.append(") ");
 
-    return program.toString();
+    return sql.toString();
   }
 
   /**
@@ -828,7 +780,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * filter is specified.
    */
   private String getWhereClauseFromFilterConditions(
-      TrackedEntityQueryParams params, MapSqlParameterSource sqlParameters, SqlHelper hlp) {
+      SqlHelper hlp, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     if (params.getFilters().isEmpty()) {
       return "";
     }
@@ -843,145 +795,82 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     return sql.toString();
   }
 
-  /**
-   * Generates an INNER JOIN with the enrollments if event-filters are specified. In the case of
-   * user assignment is part of the filter, we join with the userinfo table as well.
-   *
-   * @return an SQL INNER JOIN for filtering on events.
-   */
-  private String getFromSubQueryEvent(TrackedEntityQueryParams params) {
-    StringBuilder events = new StringBuilder();
-    SqlHelper whereHlp = new SqlHelper(true);
-
-    events.append("INNER JOIN (").append("SELECT EV.enrollmentid ").append("FROM event EV ");
+  /** Adds event query with event related query params to given {@code sql}. */
+  private void addEventQuery(
+      StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
+    sql.append("select ev.enrollmentid ").append("from event ev ");
 
     if (params.getAssignedUserQueryParam().hasAssignedUsers()) {
-      events
-          .append("INNER JOIN (")
-          .append("SELECT userinfoid AS userid ")
-          .append("FROM userinfo ")
-          .append("WHERE uid IN (")
-          .append(
-              encodeAndQuote(UID.toValueSet(params.getAssignedUserQueryParam().getAssignedUsers())))
-          .append(") ")
-          .append(") AU ON AU.userid = EV.assigneduserid");
+      sql.append("inner join (")
+          .append("select userinfoid as userid ")
+          .append("from userinfo ")
+          .append("where uid in (:assignedUserUids) ")
+          .append(") au on au.userid = ev.assigneduserid");
+      sqlParameters.addValue(
+          "assignedUserUids",
+          UID.toValueSet(params.getAssignedUserQueryParam().getAssignedUsers()));
     }
 
+    SqlHelper whereHlp = new SqlHelper(true);
     if (params.hasEventStatus()) {
-      String start = toLongDateWithMillis(params.getEventStartDate());
-      String end = toLongDateWithMillis(params.getEventEndDate());
-
-      if (params.isEventStatus(EventStatus.COMPLETED)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_OCCURREDDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(EQUALS)
-            .append(SINGLE_QUOTE)
-            .append(EventStatus.COMPLETED.name())
-            .append(SINGLE_QUOTE)
-            .append(SPACE);
-      } else if (params.isEventStatus(EventStatus.VISITED)
-          || params.isEventStatus(EventStatus.ACTIVE)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_OCCURREDDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(EQUALS)
-            .append(SINGLE_QUOTE)
-            .append(EventStatus.ACTIVE.name())
-            .append(SINGLE_QUOTE)
-            .append(SPACE);
-      } else if (params.isEventStatus(EventStatus.SCHEDULE)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_SCHEDULEDDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(SPACE)
-            .append(IS_NOT_NULL)
-            .append(whereHlp.whereAnd())
-            .append(EV_OCCURREDDATE)
-            .append(SPACE)
-            .append(IS_NULL)
-            .append(whereHlp.whereAnd())
-            .append("date(now()) <= date(EV.scheduleddate) ");
-      } else if (params.isEventStatus(EventStatus.OVERDUE)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_SCHEDULEDDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(SPACE)
-            .append(IS_NOT_NULL)
-            .append(whereHlp.whereAnd())
-            .append(EV_OCCURREDDATE)
-            .append(SPACE)
-            .append(IS_NULL)
-            .append(whereHlp.whereAnd())
-            .append("date(now()) > date(EV.scheduleddate) ");
-      } else if (params.isEventStatus(EventStatus.SKIPPED)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_SCHEDULEDDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(EQUALS)
-            .append(SINGLE_QUOTE)
-            .append(EventStatus.SKIPPED.name())
-            .append(SINGLE_QUOTE)
-            .append(SPACE);
-      }
+      sql.append(whereHlp.whereAnd());
+      addEventDateRange(sql, sqlParameters, params);
+      sql.append(whereHlp.whereAnd());
+      addEventStatus(sql, sqlParameters, params);
     }
 
     if (params.hasProgramStage()) {
-      events
-          .append(whereHlp.whereAnd())
-          .append("EV.programstageid = ")
-          .append(params.getProgramStage().getId())
-          .append(SPACE);
+      sql.append(whereHlp.whereAnd()).append("ev.programstageid = :programStageId ");
+      sqlParameters.addValue("programStageId", params.getProgramStage().getId());
     }
 
     if (AssignedUserSelectionMode.NONE == params.getAssignedUserQueryParam().getMode()) {
-      events.append(whereHlp.whereAnd()).append("EV.assigneduserid IS NULL ");
+      sql.append(whereHlp.whereAnd()).append("ev.assigneduserid is null ");
     }
 
     if (AssignedUserSelectionMode.ANY == params.getAssignedUserQueryParam().getMode()) {
-      events.append(whereHlp.whereAnd()).append("EV.assigneduserid IS NOT NULL ");
+      sql.append(whereHlp.whereAnd()).append("ev.assigneduserid is not null ");
     }
 
     if (!params.isIncludeDeleted()) {
-      events.append(whereHlp.whereAnd()).append("EV.deleted IS FALSE");
+      sql.append(whereHlp.whereAnd()).append("ev.deleted is false");
     }
-
-    events.append(") EV ON EV.enrollmentid = EN.enrollmentid ");
-
-    return events.toString();
   }
 
-  /**
-   * Helper method for making a date condition. The format is "[WHERE|AND] date >= start AND date <=
-   * end".
-   *
-   * @param whereHelper tracking whether WHERE has been invoked or not
-   * @param column the column for filter on
-   * @param start the start date
-   * @param end the end date
-   * @return a SQL filter for finding dates between two dates.
-   */
-  private String getQueryDateConditionBetween(
-      SqlHelper whereHelper, String column, String start, String end) {
-    return whereHelper.whereAnd()
-        + column
-        + " >= '"
-        + start
-        + SINGLE_QUOTE
-        + whereHelper.whereAnd()
-        + column
-        + " <= '"
-        + end
-        + "' ";
+  private void addEventDateRange(
+      StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
+    sql.append(
+        switch (params.getEventStatus()) {
+          case COMPLETED, VISITED, ACTIVE ->
+              "ev.occurreddate >= :eventStartDate and ev.occurreddate <= :eventEndDate";
+          case SCHEDULE, OVERDUE, SKIPPED ->
+              "ev.scheduleddate >= :eventStartDate and ev.scheduleddate <= :eventEndDate";
+        });
+    sqlParameters.addValue("eventStartDate", timestampParameter(params.getEventStartDate()));
+    sqlParameters.addValue("eventEndDate", timestampParameter(params.getEventEndDate()));
+  }
+
+  private void addEventStatus(
+      StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
+    if (params.isEventStatus(EventStatus.COMPLETED)) {
+      sql.append("ev.status = :eventStatus");
+      sqlParameters.addValue("eventStatus", EventStatus.COMPLETED.name());
+    } else if (params.isEventStatus(EventStatus.VISITED)
+        || params.isEventStatus(EventStatus.ACTIVE)) {
+      sql.append("ev.status = :eventStatus");
+      sqlParameters.addValue("eventStatus", EventStatus.ACTIVE.name());
+    } else if (params.isEventStatus(EventStatus.SKIPPED)) {
+      sql.append("ev.status = :eventStatus");
+      sqlParameters.addValue("eventStatus", EventStatus.SKIPPED.name());
+    } else if (params.isEventStatus(EventStatus.SCHEDULE)
+        || params.isEventStatus(EventStatus.OVERDUE)) {
+      sql.append(
+          "ev.status is not null and ev.occurreddate is null and date(now()) <= date(EV.scheduleddate) ");
+    }
   }
 
   private String getLimitClause(int limit) {
-    return "LIMIT " + limit;
+    return "limit " + limit;
   }
 
   /**
@@ -1022,10 +911,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     if (!orderFields.isEmpty()) {
-      return "ORDER BY " + StringUtils.join(orderFields, ',') + ", " + DEFAULT_ORDER + SPACE;
+      return "order by " + StringUtils.join(orderFields, ',') + ", " + DEFAULT_ORDER + SPACE;
     }
 
-    return "ORDER BY " + DEFAULT_ORDER + SPACE;
+    return "order by " + DEFAULT_ORDER + SPACE;
   }
 
   /**
@@ -1076,5 +965,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     return 0;
+  }
+
+  @Nonnull
+  private static SqlParameterValue timestampParameter(Date date) {
+    return new SqlParameterValue(Types.TIMESTAMP, date);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -727,7 +727,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
     if (params.hasFilterForEvents()) {
       sql.append("inner join (");
-      addEventQuery(sql, sqlParameters, params);
+      addEventFilter(sql, sqlParameters, params);
       sql.append(") EV on EV.enrollmentid = en.enrollmentid ");
     }
 
@@ -796,7 +796,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   }
 
   /** Adds event query with event related query params to given {@code sql}. */
-  private void addEventQuery(
+  private void addEventFilter(
       StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
     sql.append("select ev.enrollmentid ").append("from event ev ");
 
@@ -862,10 +862,12 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     } else if (params.isEventStatus(EventStatus.SKIPPED)) {
       sql.append("ev.status = :eventStatus");
       sqlParameters.addValue("eventStatus", EventStatus.SKIPPED.name());
-    } else if (params.isEventStatus(EventStatus.SCHEDULE)
-        || params.isEventStatus(EventStatus.OVERDUE)) {
+    } else if (params.isEventStatus(EventStatus.SCHEDULE)) {
       sql.append(
           "ev.status is not null and ev.occurreddate is null and date(now()) <= date(EV.scheduleddate) ");
+    } else if (params.isEventStatus(EventStatus.OVERDUE)) {
+      sql.append(
+          "ev.status is not null and ev.occurreddate is null and date(now()) > date(EV.scheduleddate) ");
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -258,17 +258,7 @@ public class TrackedEntityQueryParams {
    * Indicates whether the event status specified for the params is equal to the given event status.
    */
   public boolean isEventStatus(EventStatus eventStatus) {
-    return this.eventStatus != null && this.eventStatus.equals(eventStatus);
-  }
-
-  /** Indicates whether these parameters specify an event start date. */
-  public boolean hasEventStartDate() {
-    return eventStartDate != null;
-  }
-
-  /** Indicates whether these parameters specify an event end date. */
-  public boolean hasEventEndDate() {
-    return eventEndDate != null;
+    return this.eventStatus == eventStatus;
   }
 
   /** Check whether we are filtering for potential duplicate property. */

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/SqlUtils.java
@@ -95,7 +95,13 @@ public class SqlUtils {
    *
    * @param value the value.
    * @return the single quoted relation.
+   * @deprecated this single quotes and escapes the values single quotes and backslashes which is
+   *     not correct in every context. Backslashes only need to be escaped in a like and in case <a
+   *     href="https://postgresqlco.nf/doc/en/param/standard_conforming_strings/">standard_conforming_strings</a>
+   *     is enabled. The latter is taken care of by the JDBC driver. Quoting single quotes is also
+   *     taken care of by the JDBC driver when using JDBC templates with SQL parameters.
    */
+  @Deprecated(forRemoval = true)
   public static String singleQuote(String value) {
     return SINGLE_QUOTE + escape(value) + SINGLE_QUOTE;
   }
@@ -106,7 +112,13 @@ public class SqlUtils {
    *
    * @param value the value to escape.
    * @return the escaped value.
+   * @deprecated this escapes single quotes and backslashes which is not correct in every context.
+   *     Backslashes only need to be escaped in a like and in case <a
+   *     href="https://postgresqlco.nf/doc/en/param/standard_conforming_strings/">standard_conforming_strings</a>
+   *     is enabled. The latter is taken care of by the JDBC driver. Quoting single quotes is also
+   *     taken care of by the JDBC driver when using JDBC templates with SQL parameters.
    */
+  @Deprecated(forRemoval = true)
   public static String escape(String value) {
     return value
         .replace(SINGLE_QUOTE, (SINGLE_QUOTE + SINGLE_QUOTE))


### PR DESCRIPTION
Use named parameters in `HibernateTrackedEntityStore`. There are more places we should use them though. The `orgUnit` logic is quite complex. I'll try to follow up.

Remember that the JDBC driver will escape single quotes for us. Spring handles collections and different data types for us in its named parameters.

Please use lowercase when writing SQL! No need to scream 🙀 😂 

## Generating SQL

I suggest we structure our SQL generation into composable functions with signatures like

```java
private void addEventQuery(
    StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
```

The convention being to **pass in these parameters in that order** in all our JDBC stores SQL generating functions. Any additionally needed parameters should come after them.

These functions follow the same principle as the `JdbcPredicate` introduced in https://github.com/dhis2/dhis2-core/pull/20586. They generate/add "valid" SQL based on params and add necessary parameters to the SQL parameter map. "valid" is in quotes as the SQL might be a valid SQL predicate but is not a valid SQL query you could execute. So sometimes these SQL snippets will still need to be embedded into a projection, subquery, where clause, ... 

You can see that the change to `getFromSubQueryEvent` makes sure the function generates/adds SQL that is in itself valid. Each atomic SQL function should not prefix/suffix any spaces or `where` or `and` (see `addEventQuery`, `addEventDateRange`, ...). Only then can you actually compose them into bigger queries.

The need for the old javadoc on `addEventQuery` showed that you needed to explain the context that you actually get from its call site. So moving out how it is integrated into a bigger query makes it reusable and easy to understand and test/debug.

That does not mean we should create tons of small functions. If there is no branching/repetition but only an unconditional add sql and an add param I don't think an extra function is any good.

Keep the introduction of a parameter and adding it to the SQL parameter source close! Like a variable declaration and its usage in any other language.

## Next PR

* adopt the pattern in more of `HibernateTrackedEntityStore` methods

## Open Question

* there is a risk of accidentally overriding a SQL parameter. So we need to structure our code so that a single function is responsible for turning user input into a parameter