### PR TITLE
fix: system settings notifierGistOverview method naming [DHIS2-19128]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -118,7 +118,8 @@ public non-sealed interface SystemSettings extends Settings {
     return LazySettings.isTranslatable(key);
   }
 
-  /** Settings used in core */
+  /* Settings used in core - all names have to start with "get" */
+
   default Locale getUiLocale() {
     return asLocale("keyUiLocale", LocaleManager.DEFAULT_LOCALE);
   }
@@ -730,16 +731,6 @@ public non-sealed interface SystemSettings extends Settings {
     return asBoolean("enforceVerifiedEmail", false);
   }
 
-  /** Combinators based on several settings. */
-  default boolean isEmailConfigured() {
-    return !getEmailHostName().isBlank() && !getEmailUsername().isBlank();
-  }
-
-  default boolean isHideUnapprovedDataInAnalytics() {
-    // -1 means approval is disabled
-    return getIgnoreAnalyticsApprovalYearThreshold() >= 0;
-  }
-
   /**
    * @since 2.42
    * @return the minimum level required to include a notification in the list for notifications
@@ -780,7 +771,7 @@ public non-sealed interface SystemSettings extends Settings {
    * @return when true, only the first and last message are included in the message stack when
    *     listing multiple jobs in the single or all job types overview.
    */
-  default boolean isNotifierGistOverview() {
+  default boolean getNotifierGistOverview() {
     return asBoolean("notifierGistOverview", true);
   }
 
@@ -801,5 +792,16 @@ public non-sealed interface SystemSettings extends Settings {
    */
   default boolean getAutoVerifyInvitedUserEmail() {
     return asBoolean("autoVerifyInvitedUserEmail", true);
+  }
+
+  /* Combinators based on several settings. */
+
+  default boolean isEmailConfigured() {
+    return !getEmailHostName().isBlank() && !getEmailUsername().isBlank();
+  }
+
+  default boolean isHideUnapprovedDataInAnalytics() {
+    // -1 means approval is disabled
+    return getIgnoreAnalyticsApprovalYearThreshold() >= 0;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -95,11 +95,12 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(144, keys.size());
+    assertEquals(145, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));
     assertTrue(keys.contains("experimentalAnalyticsSqlEngineEnabled"));
+    assertTrue(keys.contains("notifierGistOverview"));
   }
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/DefaultNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/DefaultNotifier.java
@@ -261,7 +261,7 @@ public class DefaultNotifier implements Notifier {
 
   @Override
   public Map<String, Deque<Notification>> getNotificationsByJobType(JobType jobType, Boolean gist) {
-    if (gist == null) gist = settingsService.getCurrentSettings().isNotifierGistOverview();
+    if (gist == null) gist = settingsService.getCurrentSettings().getNotifierGistOverview();
     BiFunction<JobType, UID, Deque<Notification>> read =
         gist ? this::getGistNotificationsByJobId : this::getAllNotificationsByJobId;
     Map<String, Deque<Notification>> res = new LinkedHashMap<>();

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
@@ -72,7 +72,7 @@ public interface Notifier {
 
   /**
    * @param gist when true, only the first and last message are included for each job. When {@code
-   *     null} the {@link SystemSettings#isNotifierGistOverview()} is used.
+   *     null} the {@link SystemSettings#getNotifierGistOverview()} is used.
    * @return a map with notifications for all job types and jobs
    */
   Map<JobType, Map<String, Deque<Notification>>> getNotifications(@CheckForNull Boolean gist);
@@ -82,7 +82,7 @@ public interface Notifier {
   /**
    * @param jobType include jobs of this type in the result
    * @param gist when true, only the first and last message are included for each job. When {@code
-   *     null} the {@link SystemSettings#isNotifierGistOverview()} is used.
+   *     null} the {@link SystemSettings#getNotifierGistOverview()} is used.
    * @return a map with notifications for all jobs of the provided type
    */
   Map<String, Deque<Notification>> getNotificationsByJobType(


### PR DESCRIPTION
The default method for `notifierGistOverview` was not starting with `get` and thus wasn't recognized as setting with meant it was not possible to read or write the setting.

The confusion was likely created because convenience methods that merely call other settings can start with `is` since they are not a setting themselves. Therefore I reorganized the methods again so such methods are listed at the end. I also updated the comments leading the sections to be more clear.

I also checked that no other settings are affected by a similar issue.

### Automatic Testing
Added an assert that checks that `notifierGistOverview` is a recognized setting.

### Manual Testing
* read ` GET api/systemSettings/notifierGistOverview`
* update `POST api/systemSettings/notifierGistOverview?value=true`