### PR TITLE
fix: use  explicit character class in Analytics regexp

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -113,7 +113,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
    * </ul>
    */
   protected static final String DATE_REGEXP =
-      "'^\\d{4}-\\d{2}-\\d{2}(\\s|T)?((\\d{2}:)(\\d{2}:)?(\\d{2}))?(|.(\\d{3})|.(\\d{3})Z)?$'";
+      "'^[0-9]{4}-[0-9]{2}-[0-9]{2}(\\s|T)?(([0-9]{2}:)([0-9]{2}:)?([0-9]{2}))?(|.([0-9]{3})|.([0-9]{3})Z)?$'";
 
   protected static final String NUMERIC_REGEXP = "'" + MathUtils.NUMERIC_LENIENT_REGEXP + "'";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManagerTest.java
@@ -120,7 +120,7 @@ class AbstractEventJdbcTableManagerTest {
   void testGetSelectExpressionDate() {
     String expected =
         """
-        case when eventdatavalues #>> '{AL04Wbutskk, value}' ~* '^\\d{4}-\\d{2}-\\d{2}(\\s|T)?((\\d{2}:)(\\d{2}:)?(\\d{2}))?(|.(\\d{3})|.(\\d{3})Z)?$' \
+        case when eventdatavalues #>> '{AL04Wbutskk, value}' ~* '^[0-9]{4}-[0-9]{2}-[0-9]{2}(\\s|T)?(([0-9]{2}:)([0-9]{2}:)?([0-9]{2}))?(|.([0-9]{3})|.([0-9]{3})Z)?$' \
         then cast(eventdatavalues #>> '{AL04Wbutskk, value}' as timestamp) \
         end""";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
@@ -185,7 +185,7 @@ class JdbcEventAnalyticsTableManagerDorisTest {
     String aliasC =
         "case when json_unquote(json_extract(eventdatavalues, '$.%s.value')) = 'true' then 1 when json_unquote(json_extract(eventdatavalues, '$.%s.value')) = 'false' then 0 else null end as `%s`";
     String aliasD =
-        "case when json_unquote(json_extract(eventdatavalues, '$.%s.value')) regexp '^\\d{4}-\\d{2}-\\d{2}(\\s|T)?((\\d{2}:)(\\d{2}:)?(\\d{2}))?(|.(\\d{3})|.(\\d{3})Z)?$' then cast(json_unquote(json_extract(eventdatavalues, '$.%s.value')) as datetime(3)) end as `%s`";
+        "case when json_unquote(json_extract(eventdatavalues, '$.%s.value')) regexp '^[0-9]{4}-[0-9]{2}-[0-9]{2}(\\s|T)?(([0-9]{2}:)([0-9]{2}:)?([0-9]{2}))?(|.([0-9]{3})|.([0-9]{3})Z)?$' then cast(json_unquote(json_extract(eventdatavalues, '$.%s.value')) as datetime(3)) end as `%s`";
     String aliasE = "json_unquote(json_extract(eventdatavalues, '$.%s.value')) as `%s`";
     String aliasF =
         "(select ou.name from dhis2.public.`organisationunit` ou where ou.uid = json_unquote(json_extract(eventdatavalues, '$.%s.value'))) as `%s`";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -153,7 +153,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   private static final int OU_NAME_HIERARCHY_COUNT = 1;
 
-  private List<AnalyticsTableColumn> periodColumns =
+  private final List<AnalyticsTableColumn> periodColumns =
       PeriodType.getAvailablePeriodTypes().stream()
           .map(
               pt -> {
@@ -386,7 +386,7 @@ class JdbcEventAnalyticsTableManagerTest {
         when eventdatavalues #>> '{deabcdefghY, value}' = 'false' then 0 else null end as "deabcdefghY\"""";
     String aliasD4 =
         """
-        case when eventdatavalues #>> '{deabcdefghW, value}' ~* '^\\d{4}-\\d{2}-\\d{2}(\\s|T)?((\\d{2}:)(\\d{2}:)?(\\d{2}))?(|.(\\d{3})|.(\\d{3})Z)?$' \
+        case when eventdatavalues #>> '{deabcdefghW, value}' ~* '^[0-9]{4}-[0-9]{2}-[0-9]{2}(\\s|T)?(([0-9]{2}:)([0-9]{2}:)?([0-9]{2}))?(|.([0-9]{3})|.([0-9]{3})Z)?$' \
         then cast(eventdatavalues #>> '{deabcdefghW, value}' as timestamp) end as "deabcdefghW\"""";
     String aliasD5 =
         "eventdatavalues #>> '{" + d5.getUid() + ", value}' as \"" + d5.getUid() + "\"";


### PR DESCRIPTION
## Summary 

**Context**
When DHIS2 is configured to use **Apache Doris** for analytics, the SQL generated to populate the `analytics_event_*` temporary tables attempts to cast date-time values pulled from the `eventdatavalues` JSON blob. The `CASE` expression relies on a regular expression containing the shorthand `\d` (digit). Doris’ regexp engine treats the back-slash differently, so the check always fails and the casted column (e.g. `msodh3rEMJa`) is written as **`NULL`**.

**Fix**
Replaced every `\d` in the date-matching pattern with the explicit character class `[0-9]`. Using a fully expanded class avoids Doris’ escaping quirks while remaining fully compatible with PostgreSQL.

**Result**

* Date attributes matching any of the supported formats (e.g. `1999-12-12`, `2021-12-14T11:45:00.000Z`, etc.) are now correctly recognised and stored.
* Prevents silent data loss in the event-analytics table when running on Doris.
