### PR TITLE
fix: null boolean value normalisation [DHIS2-19597]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -670,6 +670,7 @@ public class ValidationUtils {
    * @return normalized boolean value.
    */
   public static String normalizeBoolean(String bool, ValueType valueType) {
+    if (bool == null) return null;
     if (valueType != null && valueType.isBoolean()) {
       if (BOOL_FALSE_VARIANTS.contains(bool) && valueType != ValueType.TRUE_ONLY) {
         return FALSE;

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -590,7 +590,7 @@ class ValidationUtilsTest {
     assertEquals("false", normalizeBoolean("False", BOOLEAN));
     assertEquals("false", normalizeBoolean("FALSE", BOOLEAN));
     assertEquals("false", normalizeBoolean("F", BOOLEAN));
-    assertNull(null, normalizeBoolean(null, TRUE_ONLY));
+    assertNull(normalizeBoolean(null, TRUE_ONLY));
   }
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -590,6 +590,7 @@ class ValidationUtilsTest {
     assertEquals("false", normalizeBoolean("False", BOOLEAN));
     assertEquals("false", normalizeBoolean("FALSE", BOOLEAN));
     assertEquals("false", normalizeBoolean("F", BOOLEAN));
+    assertNull(null, normalizeBoolean(null, TRUE_ONLY));
   }
 
   @Test


### PR DESCRIPTION
When mapping possible values for `true` or `false` to a boolean value the normalisation did not handle null since the collections used do not allow checking `contains` with a `null` value and would throw a NPE.