### PR TITLE
fix: allow filtering settings by key [DHIS2-19606]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMeDto.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMeDto.java
@@ -33,6 +33,8 @@ import java.time.LocalDateTime;
 import org.hisp.dhis.jsontree.JsonBoolean;
 import org.hisp.dhis.jsontree.JsonDate;
 import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonMixed;
 
 /**
  * Web API equivalent of a {@link org.hisp.dhis.webapi.controller.user.MeDto}.
@@ -82,5 +84,9 @@ public interface JsonMeDto extends JsonIdentifiableObject {
 
   default String getTwoFactorType() {
     return getString("twoFactorType").string();
+  }
+
+  default JsonMap<JsonMixed> getSettings() {
+    return getMap("settings", JsonMixed.class);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemSettingsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemSettingsControllerTest.java
@@ -38,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.setting.SystemSettings;
@@ -85,7 +87,7 @@ class SystemSettingsControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void testSetSystemSettingV29() {
+  void testSetSystemSetting() {
     assertWebMessage(
         "OK",
         200,
@@ -97,7 +99,7 @@ class SystemSettingsControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void testSetSystemSettingV29_Empty() {
+  void testSetSystemSetting_Empty() {
     assertWebMessage(
         "OK",
         200,
@@ -136,6 +138,18 @@ class SystemSettingsControllerTest extends H2ControllerIntegrationTestBase {
             key ->
                 assertFalse(
                     setting.get(key).exists(), key + " is confidential and should not be exposed"));
+  }
+
+  @Test
+  void testGetSystemSettingsJson_ByKey() {
+    JsonObject settings = GET("/systemSettings?key=keyEmailUsername").content(HttpStatus.OK);
+    assertEquals(1, settings.size());
+    assertEquals(List.of("keyEmailUsername"), settings.names());
+
+    settings =
+        GET("/systemSettings?key=keyEmailUsername&key=keyEmailSender").content(HttpStatus.OK);
+    assertEquals(2, settings.size());
+    assertEquals(Set.of("keyEmailUsername", "keyEmailSender"), Set.copyOf(settings.names()));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserSettingsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserSettingsControllerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.setting.UserSettings;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link UserSettingsController} using (mocked) REST requests.
+ *
+ * @author Jan Bernitt
+ */
+class UserSettingsControllerTest extends H2ControllerIntegrationTestBase {
+
+  @Test
+  void testGetAllUserSettings() {
+    JsonObject settings = GET("/userSettings").content();
+    assertTrue(settings.isObject());
+    UserSettings.keysWithDefaults()
+        .forEach(key -> assertTrue(settings.get(key).exists(), "expected " + key));
+  }
+
+  @Test
+  void testGetAllUserSettings_ByKey() {
+    JsonObject settings = GET("/userSettings?key=keyMessageSmsNotification").content();
+    assertTrue(settings.isObject());
+    assertEquals(1, settings.size());
+    assertEquals(List.of("keyMessageSmsNotification"), settings.names());
+
+    settings = GET("/userSettings?key=keyMessageSmsNotification&key=keyUiLocale").content();
+    assertTrue(settings.isObject());
+    assertEquals(2, settings.size());
+    assertEquals(Set.of("keyMessageSmsNotification", "keyUiLocale"), Set.copyOf(settings.names()));
+  }
+
+  @Test
+  void testGetUserSettingByKey() {
+    assertEquals("en", GET("/userSettings/keyUiLocale").content("text/plain"));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingsController.java
@@ -142,10 +142,13 @@ public class SystemSettingsController {
   }
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<SystemSettings> getSystemSettingsJson() {
-    return ResponseEntity.ok()
-        .headers(noCacheNoStoreMustRevalidate())
-        .body(settingsService.getCurrentSettings());
+  @OpenApi.Response(SystemSettings.class)
+  public ResponseEntity<JsonMap<JsonMixed>> getSystemSettingsJson(
+      @RequestParam(required = false) Set<String> key) {
+    SystemSettings settings = settingsService.getCurrentSettings();
+    JsonMap<JsonMixed> res =
+        key == null || key.isEmpty() ? settings.toJson(false) : settings.toJson(true, key);
+    return ResponseEntity.ok().headers(noCacheNoStoreMustRevalidate()).body(res);
   }
 
   @GetMapping(value = "/{key}", produces = APPLICATION_JSON_VALUE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -156,6 +156,7 @@ public class MeController {
 
   @GetMapping
   @OpenApi.Response(MeDto.class)
+  @OpenApi.EntityType(MeDto.class)
   public @ResponseBody ResponseEntity<JsonNode> getCurrentUser(
       @CurrentUser(required = true) User user, GetObjectParams params) {
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.webapi.controller.user;
 
+import static org.hisp.dhis.fieldfiltering.FieldFilterParams.*;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.CacheControl.noStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -59,6 +60,8 @@ import org.hisp.dhis.fieldfiltering.FieldPreset;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.interpretation.InterpretationService;
+import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.node.NodeService;
@@ -67,6 +70,7 @@ import org.hisp.dhis.node.types.CollectionNode;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.node.types.SimpleNode;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.query.GetObjectParams;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.PasswordManager;
 import org.hisp.dhis.security.acl.Access;
@@ -85,6 +89,7 @@ import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.webdomain.Dashboard;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -152,10 +157,12 @@ public class MeController {
   @GetMapping
   @OpenApi.Response(MeDto.class)
   public @ResponseBody ResponseEntity<JsonNode> getCurrentUser(
-      @CurrentUser(required = true) User user,
-      @RequestParam(defaultValue = "*") List<String> fields) {
+      @CurrentUser(required = true) User user, GetObjectParams params) {
 
     UserDetails userDetails = UserDetails.fromUser(user);
+
+    List<String> fields = params.getFields();
+    if (fields == null || fields.isEmpty()) fields = List.of("*");
 
     if (fieldsContains("access", fields)) {
       Access access = aclService.getAccess(user, user);
@@ -172,12 +179,19 @@ public class MeController {
 
     List<ApiToken> patTokens = apiTokenService.getAllOwning(user);
 
-    MeDto meDto = new MeDto(user, UserSettings.getCurrentSettings(), programs, dataSets, patTokens);
+    Set<String> settingKeys =
+        fields.stream()
+            .filter(f -> f.startsWith("settings["))
+            .findFirst()
+            .map(f -> Set.of(f.substring(9, f.length() - 1).split(",")))
+            .orElse(Set.of());
+    UserSettings settings = UserSettings.getCurrentSettings();
+    JsonMap<JsonMixed> s =
+        settingKeys.isEmpty() ? settings.toJson(false) : settings.toJson(true, settingKeys);
+    MeDto meDto = new MeDto(user, s, programs, dataSets, patTokens);
     determineUserImpersonation(meDto);
 
-    var params = org.hisp.dhis.fieldfiltering.FieldFilterParams.of(meDto, fields);
-
-    ObjectNode jsonNodes = fieldFilterService.toObjectNodes(params).get(0);
+    ObjectNode jsonNodes = fieldFilterService.toObjectNodes(of(meDto, fields)).get(0);
 
     return ResponseEntity.ok(jsonNodes);
   }
@@ -291,8 +305,13 @@ public class MeController {
   }
 
   @GetMapping(value = "/settings", produces = APPLICATION_JSON_VALUE)
-  public @ResponseBody UserSettings getSettings() {
-    return UserSettings.getCurrentSettings();
+  @OpenApi.Response(UserSettings.class)
+  public ResponseEntity<JsonMap<JsonMixed>> getSettings(
+      @RequestParam(required = false) Set<String> key) {
+    UserSettings settings = UserSettings.getCurrentSettings();
+    JsonMap<JsonMixed> res =
+        key == null || key.isEmpty() ? settings.toJson(false) : settings.toJson(false, key);
+    return ResponseEntity.ok().cacheControl(CacheControl.noCache().cachePrivate()).body(res);
   }
 
   @GetMapping(value = "/settings/{key}", produces = APPLICATION_JSON_VALUE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
@@ -44,11 +44,12 @@ import org.hisp.dhis.attribute.AttributeValuesSerializer;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.acl.Access;
 import org.hisp.dhis.security.apikey.ApiToken;
 import org.hisp.dhis.security.twofa.TwoFactorType;
-import org.hisp.dhis.setting.UserSettings;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
@@ -63,7 +64,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 public class MeDto {
   public MeDto(
       User user,
-      UserSettings settings,
+      JsonMap<JsonMixed> settings,
       List<String> programs,
       List<String> dataSets,
       List<ApiToken> patTokens) {
@@ -199,7 +200,7 @@ public class MeDto {
   @JsonProperty
   private Set<UserRole> userRoles;
 
-  @JsonProperty private UserSettings settings;
+  @JsonProperty private JsonMap<JsonMixed> settings;
 
   @JsonProperty private List<String> programs;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Property.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Property.java
@@ -123,6 +123,7 @@ class Property {
 
   private static List<Property> propertiesIn(Class<?> object) {
     if (JsonObject.class.isAssignableFrom(object)) return propertiesInJson(object);
+    if (JsonValue.class.isAssignableFrom(object)) return List.of();
     // map for order by name and avoiding duplicates
     Map<String, Property> properties = new TreeMap<>();
     Consumer<Property> add = property -> properties.putIfAbsent(property.name, property);


### PR DESCRIPTION
### Summary
When listing settings or user settings it should be possible to limit the response to one or more specific keys using the `key` parameter one or more times. 

In addition, when getting the the `/me` user information the settings can now be filtered using field filtering, for example: `fields=name,settings[keyStyle]`. This is a new feature but was requested and not very hard to do.

### Automatic Testing
New tests where added for all added use cases.

### Manual Testing
Things I tried...
```bash
curl -u "admin:district" -X GET "http://localhost:8080/api/systemSettings"
curl -u "admin:district" -X GET "http://localhost:8080/api/systemSettings?key=keyInstanceBaseUrl"
curl -u "admin:district" -X GET "http://localhost:8080/api/systemSettings?key=keyInstanceBaseUrl&key=keyRequireAddToView"

curl -u "admin:district" -X GET "http://localhost:8080/api/userSettings"
curl -u "admin:district" -X GET "http://localhost:8080/api/userSettings?key=keyCurrentStyle"

curl -u "admin:district" -X GET "http://localhost:8080/api/me?fields=name,settings%5BkeyCurrentStyle%5D"
curl -u "admin:district" -X GET "http://localhost:8080/api/me?fields=name,settings%5BkeyCurrentStyle,keyStyle%5D"
curl -u "admin:district" -X GET "http://localhost:8080/api/me"
curl -u "admin:district" -X GET "http://localhost:8080/api/me?fields=name,settings"
```
When using a `key=` or `fields=settings[...]` parameter the response should only contain the named settings, otherwise it should contain all settings (except confidential ones). 