### PR TITLE
fix: [DHIS2-19607] Handle optionSets error responses in dataentry app (2.41)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -3585,13 +3585,15 @@ dhis2.de.loadOptionSets = function()
                             url: '../api/optionSets/' + item.uid + '.json?fields=' + encodedFields,
                             type: 'GET',
                             cache: false
-                        } ).done( function ( data ) {
+                        } ).then( function ( data ) {
                             console.log( 'Successfully stored optionSet: ' + item.uid );
 
                             var obj = {};
                             obj.id = item.uid;
                             obj.optionSet = data;
                             DAO.store.set( 'optionSets', obj );
+                        }, function (error) {
+                            console.warn( 'Failed to load optionSet: ' + item.uid, error);
                         } );
                     } );
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-19607

**Problem**: The dataentry app attemps to preload all available `optionSets` at startup. It first retrieves the complete list  via a `getMetadata.action` call, and then fetches each individually.
However, for some users, it is trying to get unrelated optionSets (from other datasets) for which they lack permissions. This results in unhandled 404 errors, preventing all optionSets in the form from rendering properly.

**Solution**: Catch and handle these 404 errors. Instead of letting them propagate and break the rendering of valid optionSets, log a warning to the console.
This is a workaround to ensure the form remains usable even when certain optionSets are inaccessible.