### PR TITLE
chore: Make program field mandatory for event exporter [DHIS2-19578]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -931,7 +931,7 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
         && !params.getEvents().isEmpty()
         && !params.hasDataElementFilter()) {
       sqlParameters.addValue(COLUMN_EVENT_UID, UID.toValueSet(params.getEvents()));
-      fromBuilder.append(hlp.whereAnd()).append(" (ev.uid in (").append(":ev_uid").append(")) ");
+      fromBuilder.append(hlp.whereAnd()).append(" ev.uid in (").append(":ev_uid").append(") ");
     }
 
     if (params.getAssignedUserQueryParam().hasAssignedUsers()) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportFileTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportFileTest.java
@@ -303,7 +303,10 @@ public class TrackerExportFileTest extends TrackerApiTest {
         gZipToStringContent(
             trackerImportExportActions
                 .getEventsJsonGZip(
-                    new QueryParamsBuilder().add("events", event).add("fields", "*,relationships"))
+                    new QueryParamsBuilder()
+                        .add("events", event)
+                        .add("fields", "*,relationships")
+                        .add("program", "f1AyMswryyQ"))
                 .validate()
                 .statusCode(200)
                 .contentType("application/json+gzip;charset=utf-8")
@@ -324,7 +327,10 @@ public class TrackerExportFileTest extends TrackerApiTest {
         mapZipEntryToStringContent(
             trackerImportExportActions
                 .getEventsJsonZip(
-                    new QueryParamsBuilder().add("events", event).add("fields", "*,relationships"))
+                    new QueryParamsBuilder()
+                        .add("events", event)
+                        .add("fields", "*,relationships")
+                        .add("program", "f1AyMswryyQ"))
                 .validate()
                 .statusCode(200)
                 .contentType("application/json+zip;charset=utf-8")
@@ -461,7 +467,8 @@ public class TrackerExportFileTest extends TrackerApiTest {
     String s =
         gZipToStringContent(
             trackerImportExportActions
-                .getEventsCsvGZip(new QueryParamsBuilder().add("events", event))
+                .getEventsCsvGZip(
+                    new QueryParamsBuilder().add("events", event).add("program", "f1AyMswryyQ"))
                 .validate()
                 .statusCode(200)
                 .contentType("application/csv+gzip;charset=utf-8")
@@ -483,7 +490,8 @@ public class TrackerExportFileTest extends TrackerApiTest {
     Map<String, String> s =
         mapZipEntryToStringContent(
             trackerImportExportActions
-                .getEventsCsvZip(new QueryParamsBuilder().add("events", event))
+                .getEventsCsvZip(
+                    new QueryParamsBuilder().add("events", event).add("program", "f1AyMswryyQ"))
                 .validate()
                 .statusCode(200)
                 .contentType("application/csv+zip;charset=utf-8")

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -454,7 +454,7 @@ public class TrackerExportTest extends TrackerApiTest {
   @Test
   public void shouldReturnRelationshipsWhenEventHasRelationshipsAndFieldsIncludeRelationships() {
     trackerImportExportActions
-        .get("events?events=" + event + "&fields=relationships")
+        .get("events?events=" + event + "&fields=relationships" + "&program=f1AyMswryyQ")
         .validate()
         .statusCode(200)
         .body("events", hasSize(greaterThanOrEqualTo(1)))
@@ -467,7 +467,7 @@ public class TrackerExportTest extends TrackerApiTest {
   @Test
   public void shouldNotReturnRelationshipsWhenEventHasRelationshipsAndFieldsExcludeRelationships() {
     trackerImportExportActions
-        .get("events?events=" + event)
+        .get("events?events=" + event + "&program=f1AyMswryyQ")
         .validate()
         .statusCode(200)
         .body("events[0].relationships", emptyOrNullString());
@@ -477,7 +477,7 @@ public class TrackerExportTest extends TrackerApiTest {
   public void shouldReturnEventWithEnrollmentOccurredOnADateWhenBeforeAndAfterIsTheSameDate() {
     trackerImportExportActions
         .get(
-            "events?enrollmentOccurredAfter=2019-08-19&enrollmentOccurredBefore=2019-08-19&events=ZwwuwNp6gVd")
+            "events?enrollmentOccurredAfter=2019-08-19&enrollmentOccurredBefore=2019-08-19&events=ZwwuwNp6gVd&program=f1AyMswryyQ")
         .validate()
         .statusCode(200)
         .rootPath("events[0]")
@@ -488,7 +488,7 @@ public class TrackerExportTest extends TrackerApiTest {
   public void shouldReturnDescOrderedEventByTrackedEntityAttribute() {
     ApiResponse response =
         trackerImportExportActions.get(
-            "events?order=dIVt4l5vIOa:desc&events=olfXZzSGacW,ZwwuwNp6gVd");
+            "events?order=dIVt4l5vIOa:desc&events=olfXZzSGacW,ZwwuwNp6gVd&program=f1AyMswryyQ");
     response.validate().statusCode(200).body("events", hasSize(equalTo(2)));
     List<String> events = response.extractList("events.event.flatten()");
     assertEquals(
@@ -499,7 +499,7 @@ public class TrackerExportTest extends TrackerApiTest {
   public void shouldReturnAscOrderedEventByTrackedEntityAttribute() {
     ApiResponse response =
         trackerImportExportActions.get(
-            "events?order=dIVt4l5vIOa:asc&events=olfXZzSGacW,ZwwuwNp6gVd");
+            "events?order=dIVt4l5vIOa:asc&events=olfXZzSGacW,ZwwuwNp6gVd&program=f1AyMswryyQ");
     response.validate().statusCode(200).body("events", hasSize(equalTo(2)));
     List<String> events = response.extractList("events.event.flatten()");
     assertEquals(
@@ -559,7 +559,7 @@ public class TrackerExportTest extends TrackerApiTest {
   void whenGetEventsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
     ApiResponse response =
         trackerImportExportActions.getWithHeaders(
-            "events?events=" + event,
+            "events?events=" + event + "&program=f1AyMswryyQ",
             null,
             new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
 
@@ -574,7 +574,7 @@ public class TrackerExportTest extends TrackerApiTest {
   void whenGetEventsCsvShouldGetCsvContentTypeWithHtmlAcceptHeader() {
     ApiResponse response =
         trackerImportExportActions.getWithHeaders(
-            "events.csv?events=" + event,
+            "events.csv?events=" + event + "&program=f1AyMswryyQ",
             null,
             new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -255,7 +255,7 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
   @Test
   void shouldGetEmptyEventsPage() {
     JsonPage page =
-        GET("/tracker/events?events={uid}", UID.generate())
+        GET("/tracker/events?events={uid}&program={programUid}", UID.generate(), "BFcipDERJnf")
             .content(HttpStatus.OK)
             .asA(JsonPage.class);
 
@@ -270,7 +270,11 @@ class ExportControllerPaginationTest extends PostgresControllerIntegrationTestBa
   @Test
   void shouldGetPaginatedEventsWithDefaults() {
     JsonPage page =
-        GET("/tracker/events?events={uid},{uid}", event1.getUid(), event2.getUid())
+        GET(
+                "/tracker/events?program={programUid}&events={uid},{uid}",
+                "BFcipDERJnf",
+                event1.getUid(),
+                event2.getUid())
             .content(HttpStatus.OK)
             .asA(JsonPage.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/IdSchemeExportControllerTest.java
@@ -233,7 +233,7 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
         "test expects both events to have at least one data value for the same data element");
 
     JsonList<JsonEvent> jsonEvents =
-        GET("/tracker/events?events=QRYjLTiJTrA,kWjSezkXHVp&fields=event,dataValues&dataElementIdScheme=NAME")
+        GET("/tracker/events?events=QRYjLTiJTrA,kWjSezkXHVp&program=iS7eutanDry&fields=event,dataValues&dataElementIdScheme=NAME")
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class);
 
@@ -294,7 +294,12 @@ class IdSchemeExportControllerTest extends PostgresControllerIntegrationTestBase
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"/{id}?", "?events={id}&paging=true&", "?events={id}&paging=false&"})
+  @ValueSource(
+      strings = {
+        "/{id}?",
+        "?events={id}&program=iS7eutanDry&paging=true&",
+        "?events={id}&program=iS7eutanDry&paging=false&"
+      })
   void shouldReportEventMetadataWhichDoesNotHaveAnIdentifierForGivenIdScheme(String urlPortion) {
     Event event = get(Event.class, "QRYjLTiJTrA");
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerH2Test.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerH2Test.java
@@ -77,27 +77,27 @@ class EventsExportControllerH2Test extends H2ControllerIntegrationTestBase {
       shouldMatchContentTypeAndAttachment_whenEndpointForCompressedEventJsonIsInvoked() {
     return Stream.of(
         arguments(
-            "/tracker/events.json.zip",
+            "/tracker/events.json.zip?program=bMcwwoVnbSR",
             "application/json+zip",
             "attachment; filename=events.json.zip",
             "binary"),
         arguments(
-            "/tracker/events.json.gz",
+            "/tracker/events.json.gz?program=bMcwwoVnbSR",
             "application/json+gzip",
             "attachment; filename=events.json.gz",
             "binary"),
         arguments(
-            "/tracker/events.csv",
+            "/tracker/events.csv?program=bMcwwoVnbSR",
             "application/csv; charset=UTF-8",
             "attachment; filename=events.csv",
             null),
         arguments(
-            "/tracker/events.csv.gz",
+            "/tracker/events.csv.gz?program=bMcwwoVnbSR",
             "application/csv+gzip",
             "attachment; filename=events.csv.gz",
             "binary"),
         arguments(
-            "/tracker/events.csv.zip",
+            "/tracker/events.csv.zip?program=bMcwwoVnbSR",
             "application/csv+zip",
             "attachment; filename=events.csv.zip",
             "binary"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -190,7 +190,10 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
             .content(HttpStatus.OK)
             .as(JsonEvent.class);
     JsonList<JsonEvent> queryEvents =
-        GET("/tracker/events?fields=*&events={id}", event.getUid())
+        GET(
+                "/tracker/events?fields=*&events={id}&program={programUid}",
+                event.getUid(),
+                program.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class);
 
@@ -272,7 +275,10 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonList<JsonRelationship> relationships =
-        GET("/tracker/events/?events={id}&fields=relationships&includeDeleted=false", from.getUid())
+        GET(
+                "/tracker/events/?events={id}&program={programUid}&fields=relationships&includeDeleted=false",
+                from.getUid(),
+                program.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class)
             .get(0)
@@ -290,7 +296,10 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonList<JsonRelationship> relationships =
-        GET("/tracker/events/?events={id}&fields=relationships&includeDeleted=true", from.getUid())
+        GET(
+                "/tracker/events/?events={id}&fields=relationships&includeDeleted=true&program={programUid}",
+                from.getUid(),
+                program.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class)
             .get(0)
@@ -329,7 +338,10 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonList<JsonRelationship> relationships =
-        GET("/tracker/events/?events={id}&fields=relationships", to.getUid())
+        GET(
+                "/tracker/events/?events={id}&program={programUid}&fields=relationships",
+                to.getUid(),
+                program.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class)
             .get(0)
@@ -441,8 +453,9 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
 
     JsonList<JsonEvent> events =
         GET(
-                "/tracker/events?trackedEntity={te}&includeDeleted=true&fields=deleted,trackedEntity",
-                te.getUid())
+                "/tracker/events?trackedEntity={te}&program={programUid}&includeDeleted=true&fields=deleted,trackedEntity",
+                te.getUid(),
+                program.getUid())
             .content(HttpStatus.OK)
             .getList("events", JsonEvent.class);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -75,6 +75,7 @@ class EventRequestParamsMapper {
   public EventOperationParams map(
       EventRequestParams eventRequestParams, TrackerIdSchemeParams idSchemeParams)
       throws BadRequestException {
+    validateProgram(eventRequestParams);
     OrganisationUnitSelectionMode orgUnitMode =
         validateOrgUnitModeForEnrollmentsAndEvents(
             eventRequestParams.getOrgUnit() != null
@@ -220,6 +221,12 @@ class EventRequestParamsMapper {
         && DateUtils.getDuration(eventRequestParams.getUpdatedWithin()) == null) {
       throw new BadRequestException(
           "Duration is not valid: " + eventRequestParams.getUpdatedWithin());
+    }
+  }
+
+  private void validateProgram(EventRequestParams eventRequestParams) throws BadRequestException {
+    if (eventRequestParams.getProgram() == null) {
+      throw new BadRequestException("Program is mandatory");
     }
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -179,6 +179,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     mapper.map(eventRequestParams, idSchemeParams);
 
@@ -186,6 +187,13 @@ class EventRequestParamsMapperTest {
     verifyNoInteractions(programStageService);
     verifyNoInteractions(organisationUnitService);
     verifyNoInteractions(trackedEntityService);
+  }
+
+  @Test
+  void shouldFailMappingParamsWithoutMandatoryProgram() {
+    EventRequestParams eventRequestParams = new EventRequestParams();
+
+    assertThrows(BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
   }
 
   @Test
@@ -201,6 +209,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrgUnit(UID.of(orgUnit));
     eventRequestParams.setOrgUnitMode(SELECTED);
 
@@ -212,6 +221,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldFailIfDeprecatedAndNewEnrollmentStatusParameterIsSet() {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
     eventRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
 
@@ -226,6 +236,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldReturnOrgUnitWhenCorrectOrgUnitMapped() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrgUnit(UID.of(orgUnit));
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -236,6 +247,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingTrackedEntity() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setTrackedEntity(UID.of("qnR1RK4cTIZ"));
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -246,6 +258,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingOccurredAfterBefore() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     StartDateTime occurredAfter = StartDateTime.of("2020-01-01");
     eventRequestParams.setOccurredAfter(occurredAfter);
@@ -261,6 +274,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingScheduledAfterBefore() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     StartDateTime scheduledAfter = StartDateTime.of("2021-01-01");
     eventRequestParams.setScheduledAfter(scheduledAfter);
@@ -276,6 +290,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAfterAndBeforeDatesWhenSupplied() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     StartDateTime updatedAfter = StartDateTime.of("2022-01-01");
     eventRequestParams.setUpdatedAfter(updatedAfter);
@@ -291,6 +306,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapUpdatedWithinDateWhenSupplied() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     String updatedWithin = "6m";
     eventRequestParams.setUpdatedWithin(updatedWithin);
 
@@ -302,6 +318,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldFailWithBadRequestExceptionWhenTryingToMapAllUpdateDatesTogether() {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     StartDateTime updatedAfter = StartDateTime.of("2022-01-01");
     eventRequestParams.setUpdatedAfter(updatedAfter);
@@ -322,6 +339,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingEnrollmentEnrolledAtDates() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EndDateTime enrolledBefore = EndDateTime.of("2022-01-01");
     eventRequestParams.setEnrollmentEnrolledBefore(enrolledBefore);
@@ -337,6 +355,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingEnrollmentOccurredAtDates() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EndDateTime enrolledBefore = EndDateTime.of("2022-01-01");
     eventRequestParams.setEnrollmentOccurredBefore(enrolledBefore);
@@ -352,6 +371,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingEnrollments() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     eventRequestParams.setEnrollments(Set.of(UID.of("NQnuK2kLm6e")));
 
@@ -363,6 +383,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingEvents() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setEvents(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"));
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -373,6 +394,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingEventIsNull() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
 
@@ -382,6 +404,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMappingAssignedUsers() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setAssignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"));
     eventRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
 
@@ -394,6 +417,7 @@ class EventRequestParamsMapperTest {
   @Test
   void testMutualExclusionOfEventsAndFilter() {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilter(DE_1_UID + ":ge:1:le:2");
     eventRequestParams.setEvents(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"));
 
@@ -407,6 +431,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapDataElementFilters() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilter(DE_1_UID + ":eq:2," + DE_2_UID + ":like:foo");
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -425,6 +450,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapDataElementFiltersWhenDataElementHasMultipleFilters() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilter(DE_1_UID + ":gt:10:lt:20");
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -442,6 +468,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapDataElementFiltersWhenQueryFilterHasUIDOnly() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilter(DE_1_UID.getValue());
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -456,6 +483,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapDataElementFiltersToDefaultIfNoneSet() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
 
@@ -468,6 +496,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAttributeFilters() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilterAttributes(TEA_1_UID + ":eq:2," + TEA_2_UID + ":like:foo");
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -486,6 +515,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAttributeFiltersWhenAttributeHasMultipleFilters() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilterAttributes(TEA_1_UID + ":gt:10:lt:20");
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -503,6 +533,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAttributeFiltersWhenOnlyGivenUID() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFilterAttributes(TEA_1_UID.getValue());
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -517,6 +548,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapAttributeFiltersToDefaultIfNoneSet() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
 
@@ -529,6 +561,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrder(
         OrderCriteria.fromOrderString(
             "createdAt:asc,zGlzbfreTOH,programStage:desc,scheduledAt:asc"));
@@ -547,6 +580,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldFailGivenInvalidOrderFieldName() {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrder(
         OrderCriteria.fromOrderString("unsupportedProperty1:asc,enrolledAt:asc"));
 
@@ -561,6 +595,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapSelectedOrgUnitModeWhenOrgUnitModeNotProvided() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrgUnit(UID.of(orgUnit));
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
@@ -572,6 +607,7 @@ class EventRequestParamsMapperTest {
   void shouldMapAccessibleOrgUnitModeWhenOrgUnitModeNorOrgUnitProvided()
       throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
 
     EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
 
@@ -587,6 +623,7 @@ class EventRequestParamsMapperTest {
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
 
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrgUnit(UID.of(orgUnit));
     eventRequestParams.setOrgUnitMode(orgUnitMode);
 
@@ -605,6 +642,7 @@ class EventRequestParamsMapperTest {
   void shouldFailWhenNoOrgUnitSuppliedAndOrgUnitModeNeedsOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setOrgUnitMode(orgUnitMode);
 
     Exception exception =
@@ -619,6 +657,7 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapEventParamsTrueWhenFieldPathIncludeRelationships() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgram(PROGRAM_UID);
     List<FieldPath> fieldPaths = FieldFilterParser.parse("relationships");
     eventRequestParams.setFields(fieldPaths);
     when(fieldFilterService.filterIncludes(Event.class, fieldPaths, "relationships"))
@@ -633,6 +672,7 @@ class EventRequestParamsMapperTest {
   void shouldMapEventParamsFalseWhenFieldPathIncludeRelationships() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
     List<FieldPath> fieldPaths = FieldFilterParser.parse("relationships");
+    eventRequestParams.setProgram(PROGRAM_UID);
     eventRequestParams.setFields(fieldPaths);
     when(fieldFilterService.filterIncludes(Event.class, fieldPaths, "relationships"))
         .thenReturn(false);


### PR DESCRIPTION
Make `program` field mandatory in `GET /tracker/events` endpoint.

***IMPORTANT NOTE***
This change is required to make it possible to separate the flows for different type of events at the service level.
This change could be overseeded when we manage to have completely separate APIs for the 2 types of events.
I am not documenting it and create release notes for this change right away, I will create a new task to document breaking changes for this whole epic so we can re-evaluate this kind of changes when we have a better understanding of our API and how it should work.