### PR TITLE
task: use jdbc in enrollment store [DHIS2-19543]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
@@ -148,7 +148,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       errors.add("User has no data read access to program: " + program.getUid());
     }
 
-    if (!program.isWithoutRegistration()) {
+    if (program.isRegistration()) {
       if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
         errors.add(
             "User has no data read access to tracked entity type: "

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
@@ -190,7 +190,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       errors.add("User has no data write access to program: " + program.getUid());
     }
 
-    if (!program.isWithoutRegistration()) {
+    if (program.isRegistration()) {
       if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
         errors.add(
             "User has no data read access to tracked entity type: "
@@ -222,7 +222,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       errors.add("User has no data write access to program: " + program.getUid());
     }
 
-    if (!program.isWithoutRegistration()) {
+    if (program.isRegistration()) {
       if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
         errors.add(
             "User has no data read access to tracked entity type: "
@@ -258,7 +258,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       errors.add("User has no data write access to program: " + program.getUid());
     }
 
-    if (!program.isWithoutRegistration()) {
+    if (program.isRegistration()) {
       if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
         errors.add(
             "User has no data read access to tracked entity type: "
@@ -298,7 +298,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       errors.add("User has no data read access to program: " + program.getUid());
     }
 
-    if (!program.isWithoutRegistration()) {
+    if (program.isRegistration()) {
       if (!aclService.canDataRead(user, programStage)) {
         errors.add("User has no data read access to program stage: " + programStage.getUid());
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -70,8 +70,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service("org.hisp.dhis.tracker.export.enrollment.EnrollmentService")
 class DefaultEnrollmentService implements EnrollmentService {
   private final JdbcEnrollmentStore enrollmentStore;
-  // TODO Remove this usage
-  // private final HibernateEnrollmentStore enrollmentStore;
 
   private final EventService eventService;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -91,6 +91,7 @@ class EnrollmentOperationParamsMapper {
     params.setIncludeDeleted(operationParams.isIncludeDeleted());
     params.setOrder(operationParams.getOrder());
     params.setEnrollments(operationParams.getEnrollments());
+    params.setIncludeAttributes(operationParams.getFields().isIncludesAttributes());
 
     mergeOrgUnitModes(operationParams, params, user);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
@@ -95,6 +95,9 @@ class EnrollmentQueryParams {
   /** Indicates whether to include soft-deleted enrollments */
   private boolean includeDeleted;
 
+  /** Indicates whether to include tracked entity attribute data in the enrollment */
+  private boolean includeAttributes;
+
   private List<Order> order;
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -29,61 +29,20 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
-import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
-import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
-import static org.hisp.dhis.util.DateUtils.nowMinusDuration;
-import static org.hisp.dhis.util.DateUtils.toLongDateWithMillis;
-import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
-
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import lombok.Builder;
-import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.query.Query;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
-import org.hisp.dhis.commons.util.SqlHelper;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
-import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.tracker.Page;
-import org.hisp.dhis.tracker.PageParams;
-import org.hisp.dhis.tracker.export.Order;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 // This class is annotated with @Component instead of @Repository because @Repository creates a
 // proxy that can't be used to inject the class.
-@Component("org.hisp.dhis.tracker.export.enrollment.EnrollmentStore")
+@Component("org.hisp.dhis.tracker.export.enrollment.HibernateEnrollmentStore")
 class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment> {
-
-  private static final String DEFAULT_ORDER = "id desc";
-
-  private static final String STATUS = "status";
-
-  /**
-   * Enrollments can be ordered by given fields which correspond to fields on {@link
-   * org.hisp.dhis.program.Enrollment}.
-   */
-  private static final Set<String> ORDERABLE_FIELDS =
-      Set.of(
-          "completedDate",
-          "created",
-          "createdAtClient",
-          "enrollmentDate",
-          "lastUpdated",
-          "lastUpdatedAtClient");
 
   public HibernateEnrollmentStore(
       EntityManager entityManager,
@@ -91,196 +50,6 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
       ApplicationEventPublisher publisher,
       AclService aclService) {
     super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, true);
-  }
-
-  private String buildCountEnrollmentHql(EnrollmentQueryParams params) {
-    return buildEnrollmentHql(params)
-        .getQuery()
-        .replaceFirst("from Enrollment en", "select count(distinct uid) from Enrollment en");
-  }
-
-  public List<Enrollment> getEnrollments(EnrollmentQueryParams params) {
-    String hql = buildEnrollmentHql(params).getFullQuery();
-    Query<Enrollment> query = getQuery(hql);
-    return query.list();
-  }
-
-  public Page<Enrollment> getEnrollments(EnrollmentQueryParams params, PageParams pageParams) {
-    String hql = buildEnrollmentHql(params).getFullQuery();
-    Query<Enrollment> query = getQuery(hql);
-
-    query.setFirstResult(pageParams.getOffset());
-    query.setMaxResults(
-        pageParams.getPageSize() + 1); // get extra enrollment to determine if there is a nextPage
-
-    return new Page<>(query.list(), pageParams, () -> countEnrollments(params));
-  }
-
-  private long countEnrollments(EnrollmentQueryParams params) {
-    String hql = buildCountEnrollmentHql(params);
-    Query<Long> query = getTypedQuery(hql);
-    return query.getSingleResult();
-  }
-
-  private QueryWithOrderBy buildEnrollmentHql(EnrollmentQueryParams params) {
-    String hql = "from Enrollment en";
-    SqlHelper hlp = new SqlHelper(true);
-
-    if (params.hasEnrollmentUids()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.uid in ("
-              + getQuotedCommaDelimitedString(UID.toValueList(params.getEnrollments()))
-              + ")";
-    }
-
-    if (params.hasLastUpdatedDuration()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.lastUpdated >= '"
-              + toLongGmtDate(nowMinusDuration(params.getLastUpdatedDuration()))
-              + "'";
-    } else if (params.hasLastUpdated()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.lastUpdated >= '"
-              + toLongDateWithMillis(params.getLastUpdated())
-              + "'";
-    }
-
-    if (params.hasTrackedEntity()) {
-      hql += hlp.whereAnd() + "en.trackedEntity.uid = '" + params.getTrackedEntity().getUid() + "'";
-    }
-
-    if (params.hasTrackedEntityType()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.trackedEntity.trackedEntityType.uid = '"
-              + params.getTrackedEntityType().getUid()
-              + "'";
-    }
-
-    if (params.hasOrganisationUnits()) {
-      if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)) {
-        hql += hlp.whereAnd() + getDescendantsQuery(params.getOrganisationUnits());
-      } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CHILDREN)) {
-        hql += hlp.whereAnd() + getChildrenQuery(hlp, params.getOrganisationUnits());
-
-      } else {
-        hql += hlp.whereAnd() + getSelectedQuery(params.getOrganisationUnits());
-      }
-    }
-
-    if (params.hasProgram()) {
-      hql += hlp.whereAnd() + "en.program.uid = '" + params.getProgram().getUid() + "'";
-    }
-
-    // TODO(DHIS2-17961) This will be removed when dummy enrollments will not exist anymore
-    hql += hlp.whereAnd() + "en.program.programType = '" + ProgramType.WITH_REGISTRATION + "'";
-
-    if (params.hasEnrollmentStatus()) {
-      hql += hlp.whereAnd() + "en." + STATUS + " = '" + params.getEnrollmentStatus() + "'";
-    }
-
-    if (params.hasFollowUp()) {
-      hql += hlp.whereAnd() + "en.followup = " + params.getFollowUp();
-    }
-
-    if (params.hasProgramStartDate()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.enrollmentDate >= '"
-              + toLongDateWithMillis(params.getProgramStartDate())
-              + "'";
-    }
-
-    if (params.hasProgramEndDate()) {
-      hql +=
-          hlp.whereAnd()
-              + "en.enrollmentDate <= '"
-              + toLongDateWithMillis(params.getProgramEndDate())
-              + "'";
-    }
-
-    if (!params.isIncludeDeleted()) {
-      hql += hlp.whereAnd() + " en.deleted is false ";
-    }
-
-    return QueryWithOrderBy.builder().query(hql).orderBy(orderBy(params.getOrder())).build();
-  }
-
-  private String getDescendantsQuery(Set<OrganisationUnit> organisationUnits) {
-    StringBuilder ouClause = new StringBuilder();
-    ouClause.append("(");
-
-    SqlHelper orHlp = new SqlHelper(true);
-
-    for (OrganisationUnit organisationUnit : organisationUnits) {
-      ouClause
-          .append(orHlp.or())
-          .append("en.organisationUnit.path LIKE '")
-          .append(organisationUnit.getStoredPath())
-          .append("%'");
-    }
-
-    ouClause.append(")");
-
-    return ouClause.toString();
-  }
-
-  private String getChildrenQuery(SqlHelper hlp, Set<OrganisationUnit> organisationUnits) {
-    StringBuilder orgUnits = new StringBuilder();
-    for (OrganisationUnit organisationUnit : organisationUnits) {
-      orgUnits
-          .append(hlp.or())
-          .append("en.organisationUnit.path LIKE '")
-          .append(organisationUnit.getStoredPath())
-          .append("%'")
-          .append(" AND (en.organisationUnit.hierarchyLevel = ")
-          .append(organisationUnit.getHierarchyLevel())
-          .append(" OR en.organisationUnit.hierarchyLevel = ")
-          .append((organisationUnit.getHierarchyLevel() + 1))
-          .append(")");
-    }
-    return orgUnits.toString();
-  }
-
-  private String getSelectedQuery(Set<OrganisationUnit> organisationUnits) {
-    return "en.organisationUnit.uid in ("
-        + getQuotedCommaDelimitedString(getUids(organisationUnits))
-        + ")";
-  }
-
-  private static String orderBy(List<Order> orders) {
-    if (orders.isEmpty()) {
-      return " order by " + DEFAULT_ORDER;
-    }
-
-    StringJoiner orderJoiner = new StringJoiner(", ");
-    for (Order order : orders) {
-      orderJoiner.add(
-          order.getField() + " " + (order.getDirection().isAscending() ? "asc" : "desc"));
-    }
-    return " order by " + orderJoiner + ", " + DEFAULT_ORDER;
-  }
-
-  @Getter
-  @Builder(toBuilder = true)
-  static class QueryWithOrderBy {
-    private final String query;
-
-    private final String orderBy;
-
-    String getFullQuery() {
-      return Stream.of(query, orderBy)
-          .map(StringUtils::trimToEmpty)
-          .filter(Objects::nonNull)
-          .collect(Collectors.joining(" "));
-    }
-  }
-
-  public Set<String> getOrderableFields() {
-    return ORDERABLE_FIELDS;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -138,6 +138,10 @@ public class JdbcEnrollmentStore {
     }
   }
 
+  private void addCountSelect(StringBuilder sql) {
+    sql.append(" select count(distinct e.uid) ");
+  }
+
   private void addEnrollmentFromItem(StringBuilder sql, EnrollmentQueryParams params) {
     sql.append(" from enrollment e ");
     addInnerJoins(sql);
@@ -313,7 +317,7 @@ public class JdbcEnrollmentStore {
 
   private String getCountQuery(EnrollmentQueryParams params) {
     StringBuilder sql = new StringBuilder();
-    addSelect(sql, params);
+    addCountSelect(sql);
     addEnrollmentFromItem(sql, params);
 
     return sql.toString()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -555,7 +555,10 @@ class JdbcEnrollmentStore {
         attributes = mapper.readValue(jsonAttributes, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
         log.error("Error mapping enrollment attributes: {}", jsonAttributes);
-        return Set.of();
+        throw new IllegalArgumentException(
+            String.format(
+                "Enrollment attributes cannot be mapped: %s. Request enrollments without attributes to receive a valid response.",
+                jsonAttributes));
       }
 
       Set<TrackedEntityAttributeValue> trackedEntityAttributeValues = new HashSet<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -138,10 +138,6 @@ public class JdbcEnrollmentStore {
     }
   }
 
-  private void addCountSelect(StringBuilder sql) {
-    sql.append(" select count(distinct e.uid) ");
-  }
-
   private void addEnrollmentFromItem(StringBuilder sql, EnrollmentQueryParams params) {
     sql.append(" from enrollment e ");
     addInnerJoins(sql);
@@ -320,9 +316,11 @@ public class JdbcEnrollmentStore {
     addCountSelect(sql);
     addEnrollmentFromItem(sql, params);
 
-    return sql.toString()
-        .replaceFirst(
-            "(?s)^.*?from enrollment e", "select count(distinct e.uid) from enrollment e");
+    return sql.toString();
+  }
+
+  private void addCountSelect(StringBuilder sql) {
+    sql.append(" select count(distinct e.uid) ");
   }
 
   private String getDescendantsQuery(Set<OrganisationUnit> organisationUnits) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.enrollment;
+
+import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
+import static org.hisp.dhis.util.DateUtils.nowMinusDuration;
+import static org.hisp.dhis.util.DateUtils.toLongDateWithMillis;
+import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.AccessLevel;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.commons.util.SqlHelper;
+import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
+import org.hisp.dhis.message.MessageConversation;
+import org.hisp.dhis.note.Note;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.Page;
+import org.hisp.dhis.tracker.PageParams;
+import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.Sharing;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component("org.hisp.dhis.tracker.export.enrollment.JdbcEnrollmentStore")
+@RequiredArgsConstructor
+public class JdbcEnrollmentStore {
+
+  private static final String DEFAULT_ORDER = "e.enrollmentid desc";
+  private static final Set<String> ORDERABLE_FIELDS =
+      Set.of(
+          "completedDate",
+          "created",
+          "createdAtClient",
+          "enrollmentDate",
+          "lastUpdated",
+          "lastUpdatedAtClient");
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public List<Enrollment> getEnrollments(EnrollmentQueryParams params) {
+    String sql = buildEnrollmentSql(params).getFullQuery();
+    return jdbcTemplate.query(sql, new EnrollmentRowMapper(params.isIncludeAttributes()));
+  }
+
+  public Page<Enrollment> getEnrollments(EnrollmentQueryParams params, PageParams pageParams) {
+    String sql = buildEnrollmentSql(params).getFullQuery();
+    sql +=
+        String.format(" LIMIT %d OFFSET %d", pageParams.getPageSize() + 1, pageParams.getOffset());
+
+    List<Enrollment> enrollments =
+        jdbcTemplate.query(sql, new EnrollmentRowMapper(params.isIncludeAttributes()));
+    return new Page<>(enrollments, pageParams, () -> countEnrollments(params));
+  }
+
+  private long countEnrollments(EnrollmentQueryParams params) {
+    String sql = buildCountEnrollmentSql(params);
+    return jdbcTemplate.queryForObject(sql, Long.class);
+  }
+
+  private QueryWithOrderBy buildEnrollmentSql(EnrollmentQueryParams params) {
+    StringBuilder sql =
+        new StringBuilder(
+            // language=sql
+            """
+                select e.*,
+                p.programid as program_id, p.uid as program_uid, p.name as program_name, p.code as program_code, p.sharing as program_sharing,
+                p.description as program_description, p.created as program_created, p.lastupdated as program_lastupdated,
+                p.shortname as program_short_name, p.type as program_type, p.accesslevel as program_accesslevel,
+                te.uid as tracked_entity_uid, te.code as tracked_entity_code,
+                en_ou.uid as en_org_unit_uid, en_ou.path as en_org_unit_path,
+                te_ou.uid as te_org_unit_uid, te_ou.path as te_org_unit_path,
+                tet.uid as tet_uid, tet.sharing as tet_sharing, notes.jsonnotes as notes
+            """);
+
+    if (params.isIncludeAttributes()) {
+      sql.append(
+          """
+          , attrs.jsonattributes as attributes
+          """);
+    }
+
+    sql.append(
+        """
+        from enrollment e
+        join trackedentity te on te.trackedentityid = e.trackedentityid
+        join trackedentitytype tet on tet.trackedentitytypeid = te.trackedentitytypeid
+        join organisationunit en_ou on en_ou.organisationunitid = e.organisationunitid
+        join organisationunit te_ou on te_ou.organisationunitid = te.organisationunitid
+        join program p on p.programid = e.programid
+        left join lateral (
+          select json_agg(json_build_object('uid', n.uid, 'text', n.notetext,
+            'creator', n.creator, 'created', n.created, 'lastupdatedby', u.uid)) as jsonnotes
+            from enrollment_notes en
+            join note n on n.noteid = en.noteid
+            join userinfo u on u.userinfoid = n.lastupdatedby
+            where en.enrollmentid = e.enrollmentid
+        ) notes on true
+        """);
+
+    if (params.isIncludeAttributes()) {
+      sql.append(
+          """
+          left join lateral (
+              select json_agg(json_build_object('uid', tea.uid, 'name', tea.name,
+              'code', tea.code, 'value', teav.value, 'encryptedvalue', teav.encryptedvalue,
+              'valuetype', tea.valuetype, 'confidential', tea.confidential, 'created', teav.created,
+              'lastupdated', teav.lastupdated, 'storedby', teav.storedby)) as jsonattributes
+              from trackedentityattributevalue teav
+              join trackedentityattribute tea ON tea.trackedentityattributeid = teav.trackedentityattributeid
+              where teav.trackedentityid = e.trackedentityid
+          ) attrs on true
+          """);
+    }
+
+    SqlHelper hlp = new SqlHelper(true);
+
+    if (params.hasEnrollmentUids()) {
+      sql.append(hlp.whereAnd())
+          .append("e.uid in (")
+          .append(getQuotedCommaDelimitedString(UID.toValueList(params.getEnrollments())))
+          .append(")");
+    }
+
+    if (params.hasLastUpdatedDuration()) {
+      sql.append(hlp.whereAnd())
+          .append("e.lastupdated >= '")
+          .append(toLongGmtDate(nowMinusDuration(params.getLastUpdatedDuration())))
+          .append("'");
+    } else if (params.hasLastUpdated()) {
+      sql.append(hlp.whereAnd())
+          .append("e.lastupdated >= '")
+          .append(toLongDateWithMillis(params.getLastUpdated()))
+          .append("'");
+    }
+
+    if (params.hasTrackedEntity()) {
+      sql.append(hlp.whereAnd())
+          .append("te.uid = '")
+          .append(params.getTrackedEntity().getUid())
+          .append("'");
+    }
+
+    if (params.hasOrganisationUnits()) {
+      if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)) {
+        sql.append(hlp.whereAnd()).append(getDescendantsQuery(params.getOrganisationUnits()));
+      } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CHILDREN)) {
+        sql.append(hlp.whereAnd()).append(getChildrenQuery(hlp, params.getOrganisationUnits()));
+      } else {
+        sql.append(hlp.whereAnd())
+            .append("en_ou.uid IN (")
+            .append(getQuotedCommaDelimitedString(getUids(params.getOrganisationUnits())))
+            .append(")");
+      }
+    }
+
+    if (params.hasProgram()) {
+      sql.append(hlp.whereAnd())
+          .append("p.uid = '")
+          .append(params.getProgram().getUid())
+          .append("'");
+    }
+
+    sql.append(hlp.whereAnd())
+        .append("p.type = '")
+        .append(ProgramType.WITH_REGISTRATION)
+        .append("'");
+
+    if (params.hasEnrollmentStatus()) {
+      sql.append(hlp.whereAnd())
+          .append("e.status = '")
+          .append(params.getEnrollmentStatus())
+          .append("'");
+    }
+
+    if (params.hasFollowUp()) {
+      sql.append(hlp.whereAnd()).append("e.followup = ").append(params.getFollowUp());
+    }
+
+    if (params.hasProgramStartDate()) {
+      sql.append(hlp.whereAnd())
+          .append("e.enrollmentdate >= '")
+          .append(toLongDateWithMillis(params.getProgramStartDate()))
+          .append("'");
+    }
+
+    if (params.hasProgramEndDate()) {
+      sql.append(hlp.whereAnd())
+          .append("e.enrollmentdate <= '")
+          .append(toLongDateWithMillis(params.getProgramEndDate()))
+          .append("'");
+    }
+
+    if (!params.isIncludeDeleted()) {
+      sql.append(hlp.whereAnd()).append("e.deleted = false");
+    }
+
+    return QueryWithOrderBy.builder()
+        .query(sql.toString())
+        .orderBy(orderBy(params.getOrder()))
+        .build();
+  }
+
+  private String buildCountEnrollmentSql(EnrollmentQueryParams params) {
+    return buildEnrollmentSql(params)
+        .getQuery()
+        .replaceFirst(
+            "(?s)^.*?from enrollment e", "select count(distinct e.uid) from enrollment e");
+  }
+
+  private String getDescendantsQuery(Set<OrganisationUnit> organisationUnits) {
+    StringBuilder ouClause = new StringBuilder();
+    ouClause.append("(");
+
+    SqlHelper orHlp = new SqlHelper(true);
+
+    for (OrganisationUnit organisationUnit : organisationUnits) {
+      ouClause
+          .append(orHlp.or())
+          .append("en_ou.path LIKE '")
+          .append(organisationUnit.getStoredPath())
+          .append("%'");
+    }
+
+    ouClause.append(")");
+    return ouClause.toString();
+  }
+
+  private String getChildrenQuery(SqlHelper hlp, Set<OrganisationUnit> organisationUnits) {
+    StringBuilder orgUnits = new StringBuilder();
+    for (OrganisationUnit organisationUnit : organisationUnits) {
+      orgUnits
+          .append(hlp.or())
+          .append("(en_ou.path LIKE '")
+          .append(organisationUnit.getStoredPath())
+          .append("%' AND (en_ou.hierarchylevel = ")
+          .append(organisationUnit.getHierarchyLevel())
+          .append(" OR en_ou.hierarchylevel = ")
+          .append(organisationUnit.getHierarchyLevel() + 1)
+          .append("))");
+    }
+    return orgUnits.toString();
+  }
+
+  private static String orderBy(List<Order> orders) {
+    if (orders == null || orders.isEmpty()) {
+      return DEFAULT_ORDER;
+    }
+
+    StringBuilder orderBy = new StringBuilder();
+    for (Order order : orders) {
+      if (!orderBy.isEmpty()) {
+        orderBy.append(", ");
+      }
+      orderBy.append("e.").append(order.getField()).append(" ").append(order.getDirection());
+    }
+
+    return orderBy + ", " + DEFAULT_ORDER;
+  }
+
+  private static class EnrollmentRowMapper implements RowMapper<Enrollment> {
+    private final boolean isIncludeAttributes;
+
+    EnrollmentRowMapper(boolean isIncludeAttributes) {
+      this.isIncludeAttributes = isIncludeAttributes;
+    }
+
+    @Override
+    public Enrollment mapRow(ResultSet rs, int rowNum) throws SQLException {
+      Enrollment enrollment = new Enrollment();
+      enrollment.setId(rs.getLong("enrollmentid"));
+      enrollment.setUid(rs.getString("uid"));
+      enrollment.setCreated(formatDate(rs.getTimestamp("created")));
+      enrollment.setCreatedAtClient(formatDate(rs.getTimestamp("createdatclient")));
+      enrollment.setCreatedByUserInfo(mapUserInfo(rs.getString("createdbyuserinfo")));
+      enrollment.setLastUpdated(formatDate(rs.getTimestamp("lastupdated")));
+      enrollment.setLastUpdatedByUserInfo(mapUserInfo(rs.getString("lastupdatedbyuserinfo")));
+      enrollment.setLastUpdatedAtClient(formatDate(rs.getTimestamp("lastupdatedatclient")));
+      enrollment.setOccurredDate(formatDate(rs.getTimestamp("occurreddate")));
+      enrollment.setEnrollmentDate(formatDate(rs.getTimestamp(("enrollmentdate"))));
+      enrollment.setCompletedDate(formatDate(rs.getTimestamp(("completeddate"))));
+      enrollment.setFollowup(rs.getBoolean("followup"));
+      enrollment.setCompletedBy(rs.getString("completedby"));
+      enrollment.setStoredBy(rs.getString("storedby"));
+      enrollment.setDeleted(rs.getBoolean("deleted"));
+      enrollment.setStatus(EnrollmentStatus.valueOf(rs.getString("status")));
+      enrollment.setGeometry(mapGeometry(rs.getString("geometry")));
+
+      TrackedEntityType trackedEntityType = new TrackedEntityType();
+      trackedEntityType.setUid(rs.getString("tet_uid"));
+      trackedEntityType.setSharing(mapSharingJsonIntoSharingObject(rs.getString("tet_sharing")));
+
+      Program program = new Program();
+      program.setId(rs.getLong("program_id"));
+      program.setUid(rs.getString("program_uid"));
+      program.setName(rs.getString("program_name"));
+      program.setShortName(rs.getString("program_short_name"));
+      program.setCode(rs.getString("program_code"));
+      program.setDescription(rs.getString("program_description"));
+      program.setCreated(formatDate(rs.getTimestamp("program_created")));
+      program.setLastUpdated(formatDate(rs.getTimestamp("program_lastupdated")));
+      program.setTrackedEntityType(trackedEntityType);
+      program.setProgramType(ProgramType.valueOf(rs.getString("program_type")));
+      program.setAccessLevel(AccessLevel.valueOf(rs.getString("program_accesslevel")));
+      program.setSharing(mapSharingJsonIntoSharingObject(rs.getString("program_sharing")));
+      enrollment.setProgram(program);
+
+      TrackedEntity trackedEntity = new TrackedEntity();
+      trackedEntity.setUid(rs.getString("tracked_entity_uid"));
+      trackedEntity.setCode(rs.getString("tracked_entity_code"));
+      trackedEntity.setTrackedEntityType(trackedEntityType);
+      OrganisationUnit teOrgUnit = new OrganisationUnit();
+      teOrgUnit.setUid(rs.getString("te_org_unit_uid"));
+      teOrgUnit.setPath(rs.getString("te_org_unit_path"));
+      trackedEntity.setOrganisationUnit(teOrgUnit);
+      enrollment.setTrackedEntity(trackedEntity);
+
+      OrganisationUnit enrollmentOrgUnit = new OrganisationUnit();
+      enrollmentOrgUnit.setUid(rs.getString("en_org_unit_uid"));
+      enrollmentOrgUnit.setPath(rs.getString("en_org_unit_path"));
+      enrollment.setOrganisationUnit(enrollmentOrgUnit);
+
+      // TODO Map messages?
+      List<MessageConversation> messageConversations = new ArrayList<>();
+
+      String jsonNotes = rs.getString("notes");
+      if (jsonNotes != null) {
+        enrollment.setNotes(mapEnrollmentNotes(jsonNotes));
+      }
+
+      if (isIncludeAttributes) {
+        String jsonAttributes = rs.getString("attributes");
+        if (jsonAttributes != null) {
+          enrollment
+              .getTrackedEntity()
+              .setTrackedEntityAttributeValues(
+                  mapTrackedEntityAttributeValues(jsonAttributes, trackedEntity));
+        }
+      }
+
+      return enrollment;
+    }
+
+    private Geometry mapGeometry(String geometry) {
+      if (Strings.isNullOrEmpty(geometry)) {
+        return null;
+      }
+
+      try {
+        WKBReader reader = new WKBReader();
+        byte[] bytes = WKBReader.hexToBytes(geometry);
+        return reader.read(bytes);
+      } catch (ParseException e) {
+        // TODO Should this be runtime exceptions?
+        throw new RuntimeException(e);
+      }
+    }
+
+    private Sharing mapSharingJsonIntoSharingObject(String jsonSharing) {
+      if (StringUtils.isEmpty(jsonSharing)) {
+        return null;
+      }
+
+      try {
+        return JsonBinaryType.MAPPER
+            .readerFor(new TypeReference<Sharing>() {})
+            .readValue(jsonSharing);
+      } catch (IOException e) {
+        // TODO Should this be illegal argument exception?
+        throw new IllegalArgumentException(e);
+      }
+    }
+
+    private UserInfoSnapshot mapUserInfo(String jsonUser) {
+      if (StringUtils.isEmpty(jsonUser)) {
+        return null;
+      }
+
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        return mapper.readValue(jsonUser, UserInfoSnapshot.class);
+      } catch (JsonProcessingException e) {
+        // TODO Should this be runtime exceptions?
+        throw new RuntimeException(e);
+      }
+    }
+
+    private List<Note> mapEnrollmentNotes(String jsonNotes) {
+      List<JdbcNote> jdbcNotes;
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        jdbcNotes = mapper.readValue(jsonNotes, new TypeReference<>() {});
+      } catch (JsonProcessingException e) {
+        // TODO Should this be runtime exceptions?
+        throw new RuntimeException(e);
+      }
+
+      List<Note> notes = new ArrayList<>();
+      for (JdbcNote jdbcNote : jdbcNotes) {
+        Note note = new Note();
+        note.setUid(jdbcNote.getUid());
+        note.setNoteText(jdbcNote.getText());
+        note.setCreator(jdbcNote.getCreator());
+        note.setCreated(formatDate(jdbcNote.getCreated()));
+        User user = new User();
+        user.setUid(jdbcNote.getLastupdatedby());
+        note.setLastUpdatedBy(user);
+        notes.add(note);
+      }
+
+      return notes;
+    }
+
+    private Set<TrackedEntityAttributeValue> mapTrackedEntityAttributeValues(
+        String jsonAttributes, TrackedEntity trackedEntity) {
+      List<JdbcAttribute> attributes;
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        attributes = mapper.readValue(jsonAttributes, new TypeReference<>() {});
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+
+      Set<TrackedEntityAttributeValue> trackedEntityAttributeValues = new HashSet<>();
+      for (JdbcAttribute attribute : attributes) {
+        TrackedEntityAttributeValue teav = new TrackedEntityAttributeValue();
+        TrackedEntityAttribute tea = new TrackedEntityAttribute();
+        tea.setUid(attribute.getUid());
+        tea.setValueType(ValueType.valueOf(attribute.getValuetype()));
+        tea.setName(attribute.getName());
+        tea.setCode(attribute.getCode());
+        tea.setConfidential(attribute.isConfidential());
+        teav.setAttribute(tea);
+        teav.setStoredBy(attribute.getStoredby());
+        teav.setCreated(formatDate(attribute.getCreated()));
+        teav.setLastUpdated(formatDate(attribute.getLastupdated()));
+        teav.setEncryptedValue(attribute.getEncryptedvalue());
+        teav.setPlainValue(attribute.getValue());
+        teav.setTrackedEntity(trackedEntity);
+
+        trackedEntityAttributeValues.add(teav);
+      }
+
+      return trackedEntityAttributeValues;
+    }
+
+    private static final ZoneId ZONE_ID = ZoneId.systemDefault();
+
+    private Date formatDate(String date) {
+      return date == null ? null : toDate(LocalDateTime.parse(date).atZone(ZONE_ID));
+    }
+
+    private Date formatDate(Timestamp timestamp) {
+      return timestamp == null ? null : toDate(timestamp.toInstant().atZone(ZONE_ID));
+    }
+
+    private Date toDate(ZonedDateTime zonedDateTime) {
+      return Date.from(zonedDateTime.toInstant());
+    }
+  }
+
+  public Set<String> getOrderableFields() {
+    return ORDERABLE_FIELDS;
+  }
+
+  public void delete(@Nonnull Enrollment enrollment) {
+    String sql = "UPDATE enrollment SET deleted = true WHERE enrollmentid = ?";
+    jdbcTemplate.update(sql, enrollment.getId());
+  }
+
+  @Getter
+  @Setter
+  private static class JdbcNote {
+    private String uid;
+    private String text;
+    private String creator;
+    private String created;
+    private String lastupdatedby;
+  }
+
+  @Getter
+  @Setter
+  private static class JdbcAttribute {
+    private String uid;
+    private String name;
+    private String code;
+    private String value;
+    private String encryptedvalue;
+    private String valuetype;
+    private boolean confidential;
+    private String created;
+    private String lastupdated;
+    private String storedby;
+  }
+
+  @Getter
+  @Builder(toBuilder = true)
+  private static class QueryWithOrderBy {
+    private final String query;
+    private final String orderBy;
+
+    public String getFullQuery() {
+      if (orderBy == null || orderBy.isEmpty()) {
+        return query;
+      }
+      return query + " ORDER BY " + orderBy;
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -155,7 +155,9 @@ public class JdbcEnrollmentStore {
         join program p on p.programid = e.programid
         left join lateral (
           select json_agg(json_build_object('uid', n.uid, 'text', n.notetext,
-            'creator', n.creator, 'created', n.created, 'lastupdatedby', u.uid)) as jsonnotes
+            'creator', n.creator, 'created', n.created, 'updatedByUid', u.uid,
+            'updatedByUsername', u.username, 'updatedByFirstname', u.firstname,
+            'updatedBySurname', u.surname, 'updatedByName', u.name)) as jsonnotes
             from enrollment_notes en
             join note n on n.noteid = en.noteid
             join userinfo u on u.userinfoid = n.lastupdatedby
@@ -168,9 +170,9 @@ public class JdbcEnrollmentStore {
           """
           left join lateral (
               select json_agg(json_build_object('uid', tea.uid, 'name', tea.name,
-              'code', tea.code, 'value', teav.value, 'encryptedvalue', teav.encryptedvalue,
-              'valuetype', tea.valuetype, 'confidential', tea.confidential, 'created', teav.created,
-              'lastupdated', teav.lastupdated, 'storedby', teav.storedby)) as jsonattributes
+              'code', tea.code, 'value', teav.value, 'encryptedValue', teav.encryptedvalue,
+              'valueType', tea.valuetype, 'confidential', tea.confidential, 'created', teav.created,
+              'lastUpdated', teav.lastupdated, 'storedBy', teav.storedby)) as jsonattributes
               from trackedentityattributevalue teav
               join trackedentityattribute tea ON tea.trackedentityattributeid = teav.trackedentityattributeid
               where teav.trackedentityid = e.trackedentityid
@@ -468,7 +470,11 @@ public class JdbcEnrollmentStore {
         note.setCreator(jdbcNote.getCreator());
         note.setCreated(formatDate(jdbcNote.getCreated()));
         User user = new User();
-        user.setUid(jdbcNote.getLastupdatedby());
+        user.setUid(jdbcNote.getUpdatedByUid());
+        user.setUsername(jdbcNote.getUpdatedByUsername());
+        user.setFirstName(jdbcNote.getUpdatedByFirstname());
+        user.setSurname(jdbcNote.getUpdatedBySurname());
+        user.setName(jdbcNote.getUpdatedByName());
         note.setLastUpdatedBy(user);
         notes.add(note);
       }
@@ -491,15 +497,15 @@ public class JdbcEnrollmentStore {
         TrackedEntityAttributeValue teav = new TrackedEntityAttributeValue();
         TrackedEntityAttribute tea = new TrackedEntityAttribute();
         tea.setUid(attribute.getUid());
-        tea.setValueType(ValueType.valueOf(attribute.getValuetype()));
+        tea.setValueType(ValueType.valueOf(attribute.getValueType()));
         tea.setName(attribute.getName());
         tea.setCode(attribute.getCode());
         tea.setConfidential(attribute.isConfidential());
         teav.setAttribute(tea);
-        teav.setStoredBy(attribute.getStoredby());
+        teav.setStoredBy(attribute.getStoredBy());
         teav.setCreated(formatDate(attribute.getCreated()));
-        teav.setLastUpdated(formatDate(attribute.getLastupdated()));
-        teav.setEncryptedValue(attribute.getEncryptedvalue());
+        teav.setLastUpdated(formatDate(attribute.getLastUpdated()));
+        teav.setEncryptedValue(attribute.getEncryptedValue());
         teav.setPlainValue(attribute.getValue());
         teav.setTrackedEntity(trackedEntity);
 
@@ -540,7 +546,11 @@ public class JdbcEnrollmentStore {
     private String text;
     private String creator;
     private String created;
-    private String lastupdatedby;
+    private String updatedByUid;
+    private String updatedByUsername;
+    private String updatedByFirstname;
+    private String updatedBySurname;
+    private String updatedByName;
   }
 
   @Getter
@@ -550,12 +560,12 @@ public class JdbcEnrollmentStore {
     private String name;
     private String code;
     private String value;
-    private String encryptedvalue;
-    private String valuetype;
+    private String encryptedValue;
+    private String valueType;
     private boolean confidential;
     private String created;
-    private String lastupdated;
-    private String storedby;
+    private String lastUpdated;
+    private String storedBy;
   }
 
   @Getter

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -268,7 +268,7 @@ public class JdbcEnrollmentStore {
 
     if (params.hasEnrollmentStatus()) {
       sql.append(hlp.whereAnd()).append("e.status = :enrollmentStatus");
-      sqlParams.addValue("enrollmentStatus", params.getEnrollmentStatus());
+      sqlParams.addValue("enrollmentStatus", params.getEnrollmentStatus().name());
     }
 
     if (params.hasFollowUp()) {
@@ -313,7 +313,8 @@ public class JdbcEnrollmentStore {
   private long countEnrollments(EnrollmentQueryParams params) {
     MapSqlParameterSource sqlParams = new MapSqlParameterSource();
     String sql = getCountQuery(params, sqlParams);
-    return jdbcTemplate.queryForObject(sql, sqlParams, Long.class);
+    Long count = jdbcTemplate.queryForObject(sql, sqlParams, Long.class);
+    return count != null ? count : 0L;
   }
 
   private String getCountQuery(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -55,6 +55,7 @@ import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -85,7 +86,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
 
-@Component("org.hisp.dhis.tracker.export.enrollment.JdbcEnrollmentStore")
+@Slf4j
+@Component("org.hisp.dhis.tracker.export.enrollment.EnrollmentStore")
 @RequiredArgsConstructor
 public class JdbcEnrollmentStore {
 
@@ -460,8 +462,8 @@ public class JdbcEnrollmentStore {
         byte[] bytes = WKBReader.hexToBytes(geometry);
         return reader.read(bytes);
       } catch (ParseException e) {
-        // TODO Should this be runtime exceptions?
-        throw new RuntimeException(e);
+        log.error("Error mapping enrollment geometry: {}", geometry);
+        return null;
       }
     }
 
@@ -475,8 +477,8 @@ public class JdbcEnrollmentStore {
             .readerFor(new TypeReference<Sharing>() {})
             .readValue(jsonSharing);
       } catch (IOException e) {
-        // TODO Should this be illegal argument exception?
-        throw new IllegalArgumentException(e);
+        log.error("Error mapping enrollment sharing: {}", jsonSharing);
+        return null;
       }
     }
 
@@ -489,8 +491,8 @@ public class JdbcEnrollmentStore {
       try {
         return mapper.readValue(jsonUser, UserInfoSnapshot.class);
       } catch (JsonProcessingException e) {
-        // TODO Should this be runtime exceptions?
-        throw new RuntimeException(e);
+        log.error("Error mapping enrollment user info: {}", jsonUser);
+        return null;
       }
     }
 
@@ -500,8 +502,8 @@ public class JdbcEnrollmentStore {
       try {
         jdbcNotes = mapper.readValue(jsonNotes, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
-        // TODO Should this be runtime exceptions?
-        throw new RuntimeException(e);
+        log.error("Error mapping enrollment notes: {}", jsonNotes);
+        return null;
       }
 
       List<Note> notes = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -503,7 +503,7 @@ public class JdbcEnrollmentStore {
         jdbcNotes = mapper.readValue(jsonNotes, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
         log.error("Error mapping enrollment notes: {}", jsonNotes);
-        return null;
+        return List.of();
       }
 
       List<Note> notes = new ArrayList<>();
@@ -533,7 +533,8 @@ public class JdbcEnrollmentStore {
       try {
         attributes = mapper.readValue(jsonAttributes, new TypeReference<>() {});
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        log.error("Error mapping enrollment attributes: {}", jsonAttributes);
+        return Set.of();
       }
 
       Set<TrackedEntityAttributeValue> trackedEntityAttributeValues = new HashSet<>();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -90,7 +90,6 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-// TODO This needs to be transactional
 @Transactional
 class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
@@ -219,8 +218,6 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     trackedEntityA.setTrackedEntityAttributeValues(Set.of(trackedEntityAttributeValueA));
     manager.update(trackedEntityA);
 
-    // TODO Remove this
-    // programA.getProgramAttributes().clear();
     programA
         .getProgramAttributes()
         .add(createProgramTrackedEntityAttribute(programA, trackedEntityAttributeA));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -689,8 +689,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntity te =
         trackedEntityService.getTrackedEntity(
             UID.of(trackedEntityA), UID.of(programA), TrackedEntityFields.all());
-    assertEquals(1, te.getEnrollments().size());
-    assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
+    assertContainsOnly(Set.of(enrollmentA.getUid()), uids(te.getEnrollments()));
 
     final List<TrackedEntity> trackedEntities =
         trackedEntityService.findTrackedEntities(operationParams);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -200,6 +200,9 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
       assertEquals(note.getValue(), dbNote.getNoteText());
       assertEquals(note.getStoredBy(), dbNote.getCreator());
       assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
+      assertEquals(updatedBy.getUsername(), dbNote.getLastUpdatedBy().getUsername());
+      assertEquals(updatedBy.getFirstName(), dbNote.getLastUpdatedBy().getFirstName());
+      assertEquals(updatedBy.getSurname(), dbNote.getLastUpdatedBy().getSurname());
     }
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
@@ -86,6 +86,10 @@ class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestB
 
     TrackedEntityType trackedEntityType = createTrackedEntityType('A');
     manager.save(trackedEntityType);
+    trackedEntityType
+        .getSharing()
+        .addUserAccess(new UserAccess(importUser, AccessStringHelper.DATA_READ));
+    manager.update(trackedEntityType);
 
     ProgramStage programStage = createProgramStage('A', program);
     programStage
@@ -170,7 +174,6 @@ class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestB
         POST(
                 "/tracker/enrollments/" + enrollment.getUid() + "/note",
                 """
-
                         {
                            "creator": "I am the creator"
                         }
@@ -187,7 +190,6 @@ class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestB
         POST(
                 "/tracker/enrollments/" + enrollment.getUid() + "/note",
                 """
-
                         {
                            "value": "This is a note"
                         }
@@ -206,7 +208,6 @@ class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestB
         POST(
                 "/tracker/enrollments/" + enrollment.getUid() + "/note",
                 """
-
                         {
                            "note": "%s",
                            "value": "This is a note"


### PR DESCRIPTION
This PR adds a new enrollment store, which will be our default, using JDBC instead of Hibernate.

I've tested it on an environment with 73k enrollments, here are the results:

**1. Get enrollment by TE and Program**
     This query is frequently triggered in the Capture app. [Query plan](https://explain.dalibo.com/plan/043ef0c88bc7e1c8)
        - Uses indexes effectively.
        - Returns a single row.
        - Exec time: ~0.19 ms.

**2. Get all enrollments for a given TE** [Query plan](https://explain.dalibo.com/plan/63953g4b4a8512ah#raw)
       - Similar efficiency as above.
       - Uses indexes well.
       - Returns a single row.
       - Exec time: ~0.23 ms.

**3. Worst case: Get all enrollments and all fields (no filters, no pagination)** [Query plan](https://explain.dalibo.com/plan/2fc7c1dd0d3271h9#raw)
       - Joins with notes and trackedentity tables for every enrollment.
       - Most enrollments don't have notes, so the join adds unnecessary overhead.
       - Exec time: ~467 ms.

We are not running N+1 queries when fetching notes or attributes, which is great.
However, fetching all enrollments without filters results in thousands of joins for notes, even when most entries don’t have any.

Since Hibernate splits the logic into multiple queries (enrollments, tracked entities, notes, attributes, etc.), it’s hard to do a direct query plan comparison.
To benchmark, I ran the same API request 20 times locally on two instances: one using JDBC, the other using Hibernate.

I tested the Endpoint which I think it's the most common: `/api/tracker/enrollments?enrollmentId=enrollment&orgUnitId=orgUnit&programId=program&teiId=trackedEntity`.
- JDBC average response: 379 ms
- Hibernate average response: 392 ms

These results should be taken with a grain of salt, but while the difference isn’t massive, JDBC shows slightly better performance and provides more control and transparency over the queries.

### Possible Improvements
- If soft-deleted enrollments are common, we might benefit from a partial index that only includes non-deleted records.
-  Notes are joined by default, even though most enrollments don’t have any. We could consider an opt-in approach—similar to how we handle events, relationships, or attributes—where notes are only fetched when explicitly requested.