### PR TITLE
fix: login fallback page

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginTest.java
@@ -314,6 +314,17 @@ public class LoginTest extends BaseE2ETest {
     }
   }
 
+  @Test
+  void testLoginFallback() {
+    HttpHeaders headers = jsonHeaders();
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+    ResponseEntity<String> response =
+        getRestTemplateNoRedirects()
+            .exchange(serverHostUrl + "login.html", HttpMethod.GET, entity, String.class);
+    HttpStatusCode statusCode = response.getStatusCode();
+    assertEquals(HttpStatus.OK, statusCode);
+  }
+
   // --------------------------------------------------------------------------------------------
   // Helper classes and records
   // --------------------------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/LoginFallbackServlet.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/LoginFallbackServlet.java
@@ -75,12 +75,10 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class LoginFallbackServlet extends HttpServlet {
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    Object springSecurityContext = session().getAttribute("SPRING_SECURITY_CONTEXT");
-
-    if (springSecurityContext != null) {
+    if (session() != null && session().getAttribute("SPRING_SECURITY_CONTEXT") != null) {
       String referer = (String) req.getAttribute("origin");
       req.setAttribute("origin", referer);
-      resp.sendRedirect("/dhis-web-dashboard");
+      resp.sendRedirect("/");
     } else {
       String content = getResourceFileAsString(this.getClass(), "login.html");
       resp.setContentType("text/html");
@@ -92,6 +90,6 @@ public class LoginFallbackServlet extends HttpServlet {
   public static HttpSession session() {
     ServletRequestAttributes attr =
         (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
-    return attr.getRequest().getSession(false); // true == allow create
+    return attr.getRequest().getSession(false);
   }
 }


### PR DESCRIPTION
## Summary
Login fallback page/servlet was broken due to: https://github.com/dhis2/dhis2-core/pull/20706
Since after this PR, a session is not always created, but only when needed.
The fallback servlet does not take this into account and will always assume there is a session, hence causing a NP when it's not a session.

#### Problem:
When navigating to /login.html, a 500 error was shown.

#### Fix:
Check session is not NULL.

#### Test:
An E2E test was added: LoginTest.testLoginFallback()

#### Manual test step:
1. Go to /login.html
2. Make sure you see the login page.