### PR TITLE
feat: min-max bulk import and delete [DHIS2-19208]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/csv/CSV.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/csv/CSV.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.csv;
+
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.function.Predicate.not;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.UID;
+import org.intellij.lang.annotations.Language;
+
+/**
+ * A utility to read CSV into record POJOs.
+ *
+ * <p>This assumes all properties of the constructed POJOs are simple in nature.
+ *
+ * <p>Required properties either use a primitive type or are annotated with {@link Nonnull}.
+ *
+ * @author Jan Bernitt
+ * @since 2.43
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CSV {
+
+  @FunctionalInterface
+  public interface CsvReader<T> extends Iterable<T> {
+
+    @Nonnull
+    default List<T> list() {
+      return stream().toList();
+    }
+
+    @Nonnull
+    default Stream<T> stream() {
+      return StreamSupport.stream(spliteratorUnknownSize(iterator(), Spliterator.ORDERED), false);
+    }
+  }
+
+  /** Allows to configure the expected CSV formatting before starting to read the input. */
+  public interface CsvConfig {
+
+    @Nonnull
+    <T extends Record> CsvReader<T> as(Class<T> type);
+  }
+
+  public static CsvConfig of(InputStream csv) {
+    return new Config(new BufferedReader(new InputStreamReader(csv, StandardCharsets.UTF_8)));
+  }
+
+  public static CsvConfig of(@Language("csv") String csv) {
+    return new Config(new BufferedReader(new StringReader(csv)));
+  }
+
+  private static final Map<Class<?>, Function<String, ?>> DESERIALIZERS = new ConcurrentHashMap<>();
+  private static final Map<Class<?>, Columns<?>> MAPPINGS = new ConcurrentHashMap<>();
+
+  private static <C> void addDeserializer(Class<C> type, Function<String, C> deserializer) {
+    DESERIALIZERS.put(type, deserializer);
+  }
+
+  static {
+    addDeserializer(String.class, Function.identity());
+    addDeserializer(Character.class, str -> str.isEmpty() ? null : str.charAt(0));
+    addDeserializer(char.class, str -> str.charAt(0));
+    addDeserializer(Integer.class, Integer::parseInt);
+    addDeserializer(int.class, Integer::parseInt);
+    addDeserializer(Long.class, Long::parseLong);
+    addDeserializer(long.class, Long::parseLong);
+    addDeserializer(Float.class, Float::parseFloat);
+    addDeserializer(float.class, Float::parseFloat);
+    addDeserializer(Double.class, Double::parseDouble);
+    addDeserializer(double.class, Double::parseDouble);
+    addDeserializer(Boolean.class, Boolean::parseBoolean);
+    addDeserializer(boolean.class, Boolean::parseBoolean);
+    addDeserializer(UID.class, UID::of);
+  }
+
+  private record Column<T>(String name, boolean required, Function<String, T> deserializer) {}
+
+  private record Columns<T extends Record>(Class<T> type, List<Column<?>> columns) {
+
+    Function<List<String>, T> from(List<String> header) {
+      int[] compIdxByColIdx = compIdxByColIdx(header);
+      checkRequired(compIdxByColIdx);
+      Class<?>[] types = getComponentTypes(type);
+      try {
+        Constructor<T> c = type.getDeclaredConstructor(types);
+        return values -> {
+          Object[] args = new Object[types.length];
+          for (int i = 0; i < values.size(); i++) {
+            int compIdx = compIdxByColIdx[i];
+            if (compIdx >= 0) {
+              Column<?> column = columns.get(compIdx);
+              String value = values.get(i);
+              if (column.required && value == null)
+                throw new IllegalArgumentException(
+                    "Column %s is required and cannot be empty".formatted(column.name));
+              args[compIdx] = value == null ? null : column.deserializer.apply(value);
+            }
+          }
+          try {
+            return c.newInstance(args);
+          } catch (Exception ex) {
+            // should be impossible as long as there is no custom validation in the constructor
+            // throwing an exception, in which case the arguments are not proper, so this wraps as:
+            throw new IllegalArgumentException(ex);
+          }
+        };
+      } catch (NoSuchMethodException ex) {
+        // should be impossible since it uses the record canonical constructor
+        throw new NoSuchElementException(ex);
+      }
+    }
+
+    private void checkRequired(int[] compIdxByColIdx) {
+      List<String> required = columns.stream().filter(Column::required).map(Column::name).toList();
+      List<String> present =
+          IntStream.of(compIdxByColIdx)
+              .filter(i -> i >= 0)
+              .mapToObj(columns::get)
+              .map(Column::name)
+              .toList();
+      if (!present.containsAll(required))
+        throw new IllegalArgumentException(
+            "Required columns missing: "
+                + required.stream().filter(not(present::contains)).toList());
+    }
+
+    private int[] compIdxByColIdx(List<String> columns) {
+      Map<String, Integer> compIdxByName = compIdxByName();
+      int[] res = new int[columns.size()];
+      for (int i = 0; i < columns.size(); i++) {
+        String name = columns.get(i);
+        Integer compIdx = compIdxByName.get(name);
+        if (compIdx == null) compIdx = compIdxByName.get(name.toLowerCase());
+        if (compIdx == null) compIdx = -1;
+        res[i] = compIdx;
+      }
+      return res;
+    }
+
+    @Nonnull
+    private Map<String, Integer> compIdxByName() {
+      RecordComponent[] components = type.getRecordComponents();
+      Map<String, Integer> res = new HashMap<>();
+      for (int i = 0; i < components.length; i++) {
+        RecordComponent c = components[i];
+        res.put(c.getName(), i);
+        res.put(c.getName().toLowerCase(), i);
+      }
+      return res;
+    }
+  }
+
+  private static Class<?>[] getComponentTypes(Class<? extends Record> type) {
+    return Stream.of(type.getRecordComponents())
+        .map(RecordComponent::getType)
+        .toArray(Class<?>[]::new);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Record> Columns<T> toColumnsCached(Class<T> type) {
+    return (Columns<T>) MAPPINGS.computeIfAbsent(type, t -> new Columns<>(type, toColumns(type)));
+  }
+
+  private static List<Column<?>> toColumns(Class<? extends Record> type) {
+    return List.copyOf(Stream.of(type.getRecordComponents()).map(CSV::toColumn).toList());
+  }
+
+  @Nonnull
+  private static Column<?> toColumn(RecordComponent c) {
+    Class<?> type = c.getType();
+    Function<String, ?> deserializer = DESERIALIZERS.get(type);
+    if (deserializer == null)
+      throw new UnsupportedOperationException("%s is not supported".formatted(type));
+    boolean required = type.isPrimitive() || c.isAnnotationPresent(Nonnull.class);
+    return new Column<>(c.getName(), required, deserializer);
+  }
+
+  private record Config(BufferedReader csv) implements CsvConfig {
+
+    @Nonnull
+    @Override
+    public <T extends Record> CsvReader<T> as(Class<T> type) {
+      return new Reader<>(csv, toColumnsCached(type));
+    }
+  }
+
+  private record Reader<T extends Record>(BufferedReader csv, Columns<T> as)
+      implements CsvReader<T> {
+
+    @Nonnull
+    @Override
+    public Iterator<T> iterator() {
+      String header = null;
+      try {
+        header = csv.readLine();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+      if (header == null) throw new IllegalArgumentException("No header line provided.");
+      List<String> columns = List.of(header.split(","));
+      Function<List<String>, T> creator = as.from(columns);
+      LineBuffer buf = LineBuffer.of(columns);
+      return new Iterator<>() {
+        Boolean next;
+
+        @Override
+        public boolean hasNext() {
+          try {
+            next = buf.readLine(csv);
+            return next;
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        }
+
+        @Override
+        public T next() {
+          if (next == null) next = hasNext();
+          if (!next) throw new NoSuchElementException("No more rows in the CSV.");
+          return creator.apply(buf.split());
+        }
+      };
+    }
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/csv/LineBuffer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/csv/LineBuffer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.csv;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.ToString;
+
+/**
+ * A helper to efficiently read lines from a {@link BufferedReader} and split them into column
+ * values.
+ *
+ * @author Jan Bernitt
+ */
+@ToString
+final class LineBuffer {
+
+  private final List<String> header;
+  private char[] buf;
+  private int to;
+
+  public static LineBuffer of(List<String> header) {
+    return new LineBuffer(header);
+  }
+
+  private LineBuffer(List<String> header) {
+    this.header = header;
+    this.buf = new char[50 * header.size()];
+  }
+
+  boolean readLine(BufferedReader csv) throws IOException {
+    int c;
+    to = 0;
+    while (!isEOL(c = csv.read())) {
+      buf[to++] = (char) c;
+      if (to >= buf.length) buf = Arrays.copyOf(buf, buf.length * 2);
+    }
+    return to > 0;
+  }
+
+  private boolean isEOL(int c) {
+    return c == -1 || c == '\n' || c == '\r';
+  }
+
+  List<String> split() {
+    int from = skipIndent(0);
+    List<String> res = new ArrayList<>(header.size());
+    while (from < to) {
+      char c = buf[from];
+      if (c == ',') {
+        res.add(null);
+        from = skipIndent(from + 1);
+      } else if (c == '"') {
+        int nextQuote = next('"', from + 1);
+        res.add(str(from + 1, nextQuote));
+        from = skipIndent(next(',', skipIndent(nextQuote + 1)));
+      } else {
+        int nextComma = next(',', from);
+        res.add(str(from, nextComma));
+        from = skipIndent(nextComma + 1);
+      }
+    }
+    return res;
+  }
+
+  private String str(int from, int to) {
+    return new String(buf, from, to - from);
+  }
+
+  private int next(char c, int from) {
+    int i = from;
+    while (i < to && buf[i] != c) i++;
+    return i;
+  }
+
+  private int skipIndent(int from) {
+    int i = from;
+    while (i < to && (buf[i] == ' ' || buf[i] == '\t')) i++;
+    return i;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -76,7 +76,7 @@ public enum ErrorCode {
   E1128("Category combo {0} cannot have more than {1} combinations, but requires: {2}"),
 
   /* Org unit merge */
-  E1500("At least two source orgs unit must be specified"),
+  E1500("At least one source org unit must be specified"),
   E1501("Target org unit must be specified"),
   E1502("Target org unit cannot be a source org unit"),
   E1503("Source org unit does not exist: `{0}`"),
@@ -157,10 +157,12 @@ public enum ErrorCode {
   E2039("Stage offset is allowed only for repeatable stages (`{0}` is not repeatable)"),
   E2040("Both category combination and category options must be specified"),
   E2041("Attribute option combo does not exist for given category combo and category options"),
-  E2042("Min value must be specified"),
-  E2043("Max value must be specified"),
-  E2044("Max value must be greater than min value"),
+  E2042("Min value must be specified: `{0}`"),
+  E2043("Max value must be specified: `{0}`"),
+  E2044("Max value must be greater than min value: `{0}`"),
   E2045("Case insensitive operators can only be used with constant values"),
+  E2046("Error parsing CSV file: {0}"),
+  E2047("Data value key combination does not exist: {0}"),
 
   /* Outlier detection */
   E2200("At least one data element must be specified"),
@@ -621,7 +623,8 @@ public enum ErrorCode {
   E7709("Organisation unit could not be updated with new GeoJSON geometry"),
   E7710("User is not allowed to update the target organisation unit"),
   E7711("Organisation unit cannot be uniquely identified by its name"),
-  E7712("GeoJSON geometry coordinates must be non empty but was: `{0}`");
+  E7712("GeoJSON geometry coordinates must be non empty but was: `{0}`"),
+  ;
 
   private String message;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ImportSuccessResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ImportSuccessResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.feedback;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import lombok.Builder;
 
 /**
- * DTO which represents data values and min-max values for a data entry form.
+ * A simple response used for bulk imports in case of success.
  *
- * @author Lars Helge Overland
+ * @author Jan Bernitt
+ * @param message a custom message to detail the outcome
+ * @param successful number of rows or objects that were successfully processed
+ * @param ignored number of rows or objects that were ignored due to wrong data or missing
+ *     permission
  */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
-
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
-
-  @JsonProperty private LockStatus lockStatus;
-
-  @JsonProperty private CompleteStatusDto completeStatus;
-}
+@Builder(builderMethodName = "ok")
+public record ImportSuccessResponse(
+    @JsonProperty String message, @JsonProperty int successful, @JsonProperty int ignored) {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementService.java
@@ -33,19 +33,16 @@ import java.util.Collection;
 import java.util.List;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
  * @author Lars Helge Overland
  */
 public interface MinMaxDataElementService {
-  long addMinMaxDataElement(MinMaxDataElement minMaxDataElement);
 
-  void deleteMinMaxDataElement(MinMaxDataElement minMaxDataElement);
-
-  void updateMinMaxDataElement(MinMaxDataElement minMaxDataElement);
-
-  MinMaxDataElement getMinMaxDataElement(long id);
+  // TODO replace all parameter of type IdentifiableObject with their UIDs
 
   MinMaxDataElement getMinMaxDataElement(
       OrganisationUnit source, DataElement dataElement, CategoryOptionCombo optionCombo);
@@ -53,6 +50,7 @@ public interface MinMaxDataElementService {
   List<MinMaxDataElement> getMinMaxDataElements(
       OrganisationUnit source, Collection<DataElement> dataElements);
 
+  // TODO replace with use of QueryService once it does no longer require IdentifiableObject
   List<MinMaxDataElement> getMinMaxDataElements(MinMaxDataElementQueryParams query);
 
   int countMinMaxDataElements(MinMaxDataElementQueryParams query);
@@ -64,4 +62,12 @@ public interface MinMaxDataElementService {
   void removeMinMaxDataElements(CategoryOptionCombo optionCombo);
 
   void removeMinMaxDataElements(Collection<DataElement> dataElements, OrganisationUnit parent);
+
+  void importValue(MinMaxValue value) throws BadRequestException;
+
+  int importAll(MinMaxValueUpsertRequest request) throws BadRequestException;
+
+  void deleteValue(MinMaxValueKey key) throws BadRequestException, NotFoundException;
+
+  int deleteAll(MinMaxValueDeleteRequest request) throws BadRequestException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementStore.java
@@ -72,4 +72,11 @@ public interface MinMaxDataElementStore extends GenericStore<MinMaxDataElement> 
    *     passed in
    */
   List<MinMaxDataElement> getByCategoryOptionCombo(@Nonnull Collection<UID> uids);
+
+  @SuppressWarnings("unchecked")
+  List<String> getDataElementsByDataSet(UID dataSet);
+
+  int deleteByKeys(List<MinMaxValueKey> keys);
+
+  int upsertValues(List<MinMaxValue> values);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,49 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.minmax;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
- * DTO which represents data values and min-max values for a data entry form.
+ * DTO which represents a {@link MinMaxDataElement} in the API.
  *
  * @author Lars Helge Overland
  */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
+public record MinMaxValue(
+    @Nonnull @OpenApi.Property({UID.class, DataElement.class}) UID dataElement,
+    @Nonnull @OpenApi.Property({UID.class, OrganisationUnit.class}) UID orgUnit,
+    @JsonAlias("categoryOptionCombo")
+        @Nonnull
+        @OpenApi.Property({UID.class, CategoryOptionCombo.class})
+        UID optionCombo,
+    @Nonnull Integer minValue,
+    @Nonnull Integer maxValue,
+    Boolean generated)
+    implements MinMaxValueId {
 
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
+  @Nonnull
+  public static MinMaxValue of(@Nonnull MinMaxDataElement obj) {
+    return new MinMaxValue(
+        UID.of(obj.getDataElement().getUid()),
+        UID.of(obj.getSource().getUid()),
+        UID.of(obj.getOptionCombo().getUid()),
+        obj.getMin(),
+        obj.getMax(),
+        obj.isGenerated());
+  }
 
-  @JsonProperty private LockStatus lockStatus;
+  public MinMaxValue generated(boolean generated) {
+    return new MinMaxValue(dataElement, orgUnit, optionCombo, minValue, maxValue, generated);
+  }
 
-  @JsonProperty private CompleteStatusDto completeStatus;
+  public MinMaxValueKey key() {
+    return new MinMaxValueKey(dataElement, orgUnit, optionCombo);
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueDeleteRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueDeleteRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.minmax;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.common.UID;
 
 /**
- * DTO which represents data values and min-max values for a data entry form.
- *
- * @author Lars Helge Overland
+ * @author Jan Bernitt
+ * @param dataSet all deleted values must belong to this dataset
+ * @param values please note that the name has to be identical to {@link
+ *     MinMaxValueUpsertRequest#values()} so that the same JSON can be used to run delete or upsert.
  */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
-
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
-
-  @JsonProperty private LockStatus lockStatus;
-
-  @JsonProperty private CompleteStatusDto completeStatus;
-}
+public record MinMaxValueDeleteRequest(
+    @Nonnull UID dataSet, @Nonnull List<MinMaxValueKey> values) {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueId.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.minmax;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import org.hisp.dhis.common.UID;
 
-/**
- * DTO which represents data values and min-max values for a data entry form.
- *
- * @author Lars Helge Overland
- */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
+/** A key combination that points to a single row of a {@link MinMaxDataElement}. */
+public interface MinMaxValueId {
 
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
+  UID dataElement();
 
-  @JsonProperty private LockStatus lockStatus;
+  UID orgUnit();
 
-  @JsonProperty private CompleteStatusDto completeStatus;
+  UID optionCombo();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.minmax;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
- * DTO which represents data values and min-max values for a data entry form.
+ * A unique key combination for a {@link MinMaxDataElement} row.
  *
- * @author Lars Helge Overland
+ * @param dataElement data element ID
+ * @param orgUnit organisation unit ID
+ * @param optionCombo category option combo ID
  */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
+public record MinMaxValueKey(
+    @OpenApi.Property({UID.class, OrganisationUnit.class}) @Nonnull UID dataElement,
+    @OpenApi.Property({UID.class, OrganisationUnit.class}) @Nonnull UID orgUnit,
+    @OpenApi.Property({UID.class, CategoryOptionCombo.class}) @Nonnull UID optionCombo)
+    implements MinMaxValueId {
 
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
-
-  @JsonProperty private LockStatus lockStatus;
-
-  @JsonProperty private CompleteStatusDto completeStatus;
+  @Nonnull
+  public static MinMaxValueKey of(@Nonnull MinMaxDataElement obj) {
+    return new MinMaxValueKey(
+        UID.of(obj.getDataElement().getUid()),
+        UID.of(obj.getSource().getUid()),
+        UID.of(obj.getOptionCombo().getUid()));
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueUpsertRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueUpsertRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.minmax;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.common.UID;
 
 /**
- * DTO which represents data values and min-max values for a data entry form.
+ * A bulk request to insert or update {@link MinMaxDataElement}s.
  *
- * @author Lars Helge Overland
+ * @param dataSet all values must belong to this dataset
+ * @param values the individual values to insert or update, all of which must belong to a DE
+ *     connected to the {@link #dataSet()}
  */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
-
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
-
-  @JsonProperty private LockStatus lockStatus;
-
-  @JsonProperty private CompleteStatusDto completeStatus;
-}
+public record MinMaxValueUpsertRequest(@Nonnull UID dataSet, @Nonnull List<MinMaxValue> values) {}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/csv/CSVTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/csv/CSVTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.csv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.util.List;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.csv.CSV.CsvReader;
+import org.hisp.dhis.minmax.MinMaxValue;
+import org.hisp.dhis.minmax.MinMaxValueKey;
+import org.junit.jupiter.api.Test;
+
+class CSVTest {
+
+  @Test
+  void testNullForOmittedOptionalColumns() {
+    List<MinMaxValue> actual =
+        CSV.of(
+                """
+        dataElement,orgUnit,optionCombo,minValue,maxValue
+        elD9B1HiTJO,fKiYlhodhB1,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,fKiYlhodhB1,HllvX50cXC0,0,10
+        elD9B1HiTJO,MU1nUGOpV4Q,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,MU1nUGOpV4Q,HllvX50cXC0,0,10
+        """)
+            .as(MinMaxValue.class)
+            .list();
+    assertEquals(4, actual.size());
+    assertEquals(
+        new MinMaxValue(
+            UID.of("c6Fi8CNxGJ1"), UID.of("MU1nUGOpV4Q"), UID.of("HllvX50cXC0"), 0, 10, null),
+        actual.get(3));
+  }
+
+  @Test
+  void testNullForOptionalColumns() {
+    List<MinMaxValue> actual =
+        CSV.of(
+                """
+        dataElement,orgUnit,optionCombo,minValue,maxValue,generated
+        elD9B1HiTJO,fKiYlhodhB1,HllvX50cXC0,0,10,false
+        c6Fi8CNxGJ1,fKiYlhodhB1,HllvX50cXC0,0,10,true
+        elD9B1HiTJO,MU1nUGOpV4Q,HllvX50cXC0,0,10,
+        c6Fi8CNxGJ1,MU1nUGOpV4Q,HllvX50cXC0,0,10,
+        """)
+            .as(MinMaxValue.class)
+            .list();
+    assertEquals(4, actual.size());
+    assertEquals(
+        new MinMaxValue(
+            UID.of("c6Fi8CNxGJ1"), UID.of("fKiYlhodhB1"), UID.of("HllvX50cXC0"), 0, 10, true),
+        actual.get(1));
+    assertEquals(
+        new MinMaxValue(
+            UID.of("c6Fi8CNxGJ1"), UID.of("MU1nUGOpV4Q"), UID.of("HllvX50cXC0"), 0, 10, null),
+        actual.get(3));
+  }
+
+  @Test
+  void testIgnoreIrrelevantColumns() {
+    List<MinMaxValueKey> actual =
+        CSV.of(
+                """
+        dataElement,orgUnit,optionCombo,minValue,maxValue
+        elD9B1HiTJO,fKiYlhodhB1,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,fKiYlhodhB1,HllvX50cXC0,0,10
+        elD9B1HiTJO,MU1nUGOpV4Q,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,MU1nUGOpV4Q,HllvX50cXC0,0,10""")
+            .as(MinMaxValueKey.class)
+            .list();
+    assertEquals(4, actual.size());
+    assertEquals(
+        new MinMaxValueKey(UID.of("elD9B1HiTJO"), UID.of("fKiYlhodhB1"), UID.of("HllvX50cXC0")),
+        actual.get(0));
+  }
+
+  @Test
+  void testRequiresNonnullProperties_MissingColumn() {
+    CsvReader<MinMaxValueKey> reader =
+        CSV.of(
+                """
+        dataElement,xxx,optionCombo,minValue,maxValue
+        elD9B1HiTJO,fKiYlhodhB1,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,fKiYlhodhB1,HllvX50cXC0,0,10
+        elD9B1HiTJO,MU1nUGOpV4Q,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,MU1nUGOpV4Q,HllvX50cXC0,0,10""")
+            .as(MinMaxValueKey.class);
+
+    IllegalArgumentException ex = assertThrowsExactly(IllegalArgumentException.class, reader::list);
+    assertEquals("Required columns missing: [orgUnit]", ex.getMessage());
+  }
+
+  @Test
+  void testRequiresNonnullProperties_EmptyValue() {
+    CsvReader<MinMaxValueKey> reader =
+        CSV.of(
+                """
+        dataElement,orgUnit,optionCombo,minValue,maxValue
+        elD9B1HiTJO,,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,fKiYlhodhB1,HllvX50cXC0,0,10
+        elD9B1HiTJO,MU1nUGOpV4Q,HllvX50cXC0,0,10
+        c6Fi8CNxGJ1,MU1nUGOpV4Q,HllvX50cXC0,0,10""")
+            .as(MinMaxValueKey.class);
+
+    IllegalArgumentException ex = assertThrowsExactly(IllegalArgumentException.class, reader::list);
+    assertEquals("Column orgUnit is required and cannot be empty", ex.getMessage());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.42.1-SNAPSHOT</version>
+    <version>2.43-SNAPSHOT</version>
   </parent>
 
   <artifactId>dhis-service-validation</artifactId>

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.43-SNAPSHOT</version>
+    <version>2.42.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dhis-service-validation</artifactId>

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
@@ -31,9 +31,14 @@ package org.hisp.dhis.minmax;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,39 +46,12 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @author Lars Helge Overland
  */
+@Slf4j
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.minmax.MinMaxDataElementService")
 public class DefaultMinMaxDataElementService implements MinMaxDataElementService {
+
   private final MinMaxDataElementStore minMaxDataElementStore;
-
-  // -------------------------------------------------------------------------
-  // MinMaxDataElementService implementation
-  // -------------------------------------------------------------------------
-
-  @Transactional
-  @Override
-  public long addMinMaxDataElement(MinMaxDataElement minMaxDataElement) {
-    minMaxDataElementStore.save(minMaxDataElement);
-
-    return minMaxDataElement.getId();
-  }
-
-  @Transactional
-  @Override
-  public void deleteMinMaxDataElement(MinMaxDataElement minMaxDataElement) {
-    minMaxDataElementStore.delete(minMaxDataElement);
-  }
-
-  @Transactional
-  @Override
-  public void updateMinMaxDataElement(MinMaxDataElement minMaxDataElement) {
-    minMaxDataElementStore.update(minMaxDataElement);
-  }
-
-  @Override
-  public MinMaxDataElement getMinMaxDataElement(long id) {
-    return minMaxDataElementStore.get(id);
-  }
 
   @Override
   public MinMaxDataElement getMinMaxDataElement(
@@ -120,5 +98,109 @@ public class DefaultMinMaxDataElementService implements MinMaxDataElementService
   public void removeMinMaxDataElements(
       Collection<DataElement> dataElements, OrganisationUnit parent) {
     minMaxDataElementStore.delete(dataElements, parent);
+  }
+
+  @Override
+  @Transactional
+  public void importValue(MinMaxValue value) throws BadRequestException {
+    if (value.generated() == null) value = value.generated(false);
+
+    validateValue(value);
+
+    int imported = minMaxDataElementStore.upsertValues(List.of(value));
+    if (imported == 0) throw new BadRequestException(ErrorCode.E2047, value.key());
+  }
+
+  /**
+   * Imports a list of min-max values from a web service request. This method processes the incoming
+   * JSON request, validates the data, and stores the min-max values in the database.
+   *
+   * @param request the JSON request containing the min-max values to import.
+   * @return the number of values processed.
+   * @throws BadRequestException if any validation fails.
+   */
+  @Override
+  @Transactional
+  public int importAll(MinMaxValueUpsertRequest request) throws BadRequestException {
+    if (request.values().isEmpty()) return 0;
+
+    validateRequest(request);
+
+    log.info(
+        "Starting min-max import: {} values for dataset={}",
+        request.values().size(),
+        request.dataSet());
+    long startTime = System.nanoTime();
+
+    int imported = minMaxDataElementStore.upsertValues(request.values());
+
+    long elapsedMillis = (System.nanoTime() - startTime) / 1_000_000;
+
+    log.info(
+        "Min-max import completed: {} values processed in {} ms",
+        request.values().size(),
+        elapsedMillis);
+
+    return imported;
+  }
+
+  @Override
+  public void deleteValue(MinMaxValueKey key) throws BadRequestException, NotFoundException {
+    validateValueId(key);
+    int deleted = minMaxDataElementStore.deleteByKeys(List.of(key));
+    if (deleted == 0) throw new NotFoundException(ErrorCode.E2047, key);
+  }
+
+  /**
+   * Deletes a list of min-max values from a web service request. This method processes the incoming
+   * JSON request and removes the specified min-max values from the database.
+   *
+   * @param request the JSON request containing the min-max values to delete.
+   * @return the number of values processed.
+   */
+  @Override
+  @Transactional
+  public int deleteAll(MinMaxValueDeleteRequest request) throws BadRequestException {
+    if (request.values().isEmpty()) return 0;
+
+    validateRequest(request);
+
+    log.info("Starting min-max delete: {} values", request.values().size());
+    long startTime = System.nanoTime();
+    int count = minMaxDataElementStore.deleteByKeys(request.values());
+    long elapsedMillis = (System.nanoTime() - startTime) / 1_000_000;
+    log.info(
+        "Min-max delete completed: {} values processed in {} ms",
+        request.values().size(),
+        elapsedMillis);
+    return count;
+  }
+
+  private static void validateValue(MinMaxValue value) throws BadRequestException {
+    validateValueId(value);
+    if (value.minValue() == null) throw new BadRequestException(ErrorCode.E2042, value);
+    if (value.maxValue() == null) throw new BadRequestException(ErrorCode.E2043, value);
+    if (value.minValue() >= value.maxValue()) throw new BadRequestException(ErrorCode.E2044, value);
+  }
+
+  private static void validateValueId(MinMaxValueId value) throws BadRequestException {
+    if (value.dataElement() == null) throw new BadRequestException(ErrorCode.E1100, value);
+    if (value.orgUnit() == null) throw new BadRequestException(ErrorCode.E1102, value);
+    if (value.optionCombo() == null) throw new BadRequestException(ErrorCode.E1103, value);
+  }
+
+  private void validateRequest(MinMaxValueUpsertRequest request) throws BadRequestException {
+    for (MinMaxValue v : request.values()) validateValue(v);
+    if (request.dataSet() == null) return;
+    Set<String> deIds =
+        Set.copyOf(minMaxDataElementStore.getDataElementsByDataSet(request.dataSet()));
+    for (MinMaxValue v : request.values()) {
+      if (!deIds.contains(v.dataElement().getValue()))
+        throw new BadRequestException(ErrorCode.E2021, request.dataSet(), v.dataElement());
+    }
+  }
+
+  private void validateRequest(MinMaxValueDeleteRequest request) throws BadRequestException {
+    for (MinMaxValueKey v : request.values()) validateValueId(v);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_47__alter_primary_key_min_max_dataelement.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_47__alter_primary_key_min_max_dataelement.sql
@@ -1,0 +1,29 @@
+-- Migration script to change the primary key of the minmaxdataelement table
+-- Make the surrogate key (minmaxdataelementid) a sequence
+ALTER TABLE minmaxdataelement
+    ALTER COLUMN minmaxdataelementid SET DEFAULT nextval('hibernate_sequence');
+
+-- Drop any rows where source, dataelement, or categoryoptioncombo is null
+DELETE FROM minmaxdataelement
+WHERE sourceid IS NULL
+   OR dataelementid IS NULL
+   OR categoryoptioncomboid IS NULL;
+
+--  Make key columns NOT NULL
+ALTER TABLE minmaxdataelement
+    ALTER COLUMN sourceid SET NOT NULL,
+    ALTER COLUMN dataelementid SET NOT NULL,
+    ALTER COLUMN categoryoptioncomboid SET NOT NULL;
+
+-- Drop existing PK (on minmaxdataelementid)
+ALTER TABLE minmaxdataelement
+    DROP CONSTRAINT IF EXISTS minmaxdataelement_pkey;
+
+-- Drop old unique constraint (if it exists)
+ALTER TABLE minmaxdataelement
+    DROP CONSTRAINT IF EXISTS minmaxdataelement_unique_key;
+
+-- Create new PRIMARY KEY on the real business key
+ALTER TABLE minmaxdataelement
+    ADD CONSTRAINT minmaxdataelement_pkey
+    PRIMARY KEY (sourceid, dataelementid, categoryoptioncomboid);

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/hibernate-default.properties
@@ -47,3 +47,8 @@ javax.persistence.query.timeout=600000
 
 
 #hibernate.max_fetch_depth=10
+
+# Enable JDBC batching and set batch size
+hibernate.jdbc.batch_size = 1000
+hibernate.order_inserts = true
+hibernate.order_updates = true

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonImportSuccessResponse.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonImportSuccessResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.webdomain.datavalue;
+package org.hisp.dhis.test.webapi.json.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import org.hisp.dhis.dataset.LockStatus;
-import org.hisp.dhis.minmax.MinMaxValue;
-import org.hisp.dhis.webapi.webdomain.dataentry.CompleteStatusDto;
+import org.hisp.dhis.jsontree.JsonObject;
 
-/**
- * DTO which represents data values and min-max values for a data entry form.
- *
- * @author Lars Helge Overland
- */
-@Getter
-@Setter
-@Accessors(chain = true)
-@NoArgsConstructor
-public class DataValuesDto {
-  @JsonProperty private List<DataValueDto> dataValues = new ArrayList<>();
+public interface JsonImportSuccessResponse extends JsonObject {
 
-  @JsonProperty private List<MinMaxValue> minMaxValues = new ArrayList<>();
+  default String getMessage() {
+    return getString("message").string();
+  }
 
-  @JsonProperty private LockStatus lockStatus;
+  default int getSuccessful() {
+    return getNumber("successful").intValue();
+  }
 
-  @JsonProperty private CompleteStatusDto completeStatus;
+  default int getIgnored() {
+    return getNumber("ignored").intValue();
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -200,7 +200,7 @@ class DataElementMergeTest extends ApiTest {
         .body("httpStatus", equalTo("Conflict"))
         .body("status", equalTo("ERROR"))
         .body("message", containsString("ERROR: duplicate key value violates unique constraint"))
-        .body("message", containsString("minmaxdataelement_unique_key"));
+        .body("message", containsString("minmaxdataelement_pkey"));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
+import org.hisp.dhis.minmax.MinMaxValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.MonthlyPeriodType;
@@ -141,7 +142,7 @@ class MinMaxOutlierAnalysisServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testAnalyse() {
+  void testAnalyse() throws Exception {
     dataValueService.addDataValue(
         createDataValue(dataElementA, periodA, organisationUnitA, "5", categoryOptionCombo));
     dataValueService.addDataValue(
@@ -172,12 +173,15 @@ class MinMaxOutlierAnalysisServiceTest extends PostgresIntegrationTestBase {
     dataValueService.addDataValue(
         createDataValue(dataElementC, periodJ, organisationUnitA, "23", categoryOptionCombo));
 
-    minMaxDataElementService.addMinMaxDataElement(
-        new MinMaxDataElement(
-            dataElementA, organisationUnitA, categoryOptionCombo, -40, 40, false));
+    minMaxDataElementService.importValue(
+        MinMaxValue.of(
+            new MinMaxDataElement(
+                dataElementA, organisationUnitA, categoryOptionCombo, -40, 40, false)));
 
-    minMaxDataElementService.addMinMaxDataElement(
-        new MinMaxDataElement(dataElementC, organisationUnitA, categoryOptionCombo, 10, 20, false));
+    minMaxDataElementService.importValue(
+        MinMaxValue.of(
+            new MinMaxDataElement(
+                dataElementC, organisationUnitA, categoryOptionCombo, 10, 20, false)));
 
     List<DeflatedDataValue> resultA =
         minMaxOutlierAnalysisService.analyse(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceMinMaxTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceMinMaxTest.java
@@ -43,8 +43,10 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
+import org.hisp.dhis.minmax.MinMaxValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm;
 import org.hisp.dhis.outlierdetection.OutlierDetectionQuery;
@@ -138,7 +140,7 @@ class OutlierDetectionServiceMinMaxTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testGetOutlierValues() {
+  void testGetOutlierValues() throws Exception {
     addMinMaxValues(
         new MinMaxDataElement(deA, ouA, coc, 40, 60), new MinMaxDataElement(deB, ouA, coc, 45, 65));
     // 34, 39, 68, 91, 42, 45, 68, 87 are outlier values out of range
@@ -179,7 +181,7 @@ class OutlierDetectionServiceMinMaxTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testGetOutlierValue() {
+  void testGetOutlierValue() throws Exception {
     addMinMaxValues(
         new MinMaxDataElement(deA, ouA, coc, 40, 60), new MinMaxDataElement(deB, ouA, coc, 45, 65));
     addDataValues(
@@ -211,8 +213,8 @@ class OutlierDetectionServiceMinMaxTest extends PostgresIntegrationTestBase {
     Stream.of(periods).forEach(periodService::addPeriod);
   }
 
-  private void addMinMaxValues(MinMaxDataElement... minMaxValues) {
-    Stream.of(minMaxValues).forEach(minMaxService::addMinMaxDataElement);
+  private void addMinMaxValues(MinMaxDataElement... minMaxValues) throws BadRequestException {
+    for (MinMaxDataElement e : minMaxValues) minMaxService.importValue(MinMaxValue.of(e));
   }
 
   private void addDataValues(DataValue... dataValues) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
@@ -40,13 +40,13 @@ import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-abstract class AbstractDataValueControllerTest extends H2ControllerIntegrationTestBase {
+abstract class AbstractDataValueControllerTest extends PostgresControllerIntegrationTestBase {
   protected String dataElementId;
 
   protected String orgUnitId;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxDataElementControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxDataElementControllerTest.java
@@ -30,9 +30,12 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
-import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
+import static org.hisp.dhis.http.HttpStatus.CREATED;
+import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
+import static org.hisp.dhis.http.HttpStatus.NO_CONTENT;
 
 import org.hisp.dhis.http.HttpStatus;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -44,89 +47,65 @@ class MinMaxDataElementControllerTest extends AbstractDataValueControllerTest {
 
   @Test
   void testPostJsonObject() {
-    assertWebMessage(
-        "Created",
-        201,
-        "OK",
-        null,
-        POST(
-                "/minMaxDataElements/",
-                "{"
-                    + "'source':{'id':'"
-                    + orgUnitId
-                    + "'},"
-                    + "'dataElement':{'id':'"
-                    + dataElementId
-                    + "'},"
-                    + "'optionCombo':{'id':'"
-                    + categoryOptionComboId
-                    + "'},"
-                    + "'min':1,"
-                    + "'max':42"
-                    + "}")
-            .content(HttpStatus.CREATED));
+    String ou = orgUnitId;
+    String de = dataElementId;
+    String coc = categoryOptionComboId;
+    @Language("json")
+    String json =
+        """
+        {
+        "source":{"id":"%s"},
+        "dataElement":{"id":"%s"},
+        "optionCombo":{"id":"%s"},
+        "min":1,
+        "max":42
+        }
+        """;
+    assertStatus(CREATED, POST("/minMaxDataElements/", json.formatted(ou, de, coc)));
   }
 
   @Test
   void testDeleteObject() {
-    assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/minMaxDataElements/",
-            "{"
-                + "'source':{'id':'"
-                + orgUnitId
-                + "'},"
-                + "'dataElement':{'id':'"
-                + dataElementId
-                + "'},"
-                + "'optionCombo':{'id':'"
-                + categoryOptionComboId
-                + "'},"
-                + "'min':1,"
-                + "'max':42"
-                + "}"));
-    assertWebMessage(
-        "OK",
-        200,
-        "OK",
-        "MinMaxDataElement deleted.",
-        DELETE(
-                "/minMaxDataElements/",
-                "{"
-                    + "'source':{'id':'"
-                    + orgUnitId
-                    + "'},"
-                    + "'dataElement':{'id':'"
-                    + dataElementId
-                    + "'},"
-                    + "'optionCombo':{'id':'"
-                    + categoryOptionComboId
-                    + "'}"
-                    + "}")
-            .content(HttpStatus.OK));
+    String ou = orgUnitId;
+    String de = dataElementId;
+    String coc = categoryOptionComboId;
+    @Language("json")
+    String value =
+        """
+        {
+            "source":{"id":"%s"},
+            "dataElement":{"id":"%s"},
+            "optionCombo":{"id":"%s"},
+            "min":1,
+            "max":42
+        }""";
+    assertStatus(HttpStatus.CREATED, POST("/minMaxDataElements/", value.formatted(ou, de, coc)));
+
+    @Language("json")
+    String key =
+        """
+        {
+            "source":{"id":"%s"},
+            "dataElement":{"id":"%s"},
+            "optionCombo":{"id":"%s"}
+        }""";
+    assertStatus(NO_CONTENT, DELETE("/minMaxDataElements/", key.formatted(ou, de, coc)));
   }
 
   @Test
   void testDeleteObject_NoSuchObject() {
-    assertWebMessage(
-        "Not Found",
-        404,
-        "ERROR",
-        "Can not find MinMaxDataElement.",
+    @Language("json")
+    String json =
+        """
+        {
+            "source":{"id":"%s"},
+            "dataElement":{"id":"%s"},
+            "optionCombo":{"id":"%s"}
+        }""";
+    assertStatus(
+        NOT_FOUND,
         DELETE(
-                "/minMaxDataElements/",
-                "{"
-                    + "'source':{'id':'"
-                    + orgUnitId
-                    + "'},"
-                    + "'dataElement':{'id':'"
-                    + dataElementId
-                    + "'},"
-                    + "'optionCombo':{'id':'"
-                    + categoryOptionComboId
-                    + "'}"
-                    + "}")
-            .content(HttpStatus.NOT_FOUND));
+            "/minMaxDataElements/",
+            json.formatted(orgUnitId, dataElementId, categoryOptionComboId)));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxValueControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxValueControllerTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+import static org.hisp.dhis.http.HttpStatus.BAD_REQUEST;
+import static org.hisp.dhis.http.HttpStatus.CREATED;
+import static org.hisp.dhis.http.HttpStatus.NOT_FOUND;
+import static org.hisp.dhis.http.HttpStatus.NO_CONTENT;
+import static org.hisp.dhis.http.HttpStatus.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests the {@link org.hisp.dhis.webapi.controller.dataentry.MinMaxValueController} endpoints.
+ *
+ * @author Jan Bernitt
+ */
+class MinMaxValueControllerTest extends PostgresControllerIntegrationTestBase {
+
+  @Autowired private ObjectMapper jsonMapper;
+
+  private String de, ou, coc;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    this.de = assertStatus(CREATED, POST("/dataElements", toJson(createDataElement('A'))));
+    this.ou =
+        assertStatus(CREATED, POST("/organisationUnits", toJson(createOrganisationUnit('B'))));
+    this.coc = setupCategoryMetadata("C").coc1().getUid();
+  }
+
+  private String toJson(IdentifiableObject de) throws JsonProcessingException {
+    return jsonMapper.writeValueAsString(de);
+  }
+
+  @Language("json")
+  private final String json =
+      """
+      {
+      "dataElement": "%s",
+      "orgUnit": "%s",
+      "optionCombo": "%s",
+      "minValue": 1,
+      "maxValue": 100
+      }
+      """;
+
+  @Test
+  void testSaveOrUpdateMinMaxValue() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_Alias() {
+    String json =
+        """
+      {
+      "dataElement": "%s",
+      "orgUnit": "%s",
+      "categoryOptionCombo": "%s",
+      "minValue": 1,
+      "maxValue": 100
+      }
+      """;
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+  }
+
+  @Test
+  void testRemoveMinMaxValue() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    assertStatus(
+        NO_CONTENT, DELETE("/dataEntry/minMaxValues?de={de}&ou={ou}&co={coc}", de, ou, coc));
+  }
+
+  @Test
+  void testRemoveMinMaxValue_WithBody() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    assertStatus(NO_CONTENT, DELETE("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_DeDoesNotExist() {
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted("de123456789", ou, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_OuDoesNotExist() {
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, "ou123456789", coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_CocDoesNotExist() {
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, ou, "coc23456789"))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_DeUndefined() {
+    @Language("json")
+    String json =
+        """
+        {
+        "orgUnit": "%s",
+        "optionCombo": "%s",
+        "minValue": 1,
+        "maxValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(ou, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1100, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_OuUndefined() {
+    @Language("json")
+    String json =
+        """
+        {
+        "dataElement": "%s",
+        "optionCombo": "%s",
+        "minValue": 1,
+        "maxValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1102, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_CocUndefined() {
+    @Language("json")
+    String json =
+        """
+        {
+        "dataElement": "%s",
+        "orgUnit": "%s",
+        "minValue": 1,
+        "maxValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, ou))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1103, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_MinValueUndefined() {
+    @Language("json")
+    String json =
+        """
+        {
+        "dataElement": "%s",
+        "orgUnit": "%s",
+        "optionCombo": "%s",
+        "maxValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2042, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_MaxValueUndefined() {
+    @Language("json")
+    String json =
+        """
+        {
+        "dataElement": "%s",
+        "orgUnit": "%s",
+        "optionCombo": "%s",
+        "minValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2043, response.getErrorCode());
+  }
+
+  @Test
+  void testSaveOrUpdateMinMaxValue_MinNoBelowMax() {
+    @Language("json")
+    String json =
+        """
+        {
+        "dataElement": "%s",
+        "orgUnit": "%s",
+        "optionCombo": "%s",
+        "minValue": 100,
+        "maxValue": 100
+        }
+        """;
+    JsonWebMessage response =
+        POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2044, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_DeUndefined() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?ou={ou}&co={coc}", ou, coc)
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1100, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_OuUndefined() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?de={de}&co={coc}", de, coc)
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1102, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_CocUndefined() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?de={de}&ou={ou}", de, ou)
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E1103, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_DeDoesNotExist() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?de={de}&ou={ou}&co={coc}", "de123456789", ou, coc)
+            .content(NOT_FOUND)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_OuDoesNotExist() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?de={de}&ou={ou}&co={coc}", de, "ou123456789", coc)
+            .content(NOT_FOUND)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+
+  @Test
+  void testRemoveMinMaxValue_CocDoesNotExist() {
+    assertStatus(OK, POST("/dataEntry/minMaxValues", json.formatted(de, ou, coc)));
+    JsonWebMessage response =
+        DELETE("/dataEntry/minMaxValues?de={de}&ou={ou}&co={coc}", de, ou, "coc23456789")
+            .content(NOT_FOUND)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2047, response.getErrorCode());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxValueImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxValueImportControllerTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.common.CodeGenerator.generateUid;
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+import static org.hisp.dhis.http.HttpStatus.BAD_REQUEST;
+import static org.hisp.dhis.http.HttpStatus.CREATED;
+import static org.hisp.dhis.http.HttpStatus.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.test.api.TestCategoryMetadata;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonImportSuccessResponse;
+import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+/**
+ * Test the bulk import and delete endpoints of the {@link MinMaxDataElementController}.
+ *
+ * @author Jan Bernitt
+ */
+class MinMaxValueImportControllerTest extends PostgresControllerIntegrationTestBase {
+
+  @Autowired private ObjectMapper jsonMapper;
+
+  private String ds, de, coc, ou1, ou2, ou3, ou4;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    this.de = assertStatus(CREATED, POST("/dataElements", toJson(createDataElement('A'))));
+    TestCategoryMetadata catData = setupCategoryMetadata("C");
+    this.coc = catData.coc1().getUid();
+    String cc = catData.cc1().getUid();
+    String dsId = generateUid();
+    @Language("json")
+    String dsJson =
+        """
+      {
+      "id": "%s",
+      "name": "My data set",
+      "shortName": "MDS",
+      "periodType": "Monthly",
+      "categoryCombo": { "id": "%s"},
+      "dataSetElements": [{"dataSet": {"id": "%s"}, "dataElement": { "id": "%s"}}]}""";
+    this.ds = assertStatus(CREATED, POST("/dataSets", dsJson.formatted(dsId, cc, dsId, de)));
+    this.ou1 =
+        assertStatus(CREATED, POST("/organisationUnits", toJson(createOrganisationUnit('X'))));
+    this.ou2 =
+        assertStatus(CREATED, POST("/organisationUnits", toJson(createOrganisationUnit('Y'))));
+    this.ou3 =
+        assertStatus(CREATED, POST("/organisationUnits", toJson(createOrganisationUnit('Z'))));
+    this.ou4 =
+        assertStatus(CREATED, POST("/organisationUnits", toJson(createOrganisationUnit('W'))));
+  }
+
+  private String toJson(IdentifiableObject de) throws JsonProcessingException {
+    return jsonMapper.writeValueAsString(de);
+  }
+
+  @Language("json")
+  private final String json =
+      """
+      { "dataSet": "%s",
+        "values" : [{
+            "dataElement": "%s",
+            "orgUnit": "%s",
+            "optionCombo": "%s",
+              "minValue": 10,
+              "maxValue": 100
+          }]
+      }""";
+
+  @Language("csv")
+  private final String csv =
+      """
+    dataElement,orgUnit,optionCombo,minValue,maxValue
+    %1$s,%3$s,%2$s,0,10
+    %1$s,%4$s,%2$s,0,10
+    %1$s,%5$s,%2$s,0,10
+    %1$s,%6$s,%2$s,0,10
+    """;
+
+  @Test
+  void testBulkImportJson() {
+    JsonImportSuccessResponse response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc))
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(1, response.getSuccessful());
+  }
+
+  @Test
+  void testBulkImportCsv() {
+    MockMultipartFile file =
+        new MockMultipartFile("file", csv.formatted(de, coc, ou1, ou2, ou3, ou4).getBytes());
+    JsonImportSuccessResponse response =
+        POST_MULTIPART("/minMaxDataElements/upsert?dataSet=" + ds, file)
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(4, response.getSuccessful());
+  }
+
+  @Test
+  void testBulkImportJson_IgnoresNonExisting() {
+    JsonImportSuccessResponse response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds, de, "ou123456789", coc))
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(0, response.getSuccessful());
+  }
+
+  @Test
+  void testBulkImportJson_MaxValueUndefined() {
+    @Language("json")
+    String json =
+        """
+      {
+        "dataSet": "%s",
+        "values": [{
+          "dataElement": "%s",
+          "orgUnit": "%s",
+          "optionCombo": "%s",
+          "minValue": 10
+        }]
+      }""";
+    JsonWebMessage response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2043, response.getErrorCode());
+  }
+
+  @Test
+  void testBulkImportJson_MinValueUndefined() {
+    @Language("json")
+    String json =
+        """
+       {
+        "dataSet": "%s",
+        "values": [{
+          "dataElement": "%s",
+          "orgUnit": "%s",
+          "optionCombo": "%s",
+          "maxValue": 10
+        }]
+      }""";
+    JsonWebMessage response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2042, response.getErrorCode());
+  }
+
+  @Test
+  void testBulkImportJson_MinEqualMaxValue() {
+    @Language("json")
+    String json =
+        """
+      {
+        "dataSet": "%s",
+        "values": [{
+          "dataElement": "%s",
+          "orgUnit": "%s",
+          "optionCombo": "%s",
+          "minValue": 10,
+          "maxValue": 10
+        }]
+      }""";
+    JsonWebMessage response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc))
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2044, response.getErrorCode());
+  }
+
+  @Test
+  void testBulkImportJson_EmptyValues() {
+    @Language("json")
+    String json =
+        """
+        { "dataSet": "%s", "values": [] }""";
+    JsonImportSuccessResponse response =
+        POST("/minMaxDataElements/upsert", json.formatted(ds))
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(0, response.getSuccessful());
+    assertEquals(0, response.getIgnored());
+  }
+
+  @Test
+  void testBulkDeleteJson() {
+    assertStatus(OK, POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc)));
+    JsonImportSuccessResponse response =
+        POST("/minMaxDataElements/delete", json.formatted(ds, de, ou1, coc))
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(1, response.getSuccessful());
+  }
+
+  @Test
+  void testBulkDeleteJson_IgnoresNonExisting() {
+    assertStatus(OK, POST("/minMaxDataElements/upsert", json.formatted(ds, de, ou1, coc)));
+    JsonImportSuccessResponse response =
+        POST("/minMaxDataElements/delete", json.formatted(ds, de, "ou123456789", coc))
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(0, response.getSuccessful());
+    assertEquals(1, response.getIgnored());
+  }
+
+  @Test
+  void testBulkDeleteCsv() {
+    MockMultipartFile file =
+        new MockMultipartFile("file", csv.formatted(de, coc, ou1, ou2, ou3, ou4).getBytes());
+    JsonImportSuccessResponse response =
+        POST_MULTIPART("/minMaxDataElements/upsert?dataSet=" + ds, file)
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(4, response.getSuccessful());
+    response =
+        POST_MULTIPART("/minMaxDataElements/delete?dataSet=" + ds, file)
+            .content(OK)
+            .as(JsonImportSuccessResponse.class);
+    assertEquals(4, response.getSuccessful());
+  }
+
+  @Test
+  void testBulkDeleteCsv_NoMinValueColumn() {
+    @Language("csv")
+    String csv =
+        """
+      dataElement,orgUnit,optionCombo,maxValue
+      %1$s,%3$s,%2$s,10
+      """;
+    MockMultipartFile file = new MockMultipartFile("file", csv.formatted(de, coc, ou1).getBytes());
+    JsonWebMessage response =
+        POST_MULTIPART("/minMaxDataElements/upsert?dataSet=" + ds, file)
+            .content(BAD_REQUEST)
+            .as(JsonWebMessage.class);
+    assertEquals(ErrorCode.E2046, response.getErrorCode());
+    assertEquals(
+        "Error parsing CSV file: Required columns missing: [minValue]", response.getMessage());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -29,70 +29,64 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.security.Authorities.F_MINMAX_DATAELEMENT_ADD;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
 import com.google.common.collect.Lists;
-import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.Maturity;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.csv.CSV;
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ImportSuccessResponse;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementQueryParams;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
+import org.hisp.dhis.minmax.MinMaxValue;
+import org.hisp.dhis.minmax.MinMaxValueDeleteRequest;
+import org.hisp.dhis.minmax.MinMaxValueKey;
+import org.hisp.dhis.minmax.MinMaxValueUpsertRequest;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.types.RootNode;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.query.QueryParserException;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.RequiresAuthority;
-import org.hisp.dhis.util.ObjectUtils;
-import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
 @OpenApi.Document(
-    entity = DataElement.class,
-    classifiers = {"team:platform", "purpose:metadata"})
+    entity = DataValue.class,
+    classifiers = {"team:platform", "purpose:data"})
 @Controller
 @RequestMapping("/api/minMaxDataElements")
-@ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @AllArgsConstructor
 public class MinMaxDataElementController {
+
   private final ContextService contextService;
-
   private final MinMaxDataElementService minMaxService;
-
   private final FieldFilterService fieldFilterService;
-
-  private final RenderService renderService;
-
-  private final IdentifiableObjectManager manager;
-
-  // --------------------------------------------------------------------------
-  // GET
-  // --------------------------------------------------------------------------
 
   @GetMapping
   public @ResponseBody RootNode getObjectList(MinMaxDataElementQueryParams query)
@@ -127,27 +121,9 @@ public class MinMaxDataElementController {
 
   @PostMapping(consumes = APPLICATION_JSON_VALUE)
   @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
-  @ResponseBody
-  public WebMessage postJsonObject(HttpServletRequest request) throws Exception {
-    MinMaxDataElement minMax =
-        renderService.fromJson(request.getInputStream(), MinMaxDataElement.class);
-
-    validate(minMax);
-
-    minMax = getReferences(minMax);
-
-    MinMaxDataElement persisted =
-        minMaxService.getMinMaxDataElement(
-            minMax.getSource(), minMax.getDataElement(), minMax.getOptionCombo());
-
-    if (Objects.isNull(persisted)) {
-      minMaxService.addMinMaxDataElement(minMax);
-    } else {
-      persisted.mergeWith(minMax);
-      minMaxService.updateMinMaxDataElement(persisted);
-    }
-
-    return created();
+  @ResponseStatus(HttpStatus.CREATED)
+  public void postJsonObject(@RequestBody MinMaxDataElement body) throws BadRequestException {
+    minMaxService.importValue(MinMaxValue.of(body));
   }
 
   // --------------------------------------------------------------------------
@@ -156,49 +132,83 @@ public class MinMaxDataElementController {
 
   @DeleteMapping(consumes = APPLICATION_JSON_VALUE)
   @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
-  @ResponseBody
-  public WebMessage deleteObject(HttpServletRequest request) throws Exception {
-    MinMaxDataElement minMax =
-        renderService.fromJson(request.getInputStream(), MinMaxDataElement.class);
-
-    validate(minMax);
-
-    minMax = getReferences(minMax);
-
-    MinMaxDataElement persisted =
-        minMaxService.getMinMaxDataElement(
-            minMax.getSource(), minMax.getDataElement(), minMax.getOptionCombo());
-
-    if (Objects.isNull(persisted)) {
-      return notFound("Can not find MinMaxDataElement.");
-    }
-
-    minMaxService.deleteMinMaxDataElement(persisted);
-
-    return ok("MinMaxDataElement deleted.");
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteObject(@RequestBody MinMaxDataElement body)
+      throws BadRequestException, NotFoundException {
+    minMaxService.deleteValue(MinMaxValueKey.of(body));
   }
 
-  private void validate(MinMaxDataElement minMax) throws WebMessageException {
-    if (!ObjectUtils.allNonNull(
-        minMax.getDataElement(), minMax.getSource(), minMax.getOptionCombo())) {
-      throw new WebMessageException(
-          notFound("Missing required parameters : Source, DataElement, OptionCombo."));
+  /*
+  Bulk import
+  */
+
+  @PostMapping(value = "/upsert", consumes = "application/json")
+  @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
+  public @ResponseBody ImportSuccessResponse bulkPostJson(
+      @RequestBody MinMaxValueUpsertRequest request) throws BadRequestException {
+
+    int imported = minMaxService.importAll(request);
+
+    return ImportSuccessResponse.ok()
+        .message("Successfully imported %d min-max values".formatted(imported))
+        .successful(imported)
+        .ignored(request.values().size() - imported)
+        .build();
+  }
+
+  @PostMapping(value = "/delete", consumes = "application/json")
+  @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
+  public @ResponseBody ImportSuccessResponse bulkDeleteJson(
+      @RequestBody MinMaxValueDeleteRequest request) throws BadRequestException {
+
+    int deleted = minMaxService.deleteAll(request);
+
+    return ImportSuccessResponse.ok()
+        .message("Successfully deleted %d min-max values".formatted(deleted))
+        .successful(deleted)
+        .ignored(request.values().size() - deleted)
+        .build();
+  }
+
+  @PostMapping(value = "/upsert", consumes = "multipart/form-data")
+  @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
+  @Maturity.Alpha
+  public @ResponseBody ImportSuccessResponse bulkPostCsv(
+      @RequestParam("file") MultipartFile file, @RequestParam UID dataSet)
+      throws BadRequestException {
+
+    return bulkPostJson(new MinMaxValueUpsertRequest(dataSet, csvToEntries(file)));
+  }
+
+  @PostMapping(value = "/delete", consumes = "multipart/form-data")
+  @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
+  @Maturity.Alpha
+  public @ResponseBody ImportSuccessResponse bulkDeleteCsv(
+      @RequestParam("file") MultipartFile file, @RequestParam UID dataSet)
+      throws BadRequestException {
+
+    return bulkDeleteJson(new MinMaxValueDeleteRequest(dataSet, csvToKeys(file)));
+  }
+
+  private static List<MinMaxValue> csvToEntries(MultipartFile file) throws BadRequestException {
+    try (InputStream in = file.getInputStream()) {
+      List<MinMaxValue> entries = CSV.of(in).as(MinMaxValue.class).list();
+      if (entries.isEmpty())
+        throw new BadRequestException(ErrorCode.E2046, "No data found in the CSV file.");
+      return entries;
+    } catch (Exception ex) {
+      throw new BadRequestException(ErrorCode.E2046, ex.getMessage());
     }
   }
 
-  private MinMaxDataElement getReferences(MinMaxDataElement m) throws WebMessageException {
-    try {
-      m.setDataElement(
-          Objects.requireNonNull(manager.get(DataElement.class, m.getDataElement().getUid())));
-      m.setSource(
-          Objects.requireNonNull(manager.get(OrganisationUnit.class, m.getSource().getUid())));
-      m.setOptionCombo(
-          Objects.requireNonNull(
-              manager.get(CategoryOptionCombo.class, m.getOptionCombo().getUid())));
-      return m;
-    } catch (NullPointerException e) {
-      throw new WebMessageException(
-          notFound("Invalid required parameters: source, dataElement, optionCombo"));
+  private static List<MinMaxValueKey> csvToKeys(MultipartFile file) throws BadRequestException {
+    try (InputStream in = file.getInputStream()) {
+      List<MinMaxValueKey> keys = CSV.of(in).as(MinMaxValueKey.class).list();
+      if (keys.isEmpty())
+        throw new BadRequestException(ErrorCode.E2046, "No data found in the CSV file.");
+      return keys;
+    } catch (IOException ex) {
+      throw new BadRequestException(ErrorCode.E2046, ex.getMessage());
     }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
@@ -33,23 +33,23 @@ import static org.hisp.dhis.security.Authorities.F_MINMAX_DATAELEMENT_ADD;
 
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DataValue;
-import org.hisp.dhis.minmax.MinMaxDataElement;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
+import org.hisp.dhis.minmax.MinMaxValue;
+import org.hisp.dhis.minmax.MinMaxValueKey;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.RequiresAuthority;
-import org.hisp.dhis.webapi.controller.datavalue.DataValidator;
-import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.webdomain.datavalue.MinMaxValueDto;
-import org.hisp.dhis.webapi.webdomain.datavalue.MinMaxValueQueryParams;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -58,69 +58,31 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @OpenApi.Document(
     entity = DataValue.class,
-    classifiers = {"team:platform", "purpose:metadata"})
+    classifiers = {"team:platform", "purpose:data"})
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")
-@ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class MinMaxValueController {
-  private final MinMaxDataElementService minMaxValueService;
 
-  private final DataValidator dataValidator;
+  private final MinMaxDataElementService minMaxValueService;
 
   @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
   @PostMapping("/minMaxValues")
   @ResponseStatus(value = HttpStatus.OK)
-  public void saveOrUpdateMinMaxValue(@RequestBody MinMaxValueDto valueDto) {
-    saveOrUpdateMinMaxDataElement(valueDto);
+  public void saveOrUpdateMinMaxValue(@RequestBody MinMaxValue value) throws BadRequestException {
+    minMaxValueService.importValue(value);
   }
 
   @RequiresAuthority(anyOf = F_MINMAX_DATAELEMENT_ADD)
   @DeleteMapping("/minMaxValues")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  public void removeMinMaxValue(MinMaxValueQueryParams params) {
-    removeMinMaxDataElement(params);
-  }
-
-  /**
-   * Saves or updates a {@link MinMaxDataElement}.
-   *
-   * @param dto the {@link MinMaxValueDto}.
-   */
-  private void saveOrUpdateMinMaxDataElement(MinMaxValueDto dto) {
-    DataElement de = dataValidator.getAndValidateDataElement(dto.getDataElement());
-    OrganisationUnit ou = dataValidator.getAndValidateOrganisationUnit(dto.getOrgUnit());
-    CategoryOptionCombo coc =
-        dataValidator.getAndValidateCategoryOptionCombo(dto.getCategoryOptionCombo());
-    dataValidator.validateMinMaxValues(dto.getMinValue(), dto.getMaxValue());
-    MinMaxDataElement value = minMaxValueService.getMinMaxDataElement(ou, de, coc);
-
-    if (value != null) {
-      value.setMin(dto.getMinValue());
-      value.setMax(dto.getMaxValue());
-      value.setGenerated(false);
-
-      minMaxValueService.updateMinMaxDataElement(value);
-    } else {
-      value = new MinMaxDataElement(de, ou, coc, dto.getMinValue(), dto.getMaxValue());
-
-      minMaxValueService.addMinMaxDataElement(value);
-    }
-  }
-
-  /**
-   * Removes a {@link MinMaxDataElement}.
-   *
-   * @param params the {@link MinMaxValueQueryParams}.
-   */
-  private void removeMinMaxDataElement(MinMaxValueQueryParams params) {
-    DataElement de = dataValidator.getAndValidateDataElement(params.getDe());
-    OrganisationUnit ou = dataValidator.getAndValidateOrganisationUnit(params.getOu());
-    CategoryOptionCombo coc = dataValidator.getAndValidateCategoryOptionCombo(params.getCo());
-    MinMaxDataElement value = minMaxValueService.getMinMaxDataElement(ou, de, coc);
-
-    if (value != null) {
-      minMaxValueService.deleteMinMaxDataElement(value);
-    }
+  public void removeMinMaxValue(
+      @RequestBody(required = false) MinMaxValueKey key,
+      @RequestParam(required = false) @OpenApi.Param({UID.class, DataElement.class}) UID de,
+      @RequestParam(required = false) @OpenApi.Param({UID.class, OrganisationUnit.class}) UID ou,
+      @RequestParam(required = false) @OpenApi.Param({UID.class, CategoryOptionCombo.class}) UID co)
+      throws BadRequestException, NotFoundException {
+    if (key == null) key = new MinMaxValueKey(de, ou, co);
+    minMaxValueService.deleteValue(key);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -33,9 +33,11 @@ import static org.hisp.dhis.common.collection.CollectionUtils.mapToSet;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueAudit;
 import org.hisp.dhis.minmax.MinMaxDataElement;
+import org.hisp.dhis.minmax.MinMaxValue;
 
 /**
  * Class which provides methods for mapping between domain objcets and DTOs.
@@ -98,17 +100,18 @@ public class DataValueDtoMapper {
   }
 
   /**
-   * Converts a {@link MinMaxDataElement} object to a {@link MinMaxValueDto}.
+   * Converts a {@link MinMaxDataElement} object to a {@link MinMaxValue}.
    *
    * @param value the {@link MinMaxDataElement}.
-   * @return a {@link MinMaxValueDto}.
+   * @return a {@link MinMaxValue}.
    */
-  public static MinMaxValueDto toDto(MinMaxDataElement value) {
-    return new MinMaxValueDto()
-        .setDataElement(value.getDataElement().getUid())
-        .setOrgUnit(value.getSource().getUid())
-        .setCategoryOptionCombo(value.getOptionCombo().getUid())
-        .setMinValue(value.getMin())
-        .setMaxValue(value.getMax());
+  public static MinMaxValue toDto(MinMaxDataElement value) {
+    return new MinMaxValue(
+        UID.of(value.getDataElement().getUid()),
+        UID.of(value.getSource().getUid()),
+        UID.of(value.getOptionCombo().getUid()),
+        value.getMin(),
+        value.getMax(),
+        null);
   }
 }


### PR DESCRIPTION
Backport based on the changes made in #20747, #20876 and #21003 for min-max bulk operations.

The modified files were copied entirely from `master` using `git checkout master <file>`. 

The DB script was copied and renamed. I tested that all statements in the script are safe to rerun. 