### PR TITLE
fix: Remove unused programType query param in event exporter [DHIS2-19578]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.export.Order;
@@ -68,8 +67,6 @@ public class EventOperationParams {
   private UID programStage;
 
   private EnrollmentStatus enrollmentStatus;
-
-  private ProgramType programType;
 
   private Boolean followUp;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -70,8 +69,6 @@ class EventQueryParams {
   @Getter private ProgramStage programStage;
 
   @Getter private EnrollmentStatus enrollmentStatus;
-
-  @Getter private ProgramType programType;
 
   @Getter private Boolean followUp;
 
@@ -192,11 +189,6 @@ class EventQueryParams {
 
   public EventQueryParams setEnrollmentStatus(EnrollmentStatus enrollmentStatus) {
     this.enrollmentStatus = enrollmentStatus;
-    return this;
-  }
-
-  public EventQueryParams setProgramType(ProgramType programType) {
-    this.programType = programType;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -919,12 +919,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
       fromBuilder.append(hlp.whereAnd()).append(" ev.occurreddate <= :endOccurredDate ");
     }
 
-    if (params.getProgramType() != null) {
-      sqlParameters.addValue("programType", params.getProgramType().name());
-
-      fromBuilder.append(hlp.whereAnd()).append(" p.type = ").append(":programType").append(" ");
-    }
-
     fromBuilder.append(eventStatusSql(params, sqlParameters, hlp));
 
     if (params.getEvents() != null

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/FilterExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/FilterExporterTest.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -843,7 +842,6 @@ class FilterExporterTest extends PostgresIntegrationTestBase {
         operationParamsBuilder
             .enrollments(Set.of(UID.of("nxP7UnKhomJ")))
             .programStage(programStage)
-            .programType(ProgramType.WITH_REGISTRATION)
             .filterByDataElement(
                 UID.of(dataElement), List.of(new QueryFilter(QueryOperator.EW, "001")))
             .build();


### PR DESCRIPTION
Remove unused `programType` field from operation and query params in event exporter.