### PR TITLE
feat: annotation based service method time logging

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
@@ -58,7 +58,9 @@ public @interface TimeExecution {
 
   /**
    * A marker annotation to add to record components whose value should be included in the log
-   * message.
+   * message. The record needs to be the 1st parameter to the annotated method. Non-record classes
+   * are not supported. This is simply to keep it fast and simple as the reflection to read the
+   * values needs to run for each execution.
    */
   @Target(ElementType.RECORD_COMPONENT)
   @Retention(RetentionPolicy.RUNTIME)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
@@ -35,6 +35,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Logs the execution time of the annotated method.
+ *
+ * <p>Only methods in {@link org.springframework.stereotype.Service} beans (which use interfaces)
+ * are supported.
+ *
+ * @author Jan Bernitt
+ * @since 2.43
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TimeExecution {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/log/TimeExecution.java
@@ -27,19 +27,40 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.minmax;
+package org.hisp.dhis.log;
 
-import java.util.List;
-import javax.annotation.Nonnull;
-import org.hisp.dhis.common.UID;
-import org.hisp.dhis.log.TimeExecution;
+import java.lang.System.Logger;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-/**
- * A bulk request to insert or update {@link MinMaxDataElement}s.
- *
- * @param dataSet all values must belong to this dataset
- * @param values the individual values to insert or update, all of which must belong to a DE
- *     connected to the {@link #dataSet()}
- */
-public record MinMaxValueUpsertRequest(
-    @Nonnull UID dataSet, @Nonnull @TimeExecution.Include List<MinMaxValue> values) {}
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeExecution {
+
+  /**
+   * @return the log level to use
+   */
+  Logger.Level level() default Logger.Level.DEBUG;
+
+  /**
+   * @return when not empty this name is used instead of the method name
+   */
+  String name() default "";
+
+  Class<?> logger() default Class.class;
+
+  /**
+   * @return when positive only invocations that take longer than the given time (ms) will be logged
+   */
+  long threshold() default 0;
+
+  /**
+   * A marker annotation to add to record components whose value should be included in the log
+   * message.
+   */
+  @Target(ElementType.RECORD_COMPONENT)
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Include {}
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueDeleteRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValueDeleteRequest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.minmax;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.log.TimeExecution;
 
 /**
  * @author Jan Bernitt
@@ -40,4 +41,4 @@ import org.hisp.dhis.common.UID;
  *     MinMaxValueUpsertRequest#values()} so that the same JSON can be used to run delete or upsert.
  */
 public record MinMaxValueDeleteRequest(
-    @Nonnull UID dataSet, @Nonnull List<MinMaxValueKey> values) {}
+    @Nonnull UID dataSet, @Nonnull @TimeExecution.Include List<MinMaxValueKey> values) {}

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -315,6 +315,17 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>aopalliance</groupId>
+      <artifactId>aopalliance</artifactId>
+      <version>1.0</version>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
@@ -342,10 +353,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-aspects</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
@@ -34,18 +34,43 @@ import java.util.Map;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.i18n.ui.resourcebundle.DefaultResourceBundleManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
+import org.hisp.dhis.log.TimeExecution;
+import org.hisp.dhis.log.TimeExecutionInterceptor;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.DefaultOutboundMessageBatchService;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Service;
 
 /**
  * @author Luciano Fiandesio
  */
 @Configuration("coreServiceConfig")
-public class ServiceConfig {
+public class ServiceConfig implements BeanDefinitionRegistryPostProcessor {
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry)
+      throws BeansException {
+    // Note: only the spring gods will know why I have to do this explicitly
+    // an Advisor should be ROLE_INFRASTRUCTURE just based on the class but
+    // this needed manual override, otherwise the bean is ignored
+    registry.getBeanDefinition("timingAdvisor").setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+  }
+
+  @Bean
+  public Advisor timingAdvisor() {
+    Pointcut pointcut = new StaticAnnotationPointcut(Service.class, TimeExecution.class);
+    return new DefaultPointcutAdvisor(pointcut, new TimeExecutionInterceptor());
+  }
 
   @Bean("taskScheduler")
   public ThreadPoolTaskScheduler threadPoolTaskScheduler() {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/StaticAnnotationPointcut.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/StaticAnnotationPointcut.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.aop.ClassFilter;
+import org.springframework.aop.MethodMatcher;
+import org.springframework.aop.Pointcut;
+
+/**
+ * A {@link Pointcut} implementation that filters on marker annotations. One for the {@link
+ * #classLevel} and one for the {@link #methodLevel}.
+ *
+ * <p>The reason we cannot use existing implementation that basically do this is mainly that this
+ * seems to always end up requiring to switch to AspectJ AOP but also that the existing
+ * implementations do not consider interface-implementation situations where the annotation is on
+ * the implementation class. This is surprising since that is the standard way of doing it.
+ *
+ * @author Jan Bernitt
+ */
+@RequiredArgsConstructor
+public class StaticAnnotationPointcut implements Pointcut {
+
+  private final Class<? extends Annotation> classLevel;
+  private final Class<? extends Annotation> methodLevel;
+
+  @Nonnull
+  @Override
+  public ClassFilter getClassFilter() {
+    return cls -> {
+      if (!cls.isAnnotationPresent(classLevel)) return false;
+      return Stream.of(cls.getDeclaredMethods()).anyMatch(m -> m.isAnnotationPresent(methodLevel));
+    };
+  }
+
+  @Nonnull
+  @Override
+  public MethodMatcher getMethodMatcher() {
+    return new MethodMatcher() {
+      @Override
+      public boolean matches(Method method, @Nonnull Class<?> targetClass) {
+        if (method.getDeclaringClass() == targetClass)
+          return method.isAnnotationPresent(methodLevel);
+        try {
+          method = targetClass.getMethod(method.getName(), method.getParameterTypes());
+          return method.isAnnotationPresent(methodLevel);
+        } catch (NoSuchMethodException e) {
+          return false;
+        }
+      }
+
+      @Override
+      public boolean isRuntime() {
+        return false;
+      }
+
+      @Override
+      public boolean matches(
+          @Nonnull Method method, @Nonnull Class<?> targetClass, @Nonnull Object... args) {
+        return matches(method, targetClass);
+      }
+    };
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/log/TimeExecutionInterceptor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/log/TimeExecutionInterceptor.java
@@ -100,6 +100,7 @@ public class TimeExecutionInterceptor implements MethodInterceptor {
         case INFO -> logger.info(template, name, withArgs);
         case WARNING -> logger.warn(template, name, withArgs);
         case ERROR -> logger.error(template, name, withArgs);
+        default -> {} // nothing for ALL or OFF
       }
       withArgs = "";
     }
@@ -115,6 +116,7 @@ public class TimeExecutionInterceptor implements MethodInterceptor {
         case INFO -> logger.info(template, name, duration, withArgs);
         case WARNING -> logger.warn(template, name, duration, withArgs);
         case ERROR -> logger.error(template, name, duration, withArgs);
+        default -> {} // nothing for ALL or OFF
       }
     }
     return result;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/log/TimeExecutionInterceptor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/log/TimeExecutionInterceptor.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.log;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An interceptor that allows to annotate (service) bean methods with {@link TimeExecution} to have
+ * their execution time logged to the annotated classes logger.
+ *
+ * @author Jan Bernitt
+ * @since 2.43
+ */
+public class TimeExecutionInterceptor implements MethodInterceptor {
+
+  /**
+   * Remembers how many components of the record should be included in the log so that it is fast to
+   * decide if further reflection is needed to build the log line information.
+   */
+  private static final Map<Class<? extends Record>, Integer> INCLUDES_COMPONENTS_CACHE =
+      new ConcurrentHashMap<>();
+
+  /**
+   * The issue is that the invocation will use the interface method but the annotation is on the
+   * implementation. This cache is to minimize the overhead of the method and annotation lookup.
+   */
+  private static final Map<Method, TimeExecution> INFO_CACHE = new ConcurrentHashMap<>();
+
+  @Override
+  public Object invoke(MethodInvocation invocation) throws Throwable {
+    Object target = invocation.getThis();
+    if (target == null) return invocation.proceed();
+    Class<?> targetClass = target.getClass();
+    Method method = invocation.getMethod();
+    TimeExecution timeExecution =
+        INFO_CACHE.computeIfAbsent(method, m -> getAnnotation(m, targetClass));
+    if (timeExecution == null) return invocation.proceed();
+
+    Class<?> loggerClass =
+        timeExecution.logger() == Class.class ? targetClass : timeExecution.logger();
+    Logger logger = LoggerFactory.getLogger(loggerClass);
+
+    String name = timeExecution.name();
+    if (name.isEmpty()) name = method.getName();
+
+    Object[] args = invocation.getArguments();
+    List<String> values = List.of();
+    if (args.length > 0 && args[0] instanceof Record r) values = extractParameterValues(r);
+    String withArgs = values.isEmpty() ? "" : " args: " + String.join(", ", values);
+
+    long maxTime = timeExecution.threshold();
+
+    long startTime = System.nanoTime();
+    if (maxTime <= 0) {
+      String template = "Starting {}{}";
+      switch (timeExecution.level()) {
+        case TRACE -> logger.trace(template, name, withArgs);
+        case DEBUG -> logger.debug(template, name, withArgs);
+        case INFO -> logger.info(template, name, withArgs);
+        case WARNING -> logger.warn(template, name, withArgs);
+        case ERROR -> logger.error(template, name, withArgs);
+      }
+      withArgs = "";
+    }
+
+    Object result = invocation.proceed();
+
+    long duration = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+    if (maxTime <= 0 || duration > maxTime) {
+      String template = "Completed {} in {} ms{}";
+      switch (timeExecution.level()) {
+        case TRACE -> logger.trace(template, name, duration, withArgs);
+        case DEBUG -> logger.debug(template, name, duration, withArgs);
+        case INFO -> logger.info(template, name, duration, withArgs);
+        case WARNING -> logger.warn(template, name, duration, withArgs);
+        case ERROR -> logger.error(template, name, duration, withArgs);
+      }
+    }
+    return result;
+  }
+
+  private static TimeExecution getAnnotation(Method method, Class<?> targetClass) {
+    TimeExecution res = method.getAnnotation(TimeExecution.class);
+    if (res != null) return res;
+    Method m = null;
+    try {
+      m = targetClass.getMethod(method.getName(), method.getParameterTypes());
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+    return m.getAnnotation(TimeExecution.class);
+  }
+
+  /** Extracts values of components annotated with @Loggable from a record. */
+  private static List<String> extractParameterValues(Record arg) {
+    int c = numberOfIncludedComponents(arg.getClass());
+    if (c == 0) return List.of();
+    List<String> values = new ArrayList<>(c);
+    for (RecordComponent component : arg.getClass().getRecordComponents()) {
+      if (component.isAnnotationPresent(TimeExecution.Include.class)) {
+        try {
+          Method accessor = component.getAccessor();
+          Object value = toArgumentInfo(accessor.invoke(arg));
+          values.add(component.getName() + "=" + value);
+        } catch (Exception ex) {
+          values.add(component.getName() + "=" + "<%s>".formatted(ex.getClass().getSimpleName()));
+        }
+      }
+    }
+    return values;
+  }
+
+  private static Object toArgumentInfo(Object val) {
+    if (val == null) return null;
+    if (val instanceof String) return val;
+    if (val instanceof Number) return val;
+    if (val instanceof Boolean) return val;
+    if (val instanceof Character) return val;
+    if (val instanceof Enum<?>) return val;
+    if (val instanceof Date) return val;
+    if (val instanceof Collection<?> c) return c.size();
+    if (val instanceof Map<?, ?> m) return m.size();
+    if (val instanceof IdentifiableObject obj) return obj.getUid();
+    return "<%s>"
+        .formatted(
+            val.getClass()
+                .getSimpleName()); // value is shortened (omitted) as we don't know if it is too
+    // verbose
+  }
+
+  private static int numberOfIncludedComponents(Class<? extends Record> type) {
+    return INCLUDES_COMPONENTS_CACHE.computeIfAbsent(
+        type,
+        t ->
+            (int)
+                Stream.of(t.getRecordComponents())
+                    .filter(c -> c.isAnnotationPresent(TimeExecution.Include.class))
+                    .count());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.minmax;
 
+import static java.lang.System.Logger.Level.INFO;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -39,6 +41,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.log.TimeExecution;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -121,27 +124,13 @@ public class DefaultMinMaxDataElementService implements MinMaxDataElementService
    */
   @Override
   @Transactional
+  @TimeExecution(level = INFO)
   public int importAll(MinMaxValueUpsertRequest request) throws BadRequestException {
     if (request.values().isEmpty()) return 0;
 
     validateRequest(request);
 
-    log.info(
-        "Starting min-max import: {} values for dataset={}",
-        request.values().size(),
-        request.dataSet());
-    long startTime = System.nanoTime();
-
-    int imported = minMaxDataElementStore.upsertValues(request.values());
-
-    long elapsedMillis = (System.nanoTime() - startTime) / 1_000_000;
-
-    log.info(
-        "Min-max import completed: {} values processed in {} ms",
-        request.values().size(),
-        elapsedMillis);
-
-    return imported;
+    return minMaxDataElementStore.upsertValues(request.values());
   }
 
   @Override
@@ -160,20 +149,13 @@ public class DefaultMinMaxDataElementService implements MinMaxDataElementService
    */
   @Override
   @Transactional
+  @TimeExecution(level = INFO)
   public int deleteAll(MinMaxValueDeleteRequest request) throws BadRequestException {
     if (request.values().isEmpty()) return 0;
 
     validateRequest(request);
 
-    log.info("Starting min-max delete: {} values", request.values().size());
-    long startTime = System.nanoTime();
-    int count = minMaxDataElementStore.deleteByKeys(request.values());
-    long elapsedMillis = (System.nanoTime() - startTime) / 1_000_000;
-    log.info(
-        "Min-max delete completed: {} values processed in {} ms",
-        request.values().size(),
-        elapsedMillis);
-    return count;
+    return minMaxDataElementStore.deleteByKeys(request.values());
   }
 
   private static void validateValue(MinMaxValue value) throws BadRequestException {

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/DefaultMinMaxDataElementService.java
@@ -124,7 +124,7 @@ public class DefaultMinMaxDataElementService implements MinMaxDataElementService
    */
   @Override
   @Transactional
-  @TimeExecution(level = INFO)
+  @TimeExecution(level = INFO, name = "min-max import")
   public int importAll(MinMaxValueUpsertRequest request) throws BadRequestException {
     if (request.values().isEmpty()) return 0;
 
@@ -149,7 +149,7 @@ public class DefaultMinMaxDataElementService implements MinMaxDataElementService
    */
   @Override
   @Transactional
-  @TimeExecution(level = INFO)
+  @TimeExecution(level = INFO, name = "min-max delete")
   public int deleteAll(MinMaxValueDeleteRequest request) throws BadRequestException {
     if (request.values().isEmpty()) return 0;
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -532,6 +532,10 @@
             <artifactId>spring-aop</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.springframework</groupId>
             <artifactId>spring-support</artifactId>
           </exclusion>
@@ -540,11 +544,6 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>${spring-security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-aspects</artifactId>
         <version>${spring-security.version}</version>
       </dependency>
       <dependency>
@@ -2107,6 +2106,7 @@ jasperreports.version=${jasperreports.version}
           <configuration>
             <failOnWarning>true</failOnWarning>
             <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>aopalliance:aopalliance</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.springframework.data:spring-data-redis:jar</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.geotools:gt-main</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.geotools:gt-epsg-hsql</ignoredUnusedDeclaredDependency>
@@ -2137,7 +2137,6 @@ jasperreports.version=${jasperreports.version}
               <!-- Removing makes some tests fail -->
               <ignoredUnusedDeclaredDependency>io.netty:netty-all</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.cache2k:cache2k-core</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.springframework.security:spring-security-aspects</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.jclouds.api:filesystem</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.jclouds.api:s3</ignoredUnusedDeclaredDependency>
               <!-- Removing makes the startup fail -->


### PR DESCRIPTION
### Summary
Adds an annotation `@TimeExecution` that can be put on `@Service` implementation class methods to add logging of the method's execution time. 

The logging can be customized using the properties of the annotation:

* override `logger()` to not write to the log of the annotated class but a different `Class`
* override `name()` to change logging the time with the method's name as the "identifier" for the operation
* override `level()` to log on a different level than `DEBUG`
* override `threshold()` with a positive time in millis to only log executions longer than this time

In addition if the annotated method is called with a parameter `record` class (has to be 1st parameter) the components of the class can be annotated with `@TimeExecution.Include` to add the actual value of that parameter to the logs (as key=value).
Collections only log their size, not their value. Classes not explicitly supported by this value logging only log the simple class name of the actual value.

### Implementation Note (AOP)
To implement the effect of the annotation some sort of interception of the call itself is needed. While there is lots of documentation on using `@Aspect` from the AspectJ stack I intentionally avoided requiring the AspectJ stack since that changes the proxies used for speing beans which might have other side-effects apart from also requiring more dependencies and further configuration changes because of the differences from "standard" spring. To make the standard work I also needed to cleanup any of the accidentally included artifacts belonging to the AspectJ stack since some things are basically triggered by being on the classpath if the feature of interceptors is used somehow. 

### Logging
If no `threshold()` is used, one log will be made before executing the method body containing the argument values and another one after the execution stating the execution time. If  `threshold()` is used only the log after execution is made if the threshold is exceeded. In that case it will also contain the argument values.

The log before the excretion has the template `"Starting <method-name>"`, the line after `"Completed <method-name>"`.
If argument values are appended they will have the format: `args: <record-component-name>=<value>, ...`.
If `name()` is overridden the value replaces `<method-name>`.
