### PR TITLE
chore: Use event services for get compressed events [DHIS2-19578]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/DefaultSingleEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/DefaultSingleEventChangeLogService.java
@@ -60,7 +60,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DefaultSingleEventChangeLogService implements SingleEventChangeLogService {
 
-  private final SingleEventService eventService;
+  private final SingleEventService singleEventService;
   private final HibernateSingleEventChangeLogStore hibernateSingleEventChangeLogStore;
   private final DhisConfigurationProvider config;
 
@@ -71,7 +71,7 @@ public class DefaultSingleEventChangeLogService implements SingleEventChangeLogS
       UID event, SingleEventChangeLogOperationParams operationParams, PageParams pageParams)
       throws NotFoundException {
     // check existence and access
-    eventService.getEvent(event);
+    singleEventService.getEvent(event);
 
     return hibernateSingleEventChangeLogStore.getEventChangeLogs(
         event, operationParams, pageParams);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
@@ -69,7 +69,6 @@ import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -77,7 +76,6 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.query.JpaQueryUtils;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.SqlUtils;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
@@ -141,17 +139,12 @@ class JdbcSingleEventStore {
   private static final String COLUMN_PROGRAM_STAGE_NAME = "ps_name";
   private static final String COLUMN_PROGRAM_STAGE_ATTRIBUTE_VALUES = "ps_attributevalues";
   private static final String COLUMN_ENROLLMENT_UID = "en_uid";
-  private static final String COLUMN_ENROLLMENT_STATUS = "en_status";
-  private static final String COLUMN_ENROLLMENT_DATE = "en_enrollmentdate";
   private static final String COLUMN_ORG_UNIT_UID = "orgunit_uid";
   private static final String COLUMN_ORG_UNIT_CODE = "orgunit_code";
   private static final String COLUMN_ORG_UNIT_NAME = "orgunit_name";
   private static final String COLUMN_ORG_UNIT_ATTRIBUTE_VALUES = "orgunit_attributevalues";
-  private static final String COLUMN_TRACKEDENTITY_UID = "te_uid";
   private static final String COLUMN_EVENT_OCCURRED_DATE = "ev_occurreddate";
-  private static final String COLUMN_ENROLLMENT_FOLLOWUP = "en_followup";
   private static final String COLUMN_EVENT_STATUS = "ev_status";
-  private static final String COLUMN_EVENT_SCHEDULED_DATE = "ev_scheduleddate";
   private static final String COLUMN_EVENT_DATAVALUES = "ev_eventdatavalues";
   private static final String COLUMN_EVENT_STORED_BY = "ev_storedby";
   private static final String COLUMN_EVENT_LAST_UPDATED_BY = "ev_lastupdatedbyuserinfo";
@@ -270,8 +263,6 @@ class JdbcSingleEventStore {
               eventsByUid.put(eventUid, event);
               dataElementUids.put(eventUid, new HashSet<>());
 
-              TrackedEntity te = new TrackedEntity();
-              te.setUid(resultSet.getString(COLUMN_TRACKEDENTITY_UID));
               event.setStatus(EventStatus.valueOf(resultSet.getString(COLUMN_EVENT_STATUS)));
 
               ProgramType programType = ProgramType.fromValue(resultSet.getString("p_type"));
@@ -286,7 +277,6 @@ class JdbcSingleEventStore {
               Enrollment enrollment = new Enrollment();
               enrollment.setUid(resultSet.getString(COLUMN_ENROLLMENT_UID));
               enrollment.setProgram(program);
-              enrollment.setTrackedEntity(te);
 
               OrganisationUnit orgUnit = new OrganisationUnit();
               orgUnit.setUid(resultSet.getString(COLUMN_ORG_UNIT_UID));
@@ -304,9 +294,6 @@ class JdbcSingleEventStore {
                   AttributeValues.of(resultSet.getString(COLUMN_PROGRAM_STAGE_ATTRIBUTE_VALUES)));
               event.setDeleted(resultSet.getBoolean(COLUMN_EVENT_DELETED));
 
-              enrollment.setStatus(
-                  EnrollmentStatus.valueOf(resultSet.getString(COLUMN_ENROLLMENT_STATUS)));
-              enrollment.setFollowup(resultSet.getBoolean(COLUMN_ENROLLMENT_FOLLOWUP));
               event.setEnrollment(enrollment);
               event.setProgramStage(ps);
 
@@ -336,7 +323,6 @@ class JdbcSingleEventStore {
               event.setAttributeOptionCombo(coc);
 
               event.setStoredBy(resultSet.getString(COLUMN_EVENT_STORED_BY));
-              event.setScheduledDate(resultSet.getTimestamp(COLUMN_EVENT_SCHEDULED_DATE));
               event.setOccurredDate(resultSet.getTimestamp(COLUMN_EVENT_OCCURRED_DATE));
               event.setCreated(resultSet.getTimestamp(COLUMN_EVENT_CREATED));
               event.setCreatedAtClient(resultSet.getTimestamp(COLUMN_EVENT_CREATED_AT_CLIENT));
@@ -614,8 +600,6 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
             .append(COLUMN_EVENT_STATUS)
             .append(", ev.occurreddate as ")
             .append(COLUMN_EVENT_OCCURRED_DATE)
-            .append(", ev.scheduleddate as ")
-            .append(COLUMN_EVENT_SCHEDULED_DATE)
             .append(", ev.eventdatavalues as ")
             .append(COLUMN_EVENT_DATAVALUES)
             .append(", ev.completedby as ")
@@ -659,19 +643,8 @@ left join dataelement de on de.uid = eventdatavalue.dataelement_uid
             .append(getOrderFieldsForSelectClause(params.getOrder()));
 
     return selectBuilder
-        .append(
-            "en.uid as "
-                + COLUMN_ENROLLMENT_UID
-                + ", en.status as "
-                + COLUMN_ENROLLMENT_STATUS
-                + ", en.followup as "
-                + COLUMN_ENROLLMENT_FOLLOWUP
-                + ", en.enrollmentdate as "
-                + COLUMN_ENROLLMENT_DATE
-                + ", en.occurreddate as en_occurreddate, ")
-        .append("p.type as p_type, ")
-        .append("te.trackedentityid as te_id, te.uid as ")
-        .append(COLUMN_TRACKEDENTITY_UID)
+        .append("en.uid as " + COLUMN_ENROLLMENT_UID + ", ")
+        .append("p.type as p_type ")
         .append(getFromWhereClause(params, mapSqlParameterSource, user, hlp))
         .toString();
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportControllerH2Test.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportControllerH2Test.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export.singleevent;
+
+import static org.hisp.dhis.webapi.controller.tracker.export.singleevent.SingleEventsExportControllerH2Test.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.export.singleevent.SingleEventService;
+import org.hisp.dhis.webapi.controller.tracker.export.event.EventMapper;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+@ContextConfiguration(classes = Config.class)
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SingleEventsExportControllerH2Test extends H2ControllerIntegrationTestBase {
+
+  static class Config {
+    @Bean
+    public EventService eventService() {
+      EventService eventService = mock(EventService.class);
+      // Orderable fields are checked within the controller constructor
+      when(eventService.getOrderableFields())
+          .thenReturn(new HashSet<>(EventMapper.ORDERABLE_FIELDS.values()));
+      return eventService;
+    }
+
+    @Bean
+    public SingleEventService singleEventService() {
+      SingleEventService singleEventService = mock(SingleEventService.class);
+      // Orderable fields are checked within the controller constructor
+      when(singleEventService.getOrderableFields())
+          .thenReturn(new HashSet<>(EventMapper.ORDERABLE_FIELDS.values()));
+      return singleEventService;
+    }
+
+    @Bean
+    public ProgramService programService() {
+      return mock(ProgramService.class);
+    }
+  }
+
+  @Autowired private SingleEventService singleEventService;
+
+  @Autowired private EventService eventService;
+
+  @Autowired private ProgramService programService;
+
+  static Stream<Arguments> callEventsEndpoint() {
+    return Stream.of(
+        arguments(
+            "/tracker/events.json.zip?program=bMcwwoVnbSR",
+            "application/json+zip",
+            "attachment; filename=events.json.zip",
+            "binary"),
+        arguments(
+            "/tracker/events.json.gz?program=bMcwwoVnbSR",
+            "application/json+gzip",
+            "attachment; filename=events.json.gz",
+            "binary"),
+        arguments(
+            "/tracker/events.csv?program=bMcwwoVnbSR",
+            "application/csv; charset=UTF-8",
+            "attachment; filename=events.csv",
+            null),
+        arguments(
+            "/tracker/events.csv.gz?program=bMcwwoVnbSR",
+            "application/csv+gzip",
+            "attachment; filename=events.csv.gz",
+            "binary"),
+        arguments(
+            "/tracker/events.csv.zip?program=bMcwwoVnbSR",
+            "application/csv+zip",
+            "attachment; filename=events.csv.zip",
+            "binary"));
+  }
+
+  @ParameterizedTest
+  @MethodSource(value = "callEventsEndpoint")
+  void
+      shouldMatchContentTypeAndAttachment_whenEndpointForCompressedEventJsonIsInvokedForSingleEvent(
+          String url, String expectedContentType, String expectedAttachment, String encoding)
+          throws ForbiddenException, BadRequestException {
+
+    Program program = new Program();
+    program.setProgramType(ProgramType.WITHOUT_REGISTRATION);
+    when(singleEventService.findEvents(any())).thenReturn(List.of());
+    when(programService.getProgram(anyString())).thenReturn(program);
+
+    HttpResponse res = GET(url);
+    assertEquals(HttpStatus.OK, res.status());
+    assertEquals(expectedContentType, res.header("Content-Type"));
+    assertEquals(expectedAttachment, res.header(ContextUtils.HEADER_CONTENT_DISPOSITION));
+    assertEquals(encoding, res.header(ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING));
+    assertNotNull(res.content(expectedContentType));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -232,12 +232,18 @@ class EventsExportController {
   void getEventsAsJsonGzip(
       EventRequestParams requestParams,
       TrackerIdSchemeParams idSchemeParams,
-      HttpServletResponse response)
+      HttpServletResponse response,
+      @RequestParam UID program)
       throws BadRequestException, IOException, ForbiddenException, WebMessageException {
     validatePaginationParameters(requestParams);
+    Program programForEvent = getProgram(program);
 
-    List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        getEventsList(requestParams, idSchemeParams);
+    List<org.hisp.dhis.webapi.controller.tracker.view.Event> events;
+    if (programForEvent.isRegistration()) {
+      events = getTrackerEventsList(requestParams, idSchemeParams);
+    } else {
+      events = getSingleEventsList(requestParams, idSchemeParams);
+    }
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_JSON_FILE + GZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);
@@ -254,12 +260,18 @@ class EventsExportController {
   void getEventsAsJsonZip(
       EventRequestParams requestParams,
       TrackerIdSchemeParams idSchemeParams,
-      HttpServletResponse response)
+      HttpServletResponse response,
+      @RequestParam UID program)
       throws BadRequestException, ForbiddenException, IOException, WebMessageException {
     validatePaginationParameters(requestParams);
+    Program programForEvent = getProgram(program);
 
-    List<org.hisp.dhis.webapi.controller.tracker.view.Event> events =
-        getEventsList(requestParams, idSchemeParams);
+    List<org.hisp.dhis.webapi.controller.tracker.view.Event> events;
+    if (programForEvent.isRegistration()) {
+      events = getTrackerEventsList(requestParams, idSchemeParams);
+    } else {
+      events = getSingleEventsList(requestParams, idSchemeParams);
+    }
 
     ResponseHeader.addContentDispositionAttachment(response, EVENT_JSON_FILE + ZIP_EXT);
     ResponseHeader.addContentTransferEncodingBinary(response);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -179,9 +179,9 @@ class EventsExportController {
       @RequestParam UID program)
       throws BadRequestException, ForbiddenException, WebMessageException {
     validatePaginationParameters(requestParams);
-    Program programForEvent = getProgram(program);
+    Program eventProgram = getProgram(program);
 
-    if (programForEvent.isRegistration()) {
+    if (eventProgram.isRegistration()) {
       if (requestParams.isPaging()) {
         PageParams pageParams =
             PageParams.of(
@@ -236,10 +236,10 @@ class EventsExportController {
       @RequestParam UID program)
       throws BadRequestException, IOException, ForbiddenException, WebMessageException {
     validatePaginationParameters(requestParams);
-    Program programForEvent = getProgram(program);
+    Program eventProgram = getProgram(program);
 
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events;
-    if (programForEvent.isRegistration()) {
+    if (eventProgram.isRegistration()) {
       events = getTrackerEventsList(requestParams, idSchemeParams);
     } else {
       events = getSingleEventsList(requestParams, idSchemeParams);
@@ -264,10 +264,10 @@ class EventsExportController {
       @RequestParam UID program)
       throws BadRequestException, ForbiddenException, IOException, WebMessageException {
     validatePaginationParameters(requestParams);
-    Program programForEvent = getProgram(program);
+    Program eventProgram = getProgram(program);
 
     List<org.hisp.dhis.webapi.controller.tracker.view.Event> events;
-    if (programForEvent.isRegistration()) {
+    if (eventProgram.isRegistration()) {
       events = getTrackerEventsList(requestParams, idSchemeParams);
     } else {
       events = getSingleEventsList(requestParams, idSchemeParams);


### PR DESCRIPTION
***Big picture***
The final goal of this ticket is to have separate services and stores for single events and tracker events.
To achieve this we will need an intermediate phase where some endpoints will use the correct services and others that will still use the current event service that is serving both types of events.
As a final step, we will remove the generic event service and store and we will only have the ones for single and tracker events separated.

***Implemented in this PR***
- Use the right services in `getEventsAsJsonGzip` in `EventExportController`.  
- Use the right services in `getEventsAsJsonZip` in `EventExportController`.
- Remove from `SingleEventJdbcStore` any reference to `trackedEntity`, `enrollment` and `scheduledDate`.

***Next steps***
- Use the right services in `getEventsAsCsv` in `EventExportController`.
- Use the right services in `getEventsAsCsvGZip` in `EventExportController`.
- Use the right services in ` getEventsAsCsvZip` in `EventExportController`.
- Use the right services in `getEventByUid` in `EventExportController`.
- Use the right services in `getEventDataValueFile` in `EventExportController`.
- Use the right services in `getEventDataValueImage` in `EventExportController`.
- Use the right services in `getEventChangeLogsByUid` in `EventExportController`.
- Remove `export.event` package from `dhis-service-tracker` module.