### PR TITLE
fix: use server.base.url for OAuth2 issuer URI

### DIFF
--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -25,6 +25,7 @@ login.security.totp_2fa.enabled = on
 login.security.email_2fa.enabled = on
 
 oauth2.server.enabled = on
+server.base.url = http://web:8080
 oidc.jwt.token.authentication.enabled = on
 
 oidc.oauth2.login.enabled = on

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -39,9 +39,15 @@
     <spring.version>6.2.7</spring.version>
     <subethasmtp-wiser.version>1.2</subethasmtp-wiser.version>
     <aerogear-otp-java.version>1.0.0</aerogear-otp-java.version>
+    <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>${nimbus-jose-jwt.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.jboss.aerogear</groupId>
       <artifactId>aerogear-otp-java</artifactId>

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -36,8 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.ParseException;
 import java.time.Duration;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -136,7 +139,7 @@ class OAuth2Test extends BaseE2ETest {
     driver = new RemoteWebDriver(new URL(seleniumUrl), chromeOptions);
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));
 
-    // 1. Call the authorize endpoint
+    // Call the authorize endpoint
     driver.get(
         serverHostUrl
             + "/oauth2/authorize?response_type=code&client_id=dhis2-client&redirect_uri=http://localhost:9090/oauth2/code/dhis2-client&scope=openid%20email");
@@ -147,7 +150,7 @@ class OAuth2Test extends BaseE2ETest {
     // Wait for the login page to load
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("input#username")));
 
-    // 2. Login
+    // Login
     LoginPage mainPage = new LoginPage(driver);
     mainPage.inputUsername.sendKeys(username);
     mainPage.inputPassword.sendKeys(password);
@@ -161,12 +164,12 @@ class OAuth2Test extends BaseE2ETest {
             + "/oauth2/authorize?response_type=code&client_id=dhis2-client&redirect_uri=http://localhost:9090/oauth2/code/dhis2-client&scope=openid%20email",
         consentPageUrl);
 
-    // 3. Give consent
+    // Give consent
     ConsentPage consentPage = new ConsentPage(driver);
     consentPage.emailCheckbox.click();
     consentPage.submitButton.click();
 
-    // 4. Wait for the redirect to happen
+    // Wait for the redirect to happen
     wait.until(ExpectedConditions.urlContains("http://localhost:9090/oauth2/code/dhis2-client"));
     int codeStartIndex = driver.getCurrentUrl().indexOf("code=") + 5;
 
@@ -193,13 +196,32 @@ class OAuth2Test extends BaseE2ETest {
     assertTrue(
         code.length() == 128, "code has wrong size: '" + code + "', code length: " + code.length());
 
-    // 5. Call the token endpoint with the authorization code
+    // Call the token endpoint with the authorization code and get access token
     String accessToken = getAccessToken(code);
+
+    String actualIssuerUri = null;
+    String expectedIssuerUri = "http://web:8080";
+
+    // 6. Decode the access_token
+    try {
+      SignedJWT signedJWT = SignedJWT.parse(accessToken);
+      JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+      // 3. Extract the actual issuer URI from the token's "iss" claim
+      actualIssuerUri = claimsSet.getIssuer();
+    } catch (ParseException e) {
+      log.info("Parsing failed", e);
+      throw new RuntimeException(e);
+    }
+    // 5. Assert that the actual issuer URI matches the configured SERVER_BASE_URL
+    assertEquals(
+        expectedIssuerUri,
+        actualIssuerUri,
+        "The JWT issuer URI should match the configured SERVER_BASE_URL.");
 
     assertNotNull(accessToken);
     log.info("Access token: " + accessToken);
 
-    // 6. Call the /me endpoint with the access token
+    // Call the /me endpoint with the access token
     ResponseEntity<String> withBearerJwt = getWithBearerJwt(serverApiUrl + "/me", accessToken);
     HttpStatusCode statusCode = withBearerJwt.getStatusCode();
     assertEquals(HttpStatus.UNAUTHORIZED, statusCode);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
@@ -48,7 +48,6 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.condition.RedisEnabledCondition;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.oidc.KeyStoreUtil;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.condition.RedisEnabledCondition;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.oidc.KeyStoreUtil;
@@ -55,6 +56,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
@@ -75,6 +77,7 @@ import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
 @Slf4j
 @Configuration
+@Conditional(AuthorizationServerEnabledCondition.class)
 public class AuthorizationServerConfig {
 
   @Autowired private DhisConfigurationProvider config;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
@@ -217,6 +217,8 @@ public class AuthorizationServerConfig {
 
   @Bean
   public AuthorizationServerSettings authorizationServerSettings() {
-    return AuthorizationServerSettings.builder().build();
+    return AuthorizationServerSettings.builder()
+        .issuer(config.getProperty(ConfigurationKey.SERVER_BASE_URL))
+        .build();
   }
 }


### PR DESCRIPTION
**Problem:**
1. When DHIS2 is deployed behind a reverse proxy that terminates SSL, the OAuth2 authorization server (enabled via `oauth2.server.enabled`) generates JWTs with an `iss` (issuer) claim starting with `http://` instead of `https://`. This is because the issuer URI is inferred from the internal request to Tomcat, which is HTTP.
2. The `AuthorizationServerConfig.java` was not conditionally loaded based on the `OAUTH2_SERVER_ENABLED` setting, meaning its beans might be initialized even if the feature was disabled.

**Impact:**
1. The incorrect issuer URI can cause issues with token validation for clients and resource servers that expect the issuer URI to match the public-facing HTTPS URL.
2. Unnecessary initialization of OAuth2 server components if the feature is disabled.

**Solution:**
1. The `AuthorizationServerSettings` in `AuthorizationServerConfig.java` has been updated to explicitly set the issuer URI using the `server.base.url` (from `ConfigurationKey.SERVER_BASE_URL`) configuration property. This ensures the correct public-facing HTTPS URL is always used for the issuer claim in generated JWTs.
2. `AuthorizationServerConfig.java` is now annotated with `@Conditional(AuthorizationServerEnabledCondition.class)`, ensuring its beans are only loaded if `ConfigurationKey.OAUTH2_SERVER_ENABLED` is true.

**File Modified:**
* `dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java`

**Verification Steps:**
1. Confirm `server.base.url` in `dhis.conf` is set to the correct HTTPS base URL.
2. Confirm `oauth2.server.enabled` in `dhis.conf` is set to `on`.
3. Obtain an access/refresh token using the DHIS2 OAuth2 server.
4. Decode the JWT and verify the `iss` claim uses the `https://` scheme and matches the `server.base.url`.
5. Set `oauth2.server.enabled` to `off` and verify that the OAuth2 server endpoints (e.g., `/oauth2/authorize`) are not available and its beans are not loaded.