### PR TITLE
fix: Correct Task Summary Import Report stats field name [DHIS2-19660]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/metadata/feedback/ImportReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/metadata/feedback/ImportReport.java
@@ -137,7 +137,7 @@ public class ImportReport implements ErrorReportContainer {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Stats getAccumulatedStats() {
+  public Stats getStats() {
     return Stats.getAccumulatedStatsFromTypeReports(typeReportMap.values());
   }
 
@@ -190,7 +190,7 @@ public class ImportReport implements ErrorReportContainer {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("stats", getAccumulatedStats())
+        .add("stats", getStats())
         .add("typeReports", getTypeReports())
         .toString();
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/webmessage/responses/ImportReportWebMessageResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/webmessage/responses/ImportReportWebMessageResponse.java
@@ -67,7 +67,7 @@ public class ImportReportWebMessageResponse implements WebMessageResponse {
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Stats getStats() {
-    return importReport.getAccumulatedStats();
+    return importReport.getStats();
   }
 
   @JsonProperty

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
@@ -77,10 +77,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-public class MetadataImportTest extends ApiTest {
+class MetadataImportTest extends ApiTest {
   private MetadataActions metadataActions;
   private RestApiActions dataElementActions;
-
   private SystemActions systemActions;
 
   @BeforeAll
@@ -187,7 +186,7 @@ public class MetadataImportTest extends ApiTest {
 
   @ParameterizedTest(name = "withImportStrategy[{0}]")
   @CsvSource({"CREATE, ignored, 409", "CREATE_AND_UPDATE, updated, 200"})
-  public void shouldUpdateExistingMetadata(
+  void shouldUpdateExistingMetadata(
       String importStrategy, String expected, int expectedStatusCode) {
     // arrange
     JsonObject exported = metadataActions.get().getBody();
@@ -221,7 +220,7 @@ public class MetadataImportTest extends ApiTest {
   }
 
   @Test
-  public void shouldImportUniqueMetadataAndReturnObjectReports() throws Exception {
+  void shouldImportUniqueMetadataAndReturnObjectReports() throws Exception {
     // arrange
     JsonObject object =
         new FileReaderUtils()
@@ -259,8 +258,7 @@ public class MetadataImportTest extends ApiTest {
   }
 
   @Test
-  public void shouldReturnObjectReportsWhenSomeMetadataWasIgnoredAndAtomicModeFalse()
-      throws Exception {
+  void shouldReturnObjectReportsWhenSomeMetadataWasIgnoredAndAtomicModeFalse() throws Exception {
     // arrange
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     queryParamsBuilder.addAll(
@@ -309,7 +307,7 @@ public class MetadataImportTest extends ApiTest {
   }
 
   @Test
-  public void shouldReturnImportSummariesWhenImportingInvalidMetadataAsync() throws Exception {
+  void shouldReturnImportSummariesWhenImportingInvalidMetadataAsync() throws Exception {
     // arrange
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     queryParamsBuilder.addAll(
@@ -364,7 +362,7 @@ public class MetadataImportTest extends ApiTest {
   }
 
   @Test
-  public void shouldImportMetadataAsync() throws Exception {
+  void shouldImportMetadataAsync() throws Exception {
     JsonObject object =
         new FileReaderUtils()
             .readJsonAndGenerateData(new File("src/test/resources/metadata/uniqueMetadata.json"));
@@ -410,15 +408,20 @@ public class MetadataImportTest extends ApiTest {
         .validate()
         .body(notNullValue())
         .body("status", equalTo("OK"))
+        .body("stats", notNullValue())
+        .body("stats.total", is(greaterThanOrEqualTo(0)))
+        .body("stats.created", is(greaterThanOrEqualTo(0)))
+        .body("stats.updated", is(greaterThanOrEqualTo(0)))
+        .body("stats.deleted", is(greaterThanOrEqualTo(0)))
+        .body("stats.ignored", is(greaterThanOrEqualTo(0)))
         .body("typeReports", notNullValue())
         .rootPath("typeReports")
         .body("stats", notNullValue())
-        .body("stats.total", everyItem(greaterThan(0)))
         .body("objectReports", hasSize(greaterThan(0)));
   }
 
   @Test
-  public void shouldNotSkipSharing() {
+  void shouldNotSkipSharing() {
     JsonObject object = generateMetadataObjectWithInvalidSharing();
 
     ApiResponse response =
@@ -436,7 +439,7 @@ public class MetadataImportTest extends ApiTest {
   }
 
   @Test
-  public void shouldSkipSharing() {
+  void shouldSkipSharing() {
     JsonObject metadata = generateMetadataObjectWithInvalidSharing();
 
     ApiResponse response =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportIntegrationTest.java
@@ -77,7 +77,7 @@ class CsvMetadataImportIntegrationTest extends PostgresIntegrationTestBase {
             "dxf2/metadata/organisationUnits.csv",
             CsvImportClass.ORGANISATION_UNIT,
             metadata -> assertEquals(6, metadata.getOrganisationUnits().size()));
-    assertEquals(6, report.getAccumulatedStats().created());
+    assertEquals(6, report.getStats().created());
   }
 
   @Test
@@ -156,7 +156,7 @@ class CsvMetadataImportIntegrationTest extends PostgresIntegrationTestBase {
             null,
             params -> params.setImportStrategy(ImportStrategy.UPDATE));
     assertEquals(Status.OK, importReport.getStatus());
-    assertEquals(1, importReport.getAccumulatedStats().updated());
+    assertEquals(1, importReport.getStats().updated());
   }
 
   private ImportReport runImport(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/CsvMetadataImportTest.java
@@ -87,7 +87,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
             "metadata/organisationUnits.csv",
             CsvImportClass.ORGANISATION_UNIT,
             metadata -> assertEquals(6, metadata.getOrganisationUnits().size()));
-    assertEquals(6, importReport.getAccumulatedStats().created());
+    assertEquals(6, importReport.getStats().created());
     assertEquals(6, organisationUnitService.getAllOrganisationUnits().size());
   }
 
@@ -98,7 +98,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
             "metadata/organisationUnits.csv",
             CsvImportClass.ORGANISATION_UNIT,
             metadata -> assertEquals(6, metadata.getOrganisationUnits().size()));
-    assertEquals(6, importReport.getAccumulatedStats().created());
+    assertEquals(6, importReport.getStats().created());
     assertEquals(6, organisationUnitService.getAllOrganisationUnits().size());
   }
 
@@ -109,7 +109,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
             "metadata/dataElements.csv",
             CsvImportClass.DATA_ELEMENT,
             metadata -> assertEquals(2, metadata.getDataElements().size()));
-    assertEquals(2, importReport.getAccumulatedStats().created());
+    assertEquals(2, importReport.getStats().created());
     assertEquals(2, dataElementService.getAllDataElements().size());
   }
 
@@ -126,7 +126,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
               assertEquals(3, metadata.getOptionSets().get(2).getOptions().size());
               assertEquals(3, metadata.getOptionSets().get(3).getOptions().size());
             });
-    assertEquals(16, importReport.getAccumulatedStats().created());
+    assertEquals(16, importReport.getStats().created());
     List<OptionSet> optionSets = new ArrayList<>(optionService.getAllOptionSets());
     assertEquals(4, optionSets.size());
     assertEquals(3, optionSets.get(0).getOptions().size());
@@ -139,10 +139,10 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
   void testOptionSetReplace() throws IOException {
     // Import 1 OptionSet with 3 Options
     ImportReport importReport = runImport("metadata/optionSet_add.csv", CsvImportClass.OPTION_SET);
-    assertEquals(4, importReport.getAccumulatedStats().created());
+    assertEquals(4, importReport.getStats().created());
     // Send payload with 2 new Options
     importReport = runImport("metadata/optionSet_update.csv", CsvImportClass.OPTION_SET);
-    assertEquals(2, importReport.getAccumulatedStats().created());
+    assertEquals(2, importReport.getStats().created());
     OptionSet optionSet = optionService.getOptionSetByCode("COLOR");
     // 3 old Options are replaced by 2 new added Options
     assertEquals(2, optionSet.getOptions().size());
@@ -151,7 +151,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
   @Test
   void testImportOptionGroupSet() throws IOException {
     ImportReport importReport = runImport("metadata/option_set.csv", CsvImportClass.OPTION_SET);
-    assertEquals(5, importReport.getAccumulatedStats().created());
+    assertEquals(5, importReport.getStats().created());
     OptionSet optionSetA = manager.get(OptionSet.class, "xmRubJIhmaK");
     assertNotNull(optionSetA);
     assertEquals(2, optionSetA.getOptions().size());
@@ -159,7 +159,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
     assertNotNull(optionSetB);
     assertEquals(1, optionSetB.getOptions().size());
     importReport = runImport("metadata/option_groups.csv", CsvImportClass.OPTION_GROUP);
-    assertEquals(2, importReport.getAccumulatedStats().created());
+    assertEquals(2, importReport.getStats().created());
     OptionGroup optionGroupA = manager.get(OptionGroup.class, "UeHtizvXbx6");
     assertNotNull(optionGroupA);
     assertEquals(2, optionGroupA.getMembers().size());
@@ -167,7 +167,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
     assertNotNull(optionGroupB);
     assertEquals(1, optionGroupB.getMembers().size());
     importReport = runImport("metadata/option_group_set.csv", CsvImportClass.OPTION_GROUP_SET);
-    assertEquals(2, importReport.getAccumulatedStats().created());
+    assertEquals(2, importReport.getStats().created());
     OptionGroupSet optionGroupSetA = manager.get(OptionGroupSet.class, "FB9i0Jl2R80");
     assertNotNull(optionGroupSetA);
     OptionGroupSet optionGroupSetB = manager.get(OptionGroupSet.class, "K30djctzUtN");
@@ -175,7 +175,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
     importReport =
         runImport(
             "metadata/option_group_set_members.csv", CsvImportClass.OPTION_GROUP_SET_MEMBERSHIP);
-    assertEquals(2, importReport.getAccumulatedStats().updated());
+    assertEquals(2, importReport.getStats().updated());
     OptionGroupSet ogsA = optionService.getOptionGroupSet("FB9i0Jl2R80");
     OptionGroupSet ogsB = optionService.getOptionGroupSet("K30djctzUtN");
     assertEquals(1, ogsA.getMembers().size());
@@ -190,7 +190,7 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
             "metadata/organisationUnitMembers.csv",
             CsvImportClass.ORGANISATION_UNIT,
             metadata -> assertEquals(4, metadata.getOrganisationUnits().size()));
-    assertEquals(4, importReport.getAccumulatedStats().created());
+    assertEquals(4, importReport.getStats().created());
     assertEquals(4, organisationUnitService.getAllOrganisationUnits().size());
 
     importReport =
@@ -198,14 +198,14 @@ class CsvMetadataImportTest extends PostgresIntegrationTestBase {
             "metadata/organisationUnitGroup.csv",
             CsvImportClass.ORGANISATION_UNIT_GROUP,
             metadata -> assertEquals(2, metadata.getOrganisationUnitGroups().size()));
-    assertEquals(2, importReport.getAccumulatedStats().created());
+    assertEquals(2, importReport.getStats().created());
 
     importReport =
         runImport(
             "metadata/organisationUnitGroup_members.csv",
             CsvImportClass.ORGANISATION_UNIT_GROUP_MEMBERSHIP,
             metadata -> assertEquals(2, metadata.getOrganisationUnitGroups().size()));
-    assertEquals(2, importReport.getAccumulatedStats().updated());
+    assertEquals(2, importReport.getStats().updated());
     OrganisationUnitGroup orgUnitA = manager.get(OrganisationUnitGroup.class, "a1234567890");
     assertEquals(2, orgUnitA.getMembers().size());
     OrganisationUnitGroup orgUnitB = manager.get(OrganisationUnitGroup.class, "b1234567890");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -999,11 +999,11 @@ class MetadataImportServiceTest extends PostgresIntegrationTestBase {
     ImportReport report = importService.importMetadata(params, new MetadataObjects(metadata));
     TypeReport typeReport = report.getTypeReport(AggregateDataExchange.class);
 
-    assertNotNull(report.getAccumulatedStats());
+    assertNotNull(report.getStats());
     assertNotNull(typeReport);
     assertEquals(Status.OK, report.getStatus(), report.toString());
     assertEquals(0, report.getErrorReportsCount());
-    assertEquals(6, report.getAccumulatedStats().created());
+    assertEquals(6, report.getStats().created());
     assertEquals(3, typeReport.getStats().created());
 
     AggregateDataExchange aeA = manager.get(AggregateDataExchange.class, "iFOyIpQciyk");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
@@ -117,7 +117,7 @@ public class MetadataImportJob implements Job {
       }
 
       notifier.addJobSummary(config, report, ImportReport.class);
-      Stats count = report.getAccumulatedStats();
+      Stats count = report.getStats();
       Consumer<String> endProcess =
           report.getStatus() == Status.ERROR ? progress::failedProcess : progress::completedProcess;
       endProcess.accept(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -629,8 +629,7 @@ public class UserController
     ImportReport importReport =
         importService.importMetadata(params, new MetadataObjects().addObject(inputUser));
 
-    if (importReport.getStatus() == Status.OK
-        && importReport.getAccumulatedStats().updated() == 1) {
+    if (importReport.getStatus() == Status.OK && importReport.getStats().updated() == 1) {
       updateUserGroups(userUid, inputUser, currentUser);
 
       // If it was a pw change attempt (input.pw != null) and update was
@@ -741,8 +740,7 @@ public class UserController
     ImportReport importReport =
         importService.importMetadata(importParams, new MetadataObjects().addObject(user));
 
-    if (importReport.getStatus() == Status.OK
-        && importReport.getAccumulatedStats().created() == 1) {
+    if (importReport.getStatus() == Status.OK && importReport.getStats().created() == 1) {
       userGroupService.addUserToGroups(user, getUids(user.getGroups()), currentUser);
     }
 
@@ -781,7 +779,7 @@ public class UserController
     ObjectReport objectReport = getObjectReport(importReport);
 
     if (importReport.getStatus() == Status.OK
-        && importReport.getAccumulatedStats().created() == 1
+        && importReport.getStats().created() == 1
         && objectReport != null) {
       userService.sendRestoreOrInviteMessage(
           user, HttpServletRequestPaths.getContextPath(request), restoreOptions);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -183,7 +183,7 @@ class UserControllerTest {
   }
 
   private boolean isInStatusUpdatedOK(ImportReport report) {
-    return report.getStatus() == Status.OK && report.getAccumulatedStats().updated() == 1;
+    return report.getStatus() == Status.OK && report.getStats().updated() == 1;
   }
 
   public static void injectSecurityContext(UserDetails currentUserDetails) {


### PR DESCRIPTION
## Issue
When retrieving a task summary for Metadata Import, the `stats` object is no longer present. `accumulatedStats` is present instead. This causes issues in the UI.

## Cause
During [this fix](#20373), the `Stats` object was made immutable and had some changes. We have the concept of having multiple nested `stats` objects, an outer `stats` object which shows totals & inner `stats` object per object type.
The method name was renamed to `getAccumulatedStats` (trying to be more meaningful) which is the cause of this issue.

This only occurs on the task summary endpoint it seems. An import report returned synchronously through metadata import returns the expected format (difference in serialization mechanisms between sync/async)

## Fix
Rename the method in ImportReport to `getStats`.

## Testing
Existing E2E test updated to include checking for the outer `stats` field and its properties.
Manually tested using import app and async import. UI handles response now.