### PR TITLE
fix: TE, enrollment and event visible after breaking glass [DHIS2-19684]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilder.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.tracker.export;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.Set;
 import lombok.AccessLevel;
@@ -98,7 +97,7 @@ public class OrgUnitQueryBuilder {
       String orgUnitTableAlias,
       String trackedEntityTableAlias,
       UserDetails userDetails) {
-    if (orgUnitMode == ALL || getCurrentUserDetails().isSuper()) {
+    if (orgUnitMode == ALL || userDetails.isSuper()) {
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilder.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.export;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getIdentifiers;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
+import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.Set;
 import lombok.AccessLevel;
@@ -91,12 +92,11 @@ public class OrgUnitQueryBuilder {
       StringBuilder sql,
       MapSqlParameterSource sqlParameters,
       OrganisationUnitSelectionMode orgUnitMode,
-      Set<OrganisationUnit> effectiveSearchOrgUnits,
-      Set<OrganisationUnit> captureScopeOrgUnits,
       String programTableAlias,
       String orgUnitTableAlias,
-      String trackedEntityTableAlias,
-      UserDetails userDetails) {
+      String trackedEntityTableAlias) {
+    UserDetails userDetails = getCurrentUserDetails();
+
     if (orgUnitMode == ALL || userDetails.isSuper()) {
       return;
     }
@@ -109,11 +109,13 @@ public class OrgUnitQueryBuilder {
         .append(".accesslevel in ('OPEN', 'AUDITED') and ")
         .append(orgUnitTableAlias);
     if (orgUnitMode == CAPTURE) {
-      sql.append(".path like any (:captureScopePaths))");
+      sql.append(
+          ".path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:captureScopeOrgUnits)))");
     } else {
-      sql.append(".path like any (:effectiveSearchScopePaths))");
+      sql.append(
+          ".path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:effectiveSearchScopeOrgUnits)))");
       sqlParameters.addValue(
-          "effectiveSearchScopePaths", getOrgUnitsPathArray(effectiveSearchOrgUnits));
+          "effectiveSearchScopeOrgUnits", userDetails.getUserEffectiveSearchOrgUnitIds());
     }
 
     sql.append(sqlHelper.andOr())
@@ -121,8 +123,9 @@ public class OrgUnitQueryBuilder {
         .append(programTableAlias)
         .append(".accesslevel in ('PROTECTED', 'CLOSED') and ")
         .append(orgUnitTableAlias)
-        .append(".path like any (:captureScopePaths))");
-    sqlParameters.addValue("captureScopePaths", getOrgUnitsPathArray(captureScopeOrgUnits));
+        .append(
+            ".path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:captureScopeOrgUnits)))");
+    sqlParameters.addValue("captureScopeOrgUnits", userDetails.getUserOrgUnitIds());
 
     sql.append(sqlHelper.andOr())
         .append(
@@ -194,9 +197,5 @@ public class OrgUnitQueryBuilder {
       index++;
     }
     sql.append(")");
-  }
-
-  private static String[] getOrgUnitsPathArray(Set<OrganisationUnit> orgUnits) {
-    return orgUnits.stream().map(ou -> ou.getStoredPath() + "%").toArray(String[]::new);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -41,7 +41,6 @@ import jakarta.persistence.EntityManager;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +54,6 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.event.EventStatus;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
@@ -100,8 +98,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
           entry(ENROLLMENT_DATE_KEY, ENROLLMENT_DATE_ALIAS),
           entry("inactive", "inactive"));
 
-  private final OrganisationUnitStore organisationUnitStore;
-
   private final SystemSettingsProvider settingsProvider;
 
   private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
@@ -119,7 +115,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     checkNotNull(organisationUnitStore);
     checkNotNull(settingsProvider);
 
-    this.organisationUnitStore = organisationUnitStore;
     this.settingsProvider = settingsProvider;
     this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
   }
@@ -497,10 +492,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         programTableAlias,
         orgUnitTableAlias,
         MAIN_QUERY_ALIAS);
-  }
-
-  private Set<OrganisationUnit> getOrgUnitsFromUids(Set<String> uids) {
-    return new HashSet<>(organisationUnitStore.getByUid(uids));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.system.util.SqlUtils.quote;
 import static org.hisp.dhis.tracker.export.FilterJdbcPredicate.addPredicates;
 import static org.hisp.dhis.tracker.export.OrgUnitQueryBuilder.buildOrgUnitModeClause;
 import static org.hisp.dhis.tracker.export.OrgUnitQueryBuilder.buildOwnershipClause;
-import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import jakarta.persistence.EntityManager;
 import java.sql.Types;
@@ -65,7 +64,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.Order;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -474,12 +472,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    */
   private void addJoinOnOrgUnit(
       StringBuilder sql, MapSqlParameterSource sqlParameters, TrackedEntityQueryParams params) {
-    UserDetails userDetails = getCurrentUserDetails();
-    Set<OrganisationUnit> effectiveSearchOrgUnits =
-        getOrgUnitsFromUids(userDetails.getUserEffectiveSearchOrgUnitIds());
-    Set<OrganisationUnit> captureScopeOrgUnits =
-        getOrgUnitsFromUids(userDetails.getUserOrgUnitIds());
-
     String orgUnitTableAlias = "ou";
     String programTableAlias = "p";
 
@@ -502,12 +494,9 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         sql,
         sqlParameters,
         params.getOrgUnitMode(),
-        effectiveSearchOrgUnits,
-        captureScopeOrgUnits,
         programTableAlias,
         orgUnitTableAlias,
-        MAIN_QUERY_ALIAS,
-        userDetails);
+        MAIN_QUERY_ALIAS);
   }
 
   private Set<OrganisationUnit> getOrgUnitsFromUids(Set<String> uids) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -505,7 +505,9 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         effectiveSearchOrgUnits,
         captureScopeOrgUnits,
         programTableAlias,
-        orgUnitTableAlias);
+        orgUnitTableAlias,
+        MAIN_QUERY_ALIAS,
+        userDetails);
   }
 
   private Set<OrganisationUnit> getOrgUnitsFromUids(Set<String> uids) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OrgUnitQueryBuilderTest.java
@@ -27,7 +27,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker;
+package org.hisp.dhis.tracker.export;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
@@ -43,13 +43,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -76,7 +74,6 @@ class OrgUnitQueryBuilderTest {
   private OrganisationUnit orgUnitA;
   private OrganisationUnit orgUnitB;
   private MockedStatic<CurrentUserUtil> mockedStatic;
-  private UserDetails userDetails;
 
   @BeforeEach
   void setUp() {
@@ -86,7 +83,9 @@ class OrgUnitQueryBuilderTest {
     orgUnits.add(orgUnitB);
 
     User user = new User();
-    userDetails = UserDetails.fromUser(user);
+    UserDetails userDetails = UserDetails.fromUser(user);
+    userDetails.getUserOrgUnitIds().add(orgUnitB.getUid());
+    userDetails.getUserEffectiveSearchOrgUnitIds().add(orgUnitA.getUid());
 
     mockedStatic = mockStatic(CurrentUserUtil.class);
     mockedStatic.when(CurrentUserUtil::getCurrentUserDetails).thenReturn(userDetails);
@@ -168,7 +167,7 @@ class OrgUnitQueryBuilderTest {
     StringBuilder sql = new StringBuilder();
     MapSqlParameterSource params = new MapSqlParameterSource();
 
-    buildOwnershipClause(sql, params, ALL, Set.of(), Set.of(), "p", "ou", "t", userDetails);
+    buildOwnershipClause(sql, params, ALL, "p", "ou", "t");
 
     assertTrue(
         sql.toString().isEmpty(),
@@ -181,15 +180,14 @@ class OrgUnitQueryBuilderTest {
     StringBuilder sql = new StringBuilder();
     MapSqlParameterSource params = new MapSqlParameterSource();
 
-    buildOwnershipClause(
-        sql, params, CAPTURE, Set.of(orgUnitA), Set.of(orgUnitB), "p", "ou", "t", userDetails);
+    buildOwnershipClause(sql, params, CAPTURE, "p", "ou", "t");
 
     assertEquals(
-        " and ((p.accesslevel in ('OPEN', 'AUDITED') and ou.path like any (:captureScopePaths)) or (p.accesslevel in ('PROTECTED', 'CLOSED') and ou.path like any (:captureScopePaths)) or (p.accesslevel = 'PROTECTED' and exists (select 1 from programtempowner where programid = p.programid and trackedentityid = t.trackedentityid and userid = 0 and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0)))",
+        " and ((p.accesslevel in ('OPEN', 'AUDITED') and ou.path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:captureScopeOrgUnits))) or (p.accesslevel in ('PROTECTED', 'CLOSED') and ou.path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:captureScopeOrgUnits))) or (p.accesslevel = 'PROTECTED' and exists (select 1 from programtempowner where programid = p.programid and trackedentityid = t.trackedentityid and userid = 0 and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0)))",
         sql.toString());
 
-    expectedParams.put("captureScopePaths", orgUnitB.getPath() + "%");
-    assertScopePathsParams(params);
+    expectedParams.put("captureScopeOrgUnits", Set.of(orgUnitB.getUid()));
+    assertParameters(params);
   }
 
   private static Stream<Arguments> orgUnitModesWithEffectiveSearchScope() {
@@ -207,33 +205,20 @@ class OrgUnitQueryBuilderTest {
     StringBuilder sql = new StringBuilder();
     MapSqlParameterSource params = new MapSqlParameterSource();
 
-    buildOwnershipClause(
-        sql, params, orgUnitMode, Set.of(orgUnitA), Set.of(orgUnitB), "p", "ou", "t", userDetails);
+    buildOwnershipClause(sql, params, orgUnitMode, "p", "ou", "t");
 
     assertEquals(
-        " and ((p.accesslevel in ('OPEN', 'AUDITED') and ou.path like any (:effectiveSearchScopePaths)) or (p.accesslevel in ('PROTECTED', 'CLOSED') and ou.path like any (:captureScopePaths)) or (p.accesslevel = 'PROTECTED' and exists (select 1 from programtempowner where programid = p.programid and trackedentityid = t.trackedentityid and userid = 0 and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0)))",
+        " and ((p.accesslevel in ('OPEN', 'AUDITED') and ou.path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:effectiveSearchScopeOrgUnits))) or (p.accesslevel in ('PROTECTED', 'CLOSED') and ou.path like any (select concat(o.path, '%') from organisationunit o where o.uid in (:captureScopeOrgUnits))) or (p.accesslevel = 'PROTECTED' and exists (select 1 from programtempowner where programid = p.programid and trackedentityid = t.trackedentityid and userid = 0 and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0)))",
         sql.toString());
 
-    expectedParams.put("effectiveSearchScopePaths", orgUnitA.getPath() + "%");
-    expectedParams.put("captureScopePaths", orgUnitB.getPath() + "%");
-    assertScopePathsParams(params);
+    expectedParams.put("effectiveSearchScopeOrgUnits", Set.of(orgUnitA.getUid()));
+    expectedParams.put("captureScopeOrgUnits", Set.of(orgUnitB.getUid()));
+    assertParameters(params);
   }
 
   private void assertParameters(MapSqlParameterSource params) {
     assertContainsOnly(expectedParams.keySet(), Arrays.asList(params.getParameterNames()));
     assertContainsOnly(expectedParams.values(), params.getValues().values());
-  }
-
-  private void assertScopePathsParams(MapSqlParameterSource params) {
-    assertContainsOnly(expectedParams.keySet(), Arrays.asList(params.getParameterNames()));
-
-    Collection<Object> values = params.getValues().values();
-    Set<Object> capturedScopePaths =
-        values.stream()
-            .filter(String[].class::isInstance)
-            .flatMap(obj -> Arrays.stream((String[]) obj))
-            .collect(Collectors.toSet());
-    assertContainsOnly(expectedParams.values(), capturedScopePaths);
   }
 
   private OrganisationUnit createOrgUnit(int id, String uid, String path) {


### PR DESCRIPTION
After the ACL refactor to fix pagination for `/trackedEntities`, we didn't account for temporary access. As a result, even though the user could still break the glass, they weren't granted access to the tracked entity when requested. This PR addresses that issue by adding an extra clause to the SQL to check whether the user has temporary access.

While at it, I'm also adding the same clause to the tracker event store, as it was missing there too. For events, this is just a temporary fix, since we'll soon be using the `OrgUnitQueryBuilder`. However, because this fix also needs to be applied to version 42, I decided to include it here as well.