### PR TITLE
fix: Aggregate Data Exchange job creator as job executor [DHIS2-18324](2.40)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -200,8 +200,10 @@ public enum JobType {
   }
 
   /**
-   * @return when true, the {@link JobConfiguration#getExecutedBy()} is set to the job creator on
-   *     creation unless it was set explicitly
+   * @return when true, the {@link JobConfiguration#lastUpdatedBy()} is set to the job creator on
+   *     creation unless it was set explicitly. This is purely a workaround for this version which
+   *     will be supported for 1 more year at the time of writing. Older job scheduling has always
+   *     had issues with users missing during job execution.
    */
   public boolean isDefaultExecutedByCreator() {
     return this == AGGREGATE_DATA_EXCHANGE;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -199,6 +199,14 @@ public enum JobType {
     return this == LEADER_ELECTION;
   }
 
+  /**
+   * @return when true, the {@link JobConfiguration#getExecutedBy()} is set to the job creator on
+   *     creation unless it was set explicitly
+   */
+  public boolean isDefaultExecutedByCreator() {
+    return this == AGGREGATE_DATA_EXCHANGE;
+  }
+
   public boolean isUsingNotifications() {
     return this == RESOURCE_TABLE
         || this == SEND_SCHEDULED_MESSAGE

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
@@ -33,7 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -210,5 +212,21 @@ public class CurrentUserUtil {
         }
       }
     }
+  }
+
+  public static void injectUserInSecurityContext(UserDetails actingUser) {
+    Authentication authentication =
+        new UsernamePasswordAuthenticationToken(actingUser, "", actingUser.getAuthorities());
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(authentication);
+    SecurityContextHolder.setContext(context);
+  }
+
+  public static void clearSecurityContext() {
+    SecurityContext context = SecurityContextHolder.getContext();
+    if (context != null) {
+      SecurityContextHolder.getContext().setAuthentication(null);
+    }
+    SecurityContextHolder.clearContext();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -174,7 +174,10 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     object.setAutoFields();
 
     object.setAutoFields();
-    object.setLastUpdatedBy(user);
+
+    if (user != null) {
+      object.setLastUpdatedBy(user);
+    }
 
     if (object.getSharing().getOwner() == null) {
       object.getSharing().setOwner(user);

--- a/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
@@ -43,6 +43,10 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-acl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-hibernate</artifactId>
+    </dependency>
 
     <!-- Application -->
     <dependency>
@@ -93,6 +97,10 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
     </dependency>
 
     <!-- Test -->

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -82,16 +82,17 @@ public class AggregateDataExchangeJob implements Job {
 
       User currentUser = currentUserService.getCurrentUser();
 
-      if (currentUser == null && config.getLastUpdatedBy() != null) {
+      if (currentUser == null) {
+        String errorMessage = "A valid user is required to run the aggregate data exchange job.";
+        if (config.getLastUpdatedBy() == null) {
+          progress.failedProcess(errorMessage);
+          notifier.notify(config, NotificationLevel.ERROR, errorMessage, true);
+          return;
+        }
         User user = userService.getUser(config.getLastUpdatedBy().getUid());
         if (user == null) {
-          progress.failedProcess(
-              "A valid user is required to run the aggregate data exchange job. It can be set in the job configuration.");
-          notifier.notify(
-              config,
-              NotificationLevel.ERROR,
-              "A valid user is required to run the aggregate data exchange job. It can be set in the job configuration.",
-              true);
+          progress.failedProcess(errorMessage);
+          notifier.notify(config, NotificationLevel.ERROR, errorMessage, true);
           return;
         }
         CurrentUserDetails currentUserDetails = userService.createUserDetails(user);

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -31,7 +31,10 @@ import static java.lang.String.format;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.dbms.DbmsUtils;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
@@ -42,7 +45,11 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.AggregateDataExchangeJobParameters;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.user.CurrentUserDetails;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -50,14 +57,15 @@ import org.springframework.stereotype.Component;
  *
  * @author Jan Bernitt
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AggregateDataExchangeJob implements Job {
   private final AggregateDataExchangeService dataExchangeService;
-
   private final Notifier notifier;
-
+  private final SessionFactory sessionFactory;
   private final CurrentUserService currentUserService;
+  private final UserService userService;
 
   @Override
   public JobType getJobType() {
@@ -66,34 +74,58 @@ public class AggregateDataExchangeJob implements Job {
 
   @Override
   public void execute(JobConfiguration config, JobProgress progress) {
+    try {
+      DbmsUtils.bindSessionToThreadIfNoneOpen(sessionFactory);
     notifier.clear(config);
     AggregateDataExchangeJobParameters params =
         (AggregateDataExchangeJobParameters) config.getJobParameters();
 
-    List<String> dataExchangeIds = params.getDataExchangeIds();
-    progress.startingProcess(
-        format("Aggregate data exchange of %d exchange(s) started", dataExchangeIds.size()));
-    ImportSummaries allSummaries = new ImportSummaries();
-    for (String dataExchangeId : dataExchangeIds) {
-      AggregateDataExchange exchange;
-      try {
-        exchange = dataExchangeService.loadByUid(dataExchangeId);
-      } catch (IllegalQueryException ex) {
-        progress.startingStage("exchange aggregate data for exchange with ID " + dataExchangeId);
-        progress.failedStage(ex);
-        allSummaries.addImportSummary(new ImportSummary(ImportStatus.ERROR, ex.getMessage()));
-        continue;
+      User currentUser = currentUserService.getCurrentUser();
+
+      if (currentUser == null && config.getLastUpdatedBy() != null) {
+        User user = userService.getUser(config.getLastUpdatedBy().getUid());
+        if (user == null) {
+          progress.failedProcess(
+              "A valid user is required to run the aggregate data exchange job. It can be set in the job configuration.");
+          notifier.notify(
+              config,
+              NotificationLevel.ERROR,
+              "A valid user is required to run the aggregate data exchange job. It can be set in the job configuration.",
+              true);
+          return;
+        }
+        CurrentUserDetails currentUserDetails = userService.createUserDetails(user);
+        CurrentUserUtil.injectUserInSecurityContext(currentUserDetails);
       }
-      allSummaries.addImportSummaries(
-          dataExchangeService.exchangeData(
-              currentUserService.getCurrentUser(), exchange, progress));
-    }
-    notifier.addJobSummary(config, NotificationLevel.INFO, allSummaries, ImportSummaries.class);
-    ImportStatus status = allSummaries.getStatus();
-    if (status == ImportStatus.ERROR) {
-      progress.failedProcess("Aggregate data exchange completed with errors");
-    } else {
-      progress.completedProcess("Aggregate data exchange completed with status " + status);
+
+      List<String> dataExchangeIds = params.getDataExchangeIds();
+      progress.startingProcess(
+          format("Aggregate data exchange of %d exchange(s) started", dataExchangeIds.size()));
+      ImportSummaries allSummaries = new ImportSummaries();
+      for (String dataExchangeId : dataExchangeIds) {
+        AggregateDataExchange exchange;
+        try {
+          exchange = dataExchangeService.loadByUid(dataExchangeId);
+        } catch (IllegalQueryException ex) {
+          progress.startingStage("exchange aggregate data for exchange with ID " + dataExchangeId);
+          progress.failedStage(ex);
+          allSummaries.addImportSummary(new ImportSummary(ImportStatus.ERROR, ex.getMessage()));
+          continue;
+        }
+        allSummaries.addImportSummaries(
+            dataExchangeService.exchangeData(
+                currentUserService.getCurrentUser(), exchange, progress));
+      }
+      notifier.addJobSummary(config, NotificationLevel.INFO, allSummaries, ImportSummaries.class);
+      ImportStatus status = allSummaries.getStatus();
+      if (status == ImportStatus.ERROR) {
+        progress.failedProcess("Aggregate data exchange completed with errors");
+      } else {
+        progress.completedProcess("Aggregate data exchange completed with status " + status);
+      }
+    } finally {
+      CurrentUserUtil.clearSecurityContext();
+      DbmsUtils.unbindSessionFromThread(sessionFactory);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -76,9 +76,9 @@ public class AggregateDataExchangeJob implements Job {
   public void execute(JobConfiguration config, JobProgress progress) {
     try {
       DbmsUtils.bindSessionToThreadIfNoneOpen(sessionFactory);
-    notifier.clear(config);
-    AggregateDataExchangeJobParameters params =
-        (AggregateDataExchangeJobParameters) config.getJobParameters();
+      notifier.clear(config);
+      AggregateDataExchangeJobParameters params =
+          (AggregateDataExchangeJobParameters) config.getJobParameters();
 
       User currentUser = currentUserService.getCurrentUser();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
 
 import java.util.ArrayList;
@@ -95,9 +94,9 @@ public class JobConfigurationObjectBundleHook extends AbstractObjectBundleHook<J
 
   @Override
   public void preCreate(JobConfiguration config, ObjectBundle bundle) {
-    if (isEmpty(config.getUserUid()) && config.getJobType().isDefaultExecutedByCreator()) {
+    if (config.getJobType().isDefaultExecutedByCreator()) {
       User currentUser = currentUserService.getCurrentUser();
-      config.setUserUid(currentUser == null ? null : currentUser.getUid());
+      config.setLastUpdatedBy(currentUser);
     }
     setDefaultJobParameters(config);
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -96,6 +96,8 @@ public class JobConfigurationObjectBundleHook extends AbstractObjectBundleHook<J
   public void preCreate(JobConfiguration config, ObjectBundle bundle) {
     if (config.getJobType().isDefaultExecutedByCreator()) {
       User currentUser = currentUserService.getCurrentUser();
+      // lastUpdatedBy is used as it is the only way to store & retrieve user info without affecting
+      // clients of the Job API.
       config.setLastUpdatedBy(currentUser);
     }
     setDefaultJobParameters(config);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
 
 import java.util.ArrayList;
@@ -47,6 +48,8 @@ import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.scheduling.JobService;
 import org.hisp.dhis.scheduling.SchedulingManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
 
@@ -62,6 +65,8 @@ public class JobConfigurationObjectBundleHook extends AbstractObjectBundleHook<J
   private final SchedulingManager schedulingManager;
 
   private final JobService jobService;
+
+  private final CurrentUserService currentUserService;
 
   @Override
   public void validate(
@@ -89,8 +94,12 @@ public class JobConfigurationObjectBundleHook extends AbstractObjectBundleHook<J
   }
 
   @Override
-  public void preCreate(JobConfiguration jobConfiguration, ObjectBundle bundle) {
-    setDefaultJobParameters(jobConfiguration);
+  public void preCreate(JobConfiguration config, ObjectBundle bundle) {
+    if (isEmpty(config.getUserUid()) && config.getJobType().isDefaultExecutedByCreator()) {
+      User currentUser = currentUserService.getCurrentUser();
+      config.setUserUid(currentUser == null ? null : currentUser.getUid());
+    }
+    setDefaultJobParameters(config);
   }
 
   @Override

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/SystemActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/SystemActions.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.actions;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.with;
 
 import java.util.List;
@@ -72,7 +71,7 @@ public class SystemActions extends RestApiActions {
     Callable<Boolean> taskIsCompleted =
         () -> getTask(taskType, taskId).validateStatus(200).extractList("completed").contains(true);
 
-    with().atMost(timeout, SECONDS).await().until(() -> taskIsCompleted.call());
+    with().atMost(timeout, SECONDS).await().until(taskIsCompleted);
 
     return getTask(taskType, taskId);
   }
@@ -91,8 +90,11 @@ public class SystemActions extends RestApiActions {
   public ApiResponse waitForTaskSummaries(String taskType, String taskId) {
     String url = String.format("/taskSummaries/%s/%s", taskType, taskId);
 
-    await().ignoreExceptions().until(() -> !get(url).validateStatus(200).getBody().equals(null));
-
+    with()
+        .atMost(25, SECONDS)
+        .await()
+        .ignoreExceptions()
+        .until(() -> !get(url).validateStatus(200).getBody().equals(null));
     return get(url);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.scheduling;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import java.io.File;
 import org.hisp.dhis.ApiTest;
@@ -87,12 +87,10 @@ class SchedulingTest extends ApiTest {
     jobConfigActions.post("/" + jobId + "/execute", "null").validateStatus(200);
 
     // then it should complete without errors
-    ApiResponse apiResponse =
-        systemActions.waitUntilTaskCompleted("AGGREGATE_DATA_EXCHANGE", jobId, 24);
+    ApiResponse apiResponse = systemActions.waitForTaskSummaries("AGGREGATE_DATA_EXCHANGE", jobId);
     apiResponse
         .validate()
-        .body("level[0]", equalTo("INFO"))
-        .body("message[0]", equalTo(""))
-        .body("completed[0]", equalTo(true));
+        .body("status", equalTo("SUCCESS"))
+        .body("importSummaries[0].status", equalTo("SUCCESS"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.File;
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.actions.SystemActions;
+import org.hisp.dhis.actions.metadata.MetadataActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SchedulingTest extends ApiTest {
+
+  private MetadataActions metadataActions;
+  private RestApiActions jobConfigActions;
+  private SystemActions systemActions;
+
+  @BeforeAll
+  public void beforeAll() {
+    metadataActions = new MetadataActions();
+    systemActions = new SystemActions();
+    jobConfigActions = new RestApiActions("jobConfigurations");
+  }
+
+  @AfterAll
+  public void afterAllDelete() {
+    metadataActions
+        .importMetadata(
+            new File("src/test/resources/metadata/adex-metadata.json"),
+            "async=false&importMode=DELETE")
+        .validateStatus(200);
+  }
+
+  @Test
+  @DisplayName("Agg Data Exchange job runs without errors")
+  void aggDataExchangeJobRunsWithoutErrorsTest() {
+    // given an agg data exchange job is set up
+    metadataActions
+        .importMetadata(new File("src/test/resources/metadata/adex-metadata.json"), "async=false")
+        .validateStatus(200);
+
+    String jobConfig =
+        "{"
+            + "    \"name\": \"test-dx-job-2\","
+            + "    \"jobType\": \"AGGREGATE_DATA_EXCHANGE\","
+            + "    \"cronExpression\": \"2 1 * ? * *\","
+            + "    \"jobParameters\": {"
+            + "        \"dataExchangeIds\": ["
+            + "            \"R9Urc25BSio\""
+            + "        ]"
+            + "    }"
+            + "}";
+    String jobId = jobConfigActions.post(jobConfig).validateStatus(201).extractUid();
+
+    // when executing it manually
+    jobConfigActions.post("/" + jobId + "/execute", "null").validateStatus(200);
+
+    // then it should complete without errors
+    ApiResponse apiResponse =
+        systemActions.waitUntilTaskCompleted("AGGREGATE_DATA_EXCHANGE", jobId, 24);
+    apiResponse
+        .validate()
+        .body("level[0]", equalTo("INFO"))
+        .body("message[0]", equalTo(""))
+        .body("completed[0]", equalTo(true));
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/resources/metadata/adex-metadata.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/metadata/adex-metadata.json
@@ -1,0 +1,111 @@
+{
+  "dataSets": [
+    {
+      "name": "ANX DX test",
+      "shortName": "ANC DX test",
+      "periodType": "Monthly",
+      "dataSetElements": [
+        {
+          "dataSet": {
+            "id": "H91km2xaqGN"
+          },
+          "dataElement": {
+            "id": "ny4hnfb4rDF"
+          }
+        }
+      ],
+      "indicators": [
+        {
+          "id": "N2OO7qp1XhT"
+        }
+      ],
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "id": "H91km2xaqGN",
+      "organisationUnits": [
+        {
+          "id": "ImspTQPwCqd"
+        }
+      ]
+    }
+  ],
+  "dataElements": [
+    {
+      "code": "ANC1_TARGET",
+      "name": "ANC1 target",
+      "shortName": "ANC1 target",
+      "aggregationType": "SUM",
+      "valueType": "INTEGER_ZERO_OR_POSITIVE",
+      "domainType": "AGGREGATE",
+      "id": "ny4hnfb4rDF",
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      }
+    }
+  ],
+  "indicators": [
+    {
+      "code": "ANC1_TARGET",
+      "name": "ANC1 source",
+      "sharing": {
+        "owner": "xE7jOejl9FI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "shortName": "ANC1 source",
+      "indicatorType": {
+        "id": "JkWynlWMjJR"
+      },
+      "numerator": "#{fbfJHSPpUQD}",
+      "numeratorDescription": "ANC 1",
+      "denominator": "1",
+      "denominatorDescription": "1",
+      "id": "N2OO7qp1XhT"
+    }
+  ],
+  "indicatorTypes": [
+    {
+      "name": "test indicator type",
+      "id": "JkWynlWMjJR",
+      "factor": 12,
+      "number": true
+    }
+  ],
+  "aggregateDataExchanges": [
+    {
+      "name": "ANC test",
+      "source": {
+        "requests": [
+          {
+            "name": "ANC 1",
+            "dx": [
+              "N2OO7qp1XhT"
+            ],
+            "pe": [
+              "LAST_12_MONTHS"
+            ],
+            "ou": [
+              "fdc6uOvgoji",
+              "LEVEL-m9lBJogzE95"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "CODE",
+            "outputOrgUnitIdScheme": "CODE",
+            "outputIdScheme": "CODE"
+          }
+        ]
+      },
+      "target": {
+        "type": "INTERNAL",
+        "request": {
+          "dataElementIdScheme": "CODE",
+          "idScheme": "CODE"
+        }
+      },
+      "id": "R9Urc25BSio"
+    }
+  ]
+}


### PR DESCRIPTION
port of #20850 

This port needed extra work due to the very big differences between the job scheduling in older versions.
The issue is having no user associated with an async job (on a new thread). There is no easy way to automatically set the job creator as the user to be used when executing the job (A valid user is required for this job).

This fix uses the `lastUpdatedBy` field to set & retrieve the creator of the job. It's not nice but without making even more larger changes (DB migration for job config table) there is no other way to store and retrieve a user for jobs, without also requiring changes in clients.
