### PR TITLE
fix: make oidcuser use parent isAuthorized method (#17153)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -169,12 +169,12 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
 
   @Override
   public boolean hasAnyAuthority(Collection<String> auths) {
-    return false;
+    return user.hasAnyAuthority(auths);
   }
 
   @Override
   public boolean isAuthorized(String auth) {
-    return false;
+    return user.isAuthorized(auth);
   }
 
   @Nonnull

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -138,6 +138,11 @@
       <artifactId>dhis-support-system</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-external</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -335,8 +335,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-external</artifactId>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Backport: https://github.com/dhis2/dhis2-core/pull/17153
(cherry picked from commit 478f6026dc06b23edb64b9d69bbd5969fd058ebb)