### PR TITLE
chore: use DimensionalObject interface where possible

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -1711,7 +1711,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = DimensionalObject.class)
+  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "columns", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "column", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getColumns() {
@@ -1724,7 +1724,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = DimensionalObject.class)
+  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "rows", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "row", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getRows() {
@@ -1737,7 +1737,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = DimensionalObject.class)
+  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "filters", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "filter", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getFilters() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -1711,7 +1711,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
+  @JsonDeserialize(contentAs = DimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "columns", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "column", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getColumns() {
@@ -1724,7 +1724,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
+  @JsonDeserialize(contentAs = DimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "rows", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "row", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getRows() {
@@ -1737,7 +1737,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
   @Override
   @JsonProperty
-  @JsonDeserialize(contentAs = BaseDimensionalObject.class)
+  @JsonDeserialize(contentAs = DimensionalObject.class)
   @JacksonXmlElementWrapper(localName = "filters", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "filter", namespace = DxfNamespaces.DXF_2_0)
   public List<DimensionalObject> getFilters() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalObject.java
@@ -150,7 +150,7 @@ public class BaseDimensionalObject extends BaseNameableObject implements Dimensi
    *     value like "programUid.stageUid.dimUid".
    */
   private void with(String qualifiedDimension) {
-    Triple<Program, ProgramStage, BaseDimensionalObject> tripe = asBaseObjects(qualifiedDimension);
+    Triple<Program, ProgramStage, DimensionalObject> tripe = asBaseObjects(qualifiedDimension);
 
     this.program = tripe.getLeft() != null ? tripe.getLeft() : null;
     this.programStage = tripe.getMiddle() != null ? tripe.getMiddle() : null;
@@ -320,6 +320,7 @@ public class BaseDimensionalObject extends BaseNameableObject implements Dimensi
    * filter has the IN operator and that at least one item is specified in the filter, returns null
    * if not.
    */
+  @Override
   public List<String> getFilterItemsAsList() {
     final String inOp = QueryOperator.IN.getValue().toLowerCase();
     final int opLen = inOp.length() + 1;
@@ -427,6 +428,7 @@ public class BaseDimensionalObject extends BaseNameableObject implements Dimensi
     return items;
   }
 
+  @Override
   public void setItems(List<DimensionalItemObject> items) {
     this.items = items;
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
@@ -102,7 +102,7 @@ public interface DimensionalObject extends NameableObject, GroupableItem {
           PERIOD_DIM_ID, new MetadataItem("Period"),
           ORGUNIT_DIM_ID, new MetadataItem("Organisation unit"));
 
-  Set<Class<? extends BaseDimensionalObject>> DYNAMIC_DIMENSION_CLASSES =
+  Set<Class<? extends DimensionalObject>> DYNAMIC_DIMENSION_CLASSES =
       Set.of(
           Category.class,
           DataElementGroupSet.class,
@@ -163,6 +163,10 @@ public interface DimensionalObject extends NameableObject, GroupableItem {
   /** Dimension items. */
   List<DimensionalItemObject> getItems();
 
+  default void setItems(List<DimensionalItemObject> items) {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not have items");
+  }
+
   /** Indicates whether all available items in this dimension are included. */
   boolean isAllItems();
 
@@ -215,6 +219,8 @@ public interface DimensionalObject extends NameableObject, GroupableItem {
    * returned as is for all dimension items in the response.
    */
   boolean isFixed();
+
+  List<String> getFilterItemsAsList();
 
   /** Returns a unique key representing this dimension. */
   String getKey();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -182,7 +182,7 @@ public class DimensionalObjectUtils {
    * @return a {@link Triple} of {@link Program}, {@link ProgramStage} and {@link
    *     BaseDimensionalObject}.
    */
-  public static Triple<Program, ProgramStage, BaseDimensionalObject> asBaseObjects(
+  public static Triple<Program, ProgramStage, DimensionalObject> asBaseObjects(
       String qualifiedDimension) {
     String[] uids = qualifiedDimension.split("\\.");
     BaseDimensionalObject dimensionalObject = new BaseDimensionalObject();
@@ -458,7 +458,7 @@ public class DimensionalObjectUtils {
       return;
     }
 
-    BaseDimensionalObject dim = (BaseDimensionalObject) dimension;
+    DimensionalObject dim = dimension;
 
     List<String> filterItems = dim.getFilterItemsAsList();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
@@ -49,7 +49,7 @@ public class PrefixedDimension {
 
   private final ProgramStage programStage;
 
-  private final BaseIdentifiableObject item;
+  private final IdentifiableObject item;
 
   private final String dimensionType;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
@@ -49,7 +49,7 @@ public class PrefixedDimension {
 
   private final ProgramStage programStage;
 
-  private final IdentifiableObject item;
+  private final BaseIdentifiableObject item;
 
   private final String dimensionType;
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
@@ -170,7 +170,7 @@ class BaseAnalyticalObjectTest {
 
     assertNotNull(result.get(), "Must have a result.");
 
-    BaseDimensionalObject baseDimensionalObject = (BaseDimensionalObject) result.get();
+    DimensionalObject baseDimensionalObject = result.get();
 
     assertEquals(PROGRAM_DATA_ELEMENT, baseDimensionalObject.getDimensionType());
     assertEquals(dimensionUid, baseDimensionalObject.getDimension());
@@ -211,10 +211,8 @@ class BaseAnalyticalObjectTest {
 
     ev.populateDimensions(sameDimensions, dimensionalObjects);
 
-    BaseDimensionalObject baseDimensionalObject1 =
-        (BaseDimensionalObject) dimensionalObjects.get(0);
-    BaseDimensionalObject baseDimensionalObject2 =
-        (BaseDimensionalObject) dimensionalObjects.get(1);
+    DimensionalObject baseDimensionalObject1 = dimensionalObjects.get(0);
+    DimensionalObject baseDimensionalObject2 = dimensionalObjects.get(1);
 
     assertEquals(2, dimensionalObjects.size());
     assertEquals(PROGRAM_DATA_ELEMENT, baseDimensionalObject1.getDimensionType());

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseDimensionalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseDimensionalObjectTest.java
@@ -73,7 +73,7 @@ class BaseDimensionalObjectTest {
     target.setDimensionalKeywords(
         new DimensionItemKeywords(
             rnd.objects(BaseIdentifiableObject.class, 5).collect(Collectors.toList())));
-    BaseDimensionalObject cloned = (BaseDimensionalObject) target.instance();
+    DimensionalObject cloned = target.instance();
     assertThat(cloned.getName(), is(target.getName()));
     assertThat(cloned.getUid(), is(target.getUid()));
     assertThat(cloned.getDimensionType(), is(target.getDimensionType()));

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +44,7 @@ class DimensionalObjectTest {
 
   @Test
   void testGetFilterItemsAsList() {
-    BaseDimensionalObject objectA =
+    DimensionalObject objectA =
         new BaseDimensionalObject(
             "dimA",
             DimensionType.PROGRAM_DATA_ELEMENT,
@@ -54,9 +55,9 @@ class DimensionalObjectTest {
             "IN:uidA;uidB;uidC");
     List<String> expectedA = new ArrayList<>(Arrays.asList("uidA", "uidB", "uidC"));
     assertEquals(expectedA, objectA.getFilterItemsAsList());
-    BaseDimensionalObject objectB =
+    DimensionalObject objectB =
         new BaseDimensionalObject(
             "dimA", DimensionType.PROGRAM_DATA_ELEMENT, null, null, null, null, "EQ:uidA");
-    assertEquals(null, objectB.getFilterItemsAsList());
+    assertNull(objectB.getFilterItemsAsList());
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
@@ -296,7 +296,7 @@ class DimensionalObjectUtilsTest {
   void testLinkAssociationsSuccessfully() {
     // Given
     EventAnalyticalObject eventAnalyticalObject = stubEventAnalyticalObject();
-    BaseDimensionalObject dimensionalObject = stubDimensionalObject();
+    DimensionalObject dimensionalObject = stubDimensionalObject();
     org.hisp.dhis.eventvisualization.Attribute parent = COLUMN;
 
     // When
@@ -310,7 +310,7 @@ class DimensionalObjectUtilsTest {
   void testLinkAssociationsDoesNotFindValidAssociation() {
     // Given
     EventAnalyticalObject eventAnalyticalObject = stubEventAnalyticalObject();
-    BaseDimensionalObject dimensionalObject = stubDimensionalObject();
+    DimensionalObject dimensionalObject = stubDimensionalObject();
     dimensionalObject.setUid("nonLinkableUid");
     org.hisp.dhis.eventvisualization.Attribute parent = COLUMN;
 
@@ -325,7 +325,7 @@ class DimensionalObjectUtilsTest {
   void testLinkAssociationsWithProgramAndStage() {
     // Given
     EventAnalyticalObject eventAnalyticalObject = stubEventAnalyticalObject();
-    BaseDimensionalObject dimensionalObject = stubDimensionalObject();
+    DimensionalObject dimensionalObject = stubDimensionalObject();
     org.hisp.dhis.eventvisualization.Attribute parent = COLUMN;
 
     // When
@@ -471,7 +471,7 @@ class DimensionalObjectUtilsTest {
     String qualifiedDim = "programUid.programStageUid.dimensionUid";
 
     // When
-    Triple<Program, ProgramStage, BaseDimensionalObject> result = asBaseObjects(qualifiedDim);
+    Triple<Program, ProgramStage, DimensionalObject> result = asBaseObjects(qualifiedDim);
 
     // Then
     assertEquals("programUid", result.getLeft().getUid());
@@ -485,7 +485,7 @@ class DimensionalObjectUtilsTest {
     String qualifiedDim = "programUid.dimensionUid";
 
     // When
-    Triple<Program, ProgramStage, BaseDimensionalObject> result = asBaseObjects(qualifiedDim);
+    Triple<Program, ProgramStage, DimensionalObject> result = asBaseObjects(qualifiedDim);
 
     // Then
     assertEquals("programUid", result.getLeft().getUid());
@@ -499,7 +499,7 @@ class DimensionalObjectUtilsTest {
     String qualifiedDim = "dimensionUid";
 
     // When
-    Triple<Program, ProgramStage, BaseDimensionalObject> result = asBaseObjects(qualifiedDim);
+    Triple<Program, ProgramStage, DimensionalObject> result = asBaseObjects(qualifiedDim);
 
     // Then
     assertNull(result.getLeft());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -207,7 +207,7 @@ public class DataQueryParams {
 
   public static final int NUMERATOR_DENOMINATOR_PROPERTIES_COUNT = 5;
 
-  public static final Set<Class<? extends BaseDimensionalObject>> DYNAMIC_DIM_CLASSES =
+  public static final Set<Class<? extends DimensionalObject>> DYNAMIC_DIM_CLASSES =
       Set.of(
           OrganisationUnitGroupSet.class,
           DataElementGroupSet.class,
@@ -1625,7 +1625,7 @@ public class DataQueryParams {
   /** Sets the items for the given dimension, if the dimension exists. */
   private DataQueryParams setDimensionOptions(
       String dimension, List<DimensionalItemObject> options) {
-    BaseDimensionalObject dim = (BaseDimensionalObject) getDimension(dimension);
+    DimensionalObject dim = getDimension(dimension);
 
     if (dim != null) {
       dim.setItems(options);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -430,7 +430,7 @@ public class DefaultDataQueryService implements DataQueryService {
       return new BaseDimensionalObject(
           dimension, STATIC, null, DISPLAY_NAME_LATITUDE, new ArrayList<>());
     } else {
-      Optional<BaseDimensionalObject> baseDimensionalObject =
+      Optional<DimensionalObject> baseDimensionalObject =
           dimensionalObjectProducer.getDynamicDimension(
               dimension, items, displayProperty, inputIdScheme);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
@@ -139,7 +139,7 @@ public class DimensionalObjectProvider {
    * @param inputIdScheme the identifier scheme to use.
    * @return a dimension based instance of {@link BaseDimensionalObject}.
    */
-  public BaseDimensionalObject getDimension(List<String> items, IdScheme inputIdScheme) {
+  public DimensionalObject getDimension(List<String> items, IdScheme inputIdScheme) {
     List<DimensionalItemObject> dataDimensionItems = new ArrayList<>();
     DimensionItemKeywords dimensionalKeywords = new DimensionItemKeywords();
 
@@ -190,7 +190,7 @@ public class DimensionalObjectProvider {
    * @param relativePeriodDate date that relative periods will be generated based on.
    * @return a period based instance of {@link BaseDimensionalObject}.
    */
-  public BaseDimensionalObject getPeriodDimension(List<String> items, Date relativePeriodDate) {
+  public DimensionalObject getPeriodDimension(List<String> items, Date relativePeriodDate) {
     List<Period> periods = new ArrayList<>();
     DimensionItemKeywords dimensionalKeywords = new DimensionItemKeywords();
     AnalyticsFinancialYearStartKey financialYearStart =
@@ -360,7 +360,7 @@ public class DimensionalObjectProvider {
    * @param inputIdScheme the identifier scheme to use.
    * @return an organisation unit based instance of {@link BaseDimensionalObject}.
    */
-  public BaseDimensionalObject getOrgUnitDimension(
+  public DimensionalObject getOrgUnitDimension(
       List<String> items,
       DisplayProperty displayProperty,
       List<OrganisationUnit> userOrgUnits,
@@ -511,8 +511,7 @@ public class DimensionalObjectProvider {
    * @param inputIdScheme the identifier scheme to use.
    * @return an organisation unit group based instance of {@link BaseDimensionalObject}.
    */
-  public BaseDimensionalObject getOrgUnitGroupDimension(
-      List<String> items, IdScheme inputIdScheme) {
+  public DimensionalObject getOrgUnitGroupDimension(List<String> items, IdScheme inputIdScheme) {
     List<DimensionalItemObject> ougs = new ArrayList<>();
 
     for (String uid : items) {
@@ -541,7 +540,7 @@ public class DimensionalObjectProvider {
    * @return an {@link Optional} of a dynamic dimension based instance of {@link
    *     BaseDimensionalObject}.
    */
-  public Optional<BaseDimensionalObject> getDynamicDimension(
+  public Optional<DimensionalObject> getDynamicDimension(
       String dimension,
       List<String> items,
       DisplayProperty displayProperty,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -295,7 +295,7 @@ public class JdbcSubexpressionQueryGenerator {
   private DataQueryParams getParamsWithPeriodType(DataQueryParams query) {
     String periodType = query.getPeriodType();
     if (periodType != null) {
-      BaseDimensionalObject periodDim =
+      DimensionalObject periodDim =
           new BaseDimensionalObject(
               DimensionalObject.PERIOD_DIM_ID,
               DimensionType.PERIOD,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -43,7 +43,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.data.DimensionalObjectProvider;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -213,7 +213,7 @@ public class OutlierQueryParser {
       Set<OrganisationUnit> organisationUnitsSecurityConstrain,
       Set<String> organisationUnits,
       User currentUser) {
-    BaseDimensionalObject orgUnitDimension =
+    DimensionalObject orgUnitDimension =
         dimensionalObjectProducer.getOrgUnitDimension(
             organisationUnits.stream().toList(),
             DisplayProperty.NAME,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
@@ -68,6 +68,7 @@ import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -272,7 +273,7 @@ class GridAdaptorTest extends TestBase {
 
   private DimensionIdentifier<DimensionParam> stubDimensionIdentifier(
       List<String> ous, String programUid, String programStageUid, String dimensionUid) {
-    BaseDimensionalObject tea =
+    DimensionalObject tea =
         new BaseDimensionalObject(
             dimensionUid,
             DATA_X,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/CommonRequestParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/CommonRequestParamsMapperTest.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.analytics.common.params.dimension.StringUid;
 import org.hisp.dhis.analytics.event.EventDataQueryService;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionItemKeywords;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.dataelement.DataElement;
@@ -118,7 +119,7 @@ class CommonRequestParamsMapperTest {
             ElementWithOffset.of(programStage1, 2),
             StringUid.of("yLIPuJHRgey"));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         new BaseDimensionalObject(
             deDimensionIdentifier.getDimension().getUid(),
             DATA_X,
@@ -218,7 +219,7 @@ class CommonRequestParamsMapperTest {
             ElementWithOffset.of(programStage1, 2),
             StringUid.of(queryItem));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         new BaseDimensionalObject(
             deDimensionIdentifier.getDimension().getUid(),
             DATA_X,
@@ -320,7 +321,7 @@ class CommonRequestParamsMapperTest {
             ElementWithOffset.of(programStage1, 2),
             StringUid.of(orgUnitDimension));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         new BaseDimensionalObject(
             deDimensionIdentifier.getDimension().getUid(),
             DATA_X,
@@ -329,7 +330,7 @@ class CommonRequestParamsMapperTest {
             emptyList(),
             new DimensionItemKeywords());
 
-    BaseDimensionalObject orgUnitObject =
+    DimensionalObject orgUnitObject =
         new BaseDimensionalObject(
             ouDimensionIdentifier.getDimension().getUid(),
             ORGANISATION_UNIT,
@@ -631,7 +632,7 @@ class CommonRequestParamsMapperTest {
             ElementWithOffset.of(programStage1, 2),
             StringUid.of("yLIPuJHRgey"));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         new BaseDimensionalObject(
             deDimensionIdentifier.getDimension().getUid(),
             DATA_X,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProviderTest.java
@@ -75,11 +75,11 @@ import org.hisp.dhis.analytics.common.processing.MetadataDimensionsHandler;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionItemKeywords;
 import org.hisp.dhis.common.DimensionItemKeywords.Keyword;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -157,7 +157,7 @@ class DimensionalObjectProviderTest {
 
     List<String> itemsUid = List.of("IN_GROUP-" + indicatorGroupUid, "IN_GROUP-Behv9EO3hR1");
 
-    BaseDimensionalObject dimensionalObject = target.getDimension(itemsUid, UID);
+    DimensionalObject dimensionalObject = target.getDimension(itemsUid, UID);
 
     assertEquals("dx", dimensionalObject.getDimension());
     assertEquals("dx", dimensionalObject.getUid());
@@ -189,7 +189,7 @@ class DimensionalObjectProviderTest {
 
     List<String> itemsUid = List.of("DE_GROUP-" + deGroupUid, "DE_GROUP-Behv9EO3hR1");
 
-    BaseDimensionalObject dimensionalObject = target.getDimension(itemsUid, NAME);
+    DimensionalObject dimensionalObject = target.getDimension(itemsUid, NAME);
 
     assertEquals("dx", dimensionalObject.getDimension());
     assertEquals("dx", dimensionalObject.getUid());
@@ -236,7 +236,7 @@ class DimensionalObjectProviderTest {
             "LEVEL-" + ou1.getUid(),
             "OU_GROUP-" + ou2.getUid());
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         target.getOrgUnitDimension(itemsUid, SHORTNAME, organisationUnits, UID);
 
     assertEquals("ou", dimensionalObject.getDimension());
@@ -277,7 +277,7 @@ class DimensionalObjectProviderTest {
             "LEVEL-" + level2Ou1.getName(),
             "OU_GROUP-" + level2Ou2.getUid());
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         target.getOrgUnitDimension(itemsUid, DisplayProperty.NAME, organisationUnits, UID);
 
     assertEquals("ou", dimensionalObject.getDimension());
@@ -313,7 +313,7 @@ class DimensionalObjectProviderTest {
             substringAfter("DS-lyLU2wR22tC", KEY_DATASET)))
         .thenReturn(new ArrayList<>(asList(ou1, ou2)));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         target.getOrgUnitDimension(itemsUid, DisplayProperty.NAME, organisationUnits, UID);
 
     // Then
@@ -342,7 +342,7 @@ class DimensionalObjectProviderTest {
             substringAfter("PR-lxAQ7Zs9VYR", KEY_PROGRAM)))
         .thenReturn(new ArrayList<>(asList(ou1, ou2)));
 
-    BaseDimensionalObject dimensionalObject =
+    DimensionalObject dimensionalObject =
         target.getOrgUnitDimension(itemsUid, DisplayProperty.NAME, organisationUnits, UID);
 
     // Then
@@ -380,7 +380,7 @@ class DimensionalObjectProviderTest {
 
     List<String> itemsUid = List.of("Achv9EO3hR1", "Blhv9EO3hR1");
 
-    BaseDimensionalObject dimensionalObject = target.getOrgUnitGroupDimension(itemsUid, UID);
+    DimensionalObject dimensionalObject = target.getOrgUnitGroupDimension(itemsUid, UID);
 
     assertEquals("oug", dimensionalObject.getDimension());
     assertEquals("oug", dimensionalObject.getUid());
@@ -402,7 +402,7 @@ class DimensionalObjectProviderTest {
     when(i18nManager.getI18nFormat()).thenReturn(i18nFormat);
     when(i18nManager.getI18n()).thenReturn(i18n);
 
-    BaseDimensionalObject dimensionalObject = target.getPeriodDimension(itemsUid, new Date());
+    DimensionalObject dimensionalObject = target.getPeriodDimension(itemsUid, new Date());
 
     assertEquals("pe", dimensionalObject.getDimension());
     assertEquals("pe", dimensionalObject.getUid());
@@ -445,7 +445,7 @@ class DimensionalObjectProviderTest {
     when(settings.getAnalyticsFinancialYearStart()).thenReturn(FINANCIAL_YEAR_APRIL);
     when(i18nManager.getI18nFormat()).thenReturn(i18nFormat);
 
-    BaseDimensionalObject dimensionalObject = target.getPeriodDimension(itemsUid, new Date());
+    DimensionalObject dimensionalObject = target.getPeriodDimension(itemsUid, new Date());
 
     assertEquals("pe", dimensionalObject.getDimension());
     assertEquals("pe", dimensionalObject.getUid());
@@ -474,7 +474,7 @@ class DimensionalObjectProviderTest {
 
     when(idObjectManager.get(DYNAMIC_DIM_CLASSES, UID, categoryUid)).thenReturn(category);
 
-    Optional<BaseDimensionalObject> dimensionalObject =
+    Optional<DimensionalObject> dimensionalObject =
         target.getDynamicDimension(categoryUid, itemsUid, DisplayProperty.NAME, UID);
 
     assertEquals(categoryUid, dimensionalObject.get().getDimension());
@@ -501,7 +501,7 @@ class DimensionalObjectProviderTest {
     when(aclService.canDataOrMetadataRead(any(UserDetails.class), any(CategoryOption.class)))
         .thenReturn(true);
 
-    Optional<BaseDimensionalObject> dimensionalObject =
+    Optional<DimensionalObject> dimensionalObject =
         target.getDynamicDimension(categoryUid, items, DisplayProperty.NAME, UID);
 
     // then
@@ -521,8 +521,7 @@ class DimensionalObjectProviderTest {
     when(i18nManager.getI18n()).thenReturn(i18n);
 
     // When
-    BaseDimensionalObject baseDimensionalObject =
-        target.getPeriodDimension(periods, aDayOfJune2024);
+    DimensionalObject baseDimensionalObject = target.getPeriodDimension(periods, aDayOfJune2024);
 
     // Then
     List<DimensionalItemObject> items = baseDimensionalObject.getItems();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElementDomain;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -336,7 +337,7 @@ class QueryPlannerGroupByAggregationTypeTest {
     assertThat(dataQueryParam.getFilterOrganisationUnits(), hasSize(1));
   }
 
-  private DataQueryParams createDataQueryParams(BaseDimensionalObject filterDataElements) {
+  private DataQueryParams createDataQueryParams(DimensionalObject filterDataElements) {
     List<DimensionalItemObject> periods = new ArrayList<>();
     periods.add(new MonthlyPeriodType().createPeriod(new DateTime(2014, 4, 1, 0, 0).toDate()));
 
@@ -359,7 +360,7 @@ class QueryPlannerGroupByAggregationTypeTest {
   }
 
   private DataQueryParams createDataQueryParamsWithAggregationType(
-      BaseDimensionalObject filterDataElements, AnalyticsAggregationType analyticsAggregationType) {
+      DimensionalObject filterDataElements, AnalyticsAggregationType analyticsAggregationType) {
     return createDataQueryParams(filterDataElements)
         .copyTo(DataQueryParams.newBuilder().withAggregationType(analyticsAggregationType).build());
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParserTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.analytics.data.DimensionalObjectProvider;
 import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -81,7 +82,7 @@ class OutlierQueryParserTest {
         .thenReturn(List.of(dataElement));
 
     OrganisationUnit organisationUnit = createOrganisationUnit('O');
-    BaseDimensionalObject baseDimensionalObject = new BaseDimensionalObject();
+    DimensionalObject baseDimensionalObject = new BaseDimensionalObject();
     baseDimensionalObject.setItems(List.of(organisationUnit));
     lenient()
         .when(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -74,7 +74,6 @@ import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.category.CategoryOptionGroupSetDimension;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseAnalyticalObject;
-import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
@@ -323,12 +322,12 @@ public class DefaultDimensionService implements DimensionService {
   @Transactional(readOnly = true)
   public DimensionalObject getDimensionalObjectCopy(String uid, boolean filterCanRead)
       throws NotFoundException {
-    BaseDimensionalObject dimension =
+    DimensionalObject dimension =
         idObjectManager.get(DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid);
     if (dimension == null) {
       throw new NotFoundException("Dimension does not exist: " + uid);
     }
-    BaseDimensionalObject copy = metadataMergeService.clone(dimension);
+    DimensionalObject copy = metadataMergeService.clone(dimension);
 
     if (filterCanRead) {
       UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -88,6 +88,7 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -1612,11 +1613,11 @@ class EventAnalyticsServiceTest extends PostgresIntegrationTestBase {
 
   /** Params builder A for getting enrollments. */
   private EventQueryParams.Builder getEnrollmentQueryBuilderA() {
-    BaseDimensionalObject periodDimension =
+    DimensionalObject periodDimension =
         new BaseDimensionalObject(
             PERIOD_DIM_ID, DimensionType.PERIOD, getList(peJan, peFeb, peMar));
 
-    BaseDimensionalObject orgUnitDimension =
+    DimensionalObject orgUnitDimension =
         new BaseDimensionalObject(ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, getList(ouA));
 
     return getBaseEventQueryParamsBuilder()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
@@ -428,7 +428,7 @@ class DimensionServiceTest extends PostgresIntegrationTestBase {
   @Test
   void testMergeAnalyticalObjectB() {
     Visualization visualization = new Visualization();
-    BaseDimensionalObject deCDim =
+    DimensionalObject deCDim =
         new BaseDimensionalObject(
             deC.getUid(), DimensionType.PROGRAM_DATA_ELEMENT, null, null, null, psA, "EQ:uidA");
     visualization.getColumns().add(deCDim);
@@ -459,7 +459,7 @@ class DimensionServiceTest extends PostgresIntegrationTestBase {
   void testMergeAnalyticalEventObjectB() {
     // Given
     EventVisualization eventVisualization = new EventVisualization("any");
-    BaseDimensionalObject deCDim =
+    DimensionalObject deCDim =
         new BaseDimensionalObject(
             deC.getUid(), DimensionType.PROGRAM_DATA_ELEMENT, null, null, null, psA, "EQ:uidA");
     eventVisualization.getColumns().add(deCDim);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -44,7 +44,6 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.dimension.AnalyticsDimensionService;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DataQueryRequest;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -85,7 +84,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.EntityType(BaseDimensionalObject.class)
+@OpenApi.EntityType(DimensionalObject.class)
 @OpenApi.Document(classifiers = {"team:analytics", "purpose:metadata"})
 @Controller
 @RequestMapping("/api/dimensions")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/BaseDimensionalObjectMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/BaseDimensionalObjectMapper.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import lombok.Getter;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
-import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.webapi.dimension.BaseDimensionMapper;
@@ -51,7 +51,7 @@ public class BaseDimensionalObjectMapper extends BaseDimensionMapper {
   @Override
   public DimensionResponse map(PrefixedDimension prefixedDimension, String prefix) {
     String dimensionType =
-        ((BaseDimensionalObject) prefixedDimension.getItem()).getDimensionType().name();
+        ((DimensionalObject) prefixedDimension.getItem()).getDimensionType().name();
     return super.map(prefixedDimension, prefix)
         .withDimensionType(dimensionTypeOrElse(prefixedDimension, dimensionType));
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.analytics.data.DimensionalObjectProvider;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
@@ -107,7 +108,7 @@ class AnalyticsControllerTest {
     when(dimensionalObjectProducer.getPeriodDimension(Mockito.any(), Mockito.any()))
         .thenAnswer(
             (invocation) -> {
-              BaseDimensionalObject period = mock(BaseDimensionalObject.class);
+              DimensionalObject period = mock(BaseDimensionalObject.class);
 
               when(period.getDimensionType()).thenReturn(DimensionType.PERIOD);
 


### PR DESCRIPTION
Uses `DimensionalObject` instead of `BaseDimensionalObject` where possible.

There are plenty of usages of `BaseDimensionalObject` left but most of them are `new BaseDimensionalObject` calls in tests and in places where these are used as transient objects. 