### PR TITLE
feat: Add support for GZIPPED JSON/CSV min/max payloads

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -163,6 +163,7 @@ public enum ErrorCode {
   E2045("Case insensitive operators can only be used with constant values"),
   E2046("Error parsing CSV file: {0}"),
   E2047("Data value key combination does not exist: {0}"),
+  E2048("Failure to read gzipped min max payload: {0}"),
 
   /* Outlier detection */
   E2200("At least one data element must be specified"),


### PR DESCRIPTION
While testing this feature, it became fairly obvious that these CSV/JSON payloads of bulk min/max values can fairly easily exceed the limit imposed by the reverse proxy on body size. Adding support for GZIPPED payloads should speed things up a bit for larger payload sizes, without having to chunk things on the client side. 

@jbee I need your help/guidance with tests. It looks like the current HttpClientAdapter does not support binary bodies very well. I think you preferred the integration tests over the E2E tests where making a test for this might be a bit easier. Otherwise,I need some help there when you get a chance. 