### PR TITLE
fix: use logger name in default log configuration

### DIFF
--- a/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         pattern="%d{HH:mm:ss.SSS} %highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%15.15t] %style{%-40.40C{1.}}{cyan} : %m%n%throwable"/>
     </Console>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t]) %X{sessionId} %X{xRequestID}%n"/>
+      <PatternLayout pattern="* %-5p %d{ISO8601} %m (%c{1} [%t]) %X{sessionId} %X{xRequestID}%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
### Summary
Using `%F` means _"the class name of the class that called the logger method"_.  I propose that the better and less confusing name to use is `%c{1}` which means the name of the logger (`%c`) as simple name (`{1}`), meaning if there is a package name in the logger name cut it out.

### Confusion
This can be very confusing if meta-programming is used to resolve different loggers. 
With `%F` the log line would state the name of the class containing the meta-logging code.
If someone would want to configure the log level based they are likely to mistakenly assume that the class name in the logs would be the target of the level change. But that is not correct. The target still needs to be selected based on the logger name.
Also using `%F` defies the purpose or usefulness of resolving different loggers because it does no longer matter which logger a log is written to, the name in the log entry will always be the one containing the code that calls the "logger.log" method.
That is why it is more useful and less confusing to use `%c` or `%c{1}`.

### Performance
Using `%F` is also discouraged since it has a larger performance overhead. This is because in order to find which class called the logger method the framework needs to throw a fake exception, catch it and look at the stack trace to find this out. This overhead does not exist with `%c`. 