### PR TITLE
fix: Set issuer URI for Azure AD OIDC provider

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
@@ -116,6 +116,7 @@ public class AzureAdProvider extends AbstractOidcProvider {
     builder.authorizationUri(tenantUriStart + "/oauth2/v2.0/authorize");
     builder.tokenUri(tenantUriStart + "/oauth2/v2.0/token");
     builder.jwkSetUri(tenantUriStart + "/discovery/v2.0/keys");
+    builder.issuerUri(tenantUriStart + "/v2.0");
     builder.userInfoUri("https://graph.microsoft.com/oidc/userinfo");
     builder.redirectUri(
         StringUtils.firstNonBlank(

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/AzureProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/AzureProviderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oidc.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Properties;
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AzureProviderTest {
+
+  @Test
+  @DisplayName("AzureAdProvider issuer URI is present and has the expected format")
+  void azureAdProviderIssuerUriTest() {
+    // given
+    Properties config = new Properties();
+    config.put("oidc.provider.azure.0.tenant", "123");
+    config.put("oidc.provider.azure.0.client_id", "id123");
+    config.put("oidc.provider.azure.0.client_secret", "secret123");
+
+    // when
+    List<DhisOidcClientRegistration> parse = AzureAdProvider.parse(config);
+
+    // then
+    DhisOidcClientRegistration clientReg = parse.get(0);
+    String issuerUri = clientReg.getClientRegistration().getProviderDetails().getIssuerUri();
+    assertEquals("https://login.microsoftonline.com/123/v2.0", issuerUri);
+  }
+}


### PR DESCRIPTION
Backport of: https://github.com/dhis2/dhis2-core/pull/20906
* fix: Set issuer URI for Azure AD provider to resolve login failures (#20906)