### PR TITLE
feat(route): add support for additional response headers in RouteService

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -732,6 +732,14 @@ public enum ConfigurationKey {
    */
   ROUTE_REMOTE_SERVERS_ALLOWED("route.remote_servers_allowed", "https://*", false),
 
+  /**
+   * Additional response headers allowed to pass through from the Route endpoint. <br>
+   * These headers are added to the default set of common response headers. <br>
+   * Headers should be in a comma-separated style <br>
+   * e.g. route.response_headers_allowed = x-custom-header,x-api-version
+   */
+  ROUTE_RESPONSE_HEADERS_ALLOWED("route.response_headers_allowed", "", false),
+
   /** Enable OAuth2 authentication server. (default: off) */
   OAUTH2_SERVER_ENABLED("oauth2.server.enabled", Constants.OFF, false),
 


### PR DESCRIPTION
Summary:
- Sometimes it would be really useful to allow preconfigured response headers that should be forwarded to the client. This is typically important when you do not control the upstream service, but rely on headers for functionality.
- I know this is potentially quite dangerous, so would love some extra focus on sec


- This PR adds a new field in dhis.conf that enables the system admin to define allowed response headers through the route API. 