### PR TITLE
chore: Set test config (connection pool max size) to match default production config 80

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -1,6 +1,6 @@
 filestore.provider = transient
 filestore.container = files
-connection.pool.max_size=50
+connection.pool.max_size=80
 encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 
 hibernate.cache.use_query_cache=true


### PR DESCRIPTION
Integration tests are starting to throw errors some times like:
```text
java.sql.SQLException: Connections could not be acquired from the underlying database!
```

This change ensures that we are using the same default DB connection config that we use in production.

Test config changing from: `connection.pool.max_size=50` to `connection.pool.max_size=80`