### PR TITLE
fix: wrong manifest returned by app controller

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -40,6 +40,7 @@ import org.springframework.core.io.Resource;
  * @author Saptarshi Purkayastha
  */
 public interface AppManager {
+
   static final String ID = AppManager.class.getName();
 
   static final String BUNDLED_APP_PREFIX = "dhis-web-";
@@ -285,4 +286,15 @@ public interface AppManager {
         .filter(app -> app.getPluginType().equals(pluginType))
         .toList();
   }
+
+  /**
+   * Handles the manifest.webapp file by checking if the href for the dhis activity is set to "*".
+   * If so, it replaces it with the context path.
+   *
+   * @param resource the resource being handled
+   * @param application the application containing activities
+   * @param contextPath the context path to set if needed
+   * @return true if the manifest was handled, false otherwise
+   */
+  boolean handlingManifest(String resource, App application, String contextPath);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -417,6 +417,23 @@ public class DefaultAppManager implements AppManager {
     }
   }
 
+  @Override
+  public boolean handlingManifest(String resource, App application, String contextPath) {
+    if (!resource.contains("manifest.webapp")) {
+      return false;
+    }
+    // If request was for manifest.webapp, check for * and replace with
+    // host
+    if (application.getActivities() != null
+        && application.getActivities().getDhis() != null
+        && "*".equals(application.getActivities().getDhis().getHref())) {
+      application.getActivities().getDhis().setHref(contextPath);
+      log.debug(String.format("Manifest context path: '%s'", contextPath));
+      return true;
+    }
+    return false;
+  }
+
   // -------------------------------------------------------------------------
   // Supportive methods
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.hisp.dhis.appmanager.App;
+import org.hisp.dhis.appmanager.AppActivities;
+import org.hisp.dhis.appmanager.AppDhis;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.appmanager.ResourceResult.Redirect;
@@ -166,5 +168,24 @@ class AppManagerTest extends IntegrationTestBase {
 
     // then
     assertEquals(-1, uriContentLength);
+  }
+
+  @Test
+  void handlingManifestTest() {
+    // given
+    AppDhis appDhis = new AppDhis();
+    appDhis.setHref("*");
+    AppActivities activities = new AppActivities();
+    activities.setDhis(appDhis);
+    App app = new App();
+    app.setName("test-app");
+    app.setVersion("1.0.0");
+    app.setPluginType("test-plugin");
+    app.setActivities(activities);
+    String resource = "/manifest.webapp";
+    String contextPath = "test-context-path";
+
+    appManager.handlingManifest(resource, app, contextPath);
+    assertEquals("test-context-path", app.getActivities().getDhis().getHref());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -243,18 +243,7 @@ public class AppController {
 
     log.debug(String.format("App resource name: '%s'", resource));
 
-    // Handling of 'manifest.webapp'
-    if ("manifest.webapp".equals(resource)) {
-      // If request was for manifest.webapp, check for * and replace with
-      // host
-      if (application.getActivities() != null
-          && application.getActivities().getDhis() != null
-          && "*".equals(application.getActivities().getDhis().getHref())) {
-        log.debug(String.format("Manifest context path: '%s'", contextPath));
-
-        application.getActivities().getDhis().setHref(contextPath);
-      }
-
+    if (appManager.handlingManifest(resource, application, contextPath)) {
       jsonMapper.writeValue(response.getOutputStream(), application);
     }
     // Any other resource


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-19708

### Issue
- The check condition for `manifest.webapp` return false because the input argument was `/manifest.webapp`. 

### New functionality:
* Changed the condition so it will return true even if the input contains `/` in the beginning.
* Move the related code to service layer so I can add test for it.

### Refactoring:
* Refactored the `AppController` to delegate the handling of `manifest.webapp` to the `AppManager`'s `handlingManifest` method, removing duplicate logic from the controller.

### Testing:
* Added a new unit test, `handlingManifestTest`, to verify the behavior of the `handlingManifest` method, ensuring that the `href` is correctly updated when it is set to `*`.

