### PR TITLE
chore: Create single and tracker event class in importer [DHIS2-19701]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -53,8 +53,10 @@ import org.hisp.dhis.tracker.imports.ValidationMode;
 import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
+import org.hisp.dhis.tracker.imports.domain.SingleEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.imports.programrule.executor.RuleActionExecutor;
@@ -163,6 +165,24 @@ public class TrackerBundle {
 
   public Set<UID> getUpdatedTrackedEntities() {
     return Set.copyOf(this.updatedTrackedEntities);
+  }
+
+  public List<SingleEvent> getSingleEvents() {
+    return this.events.stream()
+        .filter(event -> preheat.getProgram(event.getProgram()) != null)
+        .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
+        .map(event -> new SingleEvent())
+        .toList();
+  }
+
+  public List<TrackerEvent> getTrackerEvents() {
+    return this.events.stream()
+        .filter(
+            event ->
+                preheat.getProgram(event.getProgram()) == null
+                    || preheat.getProgram(event.getProgram()).isRegistration())
+        .map(event -> new TrackerEvent())
+        .toList();
   }
 
   public void addUpdatedTrackedEntities(Set<UID> updatedTrackedEntities) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
@@ -29,79 +29,66 @@
  */
 package org.hisp.dhis.tracker.imports.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.tracker.TrackerType;
 import org.locationtech.jts.geom.Geometry;
 
-@JsonDeserialize(as = TrackerEvent.class)
-@JsonSerialize(as = TrackerEvent.class)
-public interface Event extends TrackerDto, Serializable {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleEvent implements TrackerDto, Serializable {
+  @Nonnull @JsonProperty private UID singleEvent;
+
+  @JsonProperty @Builder.Default private EventStatus status = EventStatus.ACTIVE;
+
+  @JsonProperty private MetadataIdentifier program;
+
+  @JsonProperty private MetadataIdentifier orgUnit;
+
+  @JsonProperty private Instant occurredAt;
+
+  @JsonProperty private String storedBy;
+
+  @JsonProperty private Instant createdAtClient;
+
+  @JsonProperty private Instant updatedAtClient;
+
+  @JsonProperty private MetadataIdentifier attributeOptionCombo;
+
+  @JsonProperty @Builder.Default
+  private Set<MetadataIdentifier> attributeCategoryOptions = new HashSet<>();
+
+  @JsonProperty private Instant completedAt;
+
+  @JsonProperty private Geometry geometry;
+
+  @JsonProperty private User assignedUser;
+
+  @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
+
+  @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
 
   @Override
-  default TrackerType getTrackerType() {
+  public UID getUid() {
+    return this.singleEvent;
+  }
+
+  @Override
+  public TrackerType getTrackerType() {
     return TrackerType.EVENT;
   }
-
-  UID getEvent();
-
-  EventStatus getStatus();
-
-  MetadataIdentifier getProgram();
-
-  MetadataIdentifier getProgramStage();
-
-  UID getEnrollment();
-
-  MetadataIdentifier getOrgUnit();
-
-  Instant getOccurredAt();
-
-  Instant getScheduledAt();
-
-  String getStoredBy();
-
-  Instant getCreatedAtClient();
-
-  Instant getUpdatedAtClient();
-
-  MetadataIdentifier getAttributeOptionCombo();
-
-  Set<MetadataIdentifier> getAttributeCategoryOptions();
-
-  Instant getCompletedAt();
-
-  Geometry getGeometry();
-
-  User getAssignedUser();
-
-  Set<DataValue> getDataValues();
-
-  List<Note> getNotes();
-
-  @JsonIgnore
-  default boolean isCreatableInSearchScope() {
-    return this.getStatus() == EventStatus.SCHEDULE
-        && this.getDataValues().isEmpty()
-        && this.getOccurredAt() == null;
-  }
-
-  void setEnrollment(UID of);
-
-  void setStatus(EventStatus eventStatus);
-
-  void setProgram(MetadataIdentifier metadataIdentifier);
-
-  void setProgramStage(MetadataIdentifier metadataIdentifier);
-
-  void setAttributeOptionCombo(MetadataIdentifier categoryOptionComboIdentifier);
-
-  void setNotes(List<Note> notes);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerEvent.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerEvent.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.event.EventStatus;
+import org.locationtech.jts.geom.Geometry;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrackerEvent implements Event {
+  @Nonnull @JsonProperty private UID event;
+
+  @JsonProperty @Builder.Default private EventStatus status = EventStatus.ACTIVE;
+
+  @JsonProperty private MetadataIdentifier program;
+
+  @JsonProperty private MetadataIdentifier programStage;
+
+  @JsonProperty private UID enrollment;
+
+  @JsonProperty private MetadataIdentifier orgUnit;
+
+  @JsonProperty private Instant occurredAt;
+
+  @JsonProperty private Instant scheduledAt;
+
+  @JsonProperty private String storedBy;
+
+  @JsonProperty private Instant createdAtClient;
+
+  @JsonProperty private Instant updatedAtClient;
+
+  @JsonProperty private MetadataIdentifier attributeOptionCombo;
+
+  @JsonProperty @Builder.Default
+  private Set<MetadataIdentifier> attributeCategoryOptions = new HashSet<>();
+
+  @JsonProperty private Instant completedAt;
+
+  @JsonProperty private Geometry geometry;
+
+  @JsonProperty private User assignedUser;
+
+  @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
+
+  @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
+
+  @Override
+  public UID getUid() {
+    return this.event;
+  }
+
+  public static TrackerEventBuilder builderFromEvent(Event event) {
+    return builderFromEvent(event, event.getEvent());
+  }
+
+  public static TrackerEventBuilder builderFromEvent(Event event, UID eventUid) {
+    return TrackerEvent.builder()
+        .event(eventUid)
+        .status(event.getStatus())
+        .program(event.getProgram())
+        .programStage(event.getProgramStage())
+        .enrollment(event.getEnrollment())
+        .orgUnit(event.getOrgUnit())
+        .occurredAt(event.getOccurredAt())
+        .scheduledAt(event.getScheduledAt())
+        .storedBy(event.getStoredBy())
+        .createdAtClient(event.getCreatedAtClient())
+        .updatedAtClient(event.getUpdatedAtClient())
+        .attributeOptionCombo(event.getAttributeOptionCombo())
+        .attributeCategoryOptions(event.getAttributeCategoryOptions())
+        .geometry(event.getGeometry())
+        .assignedUser(event.getAssignedUser())
+        .completedAt(event.getCompletedAt())
+        .dataValues(event.getDataValues())
+        .notes(event.getNotes());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListener.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.smscompression.models.SmsSubmission;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
-import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Status;
@@ -93,7 +93,8 @@ public class DeleteEventSMSListener extends CompressionSMSListener {
   @Nonnull
   private static TrackerObjects map(@Nonnull DeleteSmsSubmission submission) {
     return TrackerObjects.builder()
-        .events(List.of(Event.builder().event(UID.of(submission.getEvent().getUid())).build()))
+        .events(
+            List.of(TrackerEvent.builder().event(UID.of(submission.getEvent().getUid())).build()))
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
@@ -76,6 +76,7 @@ import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -278,7 +279,7 @@ class SmsImportMapper {
   @Nonnull
   private static Event mapToEvent(
       @Nonnull SmsEvent submission, @Nonnull String username, @Nonnull Uid enrollment) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .enrollment(UID.of(enrollment.getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
@@ -302,7 +303,7 @@ class SmsImportMapper {
   @Nonnull
   private static Event mapEvent(
       @Nonnull TrackerEventSmsSubmission submission, @Nonnull String username) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .enrollment(UID.of(submission.getEnrollment().getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
@@ -326,7 +327,7 @@ class SmsImportMapper {
   @Nonnull
   private static Event mapEvent(
       @Nonnull SimpleEventSmsSubmission submission, @Nonnull String username) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
         .program(metadataUid(submission.getEventProgram()))
@@ -505,7 +506,7 @@ class SmsImportMapper {
       @Nonnull String orgUnit,
       @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .orgUnit(MetadataIdentifier.ofUid(orgUnit))
         .program(metadataUid(smsCommand.getProgram()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 
 /**
@@ -310,7 +311,7 @@ class PersistablesFilter {
     } else if (item.getEnrollment() != null) {
       return Enrollment.builder().enrollment(item.getEnrollment()).build();
     } else if (item.getEvent() != null) {
-      return Event.builder().event(item.getEvent()).build();
+      return TrackerEvent.builder().event(item.getEvent()).build();
     }
     // only reached if a new TrackerDto implementation is added
     throw new IllegalStateException("TrackerType for relationship item not yet supported.");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.tracker.imports.domain.Note;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,7 +131,7 @@ class TrackerIdentifierCollectorTest {
   @Test
   void collectEvents() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(uid())
             .enrollment(uid())
             .program(ofAttribute("NTVsGflP5Ix", "sunshine"))
@@ -161,7 +162,7 @@ class TrackerIdentifierCollectorTest {
   @Test
   void collectEventsSkipsNotesWithoutAValue() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .notes(List.of(Note.builder().note(UID.of("i1vviSlidJE")).build()))
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleTest.java
@@ -37,8 +37,8 @@ import java.util.Collections;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.ValidationMode;
 import org.hisp.dhis.tracker.imports.domain.Enrollment;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,7 +54,7 @@ class TrackerBundleTest {
             .validationMode(ValidationMode.SKIP)
             .trackedEntities(Collections.singletonList(new TrackedEntity()))
             .enrollments(Collections.singletonList(new Enrollment()))
-            .events(Collections.singletonList(new Event()))
+            .events(Collections.singletonList(new TrackerEvent()))
             .build();
     assertEquals(AtomicMode.ALL, trackerBundle.getAtomicMode());
     assertEquals(ValidationMode.SKIP, trackerBundle.getValidationMode());
@@ -71,7 +71,7 @@ class TrackerBundleTest {
             .validationMode(ValidationMode.SKIP)
             .trackedEntities(Arrays.asList(new TrackedEntity(), new TrackedEntity()))
             .enrollments(Arrays.asList(new Enrollment(), new Enrollment()))
-            .events(Arrays.asList(new Event(), new Event()))
+            .events(Arrays.asList(new TrackerEvent(), new TrackerEvent()))
             .build();
     assertEquals(AtomicMode.ALL, trackerBundle.getAtomicMode());
     assertEquals(ValidationMode.SKIP, trackerBundle.getValidationMode());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preprocess.TrackerPreprocessService;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
@@ -91,8 +92,7 @@ class TrackerImporterServiceTest {
 
     injectSecurityContextNoSettings(user);
 
-    Event event = new Event();
-    event.setEvent(UID.generate());
+    Event event = TrackerEvent.builder().event(UID.generate()).build();
     final List<Event> events = List.of(event);
 
     params = TrackerImportParams.builder().build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
@@ -331,7 +331,7 @@ class TrackerObjectsMapperTest extends TestBase {
     preheat.putEnrollments(List.of(event(EventStatus.ACTIVE).getEnrollment()));
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(EVENT_UID)
             .enrollment(ENROLLMENT_UID)
             .status(EventStatus.COMPLETED)
@@ -355,7 +355,7 @@ class TrackerObjectsMapperTest extends TestBase {
     preheat.putEvents(List.of(dbEvent));
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(EVENT_UID)
             .enrollment(ENROLLMENT_UID)
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
@@ -380,7 +380,7 @@ class TrackerObjectsMapperTest extends TestBase {
     preheat.putEvents(List.of(dbEvent));
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(EVENT_UID)
             .enrollment(ENROLLMENT_UID)
             .status(EventStatus.COMPLETED)
@@ -412,7 +412,7 @@ class TrackerObjectsMapperTest extends TestBase {
             .build();
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(EVENT_UID)
             .enrollment(ENROLLMENT_UID)
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
@@ -443,7 +443,7 @@ class TrackerObjectsMapperTest extends TestBase {
             .build();
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(EVENT_UID)
             .enrollment(ENROLLMENT_UID)
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/job/TrackerSideValidationEffectDataBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/job/TrackerSideValidationEffectDataBundleTest.java
@@ -69,9 +69,6 @@ class TrackerSideValidationEffectDataBundleTest {
 
   @Test
   void testNotificationDataBundleForEvent() {
-    org.hisp.dhis.tracker.imports.domain.Event event =
-        new org.hisp.dhis.tracker.imports.domain.Event();
-    event.setEvent(UID.generate());
     Event expected = new Event();
     expected.setAutoFields();
     TrackerNotificationDataBundle bundle =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +95,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -140,7 +141,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(identifierParams.toMetadataIdentifier(stage))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -182,7 +183,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -228,7 +229,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -272,7 +273,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -306,7 +307,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .attributeCategoryOptions(categoryOptionIds(identifierParams, options))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier(aoc))
@@ -339,7 +340,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
             .attributeCategoryOptions(categoryOptionIds(identifierParams, options))
@@ -380,7 +381,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(identifierParams.toMetadataIdentifier(stage))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))
@@ -419,7 +420,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     Set<CategoryOption> options = aoc.getCategoryOptions();
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program.getUid()))
             .attributeCategoryOptions(categoryOptionIds(identifierParams, options))
@@ -452,7 +453,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     CategoryOptionCombo aoc = firstCategoryOptionCombo(categoryCombo);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier(aoc))
@@ -484,7 +485,7 @@ class EventCategoryOptionComboSupplierTest extends TestBase {
     program.setCategoryCombo(categoryCombo);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(identifierParams.toMetadataIdentifier((CategoryOptionCombo) null))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/FileResourceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/FileResourceSupplierTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
@@ -232,7 +233,7 @@ class FileResourceSupplierTest extends TestBase {
   }
 
   private Event event(DataValue... dataValues) {
-    return Event.builder().event(UID.generate()).dataValues(dataValues(dataValues)).build();
+    return TrackerEvent.builder().event(UID.generate()).dataValues(dataValues(dataValues)).build();
   }
 
   private Set<DataValue> dataValues(DataValue[] dataValues) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OrgUnitValueTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OrgUnitValueTypeSupplierTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
@@ -228,7 +229,7 @@ class OrgUnitValueTypeSupplierTest extends TestBase {
   }
 
   private Event event(DataValue... dataValues) {
-    return Event.builder().event(UID.generate()).dataValues(dataValues(dataValues)).build();
+    return TrackerEvent.builder().event(UID.generate()).dataValues(dataValues(dataValues)).build();
   }
 
   private Set<DataValue> dataValues(DataValue[] dataValues) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/UserSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/UserSupplierTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
@@ -127,7 +128,7 @@ class UserSupplierTest extends TestBase {
   }
 
   private Event event(User user) {
-    return Event.builder().event(UID.generate()).assignedUser(user).build();
+    return TrackerEvent.builder().event(UID.generate()).assignedUser(user).build();
   }
 
   private User user() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/AssignedUserPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/AssignedUserPreProcessorTest.java
@@ -39,9 +39,11 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.Test;
@@ -53,7 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AssignedUserPreProcessorTest extends TestBase {
-  private static final String UID = "User uid";
+  private static final String USER_UID = "User uid";
 
   private static final String USERNAME = "Username";
 
@@ -63,12 +65,12 @@ class AssignedUserPreProcessorTest extends TestBase {
 
   @Test
   void testPreprocessorWhenUserHasOnlyUidSet() {
-    Event event = new Event();
-    event.setAssignedUser(userWithOnlyUid());
+    Event event =
+        TrackerEvent.builder().event(UID.generate()).assignedUser(userWithOnlyUid()).build();
     TrackerBundle bundle =
         TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
 
-    when(preheat.getUserByUid(UID)).thenReturn(Optional.of(completeUser()));
+    when(preheat.getUserByUid(USER_UID)).thenReturn(Optional.of(completeUser()));
 
     preProcessorToTest.process(bundle);
 
@@ -76,13 +78,13 @@ class AssignedUserPreProcessorTest extends TestBase {
     verify(preheat, times(1)).getUserByUid(anyString());
 
     MatcherAssert.assertThat(event.getAssignedUser().getUsername(), equalTo(USERNAME));
-    MatcherAssert.assertThat(event.getAssignedUser().getUid(), equalTo(UID));
+    MatcherAssert.assertThat(event.getAssignedUser().getUid(), equalTo(USER_UID));
   }
 
   @Test
   void testPreprocessorWhenUserHasOnlyUsernameSet() {
-    Event event = new Event();
-    event.setAssignedUser(userWithOnlyUsername());
+    Event event =
+        TrackerEvent.builder().event(UID.generate()).assignedUser(userWithOnlyUsername()).build();
     TrackerBundle bundle =
         TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
 
@@ -94,14 +96,13 @@ class AssignedUserPreProcessorTest extends TestBase {
     verify(preheat, times(0)).getUserByUid(anyString());
 
     MatcherAssert.assertThat(event.getAssignedUser().getUsername(), equalTo(USERNAME));
-    MatcherAssert.assertThat(event.getAssignedUser().getUid(), equalTo(UID));
+    MatcherAssert.assertThat(event.getAssignedUser().getUid(), equalTo(USER_UID));
   }
 
   @ParameterizedTest
   @MethodSource("userInfoProvider")
   void testPreprocessorDoNothing(User user) {
-    Event event = new Event();
-    event.setAssignedUser(user);
+    Event event = TrackerEvent.builder().event(UID.generate()).assignedUser(user).build();
     TrackerBundle bundle =
         TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
 
@@ -117,7 +118,7 @@ class AssignedUserPreProcessorTest extends TestBase {
 
   private static User userWithOnlyUid() {
 
-    return User.builder().uid(UID).build();
+    return User.builder().uid(USER_UID).build();
   }
 
   private static User userWithOnlyUsername() {
@@ -125,12 +126,12 @@ class AssignedUserPreProcessorTest extends TestBase {
   }
 
   private static User userWithUidAndUsername() {
-    return User.builder().uid(UID).username(USERNAME).build();
+    return User.builder().uid(USER_UID).username(USERNAME).build();
   }
 
   private static org.hisp.dhis.user.User completeUser() {
     org.hisp.dhis.user.User user = new org.hisp.dhis.user.User();
-    user.setUid(UID);
+    user.setUid(USER_UID);
     user.setUsername(USERNAME);
     return user;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -131,7 +132,7 @@ class EventProgramPreProcessorTest {
     TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(identifierParams);
 
-    Event event = completeTrackerEvent();
+    Event event = completeTrackerEvent().build();
     TrackerBundle bundle =
         TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
 
@@ -154,7 +155,7 @@ class EventProgramPreProcessorTest {
     when(preheat.getProgramStage("LGSWs20XFvy")).thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.EMPTY_UID)
             .programStage(MetadataIdentifier.ofUid(programStage))
@@ -253,11 +254,13 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
     Set<MetadataIdentifier> categoryOptions =
         Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235"));
-    event.setAttributeCategoryOptions(categoryOptions);
+    Event event =
+        completeTrackerEvent()
+            .program(MetadataIdentifier.ofUid(program))
+            .attributeCategoryOptions(categoryOptions)
+            .build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
     CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo('A');
     when(preheat.getCategoryOptionComboIdentifier(categoryCombo, categoryOptions))
@@ -286,10 +289,12 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
-    event.setAttributeCategoryOptions(
-        Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")));
+    Event event =
+        completeTrackerEvent()
+            .program(MetadataIdentifier.ofUid(program))
+            .attributeCategoryOptions(
+                Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")))
+            .build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
     when(preheat.getCategoryOptionComboIdentifier(
             categoryCombo, event.getAttributeCategoryOptions()))
@@ -319,10 +324,12 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
-    event.setAttributeCategoryOptions(
-        Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")));
+    Event event =
+        completeTrackerEvent()
+            .program(MetadataIdentifier.ofUid(program))
+            .attributeCategoryOptions(
+                Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")))
+            .build();
 
     TrackerBundle bundle =
         TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
@@ -347,11 +354,13 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
-    event.setAttributeOptionCombo(MetadataIdentifier.ofCode("9871"));
-    event.setAttributeCategoryOptions(
-        Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")));
+    Event event =
+        completeTrackerEvent()
+            .program(MetadataIdentifier.ofUid(program))
+            .attributeOptionCombo(MetadataIdentifier.ofCode("9871"))
+            .attributeCategoryOptions(
+                Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235")))
+            .build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
@@ -378,9 +387,11 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
-    event.setAttributeOptionCombo(MetadataIdentifier.ofCode("9871"));
+    Event event =
+        completeTrackerEvent()
+            .program(MetadataIdentifier.ofUid(program))
+            .attributeOptionCombo(MetadataIdentifier.ofCode("9871"))
+            .build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
@@ -404,8 +415,7 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent();
-    event.setProgram(MetadataIdentifier.ofUid(program));
+    Event event = completeTrackerEvent().program(MetadataIdentifier.ofUid(program)).build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
@@ -462,7 +472,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event invalidSingleEventWithNoProgramAndNoProgramStage() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(null)
         .programStage(null)
@@ -471,7 +481,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event programEventWithProgram() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION))
         .programStage(MetadataIdentifier.EMPTY_UID)
@@ -480,7 +490,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event programEventWithProgramStage() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.EMPTY_UID)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITHOUT_REGISTRATION))
@@ -489,7 +499,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event completeSingleEvent() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITHOUT_REGISTRATION))
         .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION))
@@ -498,7 +508,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event trackerEventWithProgramStage() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.EMPTY_UID)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITH_REGISTRATION))
@@ -507,7 +517,7 @@ class EventProgramPreProcessorTest {
   }
 
   private Event trackerEventWithProgram() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION))
         .programStage(MetadataIdentifier.EMPTY_UID)
@@ -515,12 +525,11 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event completeTrackerEvent() {
-    return Event.builder()
+  private TrackerEvent.TrackerEventBuilder completeTrackerEvent() {
+    return TrackerEvent.builder()
         .event(UID.generate())
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITH_REGISTRATION))
         .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION))
-        .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-        .build();
+        .attributeOptionCombo(MetadataIdentifier.EMPTY_UID);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.preprocess;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
@@ -39,6 +40,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,10 +60,6 @@ class EventStatusPreProcessorTest {
   @Test
   void testVisitedStatusIsConvertedToActive() {
     // Given
-    Event event = new Event();
-    event.setStatus(EventStatus.VISITED);
-    event.setProgramStage(MetadataIdentifier.ofUid("programStageUid"));
-    TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
     Enrollment enrollment = new Enrollment();
     enrollment.setUid("enrollmentUid");
     Program program = new Program();
@@ -72,6 +70,13 @@ class EventStatusPreProcessorTest {
     TrackerPreheat preheat = new TrackerPreheat();
     preheat.putEnrollmentsWithoutRegistration("programUid", enrollment);
     preheat.put(programStage);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .status(EventStatus.VISITED)
+            .programStage(MetadataIdentifier.ofUid("programStageUid"))
+            .build();
+    TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
     bundle.setPreheat(preheat);
     // When
     preProcessorToTest.process(bundle);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class EventWithoutRegistrationPreProcessorTest {
   @Test
   void testEnrollmentIsAddedIntoEventWhenItBelongsToProgramWithoutRegistration() {
     // Given
-    Event event = new Event();
+    Event event = new TrackerEvent();
     event.setProgramStage(MetadataIdentifier.ofUid("programStageUid"));
     TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
     Enrollment enrollment = new Enrollment();
@@ -83,7 +84,7 @@ class EventWithoutRegistrationPreProcessorTest {
   @Test
   void testEnrollmentIsNotAddedIntoEventWhenItProgramStageHasNoReferenceToProgram() {
     // Given
-    Event event = new Event();
+    Event event = new TrackerEvent();
     event.setProgramStage(MetadataIdentifier.ofUid("programStageUid"));
     TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
     Enrollment enrollment = new Enrollment();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessorTest.java
@@ -119,10 +119,9 @@ class StrategyPreProcessorTest extends TestBase {
     newEnrollment.setEnrollment(NEW_ENROLLMENT_UID);
     dbEvent = new Event();
     dbEvent.setUid(EVENT_UID.getValue());
-    event = new org.hisp.dhis.tracker.imports.domain.Event();
-    event.setEvent(EVENT_UID);
-    newEvent = new org.hisp.dhis.tracker.imports.domain.Event();
-    newEvent.setEvent(NEW_EVENT_UID);
+    event = org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder().event(EVENT_UID).build();
+    newEvent =
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder().event(NEW_EVENT_UID).build();
     relationship = new Relationship();
     relationship.setUid(RELATIONSHIP_UID.getValue());
     payloadRelationship = new org.hisp.dhis.tracker.imports.domain.Relationship();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
@@ -373,7 +373,7 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
   }
 
   private org.hisp.dhis.tracker.imports.domain.Event payloadEvent() {
-    return org.hisp.dhis.tracker.imports.domain.Event.builder()
+    return org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
         .enrollment(UID.generate())
         .event(UID.generate())
         .programStage(MetadataIdentifier.ofUid(programStage.getUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutorTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.IssueType;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleIssue;
@@ -352,7 +353,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   private Event getEventWithDataValueSet() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(EVENT_UID)
         .status(EventStatus.ACTIVE)
         .dataValues(getDataValues())
@@ -360,7 +361,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   private Event getEventWithDataValueSet(TrackerIdSchemeParams idSchemes) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(EVENT_UID)
         .status(EventStatus.ACTIVE)
         .dataValues(getDataValues(idSchemes))
@@ -368,7 +369,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   private Event getEventWithDataValueSetSameValue() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(EVENT_UID)
         .status(EventStatus.ACTIVE)
         .dataValues(getDataValuesSameValue())
@@ -376,7 +377,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   private Event getEventWithOptionSetDataValueWithValidValue() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(EVENT_UID)
         .status(EventStatus.ACTIVE)
         .dataValues(getOptionSetDataValues())
@@ -384,7 +385,7 @@ class AssignDataValueExecutorTest extends TestBase {
   }
 
   private Event getEventWithDataValueNOTSet() {
-    return Event.builder().event(SECOND_EVENT_UID).status(EventStatus.COMPLETED).build();
+    return TrackerEvent.builder().event(SECOND_EVENT_UID).status(EventStatus.COMPLETED).build();
   }
 
   private Set<DataValue> getDataValues(TrackerIdSchemeParams idSchemes) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/RuleEngineErrorExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/RuleEngineErrorExecutorTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleIssue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,6 @@ class RuleEngineErrorExecutorTest extends TestBase {
   }
 
   private Event getEvent() {
-    return Event.builder().event(EVENT_UID).build();
+    return TrackerEvent.builder().event(EVENT_UID).build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleIssue;
 import org.junit.jupiter.api.BeforeEach;
@@ -270,7 +271,7 @@ class SetMandatoryFieldExecutorTest extends TestBase {
   }
 
   private Event getEventWithDeleteMandatoryValue() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(ACTIVE_EVENT_UID)
         .status(EventStatus.ACTIVE)
         .programStage(MetadataIdentifier.ofUid(programStage))
@@ -279,7 +280,7 @@ class SetMandatoryFieldExecutorTest extends TestBase {
   }
 
   private Event getEventWithMandatoryValueSet(TrackerIdSchemeParams idSchemes) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(ACTIVE_EVENT_UID)
         .status(EventStatus.ACTIVE)
         .programStage(idSchemes.toMetadataIdentifier(programStage))
@@ -288,7 +289,7 @@ class SetMandatoryFieldExecutorTest extends TestBase {
   }
 
   private Event getEventWithMandatoryValueSet() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(ACTIVE_EVENT_UID)
         .status(EventStatus.ACTIVE)
         .programStage(MetadataIdentifier.ofUid(programStage))
@@ -297,7 +298,7 @@ class SetMandatoryFieldExecutorTest extends TestBase {
   }
 
   private Event getEventWithMandatoryValueNOTSet() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(COMPLETED_EVENT_UID)
         .status(EventStatus.ACTIVE)
         .programStage(MetadataIdentifier.ofUid(programStage))
@@ -305,7 +306,7 @@ class SetMandatoryFieldExecutorTest extends TestBase {
   }
 
   private Event getEventWithMandatoryValueNOTSet(EventStatus status) {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(COMPLETED_EVENT_UID)
         .status(status)
         .programStage(MetadataIdentifier.ofUid(programStage))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/ValidationExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/ValidationExecutorTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.IssueType;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleIssue;
@@ -210,7 +211,7 @@ class ValidationExecutorTest extends TestBase {
   }
 
   private Event activeEvent() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(ACTIVE_EVENT_UID)
         .status(EventStatus.ACTIVE)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
@@ -218,7 +219,7 @@ class ValidationExecutorTest extends TestBase {
   }
 
   private Event completedEvent() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(COMPLETED_EVENT_UID)
         .status(EventStatus.COMPLETED)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapperTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.Test;
@@ -206,7 +207,7 @@ class SmsImportMapperTest extends TestBase {
 
     List<Event> expected =
         List.of(
-            Event.builder()
+            TrackerEvent.builder()
                 .event(UID.of(smsEvent.getEvent().getUid()))
                 .orgUnit(MetadataIdentifier.ofUid(smsEvent.getOrgUnit().getUid()))
                 .programStage(MetadataIdentifier.ofUid(smsEvent.getProgramStage().getUid()))
@@ -342,7 +343,7 @@ class SmsImportMapperTest extends TestBase {
     TrackerObjects actual = map(input, "francis");
 
     Event expected =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.of(input.getEvent().getUid()))
             .orgUnit(MetadataIdentifier.ofUid(input.getOrgUnit().getUid()))
             .programStage(MetadataIdentifier.ofUid(input.getProgramStage().getUid()))
@@ -376,7 +377,7 @@ class SmsImportMapperTest extends TestBase {
     TrackerObjects actual = map(input, "francis");
 
     Event expected =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.of(input.getEvent().getUid()))
             .orgUnit(MetadataIdentifier.ofUid(input.getOrgUnit().getUid()))
             .programStage(MetadataIdentifier.ofUid(input.getProgramStage().getUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/MessageFormatterTest.java
@@ -55,9 +55,9 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.domain.Enrollment;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -188,7 +188,7 @@ class MessageFormatterTest {
   void formatArgumentsShouldTurnEventIntoArguments() {
     List<String> args =
         MessageFormatter.formatArguments(
-            idSchemes, Event.builder().event(UID.of("zwccdzhk5zc")).build());
+            idSchemes, TrackerEvent.builder().event(UID.of("zwccdzhk5zc")).build());
 
     assertContainsOnly(List.of("zwccdzhk5zc"), args);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.domain.RelationshipItem;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.validator.AssertValidations;
 import org.junit.jupiter.api.Test;
@@ -409,9 +410,9 @@ class PersistablesFilterTest {
     private final EnumMap<TrackerType, Set<UID>> invalidEntities;
 
     /**
-     * Setup builds the arguments for calling {@link PersistablesFilter#filter(TrackerBundle,
-     * EnumMap, TrackerImportStrategy)} Adding an entity with methods like {@link
-     * #trackedEntity(String)} always assumes the entity is valid and does not yet exist.
+     * Setup builds the arguments for calling {@link PersistablesFilter#filter(TrackerBundle, Map,
+     * TrackerImportStrategy)} Adding an entity with methods like {@link #trackedEntity(String)}
+     * always assumes the entity is valid and does not yet exist.
      *
      * <p>Call {@link #isNotValid()} or {@link #isInDB()} to mark the current entity as invalid or
      * existing. You need to make sure to add entities in the right order (hierarchy) otherwise
@@ -511,7 +512,7 @@ class PersistablesFilterTest {
         // set child/parent links only if the event has a parent. Events in an event program have no
         // enrollment.
         // They do have a "fake" enrollment (a default program) but it's not set on the event DTO.
-        Event event = Event.builder().event(uid).enrollment(parent.entity.getUid()).build();
+        Event event = TrackerEvent.builder().event(uid).enrollment(parent.entity.getUid()).build();
         return new Entity<>(event);
       }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/AllTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/AllTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.validation.Error;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -140,7 +141,7 @@ class AllTest {
               }
             });
 
-    validator.validate(reporter, bundle, Event.builder().event(uid).build());
+    validator.validate(reporter, bundle, TrackerEvent.builder().event(uid).build());
 
     assertContainsOnly(List.of("V2"), actualErrorMessages());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.validation.Error;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -217,7 +218,7 @@ class SeqTest {
               }
             });
 
-    validator.validate(reporter, bundle, Event.builder().event(uid).build());
+    validator.validate(reporter, bundle, TrackerEvent.builder().event(uid).build());
 
     assertContainsOnly(List.of("V2"), actualErrorMessages());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/AssignedUserValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/AssignedUserValidatorTest.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
@@ -98,9 +99,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testAssignedUserIsValid() {
     // given
-    Event event = new Event();
-    event.setAssignedUser(VALID_USER);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(VALID_USER)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     validator.validate(reporter, bundle, event);
@@ -112,9 +116,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testAssignedUserIsNull() {
     // given
-    Event event = new Event();
-    event.setAssignedUser(null);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(null)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     validator.validate(reporter, bundle, event);
@@ -126,9 +133,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testAssignedUserIsEmpty() {
     // given
-    Event event = new Event();
-    event.setAssignedUser(User.builder().build());
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(User.builder().build())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     validator.validate(reporter, bundle, event);
@@ -140,10 +150,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testEventWithNotValidUsername() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setAssignedUser(INVALID_USER);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(INVALID_USER)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     validator.validate(reporter, bundle, event);
@@ -155,10 +167,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testEventWithUserNotPresentInPreheat() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setAssignedUser(VALID_USER);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(VALID_USER)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     TrackerPreheat preheat = new TrackerPreheat();
@@ -174,10 +188,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testEventWithNotEnabledUserAssignment() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setAssignedUser(VALID_USER);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(VALID_USER)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     programStage.setEnableUserAssignment(false);
@@ -192,10 +208,12 @@ class AssignedUserValidatorTest extends TestBase {
   @Test
   void testEventWithNullEnabledUserAssignment() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setAssignedUser(VALID_USER);
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .assignedUser(VALID_USER)
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .build();
 
     // when
     programStage.setEnableUserAssignment(null);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/CategoryOptValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/CategoryOptValidatorTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
@@ -128,10 +129,12 @@ class CategoryOptValidatorTest extends TestBase {
     program = createProgram('A');
     program.setCategoryCombo(catCombo);
 
-    event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(program));
-    event.setOccurredAt(EVENT_INSTANT);
+    event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(program))
+            .occurredAt(EVENT_INSTANT)
+            .build();
 
     bundle = TrackerBundle.builder().preheat(preheat).build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidatorTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -120,7 +121,7 @@ class DataRelationsValidatorTest extends TestBase {
     setUpDefaultCategoryCombo(program);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
@@ -150,7 +151,7 @@ class DataRelationsValidatorTest extends TestBase {
     setUpDefaultCategoryCombo(program);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(ENROLLMENT_ID)
             .program(MetadataIdentifier.ofUid(program))
@@ -178,7 +179,7 @@ class DataRelationsValidatorTest extends TestBase {
     setUpDefaultCategoryCombo(program);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
@@ -209,7 +210,7 @@ class DataRelationsValidatorTest extends TestBase {
     setUpDefaultCategoryCombo(program);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
@@ -241,7 +242,7 @@ class DataRelationsValidatorTest extends TestBase {
     setUpDefaultCategoryCombo(program);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.ofUid(program))
             .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
@@ -962,8 +963,8 @@ class DataRelationsValidatorTest extends TestBase {
     return categoryCombo.getSortedOptionCombos().get(0);
   }
 
-  private Event.EventBuilder eventBuilder() {
-    return Event.builder()
+  private TrackerEvent.TrackerEventBuilder eventBuilder() {
+    return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.ofUid(PROGRAM_UID))
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -144,7 +145,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -166,7 +167,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
@@ -201,7 +202,7 @@ class DataValuesValidatorTest {
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -237,7 +238,7 @@ class DataValuesValidatorTest {
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -278,7 +279,7 @@ class DataValuesValidatorTest {
         .thenReturn(event(eventUid, savedStatus, Set.of("MANDATORY_DE", DATA_ELEMENT_UID)));
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(eventUid)
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(newStatus)
@@ -318,7 +319,7 @@ class DataValuesValidatorTest {
     when(preheat.getEvent(eventUid)).thenReturn(event(eventUid, savedStatus));
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(eventUid)
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(newStatus)
@@ -353,7 +354,7 @@ class DataValuesValidatorTest {
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -389,7 +390,7 @@ class DataValuesValidatorTest {
     DataValue notPresentDataValue = dataValue();
     notPresentDataValue.setDataElement(MetadataIdentifier.ofUid("de_not_present_in_program_stage"));
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -424,7 +425,7 @@ class DataValuesValidatorTest {
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -450,7 +451,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
@@ -478,7 +479,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -503,7 +504,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -529,7 +530,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -557,7 +558,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(eventUid)
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -583,7 +584,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -609,7 +610,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -635,7 +636,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -660,7 +661,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SCHEDULE)
@@ -685,7 +686,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
@@ -710,7 +711,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.OVERDUE)
@@ -735,7 +736,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.COMPLETED)
@@ -762,7 +763,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue("QX4LpiTZmUH");
     when(preheat.get(FileResource.class, validDataValue.getValue())).thenReturn(fileResource);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -799,7 +800,7 @@ class DataValuesValidatorTest {
     DataValue validDataValue = dataValue("QX4LpiTZmUH");
     when(preheat.get(FileResource.class, validDataValue.getValue())).thenReturn(fileResource);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -812,7 +813,13 @@ class DataValuesValidatorTest {
 
     assertHasError(reporter, event, ValidationCode.E1009);
 
-    event.setEvent(UID.generate());
+    event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(idSchemes.toMetadataIdentifier(programStage))
+            .status(EventStatus.ACTIVE)
+            .dataValues(Set.of(validDataValue))
+            .build();
     UID uid = UID.generate();
     fileResource.setFileResourceOwner(uid.getValue());
 
@@ -824,7 +831,13 @@ class DataValuesValidatorTest {
 
     assertHasError(reporter, event, ValidationCode.E1009);
 
-    event.setEvent(uid);
+    event =
+        TrackerEvent.builder()
+            .event(uid)
+            .programStage(idSchemes.toMetadataIdentifier(programStage))
+            .status(EventStatus.ACTIVE)
+            .dataValues(Set.of(validDataValue))
+            .build();
     fileResource.setFileResourceOwner(uid.getValue());
 
     when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.UPDATE);
@@ -877,7 +890,7 @@ class DataValuesValidatorTest {
     when(optionService.existsAllOptions(any(), anyList())).thenReturn(true);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -911,7 +924,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
@@ -947,7 +960,7 @@ class DataValuesValidatorTest {
     when(optionService.existsAllOptions(any(), anyList())).thenReturn(true);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -981,7 +994,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
@@ -1006,7 +1019,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -1034,7 +1047,7 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.ACTIVE)
@@ -1059,7 +1072,7 @@ class DataValuesValidatorTest {
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
     validDataValue.setValue(value);
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidatorTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.user.UserDetails;
@@ -94,10 +95,13 @@ class DateValidatorTest extends TestBase {
   void testEventIsValid() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID)))
         .thenReturn(getProgramWithoutRegistration());
-    Event event = new Event();
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID));
-    event.setOccurredAt(now());
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID))
+            .occurredAt(now())
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -108,9 +112,11 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenOccurredDateIsNotPresentAndProgramIsWithoutRegistration() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID)))
         .thenReturn(getProgramWithoutRegistration());
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID));
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION_ID))
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -121,10 +127,12 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsActive() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -135,10 +143,12 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsCompleted() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setStatus(EventStatus.COMPLETED);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .status(EventStatus.COMPLETED)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -149,11 +159,13 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenScheduledDateIsNotPresentAndEventIsSchedule() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(Instant.now());
-    event.setStatus(EventStatus.SCHEDULE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(Instant.now())
+            .status(EventStatus.SCHEDULE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -164,12 +176,14 @@ class DateValidatorTest extends TestBase {
   void shouldFailWhenCompletedAtIsPresentAndStatusIsNotCompleted() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(now());
-    event.setCompletedAt(now());
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(now())
+            .completedAt(now())
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -180,12 +194,14 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenCompletedAtIsTooSoonAndEventIsCompleted() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(now());
-    event.setCompletedAt(sevenDaysAgo());
-    event.setStatus(EventStatus.COMPLETED);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(now())
+            .completedAt(sevenDaysAgo())
+            .status(EventStatus.COMPLETED)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -196,12 +212,14 @@ class DateValidatorTest extends TestBase {
   void testEventIsNotValidWhenOccurredAtAndScheduledAtAreNotPresent() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(null);
-    event.setScheduledAt(null);
-    event.setStatus(EventStatus.SKIPPED);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(null)
+            .scheduledAt(null)
+            .status(EventStatus.SKIPPED)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -212,11 +230,13 @@ class DateValidatorTest extends TestBase {
   void shouldFailValidationForEventWhenDateBelongsToExpiredPeriod() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(sevenDaysAgo());
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(sevenDaysAgo())
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -227,11 +247,13 @@ class DateValidatorTest extends TestBase {
   void shouldPassValidationForEventWhenDateBelongsToPastPeriodWithZeroExpiryDays() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(0));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(sevenDaysAgo());
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(sevenDaysAgo())
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -242,11 +264,13 @@ class DateValidatorTest extends TestBase {
   void shouldPassValidationForEventWhenDateBelongsPastEventPeriodButWithinExpiryDays() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(7));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setOccurredAt(sevenDaysAgo());
-    event.setStatus(EventStatus.ACTIVE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .occurredAt(sevenDaysAgo())
+            .status(EventStatus.ACTIVE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 
@@ -257,11 +281,13 @@ class DateValidatorTest extends TestBase {
   void shouldPassValidationForEventWhenScheduledDateBelongsToFuturePeriod() {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID)))
         .thenReturn(getProgramWithRegistration(5));
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID));
-    event.setScheduledAt(sevenDaysLater());
-    event.setStatus(EventStatus.SCHEDULE);
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION_ID))
+            .scheduledAt(sevenDaysLater())
+            .status(EventStatus.SCHEDULE)
+            .build();
 
     validator.validate(reporter, bundle, event);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/ExistenceValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/ExistenceValidatorTest.java
@@ -82,7 +82,9 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationSuccessWhenIsCreateAndEventIsNotPresent() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(NOT_PRESENT_EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
+            .event(NOT_PRESENT_EVENT_UID)
+            .build();
     when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
 
     validator.validate(reporter, bundle, event);
@@ -93,7 +95,9 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationSuccessWhenEventIsNotPresent() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(NOT_PRESENT_EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
+            .event(NOT_PRESENT_EVENT_UID)
+            .build();
     when(bundle.getStrategy(any(org.hisp.dhis.tracker.imports.domain.Event.class)))
         .thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
 
@@ -105,7 +109,7 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationSuccessWhenIsUpdate() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder().event(EVENT_UID).build();
     when(preheat.getEvent(EVENT_UID)).thenReturn(getEvent());
     when(bundle.getStrategy(any(org.hisp.dhis.tracker.imports.domain.Event.class)))
         .thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -118,7 +122,9 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationFailsWhenIsSoftDeleted() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(SOFT_DELETED_EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
+            .event(SOFT_DELETED_EVENT_UID)
+            .build();
     when(preheat.getEvent(SOFT_DELETED_EVENT_UID)).thenReturn(getSoftDeletedEvent());
     when(bundle.getStrategy(any(org.hisp.dhis.tracker.imports.domain.Event.class)))
         .thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -131,7 +137,7 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationFailsWhenIsCreateAndEventIsAlreadyPresent() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder().event(EVENT_UID).build();
     when(preheat.getEvent(EVENT_UID)).thenReturn(getEvent());
     when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
 
@@ -143,7 +149,9 @@ class ExistenceValidatorTest {
   @Test
   void verifyEventValidationFailsWhenIsUpdateAndEventIsNotPresent() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder().event(NOT_PRESENT_EVENT_UID).build();
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
+            .event(NOT_PRESENT_EVENT_UID)
+            .build();
     when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.UPDATE);
 
     validator.validate(reporter, bundle, event);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/GeoValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/GeoValidatorTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,9 +91,12 @@ class GeoValidatorTest {
   @Test
   void testGeometryIsValid() {
     // given
-    Event event = new Event();
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
-    event.setGeometry(new GeometryFactory().createPoint());
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .geometry(new GeometryFactory().createPoint())
+            .build();
 
     // when
     validator.validate(reporter, bundle, event);
@@ -104,9 +108,12 @@ class GeoValidatorTest {
   @Test
   void testEventWithNoProgramStageThrowsAnError() {
     // given
-    Event event = new Event();
-    event.setProgramStage(null);
-    event.setGeometry(new GeometryFactory().createPoint());
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(null)
+            .geometry(new GeometryFactory().createPoint())
+            .build();
 
     when(preheat.getProgramStage((MetadataIdentifier) null)).thenReturn(null);
 
@@ -117,10 +124,12 @@ class GeoValidatorTest {
   @Test
   void testProgramStageWithNullFeatureTypeFailsGeometryValidation() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
-    event.setGeometry(new GeometryFactory().createPoint());
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .geometry(new GeometryFactory().createPoint())
+            .build();
 
     // when
     when(preheat.getProgramStage(event.getProgramStage())).thenReturn(new ProgramStage());
@@ -134,10 +143,12 @@ class GeoValidatorTest {
   @Test
   void testProgramStageWithFeatureTypeNoneFailsGeometryValidation() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
-    event.setGeometry(new GeometryFactory().createPoint());
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .geometry(new GeometryFactory().createPoint())
+            .build();
 
     // when
     ProgramStage programStage = new ProgramStage();
@@ -153,10 +164,12 @@ class GeoValidatorTest {
   @Test
   void testProgramStageWithFeatureTypeDifferentFromGeometryFails() {
     // given
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE));
-    event.setGeometry(new GeometryFactory().createPoint());
+    Event event =
+        TrackerEvent.builder()
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE))
+            .geometry(new GeometryFactory().createPoint())
+            .build();
 
     // when
     ProgramStage programStage = new ProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/MandatoryFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/MandatoryFieldsValidatorTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -89,7 +90,7 @@ class MandatoryFieldsValidatorTest {
   @Test
   void verifyEventValidationSuccess() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
             .programStage(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
@@ -104,7 +105,7 @@ class MandatoryFieldsValidatorTest {
   @Test
   void verifyEventValidationFailsOnMissingProgram() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
             .programStage(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
@@ -119,7 +120,7 @@ class MandatoryFieldsValidatorTest {
   @Test
   void verifyEventValidationFailsOnMissingProgramStageReferenceToProgram() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
             .programStage(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
@@ -138,7 +139,7 @@ class MandatoryFieldsValidatorTest {
   @Test
   void verifyEventValidationFailsOnMissingProgramStage() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))
             .programStage(MetadataIdentifier.EMPTY_UID)
@@ -153,7 +154,7 @@ class MandatoryFieldsValidatorTest {
   @Test
   void verifyEventValidationFailsOnMissingOrgUnit() {
     Event event =
-        Event.builder()
+        TrackerEvent.builder()
             .event(UID.generate())
             .orgUnit(MetadataIdentifier.EMPTY_UID)
             .programStage(MetadataIdentifier.ofUid(CodeGenerator.generateUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/MetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/MetaValidatorTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,7 +139,7 @@ class MetaValidatorTest {
   }
 
   private Event validEvent() {
-    return Event.builder()
+    return TrackerEvent.builder()
         .event(UID.generate())
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
         .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_UID))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/NoteValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/NoteValidatorTest.java
@@ -39,11 +39,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
-import org.hisp.dhis.test.random.BeanRandomizer;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.Note;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,8 +63,6 @@ class NoteValidatorTest {
 
   private Event event;
 
-  private final BeanRandomizer rnd = BeanRandomizer.create();
-
   private TrackerBundle bundle;
 
   private TrackerPreheat preheat;
@@ -71,9 +70,9 @@ class NoteValidatorTest {
   private Reporter reporter;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     this.validator = new NoteValidator();
-    event = rnd.nextObject(Event.class);
+    event = TrackerEvent.builder().event(UID.generate()).build();
 
     bundle = mock(TrackerBundle.class);
     preheat = mock(TrackerPreheat.class);
@@ -86,7 +85,7 @@ class NoteValidatorTest {
   @Test
   void testNoteWithExistingUidWarnings() {
     // Given
-    final Note note = rnd.nextObject(Note.class);
+    final Note note = note();
     when(preheat.hasNote(note.getNote())).thenReturn(true);
 
     event.setNotes(Collections.singletonList(note));
@@ -102,7 +101,7 @@ class NoteValidatorTest {
   @Test
   void testNoteWithExistingUidAndNoTextIsIgnored() {
     // Given
-    final Note note = rnd.nextObject(Note.class);
+    final Note note = note();
     note.setValue(null);
 
     event.setNotes(Collections.singletonList(note));
@@ -118,7 +117,9 @@ class NoteValidatorTest {
   @Test
   void testNotesAreValidWhenUidDoesNotExist() {
     // Given
-    final List<Note> notes = rnd.objects(Note.class, 5).toList();
+    Note note = note();
+    Note note2 = note();
+    final List<Note> notes = List.of(note, note2);
 
     event.setNotes(notes);
 
@@ -127,6 +128,10 @@ class NoteValidatorTest {
 
     // Then
     assertIsEmpty(reporter.getErrors());
-    assertThat(event.getNotes(), hasSize(5));
+    assertThat(event.getNotes(), hasSize(2));
+  }
+
+  private Note note() {
+    return Note.builder().note(UID.generate()).value(UID.generate().getValue()).build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/RepeatedEventsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/RepeatedEventsValidatorTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Error;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
@@ -268,27 +269,26 @@ class RepeatedEventsValidatorTest extends TestBase {
   }
 
   private Event singleEvent() {
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setEnrollment(ENROLLMENT_B);
-    event.setProgramStage(
-        MetadataIdentifier.ofUid(NOT_REPEATABLE_PROGRAM_STAGE_WITHOUT_REGISTRATION));
-    return event;
+    return TrackerEvent.builder()
+        .event(UID.generate())
+        .enrollment(ENROLLMENT_B)
+        .programStage(MetadataIdentifier.ofUid(NOT_REPEATABLE_PROGRAM_STAGE_WITHOUT_REGISTRATION))
+        .build();
   }
 
   private Event notRepeatableEvent() {
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setEnrollment(ENROLLMENT_A);
-    event.setProgramStage(MetadataIdentifier.ofUid(NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION));
-    return event;
+    return TrackerEvent.builder()
+        .event(UID.generate())
+        .enrollment(ENROLLMENT_A)
+        .programStage(MetadataIdentifier.ofUid(NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION))
+        .build();
   }
 
   private Event repeatableEvent() {
-    Event event = new Event();
-    event.setEvent(UID.generate());
-    event.setEnrollment(ENROLLMENT_A);
-    event.setProgramStage(MetadataIdentifier.ofUid(REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION));
-    return event;
+    return TrackerEvent.builder()
+        .event(UID.generate())
+        .enrollment(ENROLLMENT_A)
+        .programStage(MetadataIdentifier.ofUid(REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION))
+        .build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
@@ -151,7 +151,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void verifyValidationSuccessForEventUsingDeleteStrategy() {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -182,7 +182,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
     program.setProgramType(ProgramType.WITHOUT_REGISTRATION);
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -210,7 +210,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   @Test
   void verifyValidationSuccessForTrackerEventCreation() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -238,7 +238,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   @Test
   void verifyValidationSuccessForTrackerEventUpdate() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -267,7 +267,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void verifyValidationSuccessForEventUsingUpdateStrategy() {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -298,7 +298,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
     UID enrollmentUid = UID.generate();
     UID eventUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(eventUid)
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -345,7 +345,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void verifyValidationSuccessForEventUsingUpdateStrategyAndUserWithAuthority() {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -375,7 +375,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   @Test
   void verifyValidationFailsForTrackerEventCreationAndUserNotInOrgUnitCaptureScope() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -403,7 +403,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void
       verifyValidationFailsForEventCreationThatIsCreatableInSearchScopeAndUserNotInOrgUnitSearchHierarchy() {
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(UID.generate())
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -432,7 +432,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void verifyValidationFailsForEventUsingUpdateStrategyAndUserWithoutAuthority() {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
@@ -460,7 +460,7 @@ class SecurityOwnershipValidatorTest extends TestBase {
   void verifySuccessEventValidationWhenEventHasNoOrgUnitAssigned() {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .event(UID.generate())
             .enrollment(enrollmentUid)
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidatorTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -91,7 +92,7 @@ class StatusUpdateValidatorTest {
     savedEvent.setStatus(fromStatus);
     when(preheat.getEvent(EVENT_UID)).thenReturn(savedEvent);
 
-    Event event = Event.builder().event(EVENT_UID).status(toStatus).build();
+    Event event = TrackerEvent.builder().event(EVENT_UID).status(toStatus).build();
 
     validator.validate(reporter, bundle, event);
 
@@ -107,7 +108,7 @@ class StatusUpdateValidatorTest {
     savedEvent.setStatus(fromStatus);
     when(preheat.getEvent(EVENT_UID)).thenReturn(savedEvent);
 
-    Event event = Event.builder().event(EVENT_UID).status(toStatus).build();
+    Event event = TrackerEvent.builder().event(EVENT_UID).status(toStatus).build();
 
     validator.validate(reporter, bundle, event);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/UpdatableFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/UpdatableFieldsValidatorTest.java
@@ -135,7 +135,7 @@ class UpdatableFieldsValidatorTest {
   }
 
   private org.hisp.dhis.tracker.imports.domain.Event validEvent() {
-    return org.hisp.dhis.tracker.imports.domain.Event.builder()
+    return org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
         .event(EVENT_UID)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_ID))
         .enrollment(ENROLLMENT_ID)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerObjectDeletionService;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.user.User;
 import org.joda.time.LocalDateTime;
@@ -483,13 +484,13 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         .findFirst()
         .ifPresent(
             e -> {
-              e.setOccurredAt(newDate);
-              e.setScheduledAt(newDate);
+              org.hisp.dhis.tracker.imports.domain.Event ev =
+                  TrackerEvent.builderFromEvent(e).occurredAt(newDate).scheduledAt(newDate).build();
 
               assertNoErrors(
                   trackerImportService.importTracker(
                       TrackerImportParams.builder().build(),
-                      TrackerObjects.builder().events(List.of(e)).build()));
+                      TrackerObjects.builder().events(List.of(ev)).build()));
             });
   }
 
@@ -499,12 +500,13 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         .findFirst()
         .ifPresent(
             e -> {
-              e.setScheduledAt(null);
+              org.hisp.dhis.tracker.imports.domain.Event ev =
+                  TrackerEvent.builderFromEvent(e).scheduledAt(null).build();
 
               assertNoErrors(
                   trackerImportService.importTracker(
                       TrackerImportParams.builder().build(),
-                      TrackerObjects.builder().events(List.of(e)).build()));
+                      TrackerObjects.builder().events(List.of(ev)).build()));
             });
   }
 
@@ -514,12 +516,13 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         .findFirst()
         .ifPresent(
             e -> {
-              e.setGeometry(newGeometry);
+              org.hisp.dhis.tracker.imports.domain.Event ev =
+                  TrackerEvent.builderFromEvent(e).geometry(newGeometry).build();
 
               assertNoErrors(
                   trackerImportService.importTracker(
                       TrackerImportParams.builder().build(),
-                      TrackerObjects.builder().events(List.of(e)).build()));
+                      TrackerObjects.builder().events(List.of(ev)).build()));
             });
   }
 
@@ -529,12 +532,13 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         .findFirst()
         .ifPresent(
             e -> {
-              e.setGeometry(null);
+              org.hisp.dhis.tracker.imports.domain.Event ev =
+                  TrackerEvent.builderFromEvent(e).geometry(null).build();
 
               assertNoErrors(
                   trackerImportService.importTracker(
                       TrackerImportParams.builder().build(),
-                      TrackerObjects.builder().events(List.of(e)).build()));
+                      TrackerObjects.builder().events(List.of(ev)).build()));
             });
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.user.User;
 import org.joda.time.LocalDateTime;
@@ -391,13 +392,13 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
         .findFirst()
         .ifPresent(
             e -> {
-              e.setOccurredAt(newDate);
-              e.setScheduledAt(newDate);
+              org.hisp.dhis.tracker.imports.domain.Event ev =
+                  TrackerEvent.builderFromEvent(e).occurredAt(newDate).scheduledAt(newDate).build();
 
               assertNoErrors(
                   trackerImportService.importTracker(
                       TrackerImportParams.builder().build(),
-                      TrackerObjects.builder().events(List.of(e)).build()));
+                      TrackerObjects.builder().events(List.of(ev)).build()));
             });
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
@@ -615,12 +616,13 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
 
   private org.hisp.dhis.tracker.imports.domain.Event importEventProgram() throws IOException {
     TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/single_event.json");
-    org.hisp.dhis.tracker.imports.domain.Event ev = trackerObjects.getEvents().get(0);
-    ev.setEnrollment(null);
-    ev.setEvent(UID.generate());
-    // set event program and program stage
-    ev.setProgramStage(MetadataIdentifier.of(TrackerIdScheme.UID, "NpsdDv6kKSe", null));
-    ev.setProgram(MetadataIdentifier.of(TrackerIdScheme.UID, "BFcipDERJne", null));
+    org.hisp.dhis.tracker.imports.domain.Event ev =
+        TrackerEvent.builderFromEvent(trackerObjects.getEvents().get(0))
+            .enrollment(null)
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.of(TrackerIdScheme.UID, "NpsdDv6kKSe", null))
+            .program(MetadataIdentifier.of(TrackerIdScheme.UID, "BFcipDERJne", null))
+            .build();
 
     assertNoErrors(
         trackerImportService.importTracker(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerNotificationHandlerServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerNotificationHandlerServiceTest.java
@@ -197,7 +197,7 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
             .build();
 
     org.hisp.dhis.tracker.imports.domain.Event event =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .program(MetadataIdentifier.ofUid(programA.getUid()))
             .orgUnit(MetadataIdentifier.ofUid(orgUnitA.getUid()))
             .enrollment(enrollment.getUid())
@@ -233,7 +233,7 @@ class TrackerNotificationHandlerServiceTest extends PostgresIntegrationTestBase 
         List.of("enrollment_subject", "enrollment_completion_subject"), subjectMessages);
 
     org.hisp.dhis.tracker.imports.domain.Event eventUpdated =
-        org.hisp.dhis.tracker.imports.domain.Event.builder()
+        org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
             .program(MetadataIdentifier.ofUid(programA.getUid()))
             .orgUnit(MetadataIdentifier.ofUid(orgUnitA.getUid()))
             .enrollment(enrollment.getUid())

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatIdentifiersTest.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -95,7 +96,10 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
       String id = pair.getLeft();
       TrackerIdSchemeParam param = pair.getRight();
       Event event =
-          Event.builder().event(UID.generate()).orgUnit(param.toMetadataIdentifier(id)).build();
+          TrackerEvent.builder()
+              .event(UID.generate())
+              .orgUnit(param.toMetadataIdentifier(id))
+              .build();
       TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
       TrackerIdSchemeParams params = TrackerIdSchemeParams.builder().orgUnitIdScheme(param).build();
 
@@ -112,7 +116,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
       String id = pair.getLeft();
       TrackerIdSchemeParam param = pair.getRight();
       Event event =
-          Event.builder()
+          TrackerEvent.builder()
               .event(UID.generate())
               .programStage(param.toMetadataIdentifier(id))
               .build();
@@ -135,7 +139,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
       DataValue dv1 =
           DataValue.builder().dataElement(param.toMetadataIdentifier(id)).value("val1").build();
       Event event =
-          Event.builder()
+          TrackerEvent.builder()
               .event(UID.generate())
               .programStage(MetadataIdentifier.ofUid("NpsdDv6kKSO"))
               .dataValues(Collections.singleton(dv1))
@@ -157,7 +161,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
       String id = pair.getLeft();
       TrackerIdSchemeParam param = pair.getRight();
       Event event =
-          Event.builder()
+          TrackerEvent.builder()
               .event(UID.generate())
               .attributeCategoryOptions(Set.of(param.toMetadataIdentifier(id)))
               .build();
@@ -179,7 +183,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
       String id = pair.getLeft();
       TrackerIdSchemeParam param = pair.getRight();
       Event event =
-          Event.builder()
+          TrackerEvent.builder()
               .event(UID.generate())
               .attributeOptionCombo(param.toMetadataIdentifier(id))
               .build();
@@ -211,7 +215,7 @@ class TrackerPreheatIdentifiersTest extends PostgresIntegrationTestBase {
   void testDefaultsWithIdSchemesOtherThanUID() {
     TrackerObjects trackerObjects =
         TrackerObjects.builder()
-            .events(List.of(Event.builder().event(UID.generate()).build()))
+            .events(List.of(TrackerEvent.builder().event(UID.generate()).build()))
             .build();
     TrackerIdSchemeParams params =
         TrackerIdSchemeParams.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
@@ -60,6 +60,6 @@ interface EventMapper extends DomainMapper<Event, org.hisp.dhis.tracker.imports.
       target = "attributeCategoryOptions",
       source = "attributeCategoryOptions",
       qualifiedByName = "attributeCategoryOptionsToMetadataIdentifier")
-  org.hisp.dhis.tracker.imports.domain.Event from(
+  org.hisp.dhis.tracker.imports.domain.TrackerEvent from(
       Event event, @Context TrackerIdSchemeParams idSchemeParams);
 }


### PR DESCRIPTION
***Big picture***
The goal of this ticket is to have separate domain objects for single events and tracker events that will be generated in the preprocess phase.
This will allow us to have separate flows for validation, rule-engine and persistence (even though for now we will use the same DB table).

***Implemented in this PR***
- `Event` is now an interface and `TrackerEvent` is its implementation.
- We already created `SingleEvent` class that will be used later.
- We are still using `Event` interface in all phases of the importer.

***Next steps***
- Use the concrete classes in the preprocess phase.
- Separate validation flow based on the event type.
- Separate rule-engine flow based on event type.
- Separate persistence flow based on event type.