### PR TITLE
Fix: Min max deserialization

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/minmax/MinMaxValue.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.minmax;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.OpenApi;
@@ -43,15 +44,16 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
  * @author Lars Helge Overland
  */
 public record MinMaxValue(
-    @Nonnull @OpenApi.Property({UID.class, DataElement.class}) UID dataElement,
-    @Nonnull @OpenApi.Property({UID.class, OrganisationUnit.class}) UID orgUnit,
-    @JsonAlias("categoryOptionCombo")
+    @JsonProperty @Nonnull @OpenApi.Property({UID.class, DataElement.class}) UID dataElement,
+    @JsonProperty @Nonnull @OpenApi.Property({UID.class, OrganisationUnit.class}) UID orgUnit,
+    @JsonProperty("categoryOptionCombo")
+        @JsonAlias("optionCombo")
         @Nonnull
         @OpenApi.Property({UID.class, CategoryOptionCombo.class})
         UID optionCombo,
-    @Nonnull Integer minValue,
-    @Nonnull Integer maxValue,
-    Boolean generated)
+    @JsonProperty @Nonnull Integer minValue,
+    @JsonProperty @Nonnull Integer maxValue,
+    @JsonProperty Boolean generated)
     implements MinMaxValueId {
 
   @Nonnull

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMinMaxDataElement.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMinMaxDataElement.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.webapi.json.domain;
+
+import org.hisp.dhis.jsontree.JsonBoolean;
+import org.hisp.dhis.jsontree.JsonObject;
+
+public interface JsonMinMaxDataElement extends JsonObject {
+
+  default JsonDataElement getDataElement() {
+    return getObject("dataElement").as(JsonDataElement.class);
+  }
+
+  default JsonCategoryOptionCombo getOptionCombo() {
+    return getObject("optionCombo").as(JsonCategoryOptionCombo.class);
+  }
+
+  default Integer getMin() {
+    return getNumber("min").intValue();
+  }
+
+  default Integer getMax() {
+    return getNumber("max").intValue();
+  }
+
+  default JsonOrganisationUnit getSource() {
+    return getObject("source").as(JsonOrganisationUnit.class);
+  }
+
+  default JsonBoolean getGenerated() {
+    return getBoolean("generated").as(JsonBoolean.class);
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMinMaxValue.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonMinMaxValue.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.webapi.json.domain;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+public interface JsonMinMaxValue extends JsonObject {
+
+  default String getDataElement() {
+    return getString("dataElement").string();
+  }
+
+  default String getOrganisationUnit() {
+    return getString("orgUnit").string();
+  }
+
+  default String getCategoryOptionCombo() {
+    return getString("categoryOptionCombo").string();
+  }
+
+  default Integer getMinValue() {
+    return getNumber("minValue").intValue();
+  }
+
+  default Integer getMaxValue() {
+    return getNumber("maxValue").intValue();
+  }
+}


### PR DESCRIPTION
-The min/max values were not being properly deserialized in the /dataEntry endpoint. 
-Added better tests after we import in bulk to test the actual values. 