### PR TITLE
DHIS2-19753 Route all TEA Analytics query to Postgres

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/SqlQueryExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/SqlQueryExecutor.java
@@ -49,7 +49,8 @@ import org.springframework.stereotype.Component;
 public class SqlQueryExecutor implements QueryExecutor<SqlQuery, SqlQueryResult> {
   @Nonnull private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-  public SqlQueryExecutor(@Qualifier("analyticsReadOnlyJdbcTemplate") JdbcTemplate jdbcTemplate) {
+  public SqlQueryExecutor(
+      @Qualifier("analyticsPostgresReadOnlyJdbcTemplate") JdbcTemplate jdbcTemplate) {
     this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/config/ServiceConfig.java
@@ -29,30 +29,21 @@
  */
 package org.hisp.dhis.analytics.config;
 
-import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableManager;
 import org.hisp.dhis.analytics.AnalyticsTableService;
-import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.DefaultAnalyticsTableService;
-import org.hisp.dhis.analytics.table.JdbcTrackedEntityEventsAnalyticsTableManager;
-import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
-import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.db.AnalyticsSqlBuilderProvider;
 import org.hisp.dhis.db.SqlBuilderProvider;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * @author Luciano Fiandesio
@@ -64,42 +55,18 @@ public class ServiceConfig {
     return provider.getSqlBuilder();
   }
 
+  /**
+   * A dedicated {@link org.hisp.dhis.db.sql.SqlBuilder} for Postgres. Used for classes that require
+   * a Postgres-specific dialect, regardless of the selected analytics database.
+   */
+  @Bean("postgresSqlBuilder")
+  public SqlBuilder postgresSqlBuilder() {
+    return new PostgreSqlBuilder();
+  }
+
   @Bean
   public AnalyticsSqlBuilder analyticsSqlBuilder(AnalyticsSqlBuilderProvider provider) {
     return provider.getAnalyticsSqlBuilder();
-  }
-
-  @Bean("org.hisp.dhis.analytics.TrackedEntityEventsAnalyticsTableManager")
-  public AnalyticsTableManager jdbcTrackedEntityEventsAnalyticsTableManager(
-      IdentifiableObjectManager idObjectManager,
-      OrganisationUnitService organisationUnitService,
-      CategoryService categoryService,
-      SystemSettingsProvider settingsProvider,
-      DataApprovalLevelService dataApprovalLevelService,
-      ResourceTableService resourceTableService,
-      AnalyticsTableHookService tableHookService,
-      PartitionManager partitionManager,
-      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
-      TrackedEntityTypeService trackedEntityTypeService,
-      AnalyticsTableSettings analyticsTableSettings,
-      PeriodDataProvider periodDataProvider,
-      SqlBuilder sqlBuilder,
-      AnalyticsSqlBuilder analyticsSqlBuilder) {
-    return new JdbcTrackedEntityEventsAnalyticsTableManager(
-        idObjectManager,
-        organisationUnitService,
-        categoryService,
-        settingsProvider,
-        dataApprovalLevelService,
-        resourceTableService,
-        tableHookService,
-        partitionManager,
-        jdbcTemplate,
-        trackedEntityTypeService,
-        analyticsTableSettings,
-        periodDataProvider,
-        sqlBuilder,
-        analyticsSqlBuilder);
   }
 
   @Bean("org.hisp.dhis.analytics.TrackedEntityAnalyticsTableService")
@@ -110,7 +77,7 @@ public class ServiceConfig {
       DataElementService dataElementService,
       ResourceTableService resourceTableService,
       SystemSettingsProvider settingsProvider,
-      SqlBuilder sqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     return new DefaultAnalyticsTableService(
         tableManager,
         organisationUnitService,
@@ -128,7 +95,7 @@ public class ServiceConfig {
       DataElementService dataElementService,
       ResourceTableService resourceTableService,
       SystemSettingsProvider settingsProvider,
-      SqlBuilder sqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     return new DefaultAnalyticsTableService(
         tableManager,
         organisationUnitService,
@@ -146,7 +113,7 @@ public class ServiceConfig {
       DataElementService dataElementService,
       ResourceTableService resourceTableService,
       SystemSettingsProvider settingsProvider,
-      SqlBuilder sqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     return new DefaultAnalyticsTableService(
         tableManager,
         organisationUnitService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManager.java
@@ -107,13 +107,13 @@ public class JdbcTrackedEntityAnalyticsTableManager extends AbstractEventJdbcTab
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsPostgresJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       TrackedEntityAttributeService trackedEntityAttributeService,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
       ColumnMapper columnMapper,
-      SqlBuilder sqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     super(
         idObjectManager,
         organisationUnitService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java
@@ -154,11 +154,11 @@ public class JdbcTrackedEntityEnrollmentsAnalyticsTableManager extends AbstractJ
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsPostgresJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
-      SqlBuilder sqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     super(
         idObjectManager,
         organisationUnitService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityEventsAnalyticsTableManager.java
@@ -75,6 +75,7 @@ import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.db.model.IndexType;
 import org.hisp.dhis.db.model.Logged;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
@@ -85,8 +86,10 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Component("org.hisp.dhis.analytics.TrackedEntityEventsAnalyticsTableManager")
 public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTableManager {
 
   private static final List<AnalyticsTableColumn> FIXED_COLS =
@@ -184,12 +187,11 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
       ResourceTableService resourceTableService,
       AnalyticsTableHookService tableHookService,
       PartitionManager partitionManager,
-      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsPostgresJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsTableSettings analyticsTableSettings,
       PeriodDataProvider periodDataProvider,
-      SqlBuilder sqlBuilder,
-      AnalyticsSqlBuilder analyticsSqlBuilder) {
+      @Qualifier("postgresSqlBuilder") SqlBuilder sqlBuilder) {
     super(
         idObjectManager,
         organisationUnitService,
@@ -204,7 +206,7 @@ public class JdbcTrackedEntityEventsAnalyticsTableManager extends AbstractJdbcTa
         periodDataProvider,
         sqlBuilder);
     this.trackedEntityTypeService = trackedEntityTypeService;
-    this.analyticsSqlBuilder = analyticsSqlBuilder;
+    this.analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
   }
 
   @Override


### PR DESCRIPTION
## Summary

This PR updates the Tracked Entity Analytics (TEA) logic to always use the PostgreSQL datasource for both table population and query execution, regardless of whether Doris or ClickHouse is selected as the analytics engine.

As discussed in the analysis document
[analysis document](https://github.com/user-attachments/files/20709157/Analytics.TEA.Queries.with.Doris.pdf), the effort required to adapt TEA query generation to Doris is currently too high. Additionally, TEA query performance on PostgreSQL is already sufficient.

To avoid unnecessary complexity and risk of regression, TEA queries are now explicitly routed through a dedicated PostgreSQL datasource.

### Changes

- initialize a `postgresSqlBuilder` Bean
- initialze an `analyticsPostgresJdbcTemplate` used by the TEA table managers
- initialize an `analyticsPostgresReadOnlyJdbcTemplate` used by the TEA query executor
- transformed `JdbcTrackedEntityEventsAnalyticsTableManager` into a Spring Bean, for consistency with `JdbcTrackedEntityAnalyticsTableManager` and `JdbcTrackedEntityEnrollmentsAnalyticsTableManager.java`