### PR TITLE
fix: Improve output of integrity check for OUGS with multiple groups

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/orgunits/orgunits_excess_group_memberships.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/orgunits/orgunits_excess_group_memberships.yaml
@@ -53,30 +53,56 @@ summary_sql: >-
   from ougs_multiple_groups
   WHERE array_length(ougs_groups, 1) > 1;
 details_sql: >-
-  WITH ougs_multiple_groups as (
-  SELECT ou_uid,ou_name,ougs_name,
-  NULL As comment,
-  array_agg(oug_name || ':' || oug_uid) as ougs_groups
-  FROM (
-  SELECT  ougm.organisationunitid, 
-  ougm.orgunitgroupid,
-  ougsm.orgunitgroupsetid,
-  ou.uid as ou_uid,
-  ou.name as ou_name,
-  oug.name as oug_name,
-  oug.uid as oug_uid,
-  ougs.name as ougs_name
-  FROM orgunitgroupmembers ougm
-  INNER JOIN orgunitgroupsetmembers ougsm USING(orgunitgroupid)
-  INNER JOIN orgunitgroup oug USING(orgunitgroupid)
-  INNER JOIN orgunitgroupset ougs USING(orgunitgroupsetid)
-  INNER JOIN organisationunit ou USING(organisationunitid) ) a
-  GROUP BY ou_uid,ou_name, ougs_name )
-  SELECT ou_uid as uid, ou_name as name,
-  NULL as comment,
-  ougs_groups as refs
-  from ougs_multiple_groups
-  WHERE array_length(ougs_groups, 1) > 1;
+  WITH ougs_grouped AS (
+    SELECT 
+      ou.uid AS ou_uid,
+      ou.name AS ou_name,
+      ougs.uid AS ougs_id,
+      ougs.name AS ougs_name,
+      array_agg(
+        'oug_uid: ' || oug.uid || '; oug_name: ' || oug.name
+      ) AS group_refs
+    FROM orgunitgroupmembers ougm
+    INNER JOIN orgunitgroupsetmembers ougsm USING(orgunitgroupid)
+    INNER JOIN orgunitgroup oug USING(orgunitgroupid)
+    INNER JOIN orgunitgroupset ougs USING(orgunitgroupsetid)
+    INNER JOIN organisationunit ou USING(organisationunitid)
+    GROUP BY ou.uid, ou.name, ougs.uid, ougs.name
+  ),
+  violating_group_sets AS (
+    SELECT 
+      ou_uid,
+      ou_name,
+      ougs_id,
+      ougs_name,
+      group_refs
+    FROM ougs_grouped
+    WHERE array_length(group_refs, 1) > 1
+  ),
+  flat_refs AS (
+    SELECT
+      ou_uid,
+      ou_name,
+      'ougs_name: ' || ougs_name ||
+      '; ougs_id: ' || ougs_id ||
+      '; groups: [' || string_agg(group_ref, ', ') || ']' AS ref
+    FROM violating_group_sets, unnest(group_refs) AS group_ref
+    GROUP BY ou_uid, ou_name, ougs_id, ougs_name
+  ),
+  final_output AS (
+    SELECT
+      ou_uid,
+      ou_name,
+      array_agg(ref) AS refs
+    FROM flat_refs
+    GROUP BY ou_uid, ou_name
+  )
+  SELECT
+    ou_uid AS uid,
+    ou_name AS name,
+    NULL AS comment,
+    refs
+  FROM final_output;
 details_id_type: organisationUnits
 severity: SEVERE
 introduction: >


### PR DESCRIPTION
Based on feedback from the community, this integrity check did not provide enough information regarding which group set and groups the organisation unit actually belonged to. SQL details query was adjusted and better output was added to the "refs" field. 

```
-[ RECORD 1 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------
uid     | azRICFoILuh
name    | Golu MCHP
comment | 
refs    | {"ougs_name: Facility Type; ougs_id: J5jldMd8OHv; groups: [oug_uid: EYbopBOJWsW; oug_name: MCHP, oug_uid: CXw2yu5fodb; oug_name: CHC]"}
```