### PR TITLE
chore: Separate event types in TrackerBundle [DHIS2-19701]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -87,7 +87,6 @@ public class DefaultTrackerImportService implements TrackerImportService {
       @Nonnull TrackerObjects trackerObjects,
       @Nonnull JobProgress jobProgress) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
         jobProgress.nonNullStagePostCondition(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -87,6 +87,7 @@ public class DefaultTrackerImportService implements TrackerImportService {
       @Nonnull TrackerObjects trackerObjects,
       @Nonnull JobProgress jobProgress) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
         jobProgress.nonNullStagePostCondition(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -96,7 +96,7 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
       @Nonnull TrackerObjects trackerObjects,
       @Nonnull UserDetails user) {
     TrackerPreheat preheat = trackerPreheatService.preheat(trackerObjects, params.getIdSchemes());
-    TrackerBundle trackerBundle = ParamsConverter.convert(params, trackerObjects, user);
+    TrackerBundle trackerBundle = ParamsConverter.convert(params, trackerObjects, user, preheat);
     trackerBundle.setPreheat(preheat);
 
     return trackerBundle;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -105,8 +106,9 @@ public class TrackerBundle {
   /** Enrollments to import. */
   @Builder.Default private List<Enrollment> enrollments = new ArrayList<>();
 
-  /** Events to import. */
-  @Builder.Default private List<Event> events = new ArrayList<>();
+  @Builder.Default private List<TrackerEvent> trackerEvents = new ArrayList<>();
+
+  @Builder.Default private List<SingleEvent> singleEvents = new ArrayList<>();
 
   /** Relationships to import. */
   @Builder.Default private List<Relationship> relationships = new ArrayList<>();
@@ -152,7 +154,7 @@ public class TrackerBundle {
   }
 
   public Optional<Event> findEventByUid(@Nonnull UID uid) {
-    return findById(this.events, uid);
+    return findById(this.getEvents(), uid);
   }
 
   public Optional<Relationship> findRelationshipByUid(@Nonnull UID uid) {
@@ -167,22 +169,15 @@ public class TrackerBundle {
     return Set.copyOf(this.updatedTrackedEntities);
   }
 
-  public List<SingleEvent> getSingleEvents() {
-    return this.events.stream()
-        .filter(event -> preheat.getProgram(event.getProgram()) != null)
-        .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
-        .map(event -> new SingleEvent())
-        .toList();
+  public List<Event> getEvents() {
+    return Stream.concat(this.singleEvents.stream(), this.trackerEvents.stream()).toList();
   }
 
-  public List<TrackerEvent> getTrackerEvents() {
-    return this.events.stream()
-        .filter(
-            event ->
-                preheat.getProgram(event.getProgram()) == null
-                    || preheat.getProgram(event.getProgram()).isRegistration())
-        .map(event -> new TrackerEvent())
-        .toList();
+  public void setEvents(List<Event> events) {
+    this.setTrackerEvents(
+        events.stream().filter(TrackerEvent.class::isInstance).map(e -> (TrackerEvent) e).toList());
+    this.setSingleEvents(
+        events.stream().filter(SingleEvent.class::isInstance).map(e -> (SingleEvent) e).toList());
   }
 
   public void addUpdatedTrackedEntities(Set<UID> updatedTrackedEntities) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
@@ -30,7 +30,6 @@
 package org.hisp.dhis.tracker.imports.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -50,12 +49,16 @@ import org.locationtech.jts.geom.Geometry;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SingleEvent implements TrackerDto, Serializable {
-  @Nonnull @JsonProperty private UID singleEvent;
+public class SingleEvent implements Event {
+  @Nonnull @JsonProperty private UID event;
 
   @JsonProperty @Builder.Default private EventStatus status = EventStatus.ACTIVE;
 
   @JsonProperty private MetadataIdentifier program;
+
+  @JsonProperty private MetadataIdentifier programStage;
+
+  @JsonProperty private UID enrollment;
 
   @JsonProperty private MetadataIdentifier orgUnit;
 
@@ -84,11 +87,47 @@ public class SingleEvent implements TrackerDto, Serializable {
 
   @Override
   public UID getUid() {
-    return this.singleEvent;
+    return this.event;
   }
 
   @Override
   public TrackerType getTrackerType() {
     return TrackerType.EVENT;
+  }
+
+  @Override
+  public UID getEnrollment() {
+    return enrollment;
+  }
+
+  @Override
+  public Instant getScheduledAt() {
+    return null;
+  }
+
+  @Override
+  public void setEnrollment(UID enrollment) {
+    this.enrollment = enrollment;
+  }
+
+  public static SingleEvent.SingleEventBuilder builderFromEvent(Event event) {
+    return SingleEvent.builder()
+        .event(event.getEvent())
+        .enrollment(event.getEnrollment())
+        .status(event.getStatus())
+        .program(event.getProgram())
+        .programStage(event.getProgramStage())
+        .orgUnit(event.getOrgUnit())
+        .occurredAt(event.getOccurredAt())
+        .storedBy(event.getStoredBy())
+        .createdAtClient(event.getCreatedAtClient())
+        .updatedAtClient(event.getUpdatedAtClient())
+        .attributeOptionCombo(event.getAttributeOptionCombo())
+        .attributeCategoryOptions(event.getAttributeCategoryOptions())
+        .geometry(event.getGeometry())
+        .assignedUser(event.getAssignedUser())
+        .completedAt(event.getCompletedAt())
+        .dataValues(event.getDataValues())
+        .notes(event.getNotes());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleTest.java
@@ -54,7 +54,7 @@ class TrackerBundleTest {
             .validationMode(ValidationMode.SKIP)
             .trackedEntities(Collections.singletonList(new TrackedEntity()))
             .enrollments(Collections.singletonList(new Enrollment()))
-            .events(Collections.singletonList(new TrackerEvent()))
+            .trackerEvents(Collections.singletonList(new TrackerEvent()))
             .build();
     assertEquals(AtomicMode.ALL, trackerBundle.getAtomicMode());
     assertEquals(ValidationMode.SKIP, trackerBundle.getValidationMode());
@@ -71,7 +71,7 @@ class TrackerBundleTest {
             .validationMode(ValidationMode.SKIP)
             .trackedEntities(Arrays.asList(new TrackedEntity(), new TrackedEntity()))
             .enrollments(Arrays.asList(new Enrollment(), new Enrollment()))
-            .events(Arrays.asList(new TrackerEvent(), new TrackerEvent()))
+            .trackerEvents(Arrays.asList(new TrackerEvent(), new TrackerEvent()))
             .build();
     assertEquals(AtomicMode.ALL, trackerBundle.getAtomicMode());
     assertEquals(ValidationMode.SKIP, trackerBundle.getValidationMode());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/AssignedUserPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/AssignedUserPreProcessorTest.java
@@ -42,7 +42,6 @@ import org.hamcrest.MatcherAssert;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.test.TestBase;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.User;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
@@ -65,10 +64,13 @@ class AssignedUserPreProcessorTest extends TestBase {
 
   @Test
   void testPreprocessorWhenUserHasOnlyUidSet() {
-    Event event =
+    TrackerEvent event =
         TrackerEvent.builder().event(UID.generate()).assignedUser(userWithOnlyUid()).build();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     when(preheat.getUserByUid(USER_UID)).thenReturn(Optional.of(completeUser()));
 
@@ -83,10 +85,13 @@ class AssignedUserPreProcessorTest extends TestBase {
 
   @Test
   void testPreprocessorWhenUserHasOnlyUsernameSet() {
-    Event event =
+    TrackerEvent event =
         TrackerEvent.builder().event(UID.generate()).assignedUser(userWithOnlyUsername()).build();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     when(preheat.getUserByUsername(USERNAME)).thenReturn(Optional.of(completeUser()));
 
@@ -102,9 +107,12 @@ class AssignedUserPreProcessorTest extends TestBase {
   @ParameterizedTest
   @MethodSource("userInfoProvider")
   void testPreprocessorDoNothing(User user) {
-    Event event = TrackerEvent.builder().event(UID.generate()).assignedUser(user).build();
+    TrackerEvent event = TrackerEvent.builder().event(UID.generate()).assignedUser(user).build();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preProcessorToTest.process(bundle);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.SingleEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +94,7 @@ class EventProgramPreProcessorTest {
 
     TrackerBundle bundle =
         TrackerBundle.builder()
-            .events(Collections.singletonList(trackerEventWithProgramStage()))
+            .trackerEvents(Collections.singletonList(trackerEventWithProgramStage()))
             .preheat(preheat)
             .build();
 
@@ -115,7 +115,7 @@ class EventProgramPreProcessorTest {
 
     TrackerBundle bundle =
         TrackerBundle.builder()
-            .events(Collections.singletonList(programEventWithProgramStage()))
+            .singleEvents(Collections.singletonList(singleEventWithProgramStage()))
             .preheat(preheat)
             .build();
 
@@ -132,9 +132,12 @@ class EventProgramPreProcessorTest {
     TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(identifierParams);
 
-    Event event = completeTrackerEvent().build();
+    TrackerEvent event = completeTrackerEvent().build();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -154,7 +157,7 @@ class EventProgramPreProcessorTest {
     programStage.setUid("LGSWs20XFvy");
     when(preheat.getProgramStage("LGSWs20XFvy")).thenReturn(programStage);
 
-    Event event =
+    TrackerEvent event =
         TrackerEvent.builder()
             .event(UID.generate())
             .program(MetadataIdentifier.EMPTY_UID)
@@ -163,7 +166,10 @@ class EventProgramPreProcessorTest {
             .attributeCategoryOptions(Collections.emptySet())
             .build();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -177,9 +183,11 @@ class EventProgramPreProcessorTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION)))
         .thenReturn(programWithoutRegistrationWithProgramStages());
 
-    Event event = programEventWithProgram();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .singleEvents(Collections.singletonList(singleEventWithProgram()))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -195,9 +203,12 @@ class EventProgramPreProcessorTest {
     when(preheat.getIdSchemes()).thenReturn(identifierParams);
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION)))
         .thenReturn(programWithRegistrationWithProgramStages());
-    Event event = trackerEventWithProgram();
+    TrackerEvent event = trackerEventWithProgram();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -209,9 +220,12 @@ class EventProgramPreProcessorTest {
 
   @Test
   void shouldNotProcessEventWhenEventIsInvalidWithNoProgramAndNoProgramStage() {
-    Event event = invalidSingleEventWithNoProgramAndNoProgramStage();
+    SingleEvent event = invalidSingleEventWithNoProgramAndNoProgramStage();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .singleEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -226,9 +240,12 @@ class EventProgramPreProcessorTest {
     TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(identifierParams);
 
-    Event event = completeSingleEvent();
+    SingleEvent event = completeSingleEvent();
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .singleEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -256,7 +273,7 @@ class EventProgramPreProcessorTest {
     program.setCategoryCombo(categoryCombo);
     Set<MetadataIdentifier> categoryOptions =
         Set.of(MetadataIdentifier.ofUid("123"), MetadataIdentifier.ofUid("235"));
-    Event event =
+    TrackerEvent event =
         completeTrackerEvent()
             .program(MetadataIdentifier.ofUid(program))
             .attributeCategoryOptions(categoryOptions)
@@ -267,7 +284,10 @@ class EventProgramPreProcessorTest {
         .thenReturn(identifierParams.toMetadataIdentifier(categoryOptionCombo));
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -289,7 +309,7 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event =
+    TrackerEvent event =
         completeTrackerEvent()
             .program(MetadataIdentifier.ofUid(program))
             .attributeCategoryOptions(
@@ -301,7 +321,10 @@ class EventProgramPreProcessorTest {
         .thenReturn(MetadataIdentifier.EMPTY_CODE);
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -324,7 +347,7 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event =
+    TrackerEvent event =
         completeTrackerEvent()
             .program(MetadataIdentifier.ofUid(program))
             .attributeCategoryOptions(
@@ -332,7 +355,10 @@ class EventProgramPreProcessorTest {
             .build();
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -354,7 +380,7 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event =
+    TrackerEvent event =
         completeTrackerEvent()
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(MetadataIdentifier.ofCode("9871"))
@@ -364,7 +390,10 @@ class EventProgramPreProcessorTest {
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -387,7 +416,7 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event =
+    TrackerEvent event =
         completeTrackerEvent()
             .program(MetadataIdentifier.ofUid(program))
             .attributeOptionCombo(MetadataIdentifier.ofCode("9871"))
@@ -395,7 +424,10 @@ class EventProgramPreProcessorTest {
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -415,11 +447,14 @@ class EventProgramPreProcessorTest {
     Program program = createProgram('A');
     CategoryCombo categoryCombo = createCategoryCombo('A');
     program.setCategoryCombo(categoryCombo);
-    Event event = completeTrackerEvent().program(MetadataIdentifier.ofUid(program)).build();
+    TrackerEvent event = completeTrackerEvent().program(MetadataIdentifier.ofUid(program)).build();
     when(preheat.getProgram(event.getProgram())).thenReturn(program);
 
     TrackerBundle bundle =
-        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+        TrackerBundle.builder()
+            .trackerEvents(Collections.singletonList(event))
+            .preheat(preheat)
+            .build();
 
     preprocessor.process(bundle);
 
@@ -471,8 +506,8 @@ class EventProgramPreProcessorTest {
     return program;
   }
 
-  private Event invalidSingleEventWithNoProgramAndNoProgramStage() {
-    return TrackerEvent.builder()
+  private SingleEvent invalidSingleEventWithNoProgramAndNoProgramStage() {
+    return SingleEvent.builder()
         .event(UID.generate())
         .program(null)
         .programStage(null)
@@ -480,8 +515,8 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event programEventWithProgram() {
-    return TrackerEvent.builder()
+  private SingleEvent singleEventWithProgram() {
+    return SingleEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION))
         .programStage(MetadataIdentifier.EMPTY_UID)
@@ -489,8 +524,8 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event programEventWithProgramStage() {
-    return TrackerEvent.builder()
+  private SingleEvent singleEventWithProgramStage() {
+    return SingleEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.EMPTY_UID)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITHOUT_REGISTRATION))
@@ -498,8 +533,8 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event completeSingleEvent() {
-    return TrackerEvent.builder()
+  private SingleEvent completeSingleEvent() {
+    return SingleEvent.builder()
         .event(UID.generate())
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_WITHOUT_REGISTRATION))
         .program(MetadataIdentifier.ofUid(PROGRAM_WITHOUT_REGISTRATION))
@@ -507,7 +542,7 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event trackerEventWithProgramStage() {
+  private TrackerEvent trackerEventWithProgramStage() {
     return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.EMPTY_UID)
@@ -516,7 +551,7 @@ class EventProgramPreProcessorTest {
         .build();
   }
 
-  private Event trackerEventWithProgram() {
+  private TrackerEvent trackerEventWithProgram() {
     return TrackerEvent.builder()
         .event(UID.generate())
         .program(MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
@@ -70,13 +69,14 @@ class EventStatusPreProcessorTest {
     TrackerPreheat preheat = new TrackerPreheat();
     preheat.putEnrollmentsWithoutRegistration("programUid", enrollment);
     preheat.put(programStage);
-    Event event =
+    TrackerEvent event =
         TrackerEvent.builder()
             .event(UID.generate())
             .status(EventStatus.VISITED)
             .programStage(MetadataIdentifier.ofUid("programStageUid"))
             .build();
-    TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
+    TrackerBundle bundle =
+        TrackerBundle.builder().trackerEvents(Collections.singletonList(event)).build();
     bundle.setPreheat(preheat);
     // When
     preProcessorToTest.process(bundle);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
@@ -38,9 +38,8 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
-import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
+import org.hisp.dhis.tracker.imports.domain.SingleEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,9 +59,10 @@ class EventWithoutRegistrationPreProcessorTest {
   @Test
   void testEnrollmentIsAddedIntoEventWhenItBelongsToProgramWithoutRegistration() {
     // Given
-    Event event = new TrackerEvent();
+    SingleEvent event = new SingleEvent();
     event.setProgramStage(MetadataIdentifier.ofUid("programStageUid"));
-    TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
+    TrackerBundle bundle =
+        TrackerBundle.builder().singleEvents(Collections.singletonList(event)).build();
     Enrollment enrollment = new Enrollment();
     UID enrollmentUid = UID.generate();
     enrollment.setUid(enrollmentUid.getValue());
@@ -84,9 +84,10 @@ class EventWithoutRegistrationPreProcessorTest {
   @Test
   void testEnrollmentIsNotAddedIntoEventWhenItProgramStageHasNoReferenceToProgram() {
     // Given
-    Event event = new TrackerEvent();
+    SingleEvent event = new SingleEvent();
     event.setProgramStage(MetadataIdentifier.ofUid("programStageUid"));
-    TrackerBundle bundle = TrackerBundle.builder().events(Collections.singletonList(event)).build();
+    TrackerBundle bundle =
+        TrackerBundle.builder().singleEvents(Collections.singletonList(event)).build();
     Enrollment enrollment = new Enrollment();
     enrollment.setUid("enrollmentUid");
     Program program = new Program();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessorTest.java
@@ -38,7 +38,7 @@ import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.DELETE;
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.UPDATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.collect.Lists;
+import java.util.List;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
@@ -83,9 +83,9 @@ class StrategyPreProcessorTest extends TestBase {
 
   private Relationship relationship;
 
-  private org.hisp.dhis.tracker.imports.domain.Event event;
+  private org.hisp.dhis.tracker.imports.domain.TrackerEvent event;
 
-  private org.hisp.dhis.tracker.imports.domain.Event newEvent;
+  private org.hisp.dhis.tracker.imports.domain.TrackerEvent newEvent;
 
   private org.hisp.dhis.tracker.imports.domain.Enrollment enrollment;
 
@@ -138,10 +138,10 @@ class StrategyPreProcessorTest extends TestBase {
   void testStrategyPreprocessForCreateAndUpdate() {
     TrackerBundle bundle =
         TrackerBundle.builder()
-            .trackedEntities(Lists.newArrayList(trackedEntity, newTrackedEntity))
-            .enrollments(Lists.newArrayList(enrollment, newEnrollment))
-            .events(Lists.newArrayList(event, newEvent))
-            .relationships(Lists.newArrayList(payloadRelationship, newPayloadRelationship))
+            .trackedEntities(List.of(trackedEntity, newTrackedEntity))
+            .enrollments(List.of(enrollment, newEnrollment))
+            .trackerEvents(List.of(event, newEvent))
+            .relationships(List.of(payloadRelationship, newPayloadRelationship))
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .preheat(preheat)
             .build();
@@ -161,10 +161,10 @@ class StrategyPreProcessorTest extends TestBase {
   void testStrategyPreprocessForDelete() {
     TrackerBundle bundle =
         TrackerBundle.builder()
-            .trackedEntities(Lists.newArrayList(trackedEntity, newTrackedEntity))
-            .enrollments(Lists.newArrayList(enrollment, newEnrollment))
-            .events(Lists.newArrayList(event, newEvent))
-            .relationships(Lists.newArrayList(payloadRelationship, newPayloadRelationship))
+            .trackedEntities(List.of(trackedEntity, newTrackedEntity))
+            .enrollments(List.of(enrollment, newEnrollment))
+            .trackerEvents(List.of(event, newEvent))
+            .relationships(List.of(payloadRelationship, newPayloadRelationship))
             .importStrategy(DELETE)
             .preheat(preheat)
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
@@ -119,8 +119,8 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
 
   @Test
   void shouldMapPayloadEventsToRuleEvents() {
-    org.hisp.dhis.tracker.imports.domain.Event eventA = payloadEvent();
-    org.hisp.dhis.tracker.imports.domain.Event eventB = payloadEvent();
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent eventA = payloadEvent();
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent eventB = payloadEvent();
 
     TrackerPreheat trackerPreheat = new TrackerPreheat();
     trackerPreheat.put(programStage);
@@ -372,7 +372,7 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
     return eventDataValue;
   }
 
-  private org.hisp.dhis.tracker.imports.domain.Event payloadEvent() {
+  private org.hisp.dhis.tracker.imports.domain.TrackerEvent payloadEvent() {
     return org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
         .enrollment(UID.generate())
         .event(UID.generate())

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_data.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_data.json
@@ -666,6 +666,13 @@
           "providedElsewhere": false
         }
       ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -11.4197,
+          8.1039
+        ]
+      },
       "assignedUser": {
         "uid": "xE7jOejl9FI",
         "firstName": "John",

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_metadata.json
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/tracker/base_metadata.json
@@ -980,6 +980,7 @@
       "user": {
         "id": "tTgjgobT1oS"
       },
+      "featureType": "POINT",
       "validationStrategy": "ON_UPDATE_AND_INSERT"
     },
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -317,7 +317,7 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void shouldReturnEventFieldChangeLogWhenNewDateFieldValueAdded() throws NotFoundException {
-    String event = "OTmjvJDn0Fu";
+    String event = "H0PbzJY8bJG";
 
     Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(
@@ -328,14 +328,14 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
     assertNumberOfChanges(1, scheduledAtLogs);
     assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
-        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:30.562", scheduledAtLogs.get(0)),
-        () -> assertFieldCreate("occurredAt", "2022-04-23 06:00:38.343", occurredAtLogs.get(0)));
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", scheduledAtLogs.get(0)),
+        () -> assertFieldCreate("occurredAt", "2019-01-28 00:00:00.000", occurredAtLogs.get(0)));
   }
 
   @Test
   void shouldReturnEventFieldChangeLogWhenExistingDateFieldUpdated()
       throws IOException, NotFoundException {
-    UID event = UID.of("OTmjvJDn0Fu");
+    UID event = UID.of("H0PbzJY8bJG");
     LocalDateTime currentTime = LocalDateTime.now();
 
     updateEventDates(event, currentTime.toDate().toInstant());
@@ -351,22 +351,22 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
         () ->
             assertFieldUpdate(
                 "scheduledAt",
-                "2022-04-22 06:00:30.562",
+                "2019-01-28 12:10:38.100",
                 currentTime.toString(formatter),
                 scheduledAtLogs.get(0)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:30.562", scheduledAtLogs.get(1)),
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", scheduledAtLogs.get(1)),
         () ->
             assertFieldUpdate(
                 "occurredAt",
-                "2022-04-23 06:00:38.343",
+                "2019-01-28 00:00:00.000",
                 currentTime.toString(formatter),
                 occurredAtLogs.get(0)),
-        () -> assertFieldCreate("occurredAt", "2022-04-23 06:00:38.343", occurredAtLogs.get(1)));
+        () -> assertFieldCreate("occurredAt", "2019-01-28 00:00:00.000", occurredAtLogs.get(1)));
   }
 
   @Test
   void shouldReturnEventFieldChangeLogWhenExistingDateFieldDeleted() throws NotFoundException {
-    UID event = UID.of("OTmjvJDn0Fu");
+    UID event = UID.of("H0PbzJY8bJG");
 
     deleteScheduledAtDate(event);
 
@@ -378,9 +378,9 @@ class EventChangeLogServiceTest extends PostgresIntegrationTestBase {
     assertNumberOfChanges(2, scheduledAtLogs);
     assertNumberOfChanges(1, occurredAtLogs);
     assertAll(
-        () -> assertFieldDelete("scheduledAt", "2022-04-22 06:00:30.562", scheduledAtLogs.get(0)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:30.562", scheduledAtLogs.get(1)),
-        () -> assertFieldCreate("occurredAt", "2022-04-23 06:00:38.343", occurredAtLogs.get(0)));
+        () -> assertFieldDelete("scheduledAt", "2019-01-28 12:10:38.100", scheduledAtLogs.get(0)),
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", scheduledAtLogs.get(1)),
+        () -> assertFieldCreate("occurredAt", "2019-01-28 00:00:00.000", occurredAtLogs.get(0)));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/OrderAndFilterEventChangeLogTest.java
@@ -90,7 +90,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
   private TrackerObjects trackerObjects;
 
   OrderAndFilterEventChangeLogTest() throws BadRequestException {
-    defaultPageParams = PageParams.of(1, 10, false);
+    defaultPageParams = PageParams.of(1, 50, false);
   }
 
   @BeforeAll
@@ -159,54 +159,56 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
   void shouldSortChangeLogsWhenOrderingByDataElementAsc() throws NotFoundException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder().orderBy("change", SortDirection.ASC).build();
-    Event event = getEvent("kWjSezkXHVp");
+    Event event = getEvent("D9PbzJY8bJM");
 
     updateDataValues(event, "GieVkTxp4HH", "20", "25");
-    updateDataValues(event, "GieVkTxp4HG", "20");
 
     List<EventChangeLog> changeLogs =
         eventChangeLogService
-            .getEventChangeLog(UID.of("kWjSezkXHVp"), params, defaultPageParams)
+            .getEventChangeLog(UID.of("D9PbzJY8bJM"), params, defaultPageParams)
             .getItems();
 
-    assertNumberOfChanges(9, changeLogs);
+    assertNumberOfChanges(11, changeLogs);
     assertAll(
-        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(0)),
-        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(1)),
-        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(2)),
-        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(3)),
-        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(4)),
-        () -> assertFieldCreate("occurredAt", "2022-04-22 06:00:38.343", changeLogs.get(5)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-26 06:00:34.323", changeLogs.get(6)),
-        () -> assertDataElementCreate("DATAEL00007", "text", changeLogs.get(7)),
-        () -> assertDataElementCreate("DATAEL00005", "option1", changeLogs.get(8)));
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(0)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(1)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(2)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(3)),
+        () -> assertFieldCreate("occurredAt", "2020-01-28 00:00:00.000", changeLogs.get(4)),
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", changeLogs.get(5)),
+        () -> assertDataElementCreate("DATAEL00002", "value00002", changeLogs.get(6)),
+        () -> assertDataElementCreate("DATAEL00006", "70", changeLogs.get(7)),
+        () -> assertDataElementCreate("DATAEL00007", "70", changeLogs.get(8)),
+        () -> assertDataElementCreate("DATAEL00001", "value00002", changeLogs.get(9)),
+        () -> assertDataElementCreate("DATAEL00005", "option2", changeLogs.get(10)));
   }
 
   @Test
   void shouldSortChangeLogsWhenOrderingByChangeDesc() throws NotFoundException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder().orderBy("change", SortDirection.DESC).build();
-    Event event = getEvent("kWjSezkXHVp");
+    Event event = getEvent("D9PbzJY8bJM");
 
     updateDataValues(event, "GieVkTxp4HH", "20", "25");
-    updateDataValues(event, "GieVkTxp4HG", "20");
 
     List<EventChangeLog> changeLogs =
         eventChangeLogService
-            .getEventChangeLog(UID.of("kWjSezkXHVp"), params, defaultPageParams)
+            .getEventChangeLog(UID.of("D9PbzJY8bJM"), params, defaultPageParams)
             .getItems();
 
-    assertNumberOfChanges(9, changeLogs);
+    assertNumberOfChanges(11, changeLogs);
     assertAll(
-        () -> assertDataElementCreate("DATAEL00005", "option1", changeLogs.get(0)),
-        () -> assertDataElementCreate("DATAEL00007", "text", changeLogs.get(1)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-26 06:00:34.323", changeLogs.get(2)),
-        () -> assertFieldCreate("occurredAt", "2022-04-22 06:00:38.343", changeLogs.get(3)),
-        () -> assertDataElementUpdate("GieVkTxp4HG", "10", "20", changeLogs.get(4)),
-        () -> assertDataElementCreate("GieVkTxp4HG", "10", changeLogs.get(5)),
-        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(6)),
-        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(7)),
-        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(8)));
+        () -> assertDataElementCreate("DATAEL00005", "option2", changeLogs.get(0)),
+        () -> assertDataElementCreate("DATAEL00001", "value00002", changeLogs.get(1)),
+        () -> assertDataElementCreate("DATAEL00007", "70", changeLogs.get(2)),
+        () -> assertDataElementCreate("DATAEL00006", "70", changeLogs.get(3)),
+        () -> assertDataElementCreate("DATAEL00002", "value00002", changeLogs.get(4)),
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", changeLogs.get(5)),
+        () -> assertFieldCreate("occurredAt", "2020-01-28 00:00:00.000", changeLogs.get(6)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "20", "25", changeLogs.get(7)),
+        () -> assertDataElementUpdate("GieVkTxp4HH", "15", "20", changeLogs.get(8)),
+        () -> assertDataElementCreate("GieVkTxp4HH", "15", changeLogs.get(9)),
+        () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(10)));
   }
 
   @Test
@@ -214,7 +216,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
       throws NotFoundException, IOException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder().orderBy("change", SortDirection.ASC).build();
-    UID event = UID.of("OTmjvJDn0Fu");
+    UID event = UID.of("D9PbzJY8bJM");
 
     LocalDateTime currentTime = LocalDateTime.now();
     updateEventDates(event, currentTime.toDate().toInstant());
@@ -222,7 +224,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
     List<EventChangeLog> changeLogs =
         getAllFieldChangeLogs(
             eventChangeLogService.getEventChangeLog(
-                UID.of("OTmjvJDn0Fu"), params, defaultPageParams));
+                UID.of("D9PbzJY8bJM"), params, defaultPageParams));
 
     assertNumberOfChanges(5, changeLogs);
     assertAll(
@@ -230,17 +232,17 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
         () ->
             assertFieldUpdate(
                 "occurredAt",
-                "2022-04-23 06:00:38.343",
+                "2020-01-28 00:00:00.000",
                 currentTime.toString(formatter),
                 changeLogs.get(1)),
-        () -> assertFieldCreate("occurredAt", "2022-04-23 06:00:38.343", changeLogs.get(2)),
+        () -> assertFieldCreate("occurredAt", "2020-01-28 00:00:00.000", changeLogs.get(2)),
         () ->
             assertFieldUpdate(
                 "scheduledAt",
-                "2022-04-22 06:00:30.562",
+                "2019-01-28 12:10:38.100",
                 currentTime.toString(formatter),
                 changeLogs.get(3)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:30.562", changeLogs.get(4)));
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", changeLogs.get(4)));
   }
 
   @Test
@@ -248,7 +250,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
       throws NotFoundException, IOException {
     EventChangeLogOperationParams params =
         EventChangeLogOperationParams.builder().orderBy("change", SortDirection.DESC).build();
-    UID event = UID.of("OTmjvJDn0Fu");
+    UID event = UID.of("D9PbzJY8bJM");
 
     LocalDateTime currentTime = LocalDateTime.now();
     updateEventDates(event, currentTime.toDate().toInstant());
@@ -256,24 +258,24 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
     List<EventChangeLog> changeLogs =
         getAllFieldChangeLogs(
             eventChangeLogService.getEventChangeLog(
-                UID.of("OTmjvJDn0Fu"), params, defaultPageParams));
+                UID.of("D9PbzJY8bJM"), params, defaultPageParams));
 
     assertNumberOfChanges(5, changeLogs);
     assertAll(
         () ->
             assertFieldUpdate(
                 "scheduledAt",
-                "2022-04-22 06:00:30.562",
+                "2019-01-28 12:10:38.100",
                 currentTime.toString(formatter),
                 changeLogs.get(0)),
-        () -> assertFieldCreate("scheduledAt", "2022-04-22 06:00:30.562", changeLogs.get(1)),
+        () -> assertFieldCreate("scheduledAt", "2019-01-28 12:10:38.100", changeLogs.get(1)),
         () ->
             assertFieldUpdate(
                 "occurredAt",
-                "2022-04-23 06:00:38.343",
+                "2020-01-28 00:00:00.000",
                 currentTime.toString(formatter),
                 changeLogs.get(2)),
-        () -> assertFieldCreate("occurredAt", "2022-04-23 06:00:38.343", changeLogs.get(3)),
+        () -> assertFieldCreate("occurredAt", "2020-01-28 00:00:00.000", changeLogs.get(3)),
         () -> assertFieldCreate("geometry", "(-11.419700, 8.103900)", changeLogs.get(4)));
   }
 
@@ -356,7 +358,7 @@ class OrderAndFilterEventChangeLogTest extends PostgresIntegrationTestBase {
             .build();
 
     Page<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("OTmjvJDn0Fu"), params, defaultPageParams);
+        eventChangeLogService.getEventChangeLog(UID.of("D9PbzJY8bJM"), params, defaultPageParams);
 
     Set<String> changeLogOccurredAtFields =
         changeLogs.getItems().stream()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatServiceTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +69,11 @@ class TrackerPreheatServiceTest extends PostgresIntegrationTestBase {
   @Autowired private TrackerPreheatService trackerPreheatService;
 
   @Autowired private TrackerIdentifierCollector identifierCollector;
+
+  @BeforeAll
+  void setup() throws IOException {
+    testSetup.importMetadata("tracker/event_metadata.json");
+  }
 
   @Test
   void testCollectIdentifiersEvents() throws IOException {
@@ -142,8 +148,6 @@ class TrackerPreheatServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testPreheatEvents() throws IOException {
-    testSetup.importMetadata("tracker/event_metadata.json");
-
     User importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -949,7 +950,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
 
   private List<Event> getEventsByEnrollment(UID enrollment) {
     return trackerObjects.getEvents().stream()
-        .filter(ev -> ev.getEnrollment().equals(enrollment))
+        .filter(ev -> Objects.equals(ev.getEnrollment(), enrollment))
         .toList();
   }
 


### PR DESCRIPTION
***Big picture***
The goal of this ticket is to have separate domain objects for single events and tracker events that will be generated in the preprocess phase.
This will allow us to have separate flows for validation, rule-engine and persistence (even though for now we will use the same DB table).

***Implemented in this PR***
- Remove `events` field from `TrackerBundle` and add `trackerEvents` and `singleEvents` fields.
- `trackerEvents` and `singleEvents` fields are created after preheat phase and any ambiguous event (without valid program and programStage) is mapped to a tracker event.
- We are maintaining (maybe only temporary) getter and setter for events.
- For now, `Event` interface contains fields that only belong to tracker events and `SingleEvent` class is implementing them. After we tackle validation phase we can review it and have a proper interface.

***Next steps***
- Use the concrete classes in the preprocess phase.
- Separate validation flow based on the event type.
- Separate rule-engine flow based on event type.
- Separate persistence flow based on event type.