### PR TITLE
chore: Use Hikari and set max DB conns to 200 for int tests

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -1,6 +1,6 @@
 filestore.provider = transient
 filestore.container = files
-connection.pool.max_size=80
+connection.pool.max_size=200
 encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 
 hibernate.cache.use_query_cache=true
@@ -17,4 +17,4 @@ audit.tracker=CREATE_UPDATE_DELETE
 audit.aggregate=CREATE_UPDATE_DELETE
 
 flyway.skip_migration=false
-
+db.pool.type=hikari


### PR DESCRIPTION
The CI pipeline is in a bad state. It has gradually worsened over the past few months.
The error `java.sql.SQLException: Connections could not be acquired from the underlying database!` has failed builds more frequently recently.

This change aims to provide breathing room while the issue is looked into.
Change is for Integration tests only:
- use Hikari as pool manager
- set max connections to 200 (temporary while issue looked into)