### PR TITLE
fix: OpenAPI include Setting names as keys not properties [DHIS2-19787]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/Settings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/Settings.java
@@ -49,6 +49,18 @@ import org.hisp.dhis.jsontree.JsonMixed;
 public sealed interface Settings permits UserSettings, SystemSettings {
 
   /**
+   * Resolves the key name by a Java property name as used in the settings interface
+   *
+   * @param property as derived from a default method in a {@link Settings} interface
+   * @return the key name for the given property name
+   */
+  @Nonnull
+  static String getKey(@Nonnull String property) {
+    String key = LazySettings.keyOf(property);
+    return key == null ? property : key;
+  }
+
+  /**
    * Converts Java types to a setting raw {@link String} value
    *
    * @param value a {@link Boolean}, {@link Number}, {@link String}, {@link Date}, {@link Locale} or

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -73,6 +73,14 @@ class SystemSettingsTest {
           "loginPopup");
 
   @Test
+  void testKeyByProperty() {
+    // test one that has the key-prefix
+    assertEquals("keyAnalysisDigitGroupSeparator", Settings.getKey("analysisDigitGroupSeparator"));
+    // and one that does not
+    assertEquals("startModule", Settings.getKey("startModule"));
+  }
+
+  @Test
   void testIsConfidential() {
     CONFIDENTIAL_KEYS.forEach(
         key ->

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Property.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Property.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.common.OpenApi.Access;
 import org.hisp.dhis.jsontree.Json;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
+import org.hisp.dhis.setting.Settings;
 
 /**
  * Extracts the properties of "record" like objects.
@@ -258,15 +259,19 @@ class Property {
   }
 
   private static <T extends Member & AnnotatedElement> String getPropertyName(T member) {
-    String name = getJavaPropertyName(member);
     OpenApi.Property oap = member.getAnnotation(OpenApi.Property.class);
     String nameOverride = oap == null ? "" : oap.name();
-    if (!nameOverride.isEmpty()) {
-      return nameOverride;
-    }
+    if (!nameOverride.isEmpty()) return nameOverride;
     JsonProperty property = member.getAnnotation(JsonProperty.class);
     nameOverride = property == null ? "" : property.value();
-    return nameOverride.isEmpty() ? name : nameOverride;
+    if (!nameOverride.isEmpty()) return nameOverride;
+    String name = getJavaPropertyName(member);
+    if (Settings.class.isAssignableFrom(member.getDeclaringClass())) {
+      // for now, we do this extra resolve step hard coded as it is complicated to add as a general
+      // feature
+      name = Settings.getKey(name);
+    }
+    return name;
   }
 
   private static <T extends Member & AnnotatedElement> String getJavaPropertyName(T member) {


### PR DESCRIPTION
The `SystemSettings` object schema should use the actual key names instead of the Java property names. 

This https://play.im.dhis2.org/dev/api/openapi.html?scope=entity:SystemSetting#SystemSettings currently looking like this:

![DHIS-API--06-24-2025_02_09_PM](https://github.com/user-attachments/assets/945e1c9d-1188-4097-93f5-d66ee11a96d5)

should look like this

![DHIS-API--06-24-2025_02_10_PM](https://github.com/user-attachments/assets/53c7e045-911c-4be8-b26c-f84db81d67a3)

Note that some names now have a `key` prefix (or one even `Key`). This is the name of the setting as opposed to the property name. The property mostly also works because when stating keys it is allowed to omit the `key` prefix but that still posed some issues for machine-machine API usage so this PR corrects the OpenAPI schema to state key names.

### Automatic Testing
Adds a unit test to check the mapping between key and property is captured correctly.

### Manual Testing
Check  https://play.im.dhis2.org/dev/api/openapi.html?scope=entity:SystemSetting#SystemSettings and look for `key` in the names