### PR TITLE
feat: Program rules linked to an inconsistent program stage

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -46,6 +46,7 @@ checks:
   - program_rules/program_rules_without_condition.yaml
   - program_rules/program_rules_message_no_template.yaml
   - program_rules/program_rules_no_priority.yaml
+  - program_rules/program_rules_inconsistent_program_program_stage.yaml
   - analytical_objects/visualizations_not_used_1year.yaml
   - analytical_objects/maps_not_used_1year.yaml
   - analytical_objects/dashboards_not_used_1year.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/program_rules/program_rules_inconsistent_program_program_stage.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/program_rules/program_rules_inconsistent_program_program_stage.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: program_rules_inconsistent_program_program_stage
+description: Program rules which are inconsistently linked to a program and program stage.
+section: Programs
+section_order: 3
+summary_sql: >-
+  WITH rs as (
+  SELECT a.uid,a.name,a.programid,a.programstageid,b.programid from programrule a
+  INNER JOIN programstage b on a.programstageid = b.programstageid
+  WHERE a.programid != b.programid
+  )
+  select count(*) as value,
+  100.0 * count(*) / NULLIF( (select count(*) from programrule),0) as percent
+  from rs;
+details_sql: >-
+  WITH rs as (
+  SELECT a.uid,a.name,a.programid,a.programstageid,b.programid from programrule a
+  INNER JOIN programstage b on a.programstageid = b.programstageid
+  WHERE a.programid != b.programid
+  )
+  SELECT uid,name from rs;
+severity: WARNING
+introduction: >
+  Program rules can be linked to both a program as well as a program stage.
+  If the program rule is linked to a program stage, it should also be linked to the
+  program that the program stage belongs to. This check identifies program rules that are linked to a program stage
+    but not to the program that the program stage belongs to.
+details_id_type: programRules
+recommendation: >

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/program_rules/program_rules_inconsistent_program_program_stage.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/program_rules/program_rules_inconsistent_program_program_stage.yaml
@@ -52,4 +52,16 @@ introduction: >
   program that the program stage belongs to. This check identifies program rules that are linked to a program stage
     but not to the program that the program stage belongs to.
 details_id_type: programRules
-recommendation: >
+recommendation: >-
+  The simplest way to fix this issue is to relink the program rule to the correct program. After shutting down your
+  DHIS2 instance, you can do this by running the following SQL query:
+  
+    UPDATE programrule pr
+    SET programid = (SELECT ps.programid FROM programstage ps WHERE ps.programstageid = pr.programstageid)
+    WHERE pr.programid != (SELECT ps.programid FROM programstage ps WHERE ps.programstageid = pr.programstageid);
+
+  Restart your DHIS2 instance after running the query and check the data integrity checks again. You should 
+  see that the issue has been resolved.
+  
+  As is always the case when performing database updates, it is recommended to take a backup of your database before running the query
+  and perform the update in a test environment first to ensure that it works as expected.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -59,7 +59,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(90, checks.size());
+    assertEquals(91, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -59,7 +59,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(89, checks.size());
+    assertEquals(90, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2107,6 +2107,7 @@ data_integrity.program_rules_message_no_template.name=Program rules actions whic
 data_integrity.program_rules_no_action.name=Program rules with no action.
 data_integrity.program_rules_no_expression.name=Program rules with no expression.
 data_integrity.program_rules_no_priority.name=Program rules with no priority
+data_integrity.program_rules_inconsistent_program_program_stage.name=Program rules which are inconsistently linked to a program and program stage.
 data_integrity.validation_rules_missing_value_strategy_null.name=All validation rule expressions should have a missing value strategy.
 data_integrity.dashboards_not_viewed_one_year.name=Dashboards which have not been actively viewed in the past 12 months
 data_integrity.maps_not_viewed_one_year.name=Maps which have not been viewed in the past 12 months

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
@@ -90,7 +90,7 @@ class DataIntegrityProgramRulesInconsistentlyLinkedControllerTest
     dbmsManager.clearSession();
 
     assertHasDataIntegrityIssues(
-        detailsIdType, CHECK, 50, programRuleB.getUid(), programRuleB.getName(), null, true);
+        DETAILS_ID_TYPE, CHECK, 50, programRuleB.getUid(), programRuleB.getName(), null, true);
   }
 
   public void setUpTest() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
@@ -50,19 +50,13 @@ class DataIntegrityProgramRulesInconsistentlyLinkedControllerTest
 
   @Autowired private ProgramStageService programStageService;
 
-  private ProgramRule programRuleA;
-
-  private ProgramRule programRuleB;
-
-  private ProgramStage programStageB;
-
   private ProgramStage programStageA;
 
   private Program programA;
 
   private Program programB;
 
-  private static final String detailsIdType = "programRules";
+  private static final String DETAILS_ID_TYPE = "programRules";
 
   private static final String CHECK = "program_rules_inconsistent_program_program_stage";
 
@@ -71,19 +65,19 @@ class DataIntegrityProgramRulesInconsistentlyLinkedControllerTest
 
     setUpTest();
     dbmsManager.clearSession();
-    assertHasNoDataIntegrityIssues(detailsIdType, CHECK, true);
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK, true);
   }
 
   @Test
   void testProgramRuleInconsistentlyLinked() {
     setUpTest();
 
-    programStageB = new ProgramStage();
+    ProgramStage programStageB = new ProgramStage();
     programStageB.setAutoFields();
     programStageB.setName("programStageB");
     programStageA.setProgram(programB);
 
-    programRuleB = new ProgramRule();
+    ProgramRule programRuleB = new ProgramRule();
     programRuleB.setAutoFields();
     programRuleB.setName("ProgramRuleB");
     programRuleB.setProgram(programA); // Purposefully set to program A
@@ -122,7 +116,7 @@ class DataIntegrityProgramRulesInconsistentlyLinkedControllerTest
     programStageA.setName("programStageA");
     programStageA.setProgram(programA);
 
-    programRuleA = new ProgramRule();
+    ProgramRule programRuleA = new ProgramRule();
     programRuleA.setAutoFields();
     programRuleA.setName("ProgramRuleA");
     programRuleA.setProgram(programA);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramRulesInconsistentlyLinkedControllerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import org.hisp.dhis.program.*;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Combined integrity test for program rules. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/program_rules/}
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityProgramRulesInconsistentlyLinkedControllerTest
+    extends AbstractDataIntegrityIntegrationTest {
+
+  @Autowired private ProgramService programService;
+
+  @Autowired private ProgramRuleService programRuleService;
+
+  @Autowired private ProgramStageService programStageService;
+
+  private ProgramRule programRuleA;
+
+  private ProgramRule programRuleB;
+
+  private ProgramStage programStageB;
+
+  private ProgramStage programStageA;
+
+  private Program programA;
+
+  private Program programB;
+
+  private static final String detailsIdType = "programRules";
+
+  private static final String CHECK = "program_rules_inconsistent_program_program_stage";
+
+  @Test
+  void testProgramRuleConsistentlyLinked() {
+
+    setUpTest();
+    dbmsManager.clearSession();
+    assertHasNoDataIntegrityIssues(detailsIdType, CHECK, true);
+  }
+
+  @Test
+  void testProgramRuleInconsistentlyLinked() {
+    setUpTest();
+
+    programStageB = new ProgramStage();
+    programStageB.setAutoFields();
+    programStageB.setName("programStageB");
+    programStageA.setProgram(programB);
+
+    programRuleB = new ProgramRule();
+    programRuleB.setAutoFields();
+    programRuleB.setName("ProgramRuleB");
+    programRuleB.setProgram(programA); // Purposefully set to program A
+    programRuleB.setProgramStage(programStageB);
+    programB.getProgramStages().add(programStageB);
+
+    programStageService.saveProgramStage(programStageB);
+    programRuleService.addProgramRule(programRuleB);
+
+    dbmsManager.clearSession();
+
+    assertHasDataIntegrityIssues(
+        detailsIdType, CHECK, 50, programRuleB.getUid(), programRuleB.getName(), null, true);
+  }
+
+  public void setUpTest() {
+
+    programA = new Program();
+    programA.setAutoFields();
+    programA.setName("Program A");
+    programA.setShortName("Program A");
+    programA.setProgramType(ProgramType.WITHOUT_REGISTRATION);
+    programA.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
+    programService.addProgram(programA);
+
+    programB = new Program();
+    programB.setAutoFields();
+    programB.setName("Program B");
+    programB.setShortName("Program B");
+    programB.setProgramType(ProgramType.WITHOUT_REGISTRATION);
+    programB.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
+    programService.addProgram(programB);
+
+    programStageA = new ProgramStage();
+    programStageA.setAutoFields();
+    programStageA.setName("programStageA");
+    programStageA.setProgram(programA);
+
+    programRuleA = new ProgramRule();
+    programRuleA.setAutoFields();
+    programRuleA.setName("ProgramRuleA");
+    programRuleA.setProgram(programA);
+    programRuleA.setProgramStage(programStageA);
+    programA.getProgramStages().add(programStageA);
+
+    programStageService.saveProgramStage(programStageA);
+    programRuleService.addProgramRule(programRuleA);
+  }
+}


### PR DESCRIPTION
- Program rules can be optionally linked to a program as well as a program stage. The model theoretically allows program rules to be linked to a program stage which does not exist in the associated program. 
- This check identifies program rules which are linked to both a program as well as a program stage, but the program stage is not part of the linked program. 