### PR TITLE
chore: Clean up Integration test exceptions - Artemis startup exceptions

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
@@ -57,13 +57,17 @@ public class ArtemisManager {
   @PostConstruct
   public void startArtemis() throws Exception {
     if (ArtemisMode.EMBEDDED == artemisConfigData.getMode()) {
-      Acceptor existingAcceptor = InVMRegistry.instance.getAcceptor(0);
+      Acceptor existingAcceptor =
+          InVMRegistry.instance.getAcceptor(ArtemisConfigData.EMBEDDED_ACCEPTOR_ID);
       if (existingAcceptor == null) {
-        log.info("Starting embedded Artemis ActiveMQ server with Acceptor ID 0");
+        log.info(
+            "Starting embedded Artemis ActiveMQ server with Acceptor ID {}",
+            ArtemisConfigData.EMBEDDED_ACCEPTOR_ID);
         embeddedActiveMQ.start();
       } else {
         log.warn(
-            "Acceptor with ID 0 already exists, skip starting embedded Artemis ActiveMQ server.");
+            "Acceptor with ID {} already exists, skip starting embedded Artemis ActiveMQ server.",
+            ArtemisConfigData.EMBEDDED_ACCEPTOR_ID);
       }
     }
   }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -32,7 +32,9 @@ package org.hisp.dhis.artemis;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMRegistry;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.hisp.dhis.artemis.config.ArtemisConfigData;
 import org.hisp.dhis.artemis.config.ArtemisMode;
 import org.springframework.stereotype.Service;
@@ -55,8 +57,14 @@ public class ArtemisManager {
   @PostConstruct
   public void startArtemis() throws Exception {
     if (ArtemisMode.EMBEDDED == artemisConfigData.getMode()) {
-      log.info("Starting embedded Artemis ActiveMQ server.");
-      embeddedActiveMQ.start();
+      Acceptor existingAcceptor = InVMRegistry.instance.getAcceptor(0);
+      if (existingAcceptor == null) {
+        log.info("Starting embedded Artemis ActiveMQ server with Acceptor ID 0");
+        embeddedActiveMQ.start();
+      } else {
+        log.warn(
+            "Acceptor with ID 0 already exists, skip starting embedded Artemis ActiveMQ server.");
+      }
     }
   }
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/ArtemisManager.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfig.java
@@ -161,8 +161,10 @@ public class ArtemisConfig {
     config.addAcceptorConfiguration(
         "in-vm",
         String.format(
-            "vm://0?jms.useAsyncSend=%s&nioRemotingThreads=%d",
-            artemisConfigData.isSendAsync(), embeddedConfig.getNioRemotingThreads()));
+            "vm://%d?jms.useAsyncSend=%s&nioRemotingThreads=%d",
+            ArtemisConfigData.EMBEDDED_ACCEPTOR_ID,
+            artemisConfigData.isSendAsync(),
+            embeddedConfig.getNioRemotingThreads()));
 
     config.setSecurityEnabled(embeddedConfig.isSecurity());
     config.setPersistenceEnabled(embeddedConfig.isPersistence());

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfigData.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/config/ArtemisConfigData.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.common.DxfNamespaces;
 public class ArtemisConfigData {
   private ArtemisMode mode = ArtemisMode.EMBEDDED;
 
+  public static final int EMBEDDED_ACCEPTOR_ID = 0;
+
   private String host = "127.0.0.1";
 
   // AMQP port should be 5672/5673 but we don't want to cause issues with


### PR DESCRIPTION
## Issue
For a long time (over 1 year at least), the integration tests (postgres & h2) have thrown the following exception:
```text
ERROR org.apache.activemq.artemis.core.server - AMQ224104: Error starting the Acceptor in-vm {serverId=0}
ERROR org.apache.activemq.artemis.core.server - AMQ224000: Failure in initialisation
java.lang.IllegalArgumentException: AMQ229062: Acceptor with id 0 already registered
```

Currently, it occurs 14 times, which:
- pollutes the test logs
- makes it harder to see genuine issues
- potentially slows the impacted tests

This seems to happen when a test uses a custom context config. The `embeddedActiveMQ` instance tries to be started again with the same acceptor ID (this has always been hardcoded as `0`, which seems fine for the embedded broker as it should only ever start once in production).

## Change
- check if the acceptor is already registered before trying to register/start.
- makes the acceptor ID of `0` more visible for the embedded broker, making it easier to see where it is used and also allowing to check if an acceptor with that ID is already registered.

## Startup
This results in the embedded broker still starting when the server starts and also prevents trying to register the same acceptor multiple times during the integration tests.
If there is an issue when calling `start` the server will not start, which is the current behaviour.
This seems to be an important behaviour (fail startup), and is the reason why a try catch is not preferred here instead.

Logs show the embedded broker starting up as normal:
```text
12:59:55.594  INFO [main] o.h.d.a.ArtemisManager: Starting embedded Artemis ActiveMQ server with Acceptor ID 0
```
Also tested startup locally with a metadata create audit event in the DB.