### PR TITLE
chore: Update Maven snapshots url

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1845,9 +1845,9 @@
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>centralSnapshots</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </repository>
     <repository>
       <id>jitpack.io</id>


### PR DESCRIPTION
This PR updates the snapshots url. The migration from the deprecated OSSRH service to the new Central Portal has made that the snapshots are available in a different repository.