### PR TITLE
feat: Gist API - support efficient OU tree search and offline caching  [DHIS2-19789] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -206,8 +206,10 @@ public class DefaultGistService implements GistService, GistBuilder.GistBuilderS
   private <T> List<T> fetchWithParameters(
       GistQuery gistQuery, GistBuilder builder, Query<T> query) {
     builder.addFetchParameters(query::setParameter, this::parseFilterArgument);
-    query.setMaxResults(Math.max(1, gistQuery.getPageSize()));
-    query.setFirstResult(gistQuery.getPageOffset());
+    if (gistQuery.isPaging()) {
+      query.setMaxResults(Math.max(1, gistQuery.getPageSize()));
+      query.setFirstResult(gistQuery.getPageOffset());
+    }
     query.setCacheable(false);
     return query.list();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -587,9 +587,9 @@ final class GistBuilder {
       case SIZE:
         return createSizeTransformerHQL(index, field, property, "");
       case IS_EMPTY:
-        return createSizeTransformerHQL(index, field, property, "=0");
+        return createIsEmptyTransformerHQL(field);
       case IS_NOT_EMPTY:
-        return createSizeTransformerHQL(index, field, property, ">0");
+        return createIsNotEmptyTransformerHQL(field);
       case NOT_MEMBER:
         return createHasMemberTransformerHQL(index, field, property, "=0");
       case MEMBER:
@@ -618,6 +618,14 @@ final class GistBuilder {
     return String.format(
         "(select count(*) %5$s from %2$s %1$s where %1$s in elements(e.%3$s) and %4$s)",
         tableName, property.getItemKlass().getSimpleName(), memberPath, accessFilter, compare);
+  }
+
+  private String createIsNotEmptyTransformerHQL(Field field) {
+    return "e.%s is not empty".formatted(getMemberPath(field.getPropertyPath()));
+  }
+
+  private String createIsEmptyTransformerHQL(Field field) {
+    return "e.%s is empty".formatted(getMemberPath(field.getPropertyPath()));
   }
 
   private String createIdsTransformerHQL(int index, Field field, Property property) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.gist;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import org.hisp.dhis.common.Maturity.Beta;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.query.Junction;
@@ -119,6 +120,29 @@ public final class GistParams {
       """
       By default, the Gist API includes links to referenced objects. This can be disabled by using `references=false`.""")
   boolean references = true;
+
+  @Beta
+  @OpenApi.Since(43)
+  @OpenApi.Description(
+      """
+      When true, the list is adjusted for efficient listing of organisation units for offline caching.
+      Most importantly the list will not have paging (not possible otherwise).
+      Overrides `fields` with the equivalent of `fields=path,displayName,children::isNotEmpty`.
+      Overrides `references` with `references=false`.
+      """)
+  boolean orgUnitsOffline = false;
+
+  @Beta
+  @OpenApi.Since(43)
+  @OpenApi.Description(
+      """
+      When true, the list is adjusted for efficient paged listing of organisation units displaying search results as tree.
+      Overrides `order` with the equivalent of `order=path`.
+      Overrides `references` with `references=false`.
+      Always adds `path` to the `fields` list, if not already contained.
+      For organisation units `/api/organisationUnits/gist` lists all parents up to the root (ancestors) of any match are included in the result list.
+      In that case a boolean property `match` is added to each entry indicating if the entry was added as ancestor (`false`) or as query match (`true`)""")
+  boolean orgUnitsTree = false;
 
   @OpenApi.Description(
       """

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -100,6 +100,8 @@ public final class GistQuery {
 
   private final Class<? extends PrimaryKeyObject> elementType;
 
+  private final boolean paging;
+
   @JsonProperty private final int pageOffset;
 
   @JsonProperty private final int pageSize;
@@ -178,7 +180,21 @@ public final class GistQuery {
   public GistQuery with(GistParams params) throws BadRequestException {
     int page = abs(params.getPage());
     int size = Math.min(1000, abs(params.getPageSize()));
+    boolean tree = params.isOrgUnitsTree();
+    boolean offline = params.isOrgUnitsOffline();
+    String order = tree ? "path" : params.getOrder();
+    if (offline && (order == null || order.isEmpty())) order = "level,name";
+    String fields = offline ? "path,displayName,children::isNotEmpty" : params.getFields();
+    // ensure tree always includes path in fields
+    if (tree) {
+      if (fields == null || fields.isEmpty()) {
+        fields = "path";
+      } else if (!(fields.contains(",path,"))
+          || fields.startsWith("path,")
+          || fields.endsWith(",path")) fields += ",path";
+    }
     return toBuilder()
+        .paging(!offline)
         .pageSize(size)
         .pageOffset(Math.max(0, page - 1) * size)
         .translate(params.isTranslate())
@@ -187,17 +203,14 @@ public final class GistQuery {
         .absoluteUrls(params.isAbsoluteUrls())
         .headless(params.isHeadless())
         .describe(params.isDescribe())
-        .references(params.isReferences())
+        .references(!tree && !offline && params.isReferences())
         .anyFilter(params.getRootJunction() == Junction.Type.OR)
-        .fields(
-            getStrings(params.getFields(), FIELD_SPLIT).stream()
-                .map(Field::parse)
-                .collect(toList()))
+        .fields(getStrings(fields, FIELD_SPLIT).stream().map(Field::parse).toList())
         .filters(
             getStrings(params.getFilter(), FIELD_SPLIT).stream()
                 .map(Filter::parse)
                 .collect(toList()))
-        .orders(getStrings(params.getOrder(), ",").stream().map(Order::parse).collect(toList()))
+        .orders(getStrings(order, ",").stream().map(Order::parse).toList())
         .build();
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/ControllerIntegrationTestBase.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/ControllerIntegrationTestBase.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.test.webapi;
 import static java.lang.String.format;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.http.HttpAssertions.exceptionAsFail;
+import static org.hisp.dhis.http.HttpStatus.CREATED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
 import java.io.UnsupportedEncodingException;
@@ -45,8 +46,10 @@ import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.http.HttpClientAdapter;
 import org.hisp.dhis.http.HttpMethod;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.test.IntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -294,5 +297,44 @@ public abstract class ControllerIntegrationTestBase extends IntegrationTestBase
             valueType,
             categoryCombo,
             optionSet == null ? "null" : "{'id':'" + optionSet + "'}"));
+  }
+
+  protected final List<String> toOrganisationUnitNames(JsonObject response) {
+    return response
+        .getList("organisationUnits", JsonIdentifiableObject.class)
+        .toList(JsonIdentifiableObject::getDisplayName);
+  }
+
+  protected final String addOrganisationUnit(String name) {
+    return assertStatus(
+        CREATED,
+        POST(
+            "/organisationUnits",
+            """
+              {
+                'name':'%s',
+                'shortName':'%s',
+                'openingDate':'2021',
+                'description':'Org desc',
+                'code':'Org code'
+              }
+            """
+                .formatted(name, name)));
+  }
+
+  protected final String addOrganisationUnit(String name, String parentId) {
+    return assertStatus(
+        CREATED,
+        POST(
+            "/organisationUnits",
+            "{'name':'"
+                + name
+                + "', 'shortName':'"
+                + name
+                + "', 'openingDate':'2021', 'parent': "
+                + "{'id':'"
+                + parentId
+                + "'}"
+                + " }"));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistOrgUnitsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistOrgUnitsControllerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the OU specific special Gist API parameters.
+ *
+ * @author Jan Bernitt
+ */
+class GistOrgUnitsControllerTest extends AbstractGistControllerPostgresTest {
+
+  private String ou1, ou2, ou3a, ou3b, ou4a, ou4b;
+
+  @Override
+  @BeforeEach
+  void setUp() {
+    ou1 = addOrganisationUnit("nameL1");
+    ou2 = addOrganisationUnit("nameL2", ou1);
+    ou3a = addOrganisationUnit("nameL3a", ou2);
+    ou3b = addOrganisationUnit("nameL3b", ou2);
+    ou4a = addOrganisationUnit("nameL4a", ou3a);
+    ou4b = addOrganisationUnit("nameL4b", ou3b);
+  }
+
+  @Test
+  void testOrgUnitsOffline() {
+    assertEquals(
+        List.of("nameL1", "nameL2", "nameL3a", "nameL3b", "nameL4a", "nameL4b"),
+        toOrganisationUnitNames(GET("/api/organisationUnits/gist?orgUnitsOffline=true").content()));
+    assertEquals(
+        List.of("nameL1", "nameL2", "nameL3a", "nameL3b"),
+        toOrganisationUnitNames(
+            GET("/api/organisationUnits/gist?orgUnitsOffline=true&filter=level:le:3").content()));
+  }
+
+  @Test
+  void testOrgUnitsTree() {
+    assertEquals(
+        List.of("nameL1", "nameL2", "nameL3a", "nameL4a"),
+        toOrganisationUnitNames(
+            GET(
+                    "/api/organisationUnits/gist?fields=displayName&orgUnitsTree=true&filter=id:eq:{id}",
+                    ou4a)
+                .content()));
+    assertEquals(
+        List.of("nameL1", "nameL2", "nameL3b"),
+        toOrganisationUnitNames(
+            GET(
+                    "/api/organisationUnits/gist?fields=displayName&orgUnitsTree=true&filter=id:eq:{id}",
+                    ou3b)
+                .content()));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -29,18 +29,15 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
-import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
-import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.test.webapi.json.domain.JsonOrganisationUnit;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -233,44 +230,5 @@ class OrganisationUnitControllerTest extends H2ControllerIntegrationTestBase {
   private void assertListOfOrganisationUnits(JsonObject response, String... names) {
     assertContainsOnly(List.of(names), toOrganisationUnitNames(response));
     assertEquals(names.length, response.getObject("pager").getNumber("total").intValue());
-  }
-
-  private List<String> toOrganisationUnitNames(JsonObject response) {
-    return response
-        .getList("organisationUnits", JsonIdentifiableObject.class)
-        .toList(JsonIdentifiableObject::getDisplayName);
-  }
-
-  private String addOrganisationUnit(String name) {
-    return assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/organisationUnits",
-            """
-              {
-                'name':'%s',
-                'shortName':'%s',
-                'openingDate':'2021',
-                'description':'Org desc',
-                'code':'Org code'
-              }
-            """
-                .formatted(name, name)));
-  }
-
-  private String addOrganisationUnit(String name, String parentId) {
-    return assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/organisationUnits",
-            "{'name':'"
-                + name
-                + "', 'shortName':'"
-                + name
-                + "', 'openingDate':'2021', 'parent': "
-                + "{'id':'"
-                + parentId
-                + "'}"
-                + " }"));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -29,7 +29,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.util.Arrays.asList;
+import static java.util.Comparator.comparing;
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toSet;
 import static org.springframework.http.CacheControl.noCache;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -41,8 +43,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
 import lombok.Value;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -62,6 +67,7 @@ import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.gist.GistQuery.Owner;
 import org.hisp.dhis.gist.GistService;
 import org.hisp.dhis.jsontree.JsonValue;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
@@ -258,19 +264,75 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
       return gistDescribeToJsonObjectResponse(query);
     }
     query = gistService.plan(query);
-    List<?> elements = gistService.gist(query);
     JsonBuilder responseBuilder = new JsonBuilder(jsonMapper);
-    JsonNode body = responseBuilder.skipNullOrEmpty().toArray(query.getFieldNames(), elements);
+    List<String> fieldNames = query.getFieldNames();
+    List<?> matches = gistService.gist(query);
+    List<?> elements = matches;
+    if (params.isOrgUnitsTree() && query.getElementType() == OrganisationUnit.class) {
+      fieldNames = new ArrayList<>(fieldNames);
+      fieldNames.add(0, "match");
+      elements = gistToJsonOrgUnitTreeResponse(query, matches);
+    }
+    JsonNode body = responseBuilder.skipNullOrEmpty().toArray(fieldNames, elements);
     if (!query.isHeadless()) {
       String property =
           params.getPageListName() == null ? schema.getPlural() : params.getPageListName();
       body =
-          responseBuilder.toObject(
-              asList("pager", property),
-              gistService.pager(query, elements, request.getParameterMap()),
-              body);
+          query.isPaging()
+              ? responseBuilder.toObject(
+                  List.of("pager", property),
+                  gistService.pager(query, matches, request.getParameterMap()),
+                  body)
+              : responseBuilder.toObject(List.of(property), body);
     }
     return ResponseEntity.ok().cacheControl(noCache().cachePrivate()).body(body);
+  }
+
+  private List<?> gistToJsonOrgUnitTreeResponse(GistQuery query, List<?> matches) {
+    // - add match true to all matches
+    List<Object[]> elements = matches.stream().map(e -> prependMatchElement(e, true)).toList();
+    // - isolate path column as list
+    int pathIndex =
+        query.getFieldNames().indexOf("path") + 1; // +1 as match column is inserted at 0
+    List<String> paths = elements.stream().map(e -> (String) e[pathIndex]).toList();
+    // - make a list of all matching IDs
+    List<String> matchesIds =
+        paths.stream().map(path -> path.substring(path.lastIndexOf('/') + 1)).toList();
+    // - make a set of all IDs in any of the paths
+    Set<String> ids =
+        paths.stream()
+            .flatMap(path -> Stream.of(path.split("/")).filter(not(String::isEmpty)))
+            .collect(toSet());
+    matchesIds.forEach(
+        ids::remove); // we already have those, what is left are the ancestors not yet fetched
+    // if ancestors are missing fetch them
+    if (ids.isEmpty()) return elements;
+    List<Object[]> ancestors =
+        gistService
+            .gist(
+                GistQuery.builder()
+                    .elementType(query.getElementType())
+                    .translate(query.isTranslate())
+                    .translationLocale(query.getTranslationLocale())
+                    .paging(false)
+                    .filters(List.of(new Filter("id", Comparison.IN, ids.toArray(String[]::new))))
+                    .fields(query.getFields())
+                    .build())
+            .stream()
+            .map(e -> prependMatchElement(e, false))
+            .toList();
+    // - inject ancestors into elements list (ordered by path)
+    return Stream.concat(elements.stream(), ancestors.stream())
+        .sorted(comparing(e -> ((String) e[pathIndex])))
+        .toList();
+  }
+
+  private Object[] prependMatchElement(Object row, boolean match) {
+    Object[] from = row instanceof Object[] arr ? arr : new Object[] {row};
+    Object[] to = new Object[from.length + 1];
+    System.arraycopy(from, 0, to, 1, from.length);
+    to[0] = match;
+    return to;
   }
 
   private ResponseEntity<JsonNode> gistDescribeToJsonObjectResponse(GistQuery query) {


### PR DESCRIPTION
cherry-pick backport from #21283 

Needed a small conflict resolve in `GistBuilder` because of the use of `replace` utility that isn't available in 2.42.
I kept the class as is in 2.42 and just added the 2 new methods added to it from 2.43 where `replace` was substituted with `String.format`. 