### PR TITLE
feat: Gist API - support efficient OU tree search and offline caching [DHIS2-19789] (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -204,8 +204,10 @@ public class DefaultGistService implements GistService, GistBuilder.GistBuilderS
   private <T> List<T> fetchWithParameters(
       GistQuery gistQuery, GistBuilder builder, Query<T> query) {
     builder.addFetchParameters(query::setParameter, this::parseFilterArgument);
-    query.setMaxResults(Math.max(1, gistQuery.getPageSize()));
-    query.setFirstResult(gistQuery.getPageOffset());
+    if (gistQuery.isPaging()) {
+      query.setMaxResults(Math.max(1, gistQuery.getPageSize()));
+      query.setFirstResult(gistQuery.getPageOffset());
+    }
     query.setCacheable(false);
     return query.list();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -72,6 +72,8 @@ public final class GistParams {
 
   boolean references = true;
 
+  boolean orgUnitsOffline = false;
+
   Junction.Type rootJunction = Junction.Type.AND;
 
   String fields;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -98,6 +98,8 @@ public final class GistQuery {
 
   private final Class<? extends PrimaryKeyObject> elementType;
 
+  private final boolean paging;
+
   @JsonProperty private final int pageOffset;
 
   @JsonProperty private final int pageSize;
@@ -175,7 +177,12 @@ public final class GistQuery {
   public GistQuery with(GistParams params) throws BadRequestException {
     int page = abs(params.getPage());
     int size = Math.min(1000, abs(params.getPageSize()));
+    boolean offline = params.isOrgUnitsOffline();
+    String order = params.getOrder();
+    if (offline && (order == null || order.isEmpty())) order = "level,name";
+    String fields = offline ? "path,displayName,children::isNotEmpty" : params.getFields();
     return toBuilder()
+        .paging(!offline)
         .pageSize(size)
         .pageOffset(Math.max(0, page - 1) * size)
         .translate(params.isTranslate())
@@ -184,17 +191,14 @@ public final class GistQuery {
         .absoluteUrls(params.isAbsoluteUrls())
         .headless(params.isHeadless())
         .describe(params.isDescribe())
-        .references(params.isReferences())
+        .references(!offline && params.isReferences())
         .anyFilter(params.getRootJunction() == Junction.Type.OR)
-        .fields(
-            getStrings(params.getFields(), FIELD_SPLIT).stream()
-                .map(Field::parse)
-                .collect(toList()))
+        .fields(getStrings(fields, FIELD_SPLIT).stream().map(Field::parse).toList())
         .filters(
             getStrings(params.getFilter(), FIELD_SPLIT).stream()
                 .map(Filter::parse)
                 .collect(toList()))
-        .orders(getStrings(params.getOrder(), ",").stream().map(Order::parse).collect(toList()))
+        .orders(getStrings(order, ",").stream().map(Order::parse).toList())
         .build();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.util.Arrays.asList;
 import static org.springframework.http.CacheControl.noCache;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -260,10 +259,12 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
       String property =
           params.getPageListName() == null ? schema.getPlural() : params.getPageListName();
       body =
-          responseBuilder.toObject(
-              asList("pager", property),
-              gistService.pager(query, elements, request.getParameterMap()),
-              body);
+          query.isPaging()
+              ? responseBuilder.toObject(
+                  List.of("pager", property),
+                  gistService.pager(query, elements, request.getParameterMap()),
+                  body)
+              : responseBuilder.toObject(List.of(property), body);
     }
     return ResponseEntity.ok().cacheControl(noCache().cachePrivate()).body(body);
   }


### PR DESCRIPTION
Manual backport of parts of #21283. This only includes the `orgUnitsOffline` part.

Changes were manually picked in the IDE by comparing versions and accepting (and sometimes adjusting) line diffs.