### PR TITLE
Eliminate chances of a network timeout in test

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -380,6 +380,16 @@
       <artifactId>commons-math3</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/route/RouteServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/route/RouteServiceTest.java
@@ -27,20 +27,37 @@
  */
 package org.hisp.dhis.route;
 
+import static org.mockserver.model.HttpRequest.request;
+
 import java.io.IOException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockserver.client.MockServerClient;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
 class RouteServiceTest {
 
   @Test
   @Timeout(value = 30)
   void testHttpClientConnectionManagerDefaultMaxPerRoute() throws IOException {
+    GenericContainer<?> routeTargetMockServerContainer =
+        new GenericContainer<>("mockserver/mockserver")
+            .waitingFor(new HttpWaitStrategy().forStatusCode(404))
+            .withExposedPorts(1080);
+    routeTargetMockServerContainer.start();
+
+    MockServerClient routeTargetMockServerClient =
+        new MockServerClient("localhost", routeTargetMockServerContainer.getFirstMappedPort());
+    routeTargetMockServerClient
+        .when(request().withPath("/"))
+        .respond(org.mockserver.model.HttpResponse.response("{}"));
+
     RouteService routeService = new RouteService(null, null);
     routeService.setRestTemplate(new RestTemplate());
     routeService.postConstruct();
@@ -49,7 +66,10 @@ class RouteServiceTest {
         ((HttpComponentsClientHttpRequestFactory)
                 routeService.getRestTemplate().getRequestFactory())
             .getHttpClient();
-    HttpUriRequest httpUriRequest = RequestBuilder.get("https://dhis2.org/").build();
+    HttpUriRequest httpUriRequest =
+        RequestBuilder.get(
+                "http://localhost:" + routeTargetMockServerContainer.getFirstMappedPort())
+            .build();
 
     for (int i = 0; i < RouteService.DEFAULT_MAX_HTTP_CONNECTION_PER_ROUTE; i++) {
       httpClient.execute(httpUriRequest);

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -368,7 +368,6 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-client-java</artifactId>
-      <version>5.15.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -218,6 +218,7 @@
     <!-- Test -->
     <junit.version>5.12.2</junit.version>
     <mockito.version>5.2.0</mockito.version>
+    <mockserver-client-java.version>5.15.0</mockserver-client-java.version>
     <powermock.version>2.0.9</powermock.version>
     <hamcrest.version>3.0</hamcrest.version>
     <hamcrest-date.version>2.0.8</hamcrest-date.version>
@@ -1670,6 +1671,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-client-java</artifactId>
+        <version>${mockserver-client-java.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Eliminate the chances of a network timeout in a test by using a mock server