### PR TITLE
fix: remove programTEA and programStageDE from root level in metadata export

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -893,9 +893,7 @@ public class DefaultMetadataExportService implements MetadataExportService {
           SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata,
           ProgramTrackedEntityAttribute programTrackedEntityAttribute) {
     if (programTrackedEntityAttribute == null) return metadata;
-    metadata.putValue(ProgramTrackedEntityAttribute.class, programTrackedEntityAttribute);
     handleAttributes(metadata, programTrackedEntityAttribute);
-
     handleTrackedEntityAttribute(metadata, programTrackedEntityAttribute.getAttribute());
 
     return metadata;
@@ -954,7 +952,6 @@ public class DefaultMetadataExportService implements MetadataExportService {
           SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata,
           ProgramStageDataElement programStageDataElement) {
     if (programStageDataElement == null) return metadata;
-    metadata.putValue(ProgramStageDataElement.class, programStageDataElement);
 
     handleAttributes(metadata, programStageDataElement);
     handleDataElement(metadata, programStageDataElement.getDataElement());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -30,14 +30,22 @@
 package org.hisp.dhis.metadata.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramSection;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageDataElement;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -62,5 +70,55 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
 
     assertEquals(1, export.get(Program.class).size());
     assertEquals(1, export.get(ProgramSection.class).size());
+  }
+
+  @Test
+  @DisplayName(
+      "ProgramTrackedEntityAttributes and ProgramStageDataElements should not appear at root level in dependency export")
+  void testExportProgramWithProgramStageDataElements() {
+    Program program = setUpProgramAndDependencies();
+    Map<Class<? extends IdentifiableObject>, Set<IdentifiableObject>> export =
+        metadataExportService.getMetadataWithDependencies(program);
+
+    Set<IdentifiableObject> programs = export.get(Program.class);
+    Set<IdentifiableObject> programStages = export.get(ProgramStage.class);
+    assertEquals(1, programs.size());
+    assertEquals(1, programStages.size());
+
+    Program p = (Program) programs.iterator().next();
+    ProgramStage ps = (ProgramStage) programStages.iterator().next();
+
+    assertEquals(1, p.getProgramAttributes().size());
+    assertEquals(1, ps.getProgramStageDataElements().size());
+    assertNull(export.get(ProgramTrackedEntityAttribute.class));
+    assertNull(export.get(ProgramStageDataElement.class));
+  }
+
+  private Program setUpProgramAndDependencies() {
+    Program program = createProgram('A');
+    entityManager.persist(program);
+    ProgramSection programSection = createProgramSection('A', program);
+    program.getProgramSections().add(programSection);
+    entityManager.persist(programSection);
+    TrackedEntityAttribute trackedEntityAttribute =
+        createTrackedEntityAttribute('A', ValueType.TEXT);
+    entityManager.persist(trackedEntityAttribute);
+    ProgramTrackedEntityAttribute programTrackedEntityAttribute =
+        createProgramTrackedEntityAttribute(program, trackedEntityAttribute);
+    program.getProgramAttributes().add(programTrackedEntityAttribute);
+    entityManager.persist(programTrackedEntityAttribute);
+    ProgramStage programStage = createProgramStage('A', program);
+    entityManager.persist(programStage);
+    program.getProgramStages().add(programStage);
+    entityManager.merge(program);
+
+    DataElement dataElement = createDataElement('A');
+    entityManager.persist(dataElement);
+    ProgramStageDataElement programStageDataElement =
+        createProgramStageDataElement(programStage, dataElement, 0);
+    entityManager.persist(programStageDataElement);
+    programStage.getProgramStageDataElements().add(programStageDataElement);
+    entityManager.merge(programStage);
+    return program;
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-19762





### Issue

- This issue is about the backend and the metadata dependency export feature. This feature is accessible from Apps > Import-export > Metadata dependency export.
When exporting metadata for a program with dependencies, then:
  - ProgramTrackedEntityAttributes are nested with Program.
  - ProgramStageDataElements are nested within ProgramStages.

- Now the export also include the arrays of ProgramTrackedEntityAttributes and ProgramStageDataElements again at the JSON root level. These appear to be redundant, have no effect on the import and should be removed from the overall JSON export file.


### Test

* [`MetadataExportWithDependenciesTest.java`](diffhunk://#diff-f44c09e7747291807f4ccf90452b4d5ff219c2e5a594c25b1d3e1b2c2721a53dR74-R123): Added a new test, `testExportProgramWithProgramStageDataElements`, to verify that `ProgramTrackedEntityAttribute` and `ProgramStageDataElement` do not appear at the root level in dependency exports.
