### PR TITLE
test: Remove redundant test

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ResourceTableControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ResourceTableControllerTest.java
@@ -47,12 +47,6 @@ import org.springframework.transaction.annotation.Transactional;
 class ResourceTableControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Test
-  void testAnalytics() {
-    JsonWebMessage msg = assertWebMessage(HttpStatus.OK, POST("/resourceTables/analytics"));
-    assertStartsWith("Initiated ANALYTICS_TABLE", msg.getMessage());
-  }
-
-  @Test
   void testResourceTables() {
     JsonWebMessage msg = assertWebMessage(HttpStatus.OK, POST("/resourceTables"));
     assertStartsWith("Initiated RESOURCE_TABLE", msg.getMessage());


### PR DESCRIPTION
This test throws some exceptions on the analytics side.

The job (`/resourceTables/analytics`) tries to generate the analytics tables behind the scenes, but for some reason the SQL statements to create the tables are not persisted in the integration test. When we get to a point where index creation statements are executed, exceptions are thrown because the tables where the indexes are applied cannot be found.

Even if the analytics tables were created properly, the entire process would take too long to finish.
Besides that, our e2e analytics tests already cover this specific endpoint. If it fails, all analytics tests will basically fail.

Given this scenario, I believe that it's safe to remove this test.