### PR TITLE
DHIS2-19681 Use Centroid function for DE/TEI OU Values

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -790,8 +790,22 @@ public non-sealed interface SystemSettings extends Settings {
     return asInt("notifierCleanAfterIdleTime", 60_0000); // 1 minute
   }
 
+  /**
+   * @since 2.42
+   * @return true if the experimental analytics query engine should be used for analytics queries.
+   *     This engine is only required when using ClickHouse or Doris as the analytics database.
+   */
   default boolean getUseExperimentalAnalyticsQueryEngine() {
     return asBoolean("experimentalAnalyticsSqlEngineEnabled", false);
+  }
+
+  /**
+   * @since 2.40
+   * @return if true, the analytics event tables are created with a centroid value for each Data
+   *     Element or TEA of type OU or ougeometry
+   */
+  default boolean getOrgUnitCentroidsInEventsAnalytics() {
+    return asBoolean("orgUnitCentroidsInEventsAnalytics", false);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/EventAnalyticsColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/EventAnalyticsColumn.java
@@ -68,15 +68,17 @@ public final class EventAnalyticsColumn {
    * Returns a list of {@link AnalyticsTableColumn}.
    *
    * @param sqlBuilder the {@link SqlBuilder}.
+   * @param useCentroidForOuGeometry if true, use the Postgis's ST_Centroid function for OU geometry
    * @return a list of {@link AnalyticsTableColumn}.
    */
-  public static List<AnalyticsTableColumn> getColumns(SqlBuilder sqlBuilder) {
+  public static List<AnalyticsTableColumn> getColumns(
+      SqlBuilder sqlBuilder, boolean useCentroidForOuGeometry) {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
     columns.addAll(getCommonColumns(sqlBuilder));
     columns.addAll(getJsonColumns(sqlBuilder));
 
     if (sqlBuilder.supportsGeospatialData()) {
-      columns.addAll(getGeometryColumns(sqlBuilder));
+      columns.addAll(getGeometryColumns(useCentroidForOuGeometry));
     }
 
     return columns;
@@ -209,10 +211,9 @@ public final class EventAnalyticsColumn {
   /**
    * Returns a list of geometry {@link AnalyticsTableColumn}.
    *
-   * @param sqlBuilder the {@link SqlBuilder}.
    * @return a list of {@link AnalyticsTableColumn}.
    */
-  private static List<AnalyticsTableColumn> getGeometryColumns(SqlBuilder sqlBuilder) {
+  private static List<AnalyticsTableColumn> getGeometryColumns(boolean useCentroid) {
     return List.of(
         AnalyticsTableColumn.builder()
             .name(EventAnalyticsColumnName.EVENT_GEOMETRY_COLUMN_NAME)
@@ -223,7 +224,7 @@ public final class EventAnalyticsColumn {
         AnalyticsTableColumn.builder()
             .name(EventAnalyticsColumnName.OU_GEOMETRY_COLUMN_NAME)
             .dataType(GEOMETRY)
-            .selectExpression("ou.geometry")
+            .selectExpression(useCentroid ? "ST_Centroid(ou.geometry)" : "ou.geometry")
             .indexType(IndexType.GIST)
             .build(),
         AnalyticsTableColumn.builder()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -133,7 +133,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         periodDataProvider,
         columnMapper,
         sqlBuilder);
-    fixedColumns = EventAnalyticsColumn.getColumns(sqlBuilder);
+    fixedColumns = EventAnalyticsColumn.getColumns(sqlBuilder, useCentroidForOuColumns());
   }
 
   @Override
@@ -751,5 +751,9 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
    */
   private List<Integer> getYearsForPartitionTable(List<Integer> dataYears) {
     return ListUtils.mutableCopy(!dataYears.isEmpty() ? dataYears : List.of(Year.now().getValue()));
+  }
+
+  private boolean useCentroidForOuColumns() {
+    return settingsProvider.getCurrentSettings().getOrgUnitCentroidsInEventsAnalytics();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -115,6 +115,7 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     when(jdbcTemplate.queryForRowSet(anyString())).thenReturn(this.rowSet);
     when(systemSettingsService.getCurrentSettings()).thenReturn(systemSettings);
     when(systemSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
+    when(systemSettings.getOrgUnitCentroidsInEventsAnalytics()).thenReturn(false);
     when(config.getPropertyOrDefault(ANALYTICS_DATABASE, "")).thenReturn("postgresql");
     when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
     DefaultProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder =
@@ -123,7 +124,7 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
             systemSettingsService,
             new PostgreSqlBuilder(),
             dataElementService);
-    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder);
+    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder, systemSettingsService);
 
     subject =
         new JdbcEnrollmentAnalyticsManager(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -164,7 +164,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             new PostgreSqlBuilder(),
             dataElementService);
     when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
-    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder);
+    when(systemSettings.getOrgUnitCentroidsInEventsAnalytics()).thenReturn(false);
+    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder, systemSettingsService);
 
     subject =
         new JdbcEnrollmentAnalyticsManager(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -161,7 +161,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             systemSettingsService,
             new PostgreSqlBuilder(),
             dataElementService);
-    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder);
+    ColumnMapper columnMapper = new ColumnMapper(sqlBuilder, systemSettingsService);
 
     subject =
         new JdbcEventAnalyticsManager(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -88,8 +88,6 @@ class JdbcEnrollmentAnalyticsTableManagerTest {
 
   @Mock private SystemSettingsProvider settingsProvider;
 
-  @Mock private SystemSettings settings;
-
   @Mock private DataApprovalLevelService dataApprovalLevelService;
 
   @Mock private ResourceTableService resourceTableService;
@@ -126,7 +124,7 @@ class JdbcEnrollmentAnalyticsTableManagerTest {
             jdbcTemplate,
             analyticsTableSettings,
             periodDataProvider,
-            new ColumnMapper(sqlBuilder),
+            new ColumnMapper(sqlBuilder, settingsProvider),
             sqlBuilder);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerDorisTest.java
@@ -146,6 +146,9 @@ class JdbcEventAnalyticsTableManagerDorisTest {
 
   @BeforeEach
   void setUp() {
+    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
+    when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
+    when(analyticsTableSettings.getPeriodSource()).thenReturn(PeriodSource.DATABASE);
     subject =
         new JdbcEventAnalyticsTableManager(
             idObjectManager,
@@ -159,13 +162,9 @@ class JdbcEventAnalyticsTableManagerDorisTest {
             jdbcTemplate,
             analyticsTableSettings,
             periodDataProvider,
-            new ColumnMapper(sqlBuilder),
+            new ColumnMapper(sqlBuilder, settingsProvider),
             sqlBuilder);
     today = Date.from(LocalDate.of(2019, 7, 6).atStartOfDay(ZoneId.systemDefault()).toInstant());
-
-    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
-    when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
-    when(analyticsTableSettings.getPeriodSource()).thenReturn(PeriodSource.DATABASE);
   }
 
   @Test
@@ -268,7 +267,7 @@ class JdbcEventAnalyticsTableManagerDorisTest {
             CHARACTER_11,
             legendsetAlias.formatted(tea.getUid() + "_" + lsA.getUid()),
             Skip.INCLUDE)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .build()
         .verify();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -170,6 +170,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   @BeforeEach
   public void setUp() {
+    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
     subject =
         new JdbcEventAnalyticsTableManager(
             idObjectManager,
@@ -183,11 +184,9 @@ class JdbcEventAnalyticsTableManagerTest {
             jdbcTemplate,
             analyticsTableSettings,
             periodDataProvider,
-            new ColumnMapper(sqlBuilder),
+            new ColumnMapper(sqlBuilder, settingsProvider),
             sqlBuilder);
     today = Date.from(LocalDate.of(2019, 7, 6).atStartOfDay(ZoneId.systemDefault()).toInstant());
-
-    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
     when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
   }
 
@@ -283,7 +282,7 @@ class JdbcEventAnalyticsTableManagerTest {
         .withName(TABLE_PREFIX + program.getUid().toLowerCase() + STAGING_TABLE_SUFFIX)
         .withMainName(TABLE_PREFIX + program.getUid().toLowerCase())
         .withColumnSize(57 + OU_NAME_HIERARCHY_COUNT)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .addColumns(periodColumns)
         .addColumn(
             categoryA.getUid(),
@@ -487,7 +486,7 @@ class JdbcEventAnalyticsTableManagerTest {
         .addColumn(d5.getUid() + "_geom", GEOMETRY, aliasD5_geo, IndexType.GIST)
         // element d5 also creates a Name column
         .addColumn(d5.getUid() + "_name", TEXT, aliasD5_name, Skip.SKIP)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .build()
         .verify();
   }
@@ -559,7 +558,7 @@ class JdbcEventAnalyticsTableManagerTest {
         .addColumn(tea1.getUid() + "_geom", GEOMETRY, ouGeometryQuery, IndexType.GIST)
         // Org unit name column
         .addColumn(tea1.getUid() + "_name", TEXT, ouNameQuery, Skip.SKIP)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .build()
         .verify();
   }
@@ -762,13 +761,13 @@ class JdbcEventAnalyticsTableManagerTest {
         .withMainName(TABLE_PREFIX + programA.getUid().toLowerCase())
         .withTableType(AnalyticsTableType.EVENT)
         .withColumnSize(
-            EventAnalyticsColumn.getColumns(sqlBuilder).size()
+            EventAnalyticsColumn.getColumns(sqlBuilder, false).size()
                 + PeriodType.getAvailablePeriodTypes().size()
                 + ouLevels.size()
                 + (programA.isRegistration() ? 1 : 0)
                 + OU_NAME_HIERARCHY_COUNT)
         .addColumns(periodColumns)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .addColumn(("uidlevel" + ouLevels.get(0).getLevel()), col -> match(ouLevels.get(0), col))
         .addColumn(("uidlevel" + ouLevels.get(1).getLevel()), col -> match(ouLevels.get(1), col))
         .build()
@@ -804,13 +803,13 @@ class JdbcEventAnalyticsTableManagerTest {
         .withMainName(TABLE_PREFIX + programA.getUid().toLowerCase())
         .withTableType(AnalyticsTableType.EVENT)
         .withColumnSize(
-            EventAnalyticsColumn.getColumns(sqlBuilder).size()
+            EventAnalyticsColumn.getColumns(sqlBuilder, false).size()
                 + PeriodType.getAvailablePeriodTypes().size()
                 + ouGroupSet.size()
                 + (programA.isRegistration() ? 1 : 0)
                 + OU_NAME_HIERARCHY_COUNT)
         .addColumns(periodColumns)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .addColumn(ouGroupSet.get(0).getUid(), col -> match(ouGroupSet.get(0), col))
         .addColumn(ouGroupSet.get(1).getUid(), col -> match(ouGroupSet.get(1), col))
         .build()
@@ -845,13 +844,13 @@ class JdbcEventAnalyticsTableManagerTest {
         .withMainName(TABLE_PREFIX + programA.getUid().toLowerCase())
         .withTableType(AnalyticsTableType.EVENT)
         .withColumnSize(
-            EventAnalyticsColumn.getColumns(sqlBuilder).size()
+            EventAnalyticsColumn.getColumns(sqlBuilder, false).size()
                 + PeriodType.getAvailablePeriodTypes().size()
                 + cogs.size()
                 + (programA.isRegistration() ? 1 : 0)
                 + OU_NAME_HIERARCHY_COUNT)
         .addColumns(periodColumns)
-        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder))
+        .withDefaultColumns(EventAnalyticsColumn.getColumns(sqlBuilder, false))
         .addColumn(cogs.get(0).getUid(), col -> match(cogs.get(0), col))
         .addColumn(cogs.get(1).getUid(), col -> match(cogs.get(1), col))
         .build()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcTrackedEntityAnalyticsTableManagerTest.java
@@ -117,7 +117,7 @@ class JdbcTrackedEntityAnalyticsTableManagerTest {
             trackedEntityAttributeService,
             analyticsTableSettings,
             periodDataProvider,
-            new ColumnMapper(sqlBuilder),
+            new ColumnMapper(sqlBuilder, systemSettingsProvider),
             sqlBuilder);
   }
 

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -103,7 +103,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(146, keys.size());
+    assertEquals(147, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventAggregateTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventAggregateTest.java
@@ -78,8 +78,7 @@ public class EventAggregateTest extends AnalyticsApiTest {
         "java.lang.Boolean",
         false,
         true);
-    validateHeader(
-        response, 1, "CklPZdOd6H1", "Sex", "TEXT", "java.lang.String", false, true, "hiQ3QFheQ3O");
+    validateHeader(response, 1, "CklPZdOd6H1", "Sex", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response,
         2,


### PR DESCRIPTION
## Summary

This PR introduces a new system setting: `orgUnitCentroidsInEventsAnalytics`.

When enabled (`true`), this setting modifies the way certain coordinate columns are populated in the analytics event tables by applying PostgreSQL’s `ST_Centroid` function. Specifically:

* The `ougeometry` column - representing the geometry of the organisation unit associated with an event - is generated using the centroid of the unit’s geometry (polygon or multipolygon).
* For Data Elements or Tracked Entity Attributes of type *Organisation Unit*, their corresponding `_geom` columns in the analytics event tables will also use the centroid of the referenced org unit.

Using centroids instead of full geometries provides the following benefits:

* **Reduced payload size** 
* **Reduced storage footprint** in the analytics tables.

When the setting is disabled (`false`, the default), the full geometry of the organisation units is preserved in the analytics tables, maintaining current behavior.

## Notes

* This setting affects only the analytics table generation; it does not alter metadata or raw event data.
* The centroid transformation is only applied when PostgreSQL is selected as analytics database.


### How to test

- Query an event endpoint using a program that has a "POLYGON" ou geometry: 
  - `GET ... /api/analytics/events/query/v76RdYc6bMw.json?dimension=..&filter=...&stage=...&coordinatesOnly=true&coordinateField=ougeometry`
  - The payload now contains the POINT coordinate of the ou, instead of the POLYGON
- Query an event endpoint using a program that has a Data Element attribute of type OU and the OU is set to a POLYGON shape:
  - `GET ... /api/analytics/events/query/v76RdYc6bMw.json?dimension=..&filter=...&stage=...&coordinatesOnly=true&coordinateField=qu4tyEaBOUx`
  - The payload now contains the POINT coordinate of the ou, instead of the POLYGON
  - see [before](https://gist.github.com/luciano-fiandesio/689a050a8bb426cf4148b8bdfec7e4db) and [after](https://gist.github.com/luciano-fiandesio/a1620d371d3f0eeb56834d5907f0c38e)


