### PR TITLE
DHIS2-13818: Default the C3P0 connection timeout to 30s

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -284,8 +284,8 @@ public enum ConfigurationKey {
       "analytics.connection.pool.test.on.checkin", Constants.ON, false),
 
   /**
-   * Hikari DB pool feature. Connection pool timeout: Set the maximum number of milliseconds that a
-   * client will wait for a connection from the pool. (default: 30s)
+   * Connection pool timeout: Set the maximum number of milliseconds that a client will wait for a
+   * connection from the pool. (default: 30s)
    */
   CONNECTION_POOL_TIMEOUT("connection.pool.timeout", String.valueOf(SECONDS.toMillis(30)), false),
 

--- a/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/test/java/org/hisp/dhis/external/conf/DhisConfigurationProviderTest.java
@@ -80,6 +80,7 @@ class DhisConfigurationProviderTest {
 
   @Test
   void getIntProperty() {
+    assertEquals(30000, configProvider.getIntProperty(ConfigurationKey.CONNECTION_POOL_TIMEOUT));
     assertEquals(80, configProvider.getIntProperty(ConfigurationKey.CONNECTION_POOL_MAX_SIZE));
     assertEquals(10, configProvider.getIntProperty(ConfigurationKey.CONNECTION_POOL_MIN_SIZE));
   }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -318,6 +318,8 @@ public final class DatabasePoolUtils {
             firstNonNull(
                 config.getMaxIdleTime(),
                 dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MAX_IDLE_TIME))));
+    final int connectionTimeout =
+        dhisConfig.getIntProperty(mapper.getConfigKey(CONNECTION_POOL_TIMEOUT));
 
     final int minPoolSize =
         parseInt(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MIN_SIZE)));
@@ -355,6 +357,7 @@ public final class DatabasePoolUtils {
     pooledDataSource.setIdleConnectionTestPeriod(idleConnectionTestPeriod);
     pooledDataSource.setPreferredTestQuery(preferredTestQuery);
     pooledDataSource.setNumHelperThreads(numHelperThreads);
+    pooledDataSource.setCheckoutTimeout(connectionTimeout);
 
     return pooledDataSource;
   }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/datasource/DatabasePoolUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/datasource/DatabasePoolUtilsTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.datasource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -92,6 +93,8 @@ class DatabasePoolUtilsTest {
         .willReturn(String.valueOf(ThreadLocalRandom.current().nextInt()));
     given(mockDhisConfigurationProvider.getProperty(ConfigurationKey.CONNECTION_POOL_NUM_THREADS))
         .willReturn("1");
+    given(mockDhisConfigurationProvider.getIntProperty(ConfigurationKey.CONNECTION_POOL_TIMEOUT))
+        .willReturn(250);
 
     DbPoolConfig.DbPoolConfigBuilder poolConfigBuilder =
         DbPoolConfig.builder()
@@ -108,6 +111,7 @@ class DatabasePoolUtilsTest {
 
     DataSource dataSource = DatabasePoolUtils.createDbPool(poolConfigBuilder.build());
     assertInstanceOf(ComboPooledDataSource.class, dataSource);
+    assertEquals(250, ((ComboPooledDataSource) dataSource).getCheckoutTimeout());
   }
 
   @Test


### PR DESCRIPTION
Default the C3P0 connection timeout to 30s in order to match the HikariCP default. This is the first step towards slowly deprecating C3P0

BREAKING CHANGE: this change can break a DHIS2 implementation that might experience DB pool exhaustion lasting more than 30s