### PR TITLE
feat: Introduce preferred search operators on TEA [DHIS2-12183]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -163,7 +163,7 @@ public enum QueryOperator {
       case IEQ -> EQ;
       case NIEQ -> NEQ;
       case ILIKE -> LIKE;
-      case NLIKE -> NLIKE;
+      case NILIKE -> NLIKE;
       default -> this;
     };
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -151,7 +151,7 @@ public enum QueryOperator {
 
   /**
    * Case‑insensitive operators are analytics specific and should not be used in tracker, because
-   * the values there are already converted to lowercase before comparison. For now, we are not
+   * the values there, are already converted to lowercase before comparison. For now, we are not
    * enforcing this rule in the API, so those operators can still be used. Adding such validation
    * would be a breaking change, and we are not ready for that yet.
    *

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -85,9 +85,6 @@ public enum QueryOperator {
 
   private static final Set<QueryOperator> UNARY_OPERATORS = EnumSet.of(NULL, NNULL);
 
-  private static final Set<QueryOperator> CASE_INSENSITIVE_OPERATORS =
-      EnumSet.of(IEQ, NIEQ, ILIKE, NILIKE);
-
   private final String value;
 
   private final boolean nullAllowed;
@@ -150,10 +147,6 @@ public enum QueryOperator {
 
   public boolean isUnary() {
     return UNARY_OPERATORS.contains(this);
-  }
-
-  public boolean isCaseInsensitive() {
-    return CASE_INSENSITIVE_OPERATORS.contains(this);
   }
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -33,6 +33,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.replaceOnce;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import lombok.Getter;
@@ -149,6 +150,9 @@ public enum QueryOperator {
     return UNARY_OPERATORS.contains(this);
   }
 
+  private static final Set<QueryOperator> TRACKER_OPERATORS =
+      EnumSet.of(EQ, GT, GE, LT, LE, LIKE, IN, SW, EW, NULL, NNULL);
+
   /**
    * Case‑insensitive operators are analytics specific and should not be used in tracker, because
    * the values there, are already converted to lowercase before comparison. For now, we are not
@@ -166,5 +170,9 @@ public enum QueryOperator {
       case NILIKE -> NLIKE;
       default -> this;
     };
+  }
+
+  public static Set<QueryOperator> getTrackerOperators() {
+    return Collections.unmodifiableSet(TRACKER_OPERATORS);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -153,25 +153,6 @@ public enum QueryOperator {
   private static final Set<QueryOperator> TRACKER_OPERATORS =
       EnumSet.of(EQ, GT, GE, LT, LE, LIKE, IN, SW, EW, NULL, NNULL);
 
-  /**
-   * Case‑insensitive operators are analytics specific and should not be used in tracker, because
-   * the values there, are already converted to lowercase before comparison. For now, we are not
-   * enforcing this rule in the API, so those operators can still be used. Adding such validation
-   * would be a breaking change, and we are not ready for that yet.
-   *
-   * <p>This method should therefore be used to map case‑insensitive operators, which are analytics
-   * specific, to their case‑sensitive equivalents.
-   */
-  public QueryOperator mapToTrackerQueryOperator() {
-    return switch (this) {
-      case IEQ -> EQ;
-      case NIEQ -> NEQ;
-      case ILIKE -> LIKE;
-      case NILIKE -> NLIKE;
-      default -> this;
-    };
-  }
-
   public static Set<QueryOperator> getTrackerOperators() {
     return Collections.unmodifiableSet(TRACKER_OPERATORS);
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -155,14 +155,15 @@ public enum QueryOperator {
    * enforcing this rule in the API, so those operators can still be used. Adding such validation
    * would be a breaking change, and we are not ready for that yet.
    *
-   * <p>This method should therefore be used to map case‑insensitive operators to their
-   * case‑sensitive equivalents.
+   * <p>This method should therefore be used to map case‑insensitive operators, which are analytics
+   * specific, to their case‑sensitive equivalents.
    */
-  public QueryOperator mapToCaseSensitiveOperator() {
+  public QueryOperator mapToTrackerQueryOperator() {
     return switch (this) {
       case IEQ -> EQ;
       case NIEQ -> NEQ;
-      case ILIKE, NLIKE -> LIKE;
+      case ILIKE -> LIKE;
+      case NLIKE -> NLIKE;
       default -> this;
     };
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -85,6 +85,9 @@ public enum QueryOperator {
 
   private static final Set<QueryOperator> UNARY_OPERATORS = EnumSet.of(NULL, NNULL);
 
+  private static final Set<QueryOperator> CASE_INSENSITIVE_OPERATORS =
+      EnumSet.of(IEQ, NIEQ, ILIKE, NILIKE);
+
   private final String value;
 
   private final boolean nullAllowed;
@@ -147,5 +150,27 @@ public enum QueryOperator {
 
   public boolean isUnary() {
     return UNARY_OPERATORS.contains(this);
+  }
+
+  public boolean isCaseInsensitive() {
+    return CASE_INSENSITIVE_OPERATORS.contains(this);
+  }
+
+  /**
+   * Case‑insensitive operators are analytics specific and should not be used in tracker, because
+   * the values there are already converted to lowercase before comparison. For now, we are not
+   * enforcing this rule in the API, so those operators can still be used. Adding such validation
+   * would be a breaking change, and we are not ready for that yet.
+   *
+   * <p>This method should therefore be used to map case‑insensitive operators to their
+   * case‑sensitive equivalents.
+   */
+  public QueryOperator mapToCaseSensitiveOperator() {
+    return switch (this) {
+      case IEQ -> EQ;
+      case NIEQ -> NEQ;
+      case ILIKE, NLIKE -> LIKE;
+      default -> this;
+    };
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -330,4 +330,12 @@ public enum ValueType {
         .filter(v -> Arrays.stream(AggregationType.values()).anyMatch(v::isAggregatable))
         .collect(toSet());
   }
+
+  public QueryOperator getDefaultOperator() {
+    return switch (this) {
+      case TEXT, LONG_TEXT, MULTI_TEXT, PHONE_NUMBER, EMAIL, URL, GEOJSON, COORDINATE ->
+          QueryOperator.SW;
+      default -> QueryOperator.EQ;
+    };
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -330,12 +330,4 @@ public enum ValueType {
         .filter(v -> Arrays.stream(AggregationType.values()).anyMatch(v::isAggregatable))
         .collect(toSet());
   }
-
-  public QueryOperator getDefaultOperator() {
-    return switch (this) {
-      case TEXT, LONG_TEXT, MULTI_TEXT, PHONE_NUMBER, EMAIL, URL, GEOJSON, COORDINATE ->
-          QueryOperator.SW;
-      default -> QueryOperator.EQ;
-    };
-  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -331,6 +331,7 @@ public enum ErrorCode {
   E4079(
       "Program `{0}` category mapping `{1}` has multiple option mappings for Category Option `{2}`"),
   E4080("Program `{0}` category mapping `{1}` has an invalid option mapping `{1}`"),
+  E4081("The provided preferred TEA operator `{0}` is not part of the tracker operators `{1}`"),
 
   /* SQL views */
   E4300("SQL query is null"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.ObjectStyle;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.option.OptionSet;
@@ -100,6 +101,8 @@ public class TrackedEntityAttribute extends BaseDimensionalItemObject
   private Boolean skipSynchronization = false;
 
   private int minCharactersToSearch;
+
+  private QueryOperator preferredSearchOperator;
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -379,6 +382,16 @@ public class TrackedEntityAttribute extends BaseDimensionalItemObject
 
   public void setMinCharactersToSearch(int minCharactersToSearch) {
     this.minCharactersToSearch = minCharactersToSearch;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public QueryOperator getPreferredSearchOperator() {
+    return preferredSearchOperator;
+  }
+
+  public void setPreferredSearchOperator(QueryOperator preferredSearchOperator) {
+    this.preferredSearchOperator = preferredSearchOperator;
   }
 
   @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
@@ -92,6 +92,13 @@
 
     <property name="minCharactersToSearch" column="mincharacterstosearch" />
 
+    <property name="preferredSearchOperator" column="preferredsearchoperator">
+      <type name="org.hibernate.type.EnumType">
+        <param name="enumClass">org.hisp.dhis.common.QueryOperator</param>
+        <param name="useNamed">true</param>
+      </type>
+    </property>
+
   </class>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -74,15 +74,14 @@ public class TrackedEntityAttributeObjectBundleHook
       }
     }
 
-    if (attr.getPreferredSearchOperator() != null) {
-      if (!getTrackerOperators().contains(attr.getPreferredSearchOperator())) {
-        addReports.accept(
-            new ErrorReport(
-                TrackedEntityAttribute.class,
-                ErrorCode.E4081,
-                attr.getPreferredSearchOperator(),
-                getTrackerOperators()));
-      }
+    if (attr.getPreferredSearchOperator() != null
+        && !getTrackerOperators().contains(attr.getPreferredSearchOperator())) {
+      addReports.accept(
+          new ErrorReport(
+              TrackedEntityAttribute.class,
+              ErrorCode.E4081,
+              attr.getPreferredSearchOperator(),
+              getTrackerOperators()));
     }
 
     // TODO(tracker) Validate the preferred operator is part of the allowed operators

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -72,8 +72,7 @@ public class TrackedEntityAttributeObjectBundleHook
       }
     }
 
-    if (attr.getPreferredSearchOperator() != null
-        && attr.getPreferredSearchOperator().isCaseInsensitive()) {
+    if (attr.getPreferredSearchOperator() != null) {
       attr.setPreferredSearchOperator(
           attr.getPreferredSearchOperator().mapToCaseSensitiveOperator());
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -71,6 +71,10 @@ public class TrackedEntityAttributeObjectBundleHook
                 "Not a valid TextPattern 'TEXT' segment."));
       }
     }
+
+    if (attr.getPreferredSearchOperator() == null) {
+      attr.setPreferredSearchOperator(attr.getValueType().getDefaultOperator());
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -74,7 +74,7 @@ public class TrackedEntityAttributeObjectBundleHook
 
     if (attr.getPreferredSearchOperator() != null) {
       attr.setPreferredSearchOperator(
-          attr.getPreferredSearchOperator().mapToCaseSensitiveOperator());
+          attr.getPreferredSearchOperator().mapToTrackerQueryOperator());
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -71,10 +71,6 @@ public class TrackedEntityAttributeObjectBundleHook
                 "Not a valid TextPattern 'TEXT' segment."));
       }
     }
-
-    if (attr.getPreferredSearchOperator() == null) {
-      attr.setPreferredSearchOperator(attr.getValueType().getDefaultOperator());
-    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import static org.hisp.dhis.common.QueryOperator.getTrackerOperators;
+
 import java.util.function.Consumer;
 import org.hisp.dhis.common.Objects;
 import org.hisp.dhis.common.ValueType;
@@ -73,9 +75,17 @@ public class TrackedEntityAttributeObjectBundleHook
     }
 
     if (attr.getPreferredSearchOperator() != null) {
-      attr.setPreferredSearchOperator(
-          attr.getPreferredSearchOperator().mapToTrackerQueryOperator());
+      if (!getTrackerOperators().contains(attr.getPreferredSearchOperator())) {
+        addReports.accept(
+            new ErrorReport(
+                TrackedEntityAttribute.class,
+                ErrorCode.E4081,
+                attr.getPreferredSearchOperator(),
+                getTrackerOperators()));
+      }
     }
+
+    // TODO(tracker) Validate the preferred operator is part of the allowed operators
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityAttributeObjectBundleHook.java
@@ -71,6 +71,12 @@ public class TrackedEntityAttributeObjectBundleHook
                 "Not a valid TextPattern 'TEXT' segment."));
       }
     }
+
+    if (attr.getPreferredSearchOperator() != null
+        && attr.getPreferredSearchOperator().isCaseInsensitive()) {
+      attr.setPreferredSearchOperator(
+          attr.getPreferredSearchOperator().mapToCaseSensitiveOperator());
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -208,8 +208,8 @@ class TrackedEntityOperationParamsMapper {
                 || queryFilter.getFilter().length() < tea.getMinCharactersToSearch())) {
           throw new IllegalQueryException(
               String.format(
-                  "At least %d character(s) should be present in the filter to start a search, but the filter for operator %s doesn't contain enough.",
-                  tea.getMinCharactersToSearch(), queryFilter.getOperator()));
+                  "At least %d character(s) should be present in the filter to start a search, but the filter for the TEA %s doesn't contain enough.",
+                  tea.getMinCharactersToSearch(), tea.getUid()));
         }
       }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -563,7 +563,8 @@ class TrackedEntityOperationParamsMapperTest {
         Assertions.assertThrows(
             IllegalQueryException.class, () -> mapper.map(trackedEntityOperationParams, user));
     assertContains(
-        "At least 2 character(s) should be present in the filter to start a search, but the filter for operator EQ",
+        "At least 2 character(s) should be present in the filter to start a search, but the filter for the TEA "
+            + TEA_1_UID,
         exception.getMessage());
   }
 
@@ -588,7 +589,8 @@ class TrackedEntityOperationParamsMapperTest {
         Assertions.assertThrows(
             IllegalQueryException.class, () -> mapper.map(trackedEntityOperationParams, user));
     assertContains(
-        "At least 2 character(s) should be present in the filter to start a search, but the filter for operator LIKE",
+        "At least 2 character(s) should be present in the filter to start a search, but the filter for the TEA "
+            + TEA_1_UID,
         exception.getMessage());
   }
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_11__add_tea_preferred_operator.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_11__add_tea_preferred_operator.sql
@@ -1,0 +1,3 @@
+-- Migration script to add the field preferred operator in the trackedentityattribute table
+alter table trackedentityattribute
+    add column preferredsearchoperator varchar(20) default null;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_11__add_tea_preferred_operator.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_11__add_tea_preferred_operator.sql
@@ -1,3 +1,3 @@
 -- Migration script to add the field preferred operator in the trackedentityattribute table
 alter table trackedentityattribute
-    add column preferredsearchoperator varchar(20) default null;
+    add column if not exists preferredsearchoperator varchar(20) default null;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -29,9 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.LIKE;
-import static org.hisp.dhis.common.QueryOperator.SW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -120,13 +118,13 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldSetPreferredSearchOperatorFromImportOrDefaultIfNotSpecified() {
+  void shouldSetPreferredSearchOperatorFromImportOrNullIfNotSpecified() {
     List<TrackedEntityAttribute> trackedEntityAttributes =
         trackedEntityAttributeService.getAllTrackedEntityAttributes();
 
     assertPreferredSearchOperator(trackedEntityAttributes, "sTGqP5JNy6E", LIKE);
-    assertPreferredSearchOperator(trackedEntityAttributes, "sYn3tkL3XKa", EQ);
-    assertPreferredSearchOperator(trackedEntityAttributes, "TsfP85GKsU5", SW);
+    assertPreferredSearchOperator(trackedEntityAttributes, "sYn3tkL3XKa", null);
+    assertPreferredSearchOperator(trackedEntityAttributes, "TsfP85GKsU5", null);
   }
 
   private void assertMinCharactersToSearch(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -29,12 +29,16 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
+import static org.hisp.dhis.common.QueryOperator.EQ;
+import static org.hisp.dhis.common.QueryOperator.LIKE;
+import static org.hisp.dhis.common.QueryOperator.SW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -115,6 +119,16 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
     assertMinCharactersToSearch(trackedEntityAttributes, "TsfP85GKsU5", 0);
   }
 
+  @Test
+  void shouldSetPreferredSearchOperatorFromImportOrDefaultIfNotSpecified() {
+    List<TrackedEntityAttribute> trackedEntityAttributes =
+        trackedEntityAttributeService.getAllTrackedEntityAttributes();
+
+    assertPreferredSearchOperator(trackedEntityAttributes, "sTGqP5JNy6E", LIKE);
+    assertPreferredSearchOperator(trackedEntityAttributes, "sYn3tkL3XKa", EQ);
+    assertPreferredSearchOperator(trackedEntityAttributes, "TsfP85GKsU5", SW);
+  }
+
   private void assertMinCharactersToSearch(
       List<TrackedEntityAttribute> teas, String uid, int expected) {
     TrackedEntityAttribute tea =
@@ -128,5 +142,20 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
         expected,
         tea.getMinCharactersToSearch(),
         "Expected minCharactersToSearch for UID " + uid + " to be " + expected);
+  }
+
+  private void assertPreferredSearchOperator(
+      List<TrackedEntityAttribute> teas, String uid, QueryOperator expected) {
+    TrackedEntityAttribute tea =
+        teas.stream()
+            .filter(t -> t.getUid().equals(uid))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("TrackedEntityAttribute with UID " + uid + " not found"));
+
+    assertEquals(
+        expected,
+        tea.getPreferredSearchOperator(),
+        "Expected preferredSearchOperator for UID " + uid + " to be " + expected);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
+import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.LIKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -123,7 +124,7 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
         trackedEntityAttributeService.getAllTrackedEntityAttributes();
 
     assertPreferredSearchOperator(trackedEntityAttributes, "sTGqP5JNy6E", LIKE);
-    assertPreferredSearchOperator(trackedEntityAttributes, "sYn3tkL3XKa", null);
+    assertPreferredSearchOperator(trackedEntityAttributes, "sYn3tkL3XKa", EQ);
     assertPreferredSearchOperator(trackedEntityAttributes, "TsfP85GKsU5", null);
   }
 

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
@@ -91,7 +91,7 @@
       "translations": [],
       "attributeValues": [],
       "legendSets": [],
-      "preferredSearchOperator": "IEQ",
+      "preferredSearchOperator": "EQ",
       "sharing": {
         "public": "rw------",
         "external": false,

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
@@ -56,6 +56,7 @@
       "attributeValues": [],
       "legendSets": [],
       "minCharactersToSearch": 2,
+      "preferredSearchOperator": "LIKE",
       "sharing": {
         "public": "rw------",
         "external": false,

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
@@ -91,6 +91,7 @@
       "translations": [],
       "attributeValues": [],
       "legendSets": [],
+      "preferredSearchOperator": "IEQ",
       "sharing": {
         "public": "rw------",
         "external": false,


### PR DESCRIPTION
This PR introduces the preferred search operator field on a TEA.
It's an optional field that's added to the TEA to define the recommended operator for search or comparison. 
This is merely a suggestion for the end user and will not be enforced.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-12183