### PR TITLE
fix(DHIS-19708): ensure manifest activities field is always populated

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -422,11 +422,8 @@ public class DefaultAppManager implements AppManager {
     if (!resource.endsWith("manifest.webapp")) {
       return false;
     }
-    // If request was for manifest.webapp, check for * and replace with
-    // host
-    if (application.getActivities() != null
-        && application.getActivities().getDhis() != null
-        && "*".equals(application.getActivities().getDhis().getHref())) {
+    // If request was for manifest.webapp, replace href with the host
+    if (application.getActivities() != null && application.getActivities().getDhis() != null) {
       application.getActivities().getDhis().setHref(contextPath);
       log.debug(String.format("Manifest context path: '%s'", contextPath));
       return true;


### PR DESCRIPTION
Fixes [DHIS2-19708](https://dhis2.atlassian.net/browse/DHIS2-19708)

The check for `handlingManifest` worked only the first time, when the `App` instance passed to it has the `href` value set to `*` - when that's the case, the condition here is `true` which means the `App` is updated (which in turn updates the cache since it's the same reference) - and  when the check is `true`, the `AppController` [writes](https://github.com/dhis2/dhis2-core/blob/2.41/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java#L247) the value of the `App` instance (containing the correct `href`) directly to the response stream.

The next time  a request comes, the check is false because the `App` returned from the Cache already has the `href` value set to something else other than `*` - so the AppController [falls](https://github.com/dhis2/dhis2-core/blob/2.41/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java#L251) into the path of handling manifest as any other resource, which then just uses `serveResource` to serve the original `manifest.web` file from the file system, without the updated `href`.

Relaxing the check here means that we will always update the `href` even when it's not necessary, but (I think) this is a cheap operation - just a setter that doesn't add much. The alternative would be to change `serveResult` to be aware of `manifest` files and do special logic for populating `href` or changing the `AppController` to serve from the Cache in the case of manifest - both seems like messier solutions.

[DHIS2-19708]: https://dhis2.atlassian.net/browse/DHIS2-19708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ