### PR TITLE
chore(manifest-translations): change log level to avoid spamming the logs

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -221,7 +221,7 @@ public class DefaultAppManager implements AppManager {
               try {
                 return app.localise(userLocale);
               } catch (RuntimeException e) {
-                log.warn(
+                log.debug(
                     String.format("Could not localise app information for app: %s", app.getName()));
                 return app;
               }


### PR DESCRIPTION
eventually all of the bundled apps should have manifest translations, and this might become a warning then, but for now, it's spamming the logs 