### PR TITLE
chore: revert log4j upgrade causing test errors

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -216,7 +216,7 @@
     <prometheus-metrics-model.version>1.3.1</prometheus-metrics-model.version>
 
     <!-- Logging -->
-    <log4j.version>2.25.1</log4j.version>
+    <log4j.version>2.24.3</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
 
     <!-- Test -->


### PR DESCRIPTION
Upgrade is causing Jenkins CI pipeline to fail on tests: 
[ERROR]   RelativePeriodsTest.assertPeriodEquals:826 expected: org.hisp.dhis.period.Period@153ce630<LAST_MONTH> but was: org.hisp.dhis.period.Period@1b3aa246<LAST_MONTH>