### PR TITLE
chore: Update flaky e2e test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
@@ -88,7 +88,7 @@ class SchedulingTest extends ApiTest {
     String jobId = jobConfigActions.post(jobConfig).validateStatus(201).extractUid();
 
     // when executing it manually
-    jobConfigActions.post("/" + jobId + "/execute", "null").validateStatus(200);
+    jobConfigActions.post("/" + jobId + "/execute", "null");
 
     // then it should complete without errors
     ApiResponse apiResponse =


### PR DESCRIPTION
Remove the expected response code from the API call. The call alone will suffice.
The line in question tries to manually trigger a job, but the job may already have been started (which returns a 409) when it was created earlier.