### PR TITLE
chore: Remove FK constraints from unused audit tables [DHIS2-19865]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_14__remove_unused_audit_table_foreign_keys.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_14__remove_unused_audit_table_foreign_keys.sql
@@ -1,0 +1,4 @@
+alter table if exists trackedentityattributevalueaudit
+    drop constraint if exists fk_attributevalueaudit_trackedentityinstanceid;
+alter table if exists trackedentitydatavalueaudit
+    drop constraint if exists fk_entityinstancedatavalueaudit_programstageinstanceid;


### PR DESCRIPTION
Remove foreign keys from unused `trackedentitydatavalueaudit` and `trackedentityattributevalueaudit` tables.
This change is done as part of this epic because we are going to separate `event` table and all the tables with a foreign key to this table will need to be changed.