### PR TITLE
chore: Update flaky e2e test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/scheduling/SchedulingTest.java
@@ -84,7 +84,7 @@ class SchedulingTest extends ApiTest {
     String jobId = jobConfigActions.post(jobConfig).validateStatus(201).extractUid();
 
     // when executing it manually
-    jobConfigActions.post("/" + jobId + "/execute", "null").validateStatus(200);
+    jobConfigActions.post("/" + jobId + "/execute", "null");
 
     // then it should complete without errors
     ApiResponse apiResponse = systemActions.waitForTaskSummaries("AGGREGATE_DATA_EXCHANGE", jobId);


### PR DESCRIPTION
Remove redundant assertion on response as job may already be running, which returns a 409.