### PR TITLE
fix: oucode column mismatch in TE tables [DHIS2-19874]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
@@ -149,7 +149,7 @@ public class JdbcTeiEnrollmentsAnalyticsTableManager extends AbstractJdbcTableMa
               .build(),
           AnalyticsTableColumn.builder()
               .name("oucode")
-              .dataType(CHARACTER_32)
+              .dataType(VARCHAR_50)
               .nullable(NULL)
               .selectExpression("ou.code")
               .build(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -200,7 +200,7 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
               .build(),
           AnalyticsTableColumn.builder()
               .name("oucode")
-              .dataType(CHARACTER_32)
+              .dataType(VARCHAR_50)
               .nullable(NULL)
               .selectExpression("ou.code")
               .build(),


### PR DESCRIPTION
The  `oucode` column in the `analytics_tei_events_UID_YEAR` and `analytics_tei_enrollments_UID_YEAR` tables has a size of **32** when exported. But the source `code` column in the `organisationunit` table has a size of **50**.

This PR fixes that mismatch.

It does not need to be backported as this API was introduced in 41.
Also, this has already been fixed in master and 42 as part of other changes.