### PR TITLE
fix(DHIS2-19863): expose code field in ApiToken

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiKeyTokenGenerator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiKeyTokenGenerator.java
@@ -56,7 +56,7 @@ public class ApiKeyTokenGenerator {
    * @return a token wrapper containing the plaintext token and the token
    */
   public static TokenWrapper generatePersonalAccessToken(
-      @CheckForNull List<ApiTokenAttribute> attributes, long expire) {
+      @CheckForNull List<ApiTokenAttribute> attributes, long expire, String code) {
     ApiTokenType type = ApiTokenType.getDefaultPatType();
 
     char[] plaintext = ApiKeyTokenGenerator.generatePatToken(type);
@@ -68,6 +68,7 @@ public class ApiKeyTokenGenerator {
             .attributes(attributes == null ? new ArrayList<>() : attributes)
             .expire(expire)
             .key(ApiKeyTokenGenerator.hashToken(plaintext))
+            .code(code)
             .build();
 
     return new TokenWrapper(plaintext, token);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.schema.annotation.Property;
  */
 @Getter
 @Setter
-@Builder(toBuilder = true)
 @JacksonXmlRootElement(localName = "apiToken", namespace = DxfNamespaces.DXF_2_0)
 public class ApiToken extends BaseIdentifiableObject implements MetadataObject {
   public ApiToken() {}
@@ -74,17 +73,20 @@ public class ApiToken extends BaseIdentifiableObject implements MetadataObject {
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   private List<ApiTokenAttribute> attributes = new ArrayList<>();
 
+  @Builder
   public ApiToken(
       String key,
       Integer version,
       ApiTokenType type,
       Long expire,
-      List<ApiTokenAttribute> attributes) {
+      List<ApiTokenAttribute> attributes,
+      String code) {
     this.key = key;
     this.version = version;
     this.type = type;
     this.expire = expire;
     this.attributes = attributes;
+    this.code = code;
   }
 
   private ApiTokenAttribute findApiTokenAttribute(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/apikey/ApiTokenServiceImplTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/apikey/ApiTokenServiceImplTest.java
@@ -78,7 +78,7 @@ class ApiTokenServiceImplTest extends PostgresIntegrationTestBase {
   public ApiToken createAndSaveToken() {
     long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
     ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
     apiTokenStore.save(apiTokenPair.getApiToken());
     return apiTokenPair.getApiToken();
   }
@@ -105,6 +105,18 @@ class ApiTokenServiceImplTest extends PostgresIntegrationTestBase {
     final ApiToken tokenA = createAndSaveToken();
     final ApiToken tokenB = apiTokenService.getByKey(tokenA.getKey());
     assertEquals(tokenB.getKey(), tokenA.getKey());
+  }
+
+  @Test
+  void testSaveGetWithCode() {
+    long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
+    ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, "code-1");
+    apiTokenStore.save(apiTokenPair.getApiToken());
+    final ApiToken tokenA = apiTokenPair.getApiToken();
+
+    final ApiToken tokenB = apiTokenService.getByKey(tokenA.getKey());
+    assertEquals("code-1", tokenB.getCode());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -289,7 +289,7 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
   void testPersonalAccessTokensIsPresent() {
     long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
     ApiKeyTokenGenerator.TokenWrapper wrapper =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
     apiTokenStore.save(wrapper.getApiToken());
 
     JsonObject response = GET("/me?fields=patTokens").content();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenAuthenticationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenAuthenticationTest.java
@@ -240,7 +240,7 @@ class ApiTokenAuthenticationTest extends ControllerWithApiTokenAuthTestBase {
   private ApiKeyTokenGenerator.TokenWrapper createNewToken() {
     long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
     ApiKeyTokenGenerator.TokenWrapper wrapper =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
     apiTokenService.save(wrapper.getApiToken());
     return wrapper;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -102,7 +102,8 @@ public class ApiTokenController extends AbstractCrudController<ApiToken, GetObje
     }
 
     ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
-        generatePersonalAccessToken(inputToken.getAttributes(), inputToken.getExpire());
+        generatePersonalAccessToken(
+            inputToken.getAttributes(), inputToken.getExpire(), inputToken.getCode());
 
     MetadataImportParams params =
         importService


### PR DESCRIPTION
implements https://dhis2.atlassian.net/browse/DHIS2-19863

When exposing the `code` field for `ApiToken` in the UI, we realised that it is ignored by the API. This is because `generatePersonalAccessToken` creates a new instance of `ApiToken` that uses the builder, and omits the `BaseIdentifiable` params. 

We've looked at making the method more generic so that it supports other base fields (like `name` for example), but then realised that only `code` is part of the `ApiToken` schema, so opted for just adding that one field to the builder.