### PR TITLE
fix: remove duplicate flag of denmark

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemControllerTest.java
@@ -34,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -102,5 +104,19 @@ class SystemControllerTest extends H2ControllerIntegrationTestBase {
     // testing one sensitive and one non-sensitive property
     assertNull(info.getString("javaVersion").string());
     assertNotNull(info.getString("serverDate").string());
+  }
+
+  @Test
+  void testGetFlags_NoDuplicates() {
+    JsonArray flags = GET("/system/flags").content(HttpStatus.OK);
+    assertTrue(flags.isArray());
+    assertTrue(flags.size() > 0);
+
+    Set<String> flagKeys = new HashSet<>();
+    for (int i = 0; i < flags.size(); i++) {
+      JsonObject flag = flags.getObject(i);
+      String key = flag.getString("key").string();
+      assertTrue(flagKeys.add(key), "Duplicate flag found: " + key);
+    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -419,7 +419,6 @@ public class SystemController {
               "czechia",
               "demoland",
               "denmark",
-              "denmark",
               "djibouti",
               "dominica",
               "dominican_republic",


### PR DESCRIPTION
# Summary

The flag of Denmark was listed twice in the SystemController, causing UI issues.
A test was added to check for duplicates.

### JIRA: [DHIS2-19878](https://dhis2.atlassian.net/browse/DHIS2-19878)

[DHIS2-19878]: https://dhis2.atlassian.net/browse/DHIS2-19878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ