### PR TITLE
fix(DHIS2-19863): expose code field in ApiToken

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiKeyTokenGenerator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiKeyTokenGenerator.java
@@ -54,7 +54,7 @@ public class ApiKeyTokenGenerator {
    * @return a token wrapper containing the plaintext token and the token
    */
   public static TokenWrapper generatePersonalAccessToken(
-      @CheckForNull List<ApiTokenAttribute> attributes, long expire) {
+      @CheckForNull List<ApiTokenAttribute> attributes, long expire, String code) {
     ApiTokenType type = ApiTokenType.getDefaultPatType();
 
     char[] plaintext = ApiKeyTokenGenerator.generatePatToken(type);
@@ -66,6 +66,7 @@ public class ApiKeyTokenGenerator {
             .attributes(attributes == null ? new ArrayList<>() : attributes)
             .expire(expire)
             .key(ApiKeyTokenGenerator.hashToken(plaintext))
+            .code(code)
             .build();
 
     return new TokenWrapper(plaintext, token);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.schema.annotation.Property;
  */
 @Getter
 @Setter
-@Builder(toBuilder = true)
 @JacksonXmlRootElement(localName = "apiToken", namespace = DxfNamespaces.DXF_2_0)
 public class ApiToken extends BaseIdentifiableObject implements MetadataObject {
   public ApiToken() {}
@@ -84,6 +83,22 @@ public class ApiToken extends BaseIdentifiableObject implements MetadataObject {
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   private List<ApiTokenAttribute> attributes = new ArrayList<>();
+
+  @Builder
+  public ApiToken(
+      String key,
+      Integer version,
+      ApiTokenType type,
+      Long expire,
+      List<ApiTokenAttribute> attributes,
+      String code) {
+    this.key = key;
+    this.version = version;
+    this.type = type;
+    this.expire = expire;
+    this.attributes = attributes;
+    this.code = code;
+  }
 
   private ApiTokenAttribute findApiTokenAttribute(
       Class<? extends ApiTokenAttribute> attributeClass) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/apikey/ApiTokenServiceImplTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/apikey/ApiTokenServiceImplTest.java
@@ -79,7 +79,7 @@ class ApiTokenServiceImplTest extends TransactionalIntegrationTest {
   public ApiToken createAndSaveToken() {
     long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
     ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
     apiTokenStore.save(apiTokenPair.getApiToken());
     return apiTokenPair.getApiToken();
   }
@@ -106,6 +106,18 @@ class ApiTokenServiceImplTest extends TransactionalIntegrationTest {
     final ApiToken tokenA = createAndSaveToken();
     final ApiToken tokenB = apiTokenService.getByKey(tokenA.getKey());
     assertEquals(tokenB.getKey(), tokenA.getKey());
+  }
+
+  @Test
+  void testSaveGetWithCode() {
+    long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
+    ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, "code-1");
+    apiTokenStore.save(apiTokenPair.getApiToken());
+    final ApiToken tokenA = apiTokenPair.getApiToken();
+
+    final ApiToken tokenB = apiTokenService.getByKey(tokenA.getKey());
+    assertEquals("code-1", tokenB.getCode());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -262,7 +262,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
   void testPersonalAccessTokensIsPresent() {
     long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
     ApiKeyTokenGenerator.TokenWrapper wrapper =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
     apiTokenStore.save(wrapper.getApiToken());
 
     JsonObject response = GET("/me?fields=patTokens").content();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenAuthenticationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenAuthenticationTest.java
@@ -74,14 +74,6 @@ class ApiTokenAuthenticationTest extends DhisControllerWithApiTokenAuthTest {
     super.setup();
   }
 
-  private ApiKeyTokenGenerator.TokenWrapper createNewToken() {
-    long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
-    ApiKeyTokenGenerator.TokenWrapper wrapper =
-        generatePersonalAccessToken(null, thirtyDaysInTheFuture);
-    apiTokenService.save(wrapper.getApiToken());
-    return wrapper;
-  }
-
   @Test
   void testInvalidKeyTypeNotResolvable() {
     String errorMessage =
@@ -245,5 +237,13 @@ class ApiTokenAuthenticationTest extends DhisControllerWithApiTokenAuthTest {
     assertEquals(
         "The API token does not exists",
         GET(URI, ApiTokenHeader(plaintext)).error(HttpStatus.UNAUTHORIZED).getMessage());
+  }
+
+  private ApiKeyTokenGenerator.TokenWrapper createNewToken() {
+    long thirtyDaysInTheFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30);
+    ApiKeyTokenGenerator.TokenWrapper wrapper =
+        generatePersonalAccessToken(null, thirtyDaysInTheFuture, null);
+    apiTokenService.save(wrapper.getApiToken());
+    return wrapper;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -101,7 +101,8 @@ public class ApiTokenController extends AbstractCrudController<ApiToken> {
     }
 
     ApiKeyTokenGenerator.TokenWrapper apiTokenPair =
-        generatePersonalAccessToken(inputToken.getAttributes(), inputToken.getExpire());
+        generatePersonalAccessToken(
+            inputToken.getAttributes(), inputToken.getExpire(), inputToken.getCode());
 
     MetadataImportParams params =
         importService


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/21435

`code` field works  pre-41 (pre refactoring to to use the builder pattern) so just backporting to 42 and 41.