### PR TITLE
chore: upgrade google formatter

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2052,7 +2052,7 @@ jasperreports.version=${jasperreports.version}
             </upToDateChecking>
             <java>
               <googleJavaFormat>
-                <version>1.26.0</version>
+                <version>1.27.0</version>
                 <style>GOOGLE</style>
               </googleJavaFormat>
               <trimTrailingWhitespace/>


### PR DESCRIPTION
Upgrades google formatter to latest, this includes support for Java 25 LTS