### PR TITLE
poc: Use objectMapper.readerForUpdating to patch entity

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EmbeddedObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EmbeddedObject.java
@@ -39,4 +39,6 @@ package org.hisp.dhis.common;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public interface EmbeddedObject {}
+public interface EmbeddedObject {
+  int getId();
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EmbeddedObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EmbeddedObject.java
@@ -39,6 +39,4 @@ package org.hisp.dhis.common;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public interface EmbeddedObject {
-  int getId();
-}
+public interface EmbeddedObject {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.common;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -363,4 +366,7 @@ public interface IdentifiableObjectManager {
   void persist(Object userAdmin);
 
   User find(Class<User> userClass, long id);
+
+  <T extends IdentifiableObject> T patchObject(T existed, InputStream inputStream, Class<T> clazz)
+      throws IOException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultObjectsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultObjectsService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.function.ToLongFunction;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DefaultObjectsService {
+
+  private final Cache<Long> defaultObjectCache;
+  private final IdentifiableObjectManager manager;
+
+  public DefaultObjectsService(CacheProvider cacheProvider, IdentifiableObjectManager manager) {
+    this.defaultObjectCache = cacheProvider.createDefaultObjectCache();
+    this.manager = manager;
+  }
+
+  @Nonnull
+  @Transactional(readOnly = true)
+  public Map<Class<? extends IdentifiableObject>, IdentifiableObject> getDefaults() {
+    ToLongFunction<Class<? extends IdentifiableObject>> getIdCachedByName =
+        type ->
+            defaultObjectCache.get(
+                type.getName(),
+                t -> {
+                  IdentifiableObject obj = manager.getByName(type, "default");
+                  return obj == null ? -1 : obj.getId();
+                });
+    return Map.of(
+        Category.class,
+        requireNonNull(manager.get(Category.class, getIdCachedByName.applyAsLong(Category.class))),
+        CategoryCombo.class,
+        requireNonNull(
+            manager.get(CategoryCombo.class, getIdCachedByName.applyAsLong(CategoryCombo.class))),
+        CategoryOption.class,
+        requireNonNull(
+            manager.get(CategoryOption.class, getIdCachedByName.applyAsLong(CategoryOption.class))),
+        CategoryOptionCombo.class,
+        requireNonNull(
+            manager.get(
+                CategoryOptionCombo.class,
+                getIdCachedByName.applyAsLong(CategoryOptionCombo.class))));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.preheat;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -51,6 +52,7 @@ import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionItem;
+import org.hisp.dhis.common.DefaultObjectsService;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -114,6 +116,8 @@ public class DefaultPreheatService implements PreheatService {
 
   private final UserService userService;
 
+  private final DefaultObjectsService defaultObjectsService;
+
   @Override
   @Transactional(readOnly = true)
   public Preheat preheat(PreheatParams params) {
@@ -121,7 +125,7 @@ public class DefaultPreheatService implements PreheatService {
 
     Preheat preheat = new Preheat();
     preheat.setUser(params.getUser());
-    preheat.setDefaults(manager.getDefaults());
+    preheat.setDefaults(defaultObjectsService.getDefaults());
 
     if (preheat.getUser() == null) {
       User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
@@ -770,7 +774,7 @@ public class DefaultPreheatService implements PreheatService {
               o -> {
                 Collection<Object> propertyValue =
                     ReflectionUtils.invokeMethod(o, property.getGetterMethod());
-                if (!org.apache.commons.collections4.CollectionUtils.isEmpty(propertyValue)) {
+                if (!isEmpty(propertyValue)) {
                   list.addAll(propertyValue);
                 }
               });

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
@@ -85,10 +85,13 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook<DataSet> {
             .map(IdentifiableObject::getUid)
             .collect(Collectors.toSet());
 
-    importDataSet.setCompulsoryDataElementOperands(
-        importDataSet.getCompulsoryDataElementOperands().stream()
-            .filter(dop -> dataElementIds.contains(dop.getDataElement().getUid()))
-            .collect(Collectors.toSet()));
+    importDataSet.getCompulsoryDataElementOperands().clear();
+    importDataSet
+        .getCompulsoryDataElementOperands()
+        .addAll(
+            importDataSet.getCompulsoryDataElementOperands().stream()
+                .filter(dop -> dataElementIds.contains(dop.getDataElement().getUid()))
+                .collect(Collectors.toSet()));
   }
 
   private void deleteRemovedSection(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/EmbeddedObjectObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/EmbeddedObjectObjectBundleHook.java
@@ -133,23 +133,11 @@ public class EmbeddedObjectObjectBundleHook extends AbstractObjectBundleHook<Ide
           continue;
         }
         Collection<?> collection = ReflectionUtils.invokeMethod(object, property.getGetterMethod());
-
-        if (collection != null && isNewCollection(collection)) collection.clear();
+        if (collection != null) collection.clear();
       } else {
         ReflectionUtils.invokeMethod(object, property.getSetterMethod(), (Object) null);
       }
     }
-  }
-
-  private boolean isNewCollection(Collection<?> collection) {
-    // check if each item in the collection is a new object
-    // object is considered new if its ID is 0
-    
-    return collection.stream()
-        .allMatch(
-            item ->
-                item instanceof EmbeddedObject embeddedObject
-                    && embeddedObject.getId() == 0);
   }
 
   private void handleEmbeddedObjects(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/EmbeddedObjectObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/EmbeddedObjectObjectBundleHook.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.BaseAnalyticalObject;
+import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.DefaultAnalyticalObjectImportHandler;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -132,11 +133,23 @@ public class EmbeddedObjectObjectBundleHook extends AbstractObjectBundleHook<Ide
           continue;
         }
         Collection<?> collection = ReflectionUtils.invokeMethod(object, property.getGetterMethod());
-        if (collection != null) collection.clear();
+
+        if (collection != null && isNewCollection(collection)) collection.clear();
       } else {
         ReflectionUtils.invokeMethod(object, property.getSetterMethod(), (Object) null);
       }
     }
+  }
+
+  private boolean isNewCollection(Collection<?> collection) {
+    // check if each item in the collection is a new object
+    // object is considered new if its ID is 0
+    
+    return collection.stream()
+        .allMatch(
+            item ->
+                item instanceof EmbeddedObject embeddedObject
+                    && embeddedObject.getId() == 0);
   }
 
   private void handleEmbeddedObjects(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -731,7 +731,7 @@ public abstract class AbstractCrudController<
   }
 
   protected T patchJsonToEntity(HttpServletRequest request, T existed) throws IOException {
-    return jsonMapper.readerForUpdating(existed).readValue(request.getInputStream(), getEntityClass());
+    return manager.patchObject(existed, request.getInputStream(), getEntityClass());
   }
 
   protected T deserializeXmlEntity(HttpServletRequest request) throws IOException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -418,7 +418,7 @@ public abstract class AbstractCrudController<
       throw new ForbiddenException("You don't have the proper permissions to update this object.");
     }
 
-    T parsed = deserializeJsonEntity(request);
+    T parsed = patchJsonToEntity(request, persisted);
     parsed.setUid(pvUid);
 
     preUpdateEntity(persisted, parsed);
@@ -728,6 +728,10 @@ public abstract class AbstractCrudController<
 
   protected T deserializeJsonEntity(HttpServletRequest request) throws IOException {
     return renderService.fromJson(request.getInputStream(), getEntityClass());
+  }
+
+  protected T patchJsonToEntity(HttpServletRequest request, T existed) throws IOException {
+    return jsonMapper.readerForUpdating(existed).readValue(request.getInputStream(), getEntityClass());
   }
 
   protected T deserializeXmlEntity(HttpServletRequest request) throws IOException {


### PR DESCRIPTION
### Summary
- Check if we can use `objectMapper.readerForUpdating` to patch an existing entity using the input json payload. This can potentially replace the merge mode.

### Issues
- Patching an existed entity which is wrapped by HibernateProxy does not work
- Detach the entity from hibernate context works, but `entity.detach()` doesn't cascade down to hibernate `PersistedCollection` properties.  Can be fixed by global setting below. Need to analyze if we want this (only annotation)
```
@OneToMany(mappedBy = "parent", cascade = CascadeType.DETACH)
```
- `EmbeddedObject` properties will be cleared if they are not included in the input payload. The import service will always delete and recreate. 
