### PR TITLE
feat: Introduce trigram indexable flag on TEA [DHIS2-19758]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
@@ -104,6 +104,8 @@ public class TrackedEntityAttribute extends BaseDimensionalItemObject
 
   private QueryOperator preferredSearchOperator;
 
+  private Boolean trigramIndexable = false;
+
   // -------------------------------------------------------------------------
   // Constructors
   // -------------------------------------------------------------------------
@@ -402,6 +404,16 @@ public class TrackedEntityAttribute extends BaseDimensionalItemObject
 
   public void setFieldMask(String fieldMask) {
     this.fieldMask = fieldMask;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public Boolean getTrigramIndexable() {
+    return trigramIndexable;
+  }
+
+  public void setTrigramIndexable(Boolean trigramIndexable) {
+    this.trigramIndexable = trigramIndexable;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
@@ -99,6 +99,8 @@
       </type>
     </property>
 
+    <property name="trigramIndexable" column="trigramindexable" not-null="true" />
+
   </class>
 
 </hibernate-mapping>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_15__add_tea_trigram_index_flag.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_15__add_tea_trigram_index_flag.sql
@@ -1,0 +1,3 @@
+-- Migration script to add the field trigram indexable in the trackedentityattribute table
+alter table trackedentityattribute
+    add column if not exists trigramindexable bool not null default false;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -168,6 +168,16 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
         "The provided preferred TEA operator `IEQ` is not part of the tracker operators", message);
   }
 
+  @Test
+  void shouldSetIndexableFlagFromImportOrDefaultToFalseIfNotSpecified() {
+    List<TrackedEntityAttribute> trackedEntityAttributes =
+        trackedEntityAttributeService.getAllTrackedEntityAttributes();
+
+    assertTrigramIndexableFlag(trackedEntityAttributes, "sTGqP5JNy6E", true);
+    assertTrigramIndexableFlag(trackedEntityAttributes, "sYn3tkL3XKa", false);
+    assertTrigramIndexableFlag(trackedEntityAttributes, "TsfP85GKsU5", false);
+  }
+
   private void assertMinCharactersToSearch(
       List<TrackedEntityAttribute> teas, String uid, int expected) {
     TrackedEntityAttribute tea =
@@ -196,5 +206,20 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
         expected,
         tea.getPreferredSearchOperator(),
         "Expected preferredSearchOperator for UID " + uid + " to be " + expected);
+  }
+
+  private void assertTrigramIndexableFlag(
+      List<TrackedEntityAttribute> teas, String uid, boolean expected) {
+    TrackedEntityAttribute tea =
+        teas.stream()
+            .filter(t -> t.getUid().equals(uid))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("TrackedEntityAttribute with UID " + uid + " not found"));
+
+    assertEquals(
+        expected,
+        tea.getTrigramIndexable(),
+        "Expected trigram indexable flag for UID " + uid + " to be " + expected);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/te_with_tea_metadata.json
@@ -57,6 +57,7 @@
       "legendSets": [],
       "minCharactersToSearch": 2,
       "preferredSearchOperator": "LIKE",
+      "trigramIndexable": true,
       "sharing": {
         "public": "rw------",
         "external": false,
@@ -92,6 +93,7 @@
       "attributeValues": [],
       "legendSets": [],
       "preferredSearchOperator": "EQ",
+      "trigramIndexable": false,
       "sharing": {
         "public": "rw------",
         "external": false,


### PR DESCRIPTION
This PR adds a new configuration to indicate when a TEA should have a partial trigram index.
This setting by itself does not create the index, it's just a way for administrators to explicitly choose which TEAs are candidates for trigram indexes. The indexes will be created by a job, which will be implemented in a different ticket

This configuration is placed in the TEA level, as it’s easier to implement and document (less magic involved).

The default value will be false, to ensure backward compatibility, so the behavior remains the same as in v42 after migration.