### PR TITLE
chore: Split eventchangelog table [DHIS2-19913]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -130,7 +130,8 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           // delete other objects related to events
           "delete from relationshipitem where eventid in " + eventSelect,
           "delete from trackedentitydatavalueaudit where eventid in " + eventSelect,
-          "delete from eventchangelog where eventid in " + eventSelect,
+          "delete from trackereventchangelog where eventid in " + eventSelect,
+          "delete from singleeventchangelog where eventid in " + eventSelect,
           "delete from programmessage where eventid in " + eventSelect,
           "delete from programnotificationinstance where eventid in " + eventSelect,
           // finally delete the events
@@ -211,7 +212,8 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           // delete other entries linked to events
           "delete from relationshipitem where eventid in " + eventSelect,
           "delete from trackedentitydatavalueaudit where eventid in " + eventSelect,
-          "delete from eventchangelog where eventid in " + eventSelect,
+          "delete from trackereventchangelog where eventid in " + eventSelect,
+          "delete from singleeventchangelog where eventid in " + eventSelect,
           "delete from programmessage where eventid in " + eventSelect,
           "delete from programnotificationinstance where eventid in " + eventSelect,
           // delete other entries linked to enrollments
@@ -300,7 +302,8 @@ public class JdbcMaintenanceStore implements MaintenanceStore {
           "delete from note where noteid not in (select noteid from event_notes union all select noteid from enrollment_notes)",
           // delete other objects related to obsolete events
           "delete from trackedentitydatavalueaudit where eventid in " + eventSelect,
-          "delete from eventchangelog where eventid in " + eventSelect,
+          "delete from trackereventchangelog where eventid in " + eventSelect,
+          "delete from singleeventchangelog where eventid in " + eventSelect,
           // delete other objects related to obsolete enrollments
           "delete from programmessage where enrollmentid in " + enrollmentSelect,
           "delete from event where enrollmentid in " + enrollmentSelect,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EventChangeLogDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EventChangeLogDeletionHandler.java
@@ -49,6 +49,10 @@ public class EventChangeLogDeletionHandler extends JdbcDeletionHandler {
 
   private void deleteDataElement(DataElement dataElement) {
     delete(
-        "delete from eventchangelog where dataelementid = :id", Map.of("id", dataElement.getId()));
+        "delete from trackereventchangelog where dataelementid = :id",
+        Map.of("id", dataElement.getId()));
+    delete(
+        "delete from singleeventchangelog where dataelementid = :id",
+        Map.of("id", dataElement.getId()));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/SingleEventChangeLog.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/SingleEventChangeLog.hbm.xml
@@ -4,7 +4,7 @@
   "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
-  <class name="org.hisp.dhis.tracker.export.singleevent.SingleEventChangeLog" table="eventchangelog">
+  <class name="org.hisp.dhis.tracker.export.singleevent.SingleEventChangeLog" table="singleeventchangelog">
 
     <id name="id" column="eventchangelogid">
       <generator class="sequence">

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/TrackerEventChangeLog.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchangelog.hiberante/TrackerEventChangeLog.hbm.xml
@@ -4,7 +4,7 @@
   "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping>
-  <class name="org.hisp.dhis.tracker.export.trackerevent.TrackerEventChangeLog" table="eventchangelog">
+  <class name="org.hisp.dhis.tracker.export.trackerevent.TrackerEventChangeLog" table="trackereventchangelog">
 
     <id name="id" column="eventchangelogid">
       <generator class="sequence">

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_18__separate_eventchangelog_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_18__separate_eventchangelog_table.sql
@@ -1,0 +1,34 @@
+alter table if exists eventchangelog
+    drop constraint if exists fk_eventchangelog_eventid;
+
+CREATE TABLE trackereventchangelog (LIKE eventchangelog INCLUDING ALL);
+CREATE TABLE singleeventchangelog (LIKE eventchangelog INCLUDING ALL);
+
+INSERT INTO trackereventchangelog
+SELECT *
+FROM eventchangelog
+WHERE eventid IN (
+    SELECT ev.eventid
+    FROM event ev
+             JOIN programstage ps ON ev.programstageid = ps.programstageid
+             JOIN program p ON ps.programid = p.programid
+    WHERE p.type = 'WITH_REGISTRATION'
+);
+
+INSERT INTO singleeventchangelog
+SELECT *
+FROM eventchangelog
+WHERE eventid IN (
+    SELECT ev.eventid
+    FROM event ev
+             JOIN programstage ps ON ev.programstageid = ps.programstageid
+             JOIN program p ON ps.programid = p.programid
+    WHERE p.type = 'WITHOUT_REGISTRATION'
+);
+
+alter table if exists trackereventchangelog
+    add constraint fk_trackereventchangelog_eventid FOREIGN KEY (eventid) REFERENCES event(eventid);
+alter table if exists singleeventchangelog
+    add constraint fk_singleeventchangelog_eventid FOREIGN KEY (eventid) REFERENCES event(eventid);
+
+drop table eventchangelog;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -218,7 +218,8 @@ public class HibernateDbmsManager implements DbmsManager {
 
     emptyTable("programnotificationinstance");
     emptyTable("trackedentitydatavalueaudit");
-    emptyTable("eventchangelog");
+    emptyTable("trackereventchangelog");
+    emptyTable("singleeventchangelog");
     emptyTable("trackedentityprogramowner");
 
     emptyTable("programmessage_phonenumbers");


### PR DESCRIPTION
Split `eventchangelog` table into `trackereventchangelog` and `singleeventchangelog`

***In this PR***
- Update `SingleEventChangeLog` hibernate mapping: point to the correct table and update foreign key constraint name.
- Update `TrackerEventChangeLog` hibernate object: point to the correct table and update foreign key constraint name.
- Update deletion handler and maintenance store.

***Migration plan***
In order to make the transition reviewable and understand what is happening, we are separating column in tables with foreign keys one by one. With this approach we are going to have a lot of different migration scripts and we leave the DB in an intermediate state that should be avoided.
The solution that we thought of is to create one complete migration at the end of development that will include all migrations. We will maintain the files of the old migration with a comment, just to make the process more understandable but the actual script is going to be only in one file. **We are going to break dev with this final PR**.

***Next steps***
- Use `SingleEvent` and `TrackerEvent` in `ProgramNotificationInstance` and separate columns in `programnotificationinstance` table.
- Use `SingleEvent` and `TrackerEvent` in `ProgramMessage` and separate columns in `programmessage` table.
- Split `event_notes` table to `singleevent_notes` and `trackerevent_notes` tables
- Split `event` table to `trackerevent` and `singleevent` and update all foreign keys and solve all added `TODO`s