### PR TITLE
fix: metadata export of visualization relative periods

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -320,7 +320,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
    * Keeps the uids of element + program stage, so we are able to return the correct elements in
    * cases of repeated elements with distinct program stages.
    */
-  private Set<String> addedElementsProgramStages = new HashSet<>();
+  private final Set<String> addedElementsProgramStages = new HashSet<>();
 
   private Set<Interpretation> interpretations = new HashSet<>();
 
@@ -1372,7 +1372,6 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
   }
 
   @JsonProperty
-  @JsonIgnore
   @JacksonXmlElementWrapper(localName = "rawPeriods", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "rawPeriods", namespace = DxfNamespaces.DXF_2_0)
   public List<String> getRawPeriods() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -320,7 +320,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
    * Keeps the uids of element + program stage, so we are able to return the correct elements in
    * cases of repeated elements with distinct program stages.
    */
-  private final Set<String> addedElementsProgramStages = new HashSet<>();
+  private Set<String> addedElementsProgramStages = new HashSet<>();
 
   private Set<Interpretation> interpretations = new HashSet<>();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
@@ -36,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -63,8 +65,6 @@ import org.hisp.dhis.visualization.Visualization;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
@@ -29,17 +29,26 @@
  */
 package org.hisp.dhis.dxf2.metadata;
 
+import static org.hisp.dhis.security.acl.AccessStringHelper.DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
+import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.query.Filters;
 import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.query.Query;
@@ -47,11 +56,15 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
+import org.hisp.dhis.visualization.Visualization;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -150,6 +163,380 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     assertFalse(metadata.containsKey(DataElementGroup.class));
     assertTrue(metadata.containsKey(DataElement.class));
     assertEquals(2, metadata.get(DataElement.class).size());
+  }
+
+  @Test
+  public void testDashboardMetadataExportAsNodeStream() throws IOException {
+
+    // Setup test data
+    DataElement dataElementA = createDataElement('A');
+    manager.save(dataElementA);
+    DataElement dataElementB = createDataElement('B');
+    manager.save(dataElementB);
+    Visualization visualizationA = createVisualization('A');
+    visualizationA.addDataDimensionItem(dataElementA);
+    visualizationA.addDataDimensionItem(dataElementB);
+    visualizationA.setSharing(Sharing.builder().publicAccess(DEFAULT).build());
+    List<String> rawPeriods = new ArrayList<>();
+    rawPeriods.add(RelativePeriodEnum.LAST_5_YEARS.name());
+    rawPeriods.add(RelativePeriodEnum.THIS_BIWEEK.name());
+    visualizationA.setRawPeriods(rawPeriods);
+    manager.save(visualizationA, false);
+    Dashboard dashboard =
+        createDashboardWithItem("A", Sharing.builder().publicAccess(DEFAULT).build());
+    dashboard.getItems().get(0).setVisualization(visualizationA);
+    manager.save(dashboard, false);
+    MetadataExportParams params = new MetadataExportParams();
+    params.setClasses(Sets.newHashSet(Dashboard.class, DashboardItem.class, Visualization.class));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    // method under test
+    metadataExportService.getMetadataWithDependenciesAsNodeStream(dashboard, params, out);
+
+    // assertions
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode rootNode = mapper.readTree(out.toByteArray());
+
+    JsonNode systemNode = rootNode.get("system");
+    assertNotNull(systemNode, "System node should exist");
+    assertNull(systemNode.get("id").asText(null), "System id should be null");
+    assertEquals("abc1234", systemNode.get("rev").asText(), "System revision should match");
+    assertEquals("123", systemNode.get("version").asText(), "System version should match");
+    assertNotNull(systemNode.get("date"), "System date should be present");
+    assertFalse(systemNode.get("date").asText().isEmpty(), "System date should not be empty");
+
+    // Assert Dashboards Array
+    JsonNode dashboardsNode = rootNode.get("dashboards");
+    assertNotNull(dashboardsNode, "Dashboards node should exist");
+    assertTrue(dashboardsNode.isArray(), "Dashboards should be an array");
+    assertEquals(1, dashboardsNode.size(), "Should have exactly 1 dashboard");
+
+    // Assert Dashboard Properties
+    JsonNode exportedDashboard = dashboardsNode.get(0);
+    assertNotNull(exportedDashboard.get("created"), "Dashboard created date should be present");
+    assertFalse(
+        exportedDashboard.get("created").asText().isEmpty(),
+        "Dashboard created date should not be empty");
+    assertNotNull(exportedDashboard.get("lastUpdated"), "Dashboard lastUpdated should be present");
+    assertFalse(
+        exportedDashboard.get("lastUpdated").asText().isEmpty(),
+        "Dashboard lastUpdated should not be empty");
+    assertEquals(
+        "dashboardA", exportedDashboard.get("name").asText(), "Dashboard name should match");
+    assertEquals(
+        false,
+        exportedDashboard.get("restrictFilters").asBoolean(),
+        "Dashboard restrictFilters should be false");
+    assertNotNull(exportedDashboard.get("id"), "Dashboard id should be present");
+
+    // Assert Dashboard CreatedBy User
+    JsonNode createdBy = exportedDashboard.get("createdBy");
+    assertNotNull(createdBy, "CreatedBy should exist");
+    assertNotNull(createdBy.get("id"), "Created by id should be present");
+    assertEquals("Codeadmin", createdBy.get("code").asText(), "CreatedBy code should match");
+    assertEquals(
+        "FirstNameadmin Surnameadmin",
+        createdBy.get("name").asText(),
+        "CreatedBy name should match");
+    assertEquals(
+        "FirstNameadmin Surnameadmin",
+        createdBy.get("displayName").asText(),
+        "CreatedBy displayName should match");
+    assertEquals("admin", createdBy.get("username").asText(), "CreatedBy username should match");
+
+    // Assert Dashboard LastUpdatedBy User
+    JsonNode lastUpdatedBy = exportedDashboard.get("lastUpdatedBy");
+    assertNotNull(lastUpdatedBy, "LastUpdatedBy should exist");
+    assertNotNull(lastUpdatedBy.get("id"), "LastUpdatedBy id should be present");
+    assertEquals(
+        "Codeadmin", lastUpdatedBy.get("code").asText(), "LastUpdatedBy code should match");
+    assertEquals(
+        "FirstNameadmin Surnameadmin",
+        lastUpdatedBy.get("name").asText(),
+        "LastUpdatedBy name should match");
+    assertEquals(
+        "FirstNameadmin Surnameadmin",
+        lastUpdatedBy.get("displayName").asText(),
+        "LastUpdatedBy displayName should match");
+    assertEquals(
+        "admin", lastUpdatedBy.get("username").asText(), "LastUpdatedBy username should match");
+
+    // Assert Dashboard Arrays
+    assertTrue(
+        exportedDashboard.get("allowedFilters").isArray(), "AllowedFilters should be an array");
+    assertEquals(
+        0, exportedDashboard.get("allowedFilters").size(), "AllowedFilters should be empty");
+    assertTrue(exportedDashboard.get("favorites").isArray(), "Favorites should be an array");
+    assertEquals(0, exportedDashboard.get("favorites").size(), "Favorites should be empty");
+    assertTrue(exportedDashboard.get("translations").isArray(), "Translations should be an array");
+    assertEquals(0, exportedDashboard.get("translations").size(), "Translations should be empty");
+
+    // Assert Dashboard Sharing
+    JsonNode sharing = exportedDashboard.get("sharing");
+    assertNotNull(sharing, "Sharing should exist");
+    assertNotNull(sharing.get("owner"), "Sharing owner id should be present");
+    assertEquals(false, sharing.get("external").asBoolean(), "Sharing external should be false");
+    assertEquals("--------", sharing.get("public").asText(), "Sharing public should match");
+    assertTrue(sharing.get("users").isObject(), "Sharing users should be an object");
+    assertTrue(sharing.get("userGroups").isObject(), "Sharing userGroups should be an object");
+
+    // Assert Dashboard Items
+    JsonNode dashboardItems = exportedDashboard.get("dashboardItems");
+    assertNotNull(dashboardItems, "DashboardItems should exist");
+    assertTrue(dashboardItems.isArray(), "DashboardItems should be an array");
+    assertEquals(1, dashboardItems.size(), "Should have exactly 1 dashboard item");
+
+    // Assert Dashboard Item Properties
+    JsonNode dashboardItem = dashboardItems.get(0);
+    assertEquals(
+        "dashboardItemA", dashboardItem.get("name").asText(), "DashboardItem name should match");
+    assertNotNull(dashboardItem.get("created"), "DashboardItem created should be present");
+    assertFalse(
+        dashboardItem.get("created").asText().isEmpty(),
+        "DashboardItem created should not be empty");
+    assertNotNull(dashboardItem.get("lastUpdated"), "DashboardItem lastUpdated should be present");
+    assertFalse(
+        dashboardItem.get("lastUpdated").asText().isEmpty(),
+        "DashboardItem lastUpdated should not be empty");
+    assertEquals(
+        "VISUALIZATION", dashboardItem.get("type").asText(), "DashboardItem type should match");
+    assertNotNull(dashboardItem.get("id"), "DashboardItem id should be present");
+    assertEquals(
+        "dashboardItemA",
+        dashboardItem.get("displayName").asText(),
+        "DashboardItem displayName should match");
+    assertEquals(
+        0,
+        dashboardItem.get("interpretationCount").asInt(),
+        "DashboardItem interpretationCount should be 0");
+    assertEquals(
+        0,
+        dashboardItem.get("interpretationLikeCount").asInt(),
+        "DashboardItem interpretationLikeCount should be 0");
+    assertEquals(
+        1, dashboardItem.get("contentCount").asInt(), "DashboardItem contentCount should be 1");
+    assertEquals(
+        false, dashboardItem.get("favorite").asBoolean(), "DashboardItem favorite should be false");
+
+    // Assert Dashboard Item Visualization
+    JsonNode visualization = dashboardItem.get("visualization");
+    assertNotNull(visualization, "Visualization should exist");
+    assertNotNull(visualization.get("id"), "Visualization id should be present");
+
+    // Assert Dashboard Item Access
+    JsonNode access = dashboardItem.get("access");
+    assertNotNull(access, "Access should exist");
+    assertEquals(true, access.get("manage").asBoolean(), "Access manage should be true");
+    assertEquals(true, access.get("externalize").asBoolean(), "Access externalize should be true");
+    assertEquals(true, access.get("write").asBoolean(), "Access write should be true");
+    assertEquals(true, access.get("read").asBoolean(), "Access read should be true");
+    assertEquals(true, access.get("update").asBoolean(), "Access update should be true");
+    assertEquals(true, access.get("delete").asBoolean(), "Access delete should be true");
+
+    // Assert Dashboard Item Arrays
+    assertTrue(
+        dashboardItem.get("translations").isArray(),
+        "DashboardItem translations should be an array");
+    assertEquals(
+        0, dashboardItem.get("translations").size(), "DashboardItem translations should be empty");
+    assertTrue(
+        dashboardItem.get("favorites").isArray(), "DashboardItem favorites should be an array");
+    assertEquals(
+        0, dashboardItem.get("favorites").size(), "DashboardItem favorites should be empty");
+    assertTrue(dashboardItem.get("users").isArray(), "DashboardItem users should be an array");
+    assertEquals(0, dashboardItem.get("users").size(), "DashboardItem users should be empty");
+    assertTrue(
+        dashboardItem.get("attributeValues").isArray(),
+        "DashboardItem attributeValues should be an array");
+    assertEquals(
+        0,
+        dashboardItem.get("attributeValues").size(),
+        "DashboardItem attributeValues should be empty");
+    assertTrue(dashboardItem.get("reports").isArray(), "DashboardItem reports should be an array");
+    assertEquals(0, dashboardItem.get("reports").size(), "DashboardItem reports should be empty");
+    assertTrue(
+        dashboardItem.get("resources").isArray(), "DashboardItem resources should be an array");
+    assertEquals(
+        0, dashboardItem.get("resources").size(), "DashboardItem resources should be empty");
+
+    // Assert Dashboard Item Sharing
+    JsonNode itemSharing = dashboardItem.get("sharing");
+    assertNotNull(itemSharing, "DashboardItem sharing should exist");
+    assertEquals(
+        false,
+        itemSharing.get("external").asBoolean(),
+        "DashboardItem sharing external should be false");
+    assertTrue(
+        itemSharing.get("users").isObject(), "DashboardItem sharing users should be an object");
+    assertTrue(
+        itemSharing.get("userGroups").isObject(),
+        "DashboardItem sharing userGroups should be an object");
+
+    // Assert Visualizations Array
+    JsonNode visualizationsNode = rootNode.get("visualizations");
+    assertNotNull(visualizationsNode, "Visualizations node should exist");
+    assertTrue(visualizationsNode.isArray(), "Visualizations should be an array");
+    assertEquals(1, visualizationsNode.size(), "Should have exactly 1 visualization");
+
+    // Assert Visualization Properties
+    JsonNode viz = visualizationsNode.get(0);
+    assertEquals("VisualizationA", viz.get("name").asText(), "Visualization name should match");
+    assertNotNull(viz.get("created"), "Visualization created should be present");
+    assertFalse(viz.get("created").asText().isEmpty(), "Visualization created should not be empty");
+    assertNotNull(viz.get("lastUpdated"), "Visualization lastUpdated should be present");
+    assertFalse(
+        viz.get("lastUpdated").asText().isEmpty(), "Visualization lastUpdated should not be empty");
+    assertEquals("PIVOT_TABLE", viz.get("type").asText(), "Visualization type should match");
+
+    // Assert Visualization CreatedBy and LastUpdatedBy
+    JsonNode vizCreatedBy = viz.get("createdBy");
+    assertNotNull(vizCreatedBy, "Visualization createdBy should exist");
+    assertEquals(
+        "M5zQapPyTZI", vizCreatedBy.get("id").asText(), "Visualization createdBy id should match");
+    assertEquals(
+        "admin",
+        vizCreatedBy.get("username").asText(),
+        "Visualization createdBy username should match");
+
+    JsonNode vizLastUpdatedBy = viz.get("lastUpdatedBy");
+    assertNotNull(vizLastUpdatedBy, "Visualization lastUpdatedBy should exist");
+    assertEquals(
+        "admin",
+        vizLastUpdatedBy.get("username").asText(),
+        "Visualization lastUpdatedBy username should match");
+
+    // Assert Visualization Sharing
+    JsonNode vizSharing = viz.get("sharing");
+    assertNotNull(vizSharing, "Visualization sharing should exist");
+    assertEquals(
+        false,
+        vizSharing.get("external").asBoolean(),
+        "Visualization sharing external should be false");
+    assertEquals(
+        "--------", vizSharing.get("public").asText(), "Visualization sharing public should match");
+
+    // Assert Visualization Configuration Properties
+    assertEquals("NONE", viz.get("regressionType").asText(), "RegressionType should match");
+    assertEquals("NORMAL", viz.get("displayDensity").asText(), "DisplayDensity should match");
+    assertEquals("NORMAL", viz.get("fontSize").asText(), "FontSize should match");
+    assertEquals(0, viz.get("sortOrder").asInt(), "SortOrder should be 0");
+    assertEquals(0, viz.get("topLimit").asInt(), "TopLimit should be 0");
+    assertEquals(
+        "SPACE", viz.get("digitGroupSeparator").asText(), "DigitGroupSeparator should match");
+    assertEquals("NONE", viz.get("hideEmptyRowItems").asText(), "HideEmptyRowItems should match");
+
+    // Assert Visualization Boolean Properties
+    assertEquals(false, viz.get("hideEmptyRows").asBoolean(), "HideEmptyRows should be false");
+    assertEquals(false, viz.get("showHierarchy").asBoolean(), "ShowHierarchy should be false");
+    assertEquals(
+        false, viz.get("userOrganisationUnit").asBoolean(), "UserOrganisationUnit should be false");
+    assertEquals(
+        false,
+        viz.get("userOrganisationUnitChildren").asBoolean(),
+        "UserOrganisationUnitChildren should be false");
+    assertEquals(
+        false,
+        viz.get("userOrganisationUnitGrandChildren").asBoolean(),
+        "UserOrganisationUnitGrandChildren should be false");
+    assertEquals(false, viz.get("completedOnly").asBoolean(), "CompletedOnly should be false");
+    assertEquals(false, viz.get("skipRounding").asBoolean(), "SkipRounding should be false");
+    assertEquals(false, viz.get("hideLegend").asBoolean(), "HideLegend should be false");
+    assertEquals(
+        false,
+        viz.get("noSpaceBetweenColumns").asBoolean(),
+        "NoSpaceBetweenColumns should be false");
+    assertEquals(
+        false, viz.get("cumulativeValues").asBoolean(), "CumulativeValues should be false");
+    assertEquals(
+        false, viz.get("percentStackedValues").asBoolean(), "PercentStackedValues should be false");
+    assertEquals(false, viz.get("showData").asBoolean(), "ShowData should be false");
+    assertEquals(false, viz.get("colTotals").asBoolean(), "ColTotals should be false");
+    assertEquals(false, viz.get("rowTotals").asBoolean(), "RowTotals should be false");
+    assertEquals(false, viz.get("rowSubTotals").asBoolean(), "RowSubTotals should be false");
+    assertEquals(false, viz.get("colSubTotals").asBoolean(), "ColSubTotals should be false");
+    assertEquals(false, viz.get("hideTitle").asBoolean(), "HideTitle should be false");
+    assertEquals(false, viz.get("hideSubtitle").asBoolean(), "HideSubtitle should be false");
+    assertEquals(
+        false, viz.get("showDimensionLabels").asBoolean(), "ShowDimensionLabels should be false");
+    assertEquals(false, viz.get("regression").asBoolean(), "Regression should be false");
+    assertEquals(
+        false, viz.get("hideEmptyColumns").asBoolean(), "HideEmptyColumns should be false");
+    assertEquals(
+        false, viz.get("fixColumnHeaders").asBoolean(), "FixColumnHeaders should be false");
+    assertEquals(false, viz.get("fixRowHeaders").asBoolean(), "FixRowHeaders should be false");
+
+    // Assert Visualization rawPeriods Array
+    JsonNode exportedRawPeriods = viz.get("rawPeriods");
+    assertNotNull(exportedRawPeriods, "RawPeriods should exist");
+    assertTrue(exportedRawPeriods.isArray(), "RawPeriods should be an array");
+    assertEquals(2, exportedRawPeriods.size(), "RawPeriods should have 2 elements");
+    assertEquals(
+        "LAST_5_YEARS", exportedRawPeriods.get(0).asText(), "First rawPeriod should match");
+    assertEquals(
+        "THIS_BIWEEK", exportedRawPeriods.get(1).asText(), "Second rawPeriod should match");
+
+    // Assert Visualization dataDimensionItems Array
+    JsonNode dataDimensionItems = viz.get("dataDimensionItems");
+    assertNotNull(dataDimensionItems, "DataDimensionItems should exist");
+    assertTrue(dataDimensionItems.isArray(), "DataDimensionItems should be an array");
+    assertEquals(2, dataDimensionItems.size(), "DataDimensionItems should have 2 elements");
+    assertEquals(
+        "DATA_ELEMENT",
+        dataDimensionItems.get(0).get("dataDimensionItemType").asText(),
+        "First dataDimensionItem type should match");
+    assertEquals(
+        "DATA_ELEMENT",
+        dataDimensionItems.get(1).get("dataDimensionItemType").asText(),
+        "Second dataDimensionItem type should match");
+
+    // Assert Empty Arrays in Visualization
+    String[] emptyArrayFields = {
+      "translations",
+      "favorites",
+      "filterDimensions",
+      "organisationUnits",
+      "periods",
+      "dataElementGroupSetDimensions",
+      "organisationUnitGroupSetDimensions",
+      "organisationUnitLevels",
+      "categoryDimensions",
+      "categoryOptionGroupSetDimensions",
+      "itemOrganisationUnitGroups",
+      "subscribers",
+      "columnDimensions",
+      "rowDimensions",
+      "yearlySeries",
+      "attributeValues",
+      "sorting",
+      "series",
+      "optionalAxes",
+      "icons",
+      "axes"
+    };
+
+    for (String fieldName : emptyArrayFields) {
+      JsonNode arrayField = viz.get(fieldName);
+      assertNotNull(arrayField, fieldName + " should exist");
+      assertTrue(arrayField.isArray(), fieldName + " should be an array");
+      assertEquals(0, arrayField.size(), fieldName + " should be empty");
+    }
+  }
+
+  protected Dashboard createDashboardWithItem(String name, Sharing sharing) {
+    DashboardItem dashboardItem = createDashboardItem("A");
+    Dashboard dashboard = new Dashboard();
+    dashboard.setName("dashboard" + name);
+    dashboard.setSharing(sharing);
+    dashboard.getItems().add(dashboardItem);
+    return dashboard;
+  }
+
+  protected DashboardItem createDashboardItem(String name) {
+    DashboardItem dashboardItem = new DashboardItem();
+    dashboardItem.setName("dashboardItem" + name);
+    dashboardItem.setAutoFields();
+    return dashboardItem;
   }
 
   // @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
@@ -166,7 +166,7 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  public void testDashboardMetadataExportAsNodeStream() throws IOException {
+  void testDashboardMetadataExportAsNodeStream() throws IOException {
 
     // Setup test data
     DataElement dataElementA = createDataElement('A');
@@ -224,8 +224,7 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
         "Dashboard lastUpdated should not be empty");
     assertEquals(
         "dashboardA", exportedDashboard.get("name").asText(), "Dashboard name should match");
-    assertEquals(
-        false,
+    assertFalse(
         exportedDashboard.get("restrictFilters").asBoolean(),
         "Dashboard restrictFilters should be false");
     assertNotNull(exportedDashboard.get("id"), "Dashboard id should be present");
@@ -276,7 +275,7 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     JsonNode sharing = exportedDashboard.get("sharing");
     assertNotNull(sharing, "Sharing should exist");
     assertNotNull(sharing.get("owner"), "Sharing owner id should be present");
-    assertEquals(false, sharing.get("external").asBoolean(), "Sharing external should be false");
+    assertFalse(sharing.get("external").asBoolean(), "Sharing external should be false");
     assertEquals("--------", sharing.get("public").asText(), "Sharing public should match");
     assertTrue(sharing.get("users").isObject(), "Sharing users should be an object");
     assertTrue(sharing.get("userGroups").isObject(), "Sharing userGroups should be an object");
@@ -316,8 +315,8 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
         "DashboardItem interpretationLikeCount should be 0");
     assertEquals(
         1, dashboardItem.get("contentCount").asInt(), "DashboardItem contentCount should be 1");
-    assertEquals(
-        false, dashboardItem.get("favorite").asBoolean(), "DashboardItem favorite should be false");
+    assertFalse(
+        dashboardItem.get("favorite").asBoolean(), "DashboardItem favorite should be false");
 
     // Assert Dashboard Item Visualization
     JsonNode visualization = dashboardItem.get("visualization");
@@ -327,12 +326,12 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     // Assert Dashboard Item Access
     JsonNode access = dashboardItem.get("access");
     assertNotNull(access, "Access should exist");
-    assertEquals(true, access.get("manage").asBoolean(), "Access manage should be true");
-    assertEquals(true, access.get("externalize").asBoolean(), "Access externalize should be true");
-    assertEquals(true, access.get("write").asBoolean(), "Access write should be true");
-    assertEquals(true, access.get("read").asBoolean(), "Access read should be true");
-    assertEquals(true, access.get("update").asBoolean(), "Access update should be true");
-    assertEquals(true, access.get("delete").asBoolean(), "Access delete should be true");
+    assertTrue(access.get("manage").asBoolean(), "Access manage should be true");
+    assertTrue(access.get("externalize").asBoolean(), "Access externalize should be true");
+    assertTrue(access.get("write").asBoolean(), "Access write should be true");
+    assertTrue(access.get("read").asBoolean(), "Access read should be true");
+    assertTrue(access.get("update").asBoolean(), "Access update should be true");
+    assertTrue(access.get("delete").asBoolean(), "Access delete should be true");
 
     // Assert Dashboard Item Arrays
     assertTrue(
@@ -363,10 +362,8 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     // Assert Dashboard Item Sharing
     JsonNode itemSharing = dashboardItem.get("sharing");
     assertNotNull(itemSharing, "DashboardItem sharing should exist");
-    assertEquals(
-        false,
-        itemSharing.get("external").asBoolean(),
-        "DashboardItem sharing external should be false");
+    assertFalse(
+        itemSharing.get("external").asBoolean(), "DashboardItem sharing external should be false");
     assertTrue(
         itemSharing.get("users").isObject(), "DashboardItem sharing users should be an object");
     assertTrue(
@@ -409,10 +406,8 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     // Assert Visualization Sharing
     JsonNode vizSharing = viz.get("sharing");
     assertNotNull(vizSharing, "Visualization sharing should exist");
-    assertEquals(
-        false,
-        vizSharing.get("external").asBoolean(),
-        "Visualization sharing external should be false");
+    assertFalse(
+        vizSharing.get("external").asBoolean(), "Visualization sharing external should be false");
     assertEquals(
         "--------", vizSharing.get("public").asText(), "Visualization sharing public should match");
 
@@ -427,44 +422,36 @@ class MetadataExportServiceTest extends PostgresIntegrationTestBase {
     assertEquals("NONE", viz.get("hideEmptyRowItems").asText(), "HideEmptyRowItems should match");
 
     // Assert Visualization Boolean Properties
-    assertEquals(false, viz.get("hideEmptyRows").asBoolean(), "HideEmptyRows should be false");
-    assertEquals(false, viz.get("showHierarchy").asBoolean(), "ShowHierarchy should be false");
-    assertEquals(
-        false, viz.get("userOrganisationUnit").asBoolean(), "UserOrganisationUnit should be false");
-    assertEquals(
-        false,
+    assertFalse(viz.get("hideEmptyRows").asBoolean(), "HideEmptyRows should be false");
+    assertFalse(viz.get("showHierarchy").asBoolean(), "ShowHierarchy should be false");
+    assertFalse(
+        viz.get("userOrganisationUnit").asBoolean(), "UserOrganisationUnit should be false");
+    assertFalse(
         viz.get("userOrganisationUnitChildren").asBoolean(),
         "UserOrganisationUnitChildren should be false");
-    assertEquals(
-        false,
+    assertFalse(
         viz.get("userOrganisationUnitGrandChildren").asBoolean(),
         "UserOrganisationUnitGrandChildren should be false");
-    assertEquals(false, viz.get("completedOnly").asBoolean(), "CompletedOnly should be false");
-    assertEquals(false, viz.get("skipRounding").asBoolean(), "SkipRounding should be false");
-    assertEquals(false, viz.get("hideLegend").asBoolean(), "HideLegend should be false");
-    assertEquals(
-        false,
-        viz.get("noSpaceBetweenColumns").asBoolean(),
-        "NoSpaceBetweenColumns should be false");
-    assertEquals(
-        false, viz.get("cumulativeValues").asBoolean(), "CumulativeValues should be false");
-    assertEquals(
-        false, viz.get("percentStackedValues").asBoolean(), "PercentStackedValues should be false");
-    assertEquals(false, viz.get("showData").asBoolean(), "ShowData should be false");
-    assertEquals(false, viz.get("colTotals").asBoolean(), "ColTotals should be false");
-    assertEquals(false, viz.get("rowTotals").asBoolean(), "RowTotals should be false");
-    assertEquals(false, viz.get("rowSubTotals").asBoolean(), "RowSubTotals should be false");
-    assertEquals(false, viz.get("colSubTotals").asBoolean(), "ColSubTotals should be false");
-    assertEquals(false, viz.get("hideTitle").asBoolean(), "HideTitle should be false");
-    assertEquals(false, viz.get("hideSubtitle").asBoolean(), "HideSubtitle should be false");
-    assertEquals(
-        false, viz.get("showDimensionLabels").asBoolean(), "ShowDimensionLabels should be false");
-    assertEquals(false, viz.get("regression").asBoolean(), "Regression should be false");
-    assertEquals(
-        false, viz.get("hideEmptyColumns").asBoolean(), "HideEmptyColumns should be false");
-    assertEquals(
-        false, viz.get("fixColumnHeaders").asBoolean(), "FixColumnHeaders should be false");
-    assertEquals(false, viz.get("fixRowHeaders").asBoolean(), "FixRowHeaders should be false");
+    assertFalse(viz.get("completedOnly").asBoolean(), "CompletedOnly should be false");
+    assertFalse(viz.get("skipRounding").asBoolean(), "SkipRounding should be false");
+    assertFalse(viz.get("hideLegend").asBoolean(), "HideLegend should be false");
+    assertFalse(
+        viz.get("noSpaceBetweenColumns").asBoolean(), "NoSpaceBetweenColumns should be false");
+    assertFalse(viz.get("cumulativeValues").asBoolean(), "CumulativeValues should be false");
+    assertFalse(
+        viz.get("percentStackedValues").asBoolean(), "PercentStackedValues should be false");
+    assertFalse(viz.get("showData").asBoolean(), "ShowData should be false");
+    assertFalse(viz.get("colTotals").asBoolean(), "ColTotals should be false");
+    assertFalse(viz.get("rowTotals").asBoolean(), "RowTotals should be false");
+    assertFalse(viz.get("rowSubTotals").asBoolean(), "RowSubTotals should be false");
+    assertFalse(viz.get("colSubTotals").asBoolean(), "ColSubTotals should be false");
+    assertFalse(viz.get("hideTitle").asBoolean(), "HideTitle should be false");
+    assertFalse(viz.get("hideSubtitle").asBoolean(), "HideSubtitle should be false");
+    assertFalse(viz.get("showDimensionLabels").asBoolean(), "ShowDimensionLabels should be false");
+    assertFalse(viz.get("regression").asBoolean(), "Regression should be false");
+    assertFalse(viz.get("hideEmptyColumns").asBoolean(), "HideEmptyColumns should be false");
+    assertFalse(viz.get("fixColumnHeaders").asBoolean(), "FixColumnHeaders should be false");
+    assertFalse(viz.get("fixRowHeaders").asBoolean(), "FixRowHeaders should be false");
 
     // Assert Visualization rawPeriods Array
     JsonNode exportedRawPeriods = viz.get("rawPeriods");


### PR DESCRIPTION
## Summary

Fixes an issue with metadata export no longer exporting the Visualization's relative periods. The relative periods are now exported as `rawPeriods`.

```json
"visualizations":[
  {
    "name":"ANC: ANC 1 coverage year over year",
    "created":"2018-12-03T12:47:50.052",
    "lastUpdated":"2025-07-28T14:15:29.048",
    ...
    "rawPeriods":[
            "MONTHS_THIS_YEAR"
    ],
    ...
  },
```