### PR TITLE
feat: add new settings for Azure maps API key

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -514,6 +514,10 @@ public non-sealed interface SystemSettings extends Settings {
     return asString("keyBingMapsApiKey", "");
   }
 
+  default String getAzureMapsApiKey() {
+    return asString("keyAzureMapsApiKey", "");
+  }
+
   default Date getLastMetaDataSyncSuccess() {
     return asDate("keyLastMetaDataSyncSuccess", new Date(0));
   }

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -103,7 +103,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(147, keys.size());
+    assertEquals(148, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));


### PR DESCRIPTION
# Summary
Adds a new settings key for Azure maps API keys. Bing maps API keys are being deprecated, but needs to be kept during the transition phase.