### PR TITLE
fix: handle null boundaries in PI sql generation [DHIS2-19928]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -524,7 +524,10 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
     // ---------------------------------------------------------------------
 
     if (!params.getAggregationTypeFallback().isFirstOrLastPeriodAggregationType()) {
-      sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql(params);
+      String timeFieldSql = timeFieldSqlRenderer.renderPeriodTimeFieldSql(params);
+      if (StringUtils.isNotBlank(timeFieldSql)) {
+        sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql(params);
+      }
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix an issue with invalid SQL being generated when a Program Indicator with no boundaries is used in aggregate analytics.

The engine generates a malformed query, like:

```
select
	max((date_part('year', age(cast(occurreddate as date), cast("iESIqZ0R0R0" as date))))) as value,
	'202506' as Monthly
from
	analytics_event_uy2gu8kt1jf as ax
where -- error here!
	and ax."uidlevel1" in ('ImspTQPwCqd')
	and ("iESIqZ0R0R0" is not null)
limit 200001
```

With this fix, the query no longer fails

See the [Jira](https://dhis2.atlassian.net/browse/DHIS2-19928) issue for more information.