### PR TITLE
fix: move `orgUnitCentroidsInEventsAnalytics` check at table generation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -752,9 +752,6 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
   }
 
   private boolean useCentroidForOuColumns() {
-    System.out.println(
-        "CENTROID SETTINGS: "
-            + settingsProvider.getCurrentSettings().getOrgUnitCentroidsInEventsAnalytics());
     return settingsProvider.getCurrentSettings().getOrgUnitCentroidsInEventsAnalytics();
   }
 }


### PR DESCRIPTION
## Summary

The new property `orgUnitCentroidsInEventsAnalytics` introduced [here](https://github.com/dhis2/dhis2-core/pull/21368) was accessed at Spring Bean construction time, rather then dynamically - that is, when the table generation is requested.
This caused the property to be ignored, if the value of the property was changed without restarting the server.

This PR moves the calculation of the columns away from the Bean constructor.