### PR TITLE
fix: Field filter - nested field exclusion [DHIS2-19883]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -284,9 +285,9 @@ public class FieldPathHelper {
     for (FieldPath exclusion : exclusions) {
       excludedPaths.add(exclusion.toFullPath());
 
-      for (String path : fieldPathMap.keySet()) {
-        if (fieldEqualsRootField(path, exclusion.toFullPath())) {
-          excludedPaths.add(path);
+      for (String fieldPath : fieldPathMap.keySet()) {
+        if (fieldShouldBeExcluded(fieldPath, exclusion.toFullPath())) {
+          excludedPaths.add(fieldPath);
         }
       }
     }
@@ -298,15 +299,22 @@ public class FieldPathHelper {
   // ----------------------------------------------------------------------------------------------------------------
 
   /**
-   * Method that checks whether a field is equal to the root field. <br>
-   * examples: <br>
+   * Method that checks whether a field should be excluded or not. <br>
+   * Examples: <br>
    *
-   * <ul>
-   *   <li>fullFieldPath = "root", field = "root" -> return true
-   *   <li>fullFieldPath = "root.name", field = "root" -> return true
-   *   <li>fullFieldPath = "root.name", field = "name" -> return false
-   *   <li>fullFieldPath = "username", field = "user" -> return false
-   * </ul>
+   * <pre>
+   * fullFieldPath   | fullExclusionPath   | outcome
+   * ----------------|---------------------|--------------
+   * root            | root                | true
+   * root.name       | root                | true
+   * root.name       | root.name           | true
+   * root.name       | name.root           | false
+   * root.name       | root.name.last      | false
+   * root.name       | name                | false
+   * root.name.last  | root.name           | false
+   * username        | user                | false
+   *
+   * </pre>
    *
    * @param fullFieldPath field path that represents the full path of a given field(in dot
    *     notation). It might look like any of the following examples: <br>
@@ -316,15 +324,45 @@ public class FieldPathHelper {
    *       <li>root.name.last
    *     </ul>
    *
-   * @param field is the actual field which should be checked. This will only be 1 word (no dot
-   *     notation)
-   * @return true if the field is equal to the fullFieldPath root <br>
+   * @param fullExclusionPath is the actual full exclusion path which should be checked against. It
+   *     might look like any of the following examples: <br>
+   *     <ul>
+   *       <li>root
+   *       <li>root.name
+   *       <li>root.name.last
+   *     </ul>
+   *
+   * @return true if the field should be excluded <br>
    */
-  public static boolean fieldEqualsRootField(String fullFieldPath, String field) {
-    if (ObjectUtils.anyNull(fullFieldPath, field)) return false;
-    String root = fullFieldPath.split("\\.")[0];
-    return root.equals(field);
+  public static boolean fieldShouldBeExcluded(String fullFieldPath, String fullExclusionPath) {
+    if (ObjectUtils.anyNull(fullFieldPath, fullExclusionPath)) return false;
+
+    return stringEquals.test(fullFieldPath, fullExclusionPath)
+        || exclusionIsPathOfFieldPath.test(fullFieldPath, fullExclusionPath);
   }
+
+  /** If strings match then the field should be excluded */
+  private static final BiPredicate<String, String> stringEquals = String::equals;
+
+  /** If the exclusion path is a subpath (or the same) then return true. */
+  private static final BiPredicate<String, String> exclusionIsPathOfFieldPath =
+      (fullFieldPath, fullExclusionPath) -> {
+        String[] fields = fullFieldPath.split("\\.");
+        String[] exclFields = fullExclusionPath.split("\\.");
+
+        // when the exclusion path is deeper (more '.') then the field won't be excluded
+        if (exclFields.length > fields.length) {
+          return false;
+        }
+
+        // when an exclusion path does not match a field path then it won't be excluded
+        for (int i = 0; i < exclFields.length; ++i) {
+          if (!exclFields[i].equals(fields[i])) {
+            return false;
+          }
+        }
+        return true;
+      };
 
   private boolean isReference(Property property) {
     return property.is(PropertyType.REFERENCE) || property.itemIs(PropertyType.REFERENCE);

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
@@ -45,36 +45,52 @@ import org.junit.jupiter.params.provider.MethodSource;
 class FieldPathHelperTest {
 
   @ParameterizedTest
-  @MethodSource("noMatchingFields")
-  @DisplayName("Field does not equal root field")
-  void fieldDoesNotEqualRootFieldTest(String fullFieldPath, String field) {
-    boolean result = FieldPathHelper.fieldEqualsRootField(fullFieldPath, field);
-    assertFalse(result);
+  @MethodSource("fieldShouldNotBeExcluded")
+  @DisplayName("Field should not be excluded")
+  void fieldShouldNotBeExcludedTest(String fullFieldPath, String fullExclusionPath) {
+    assertFalse(FieldPathHelper.fieldShouldBeExcluded(fullFieldPath, fullExclusionPath));
   }
 
   @ParameterizedTest
-  @MethodSource("matchingFields")
-  @DisplayName("Field equals root field")
-  void fieldEqualsRootFieldTest(String fullFieldPath, String field) {
-    boolean result = FieldPathHelper.fieldEqualsRootField(fullFieldPath, field);
-    assertTrue(result);
+  @MethodSource("fieldShouldBeExcluded")
+  @DisplayName("Field should be excluded")
+  void fieldShouldBeExcludedTest(String fullFieldPath, String fullExclusionPath) {
+    assertTrue(FieldPathHelper.fieldShouldBeExcluded(fullFieldPath, fullExclusionPath));
   }
 
-  private static Stream<Arguments> noMatchingFields() {
+  private static Stream<Arguments> fieldShouldNotBeExcluded() {
     return Stream.of(
         arguments("username", "user"),
+        arguments("task", "user"),
         arguments("userRoles", "user"),
         arguments("", "user"),
         arguments(null, "user"),
         arguments("", null),
-        arguments("test", "user"));
+        arguments("test", "user"),
+        arguments("user.name.last", "user.names"),
+        arguments("organisationUnits", "organisationUnits.translations"),
+        arguments("organisationUnits.translations", "organisationUnits.translation.locale"),
+        arguments("organisationUnits.translations", "organisationUnits.translations.locale"),
+        arguments("organisationUnits.translations", "organisationUnits.translationslocale"),
+        arguments("organisationUnits.translations", "organisationUnits.translations.locale.extra"),
+        arguments("organisationUnits.translations.locale", "translations.organisationUnits"),
+        arguments("organisationUnits.translations.locale", "organisationUnits.locale"),
+        arguments("organisationUnits.translations.locale", "organisationUnits.locale.translations"),
+        arguments(
+            "organisationUnits.translations.locale",
+            "organisationUnits.translations.locale.extra"));
   }
 
-  private static Stream<Arguments> matchingFields() {
+  private static Stream<Arguments> fieldShouldBeExcluded() {
     return Stream.of(
         arguments("user", "user"),
         arguments("user.name", "user"),
         arguments("user.address", "user"),
-        arguments("user.name.last", "user"));
+        arguments("user.name.last", "user"),
+        arguments("user.name", "user.name"),
+        arguments("organisationUnits", "organisationUnits"),
+        arguments("organisationUnits.translations", "organisationUnits"),
+        arguments("organisationUnits.translations", "organisationUnits.translations"),
+        arguments("organisationUnits.translations.locale", "organisationUnits.translations"));
   }
 }


### PR DESCRIPTION
# Issue
Nested field exclusions are not being removed from the `fieldPathMap` in `FieldPathHelper#applyExclusions`.  It seems like this is an internal issue and never materialized in an external bug. 

The issue was noticed by @teleivo while analysing field filtering code and is hard to replicate with an actual web API call.
Other sections of code may strip out the correct fields anyway, but this code change is warranted I think, to have it working correctly.
The API call `/api/users?fields=organisationUnits[!translations],organisationUnits[translations[locale]]` can be used to debug and see that the `fieldPathMap` still contains `organisationUnits.translations.locale` after checking if it should be excluded.

# Cause
The code only allowed for exclusions that were 1 level deep like `root` and did not allow for nested exclusion fields like `root.user`.

# Fix
Update code to allow excluding fields whether they are root fields or nested fields

# Testing
Updated automated unit tests with more scenarios