### PR TITLE
chore: increment settings in testKeysWithDefaults

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -95,7 +95,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(148, keys.size());
+    assertEquals(149, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));


### PR DESCRIPTION
## Summary
Number of settings needs to be incremented because two commits with new settings were merged at the same time, because the total was the same in both commits.