### PR TITLE
Backport: fix: bypass acl for user role deletion handler (#21503)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -341,6 +341,14 @@ public interface UserService {
   void updateUserRole(UserRole userRole);
 
   /**
+   * Updates a UserRole.
+   *
+   * @param userRole the UserRole.
+   * @param userDetails the UserDetails to update with
+   */
+  void updateUserRole(UserRole userRole, UserDetails userDetails);
+
+  /**
    * Retrieves the UserRole with the given identifier.
    *
    * @param id the identifier of the UserRole to retrieve.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
@@ -50,7 +50,11 @@ public class UserRoleDeletionHandler extends IdObjectDeletionHandler<UserRole> {
   private void deleteUser(User user) {
     for (UserRole role : user.getUserRoles()) {
       role.getMembers().remove(user);
-      userService.updateUserRole(role);
+
+      // Needs to bypass ACL to allow user deletion, without UserRole write access.
+      // We are just updating the membership/mapping here on the user side we have access to.
+      // See: https://dhis2.atlassian.net/browse/DHIS2-19693
+      userService.updateUserRole(role, new SystemUser());
     }
 
     user.setUserRoles(new HashSet<>());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABL
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.http.HttpClientAdapter.Accept;
 import static org.hisp.dhis.http.HttpClientAdapter.Body;
+import static org.hisp.dhis.http.HttpStatus.OK;
 import static org.hisp.dhis.http.HttpStatus.Series.SUCCESSFUL;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -579,6 +580,44 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
     assertEquals(
         "User with id does-not-exist could not be found.",
         POST("/users/does-not-exist/reset").error(HttpStatus.NOT_FOUND).getMessage());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that a user can also delete a user without UserRole write access, see: DHIS2-19693")
+  void testReplicateUserNoRoleAuth() {
+    settingsService.put("keyCanGrantOwnUserAuthorityGroups", true);
+
+    UserRole replicateRole =
+        createUserRole("ROLE_REPLICATE", "F_REPLICATE_USER", "F_USER_ADD", "F_USER_DELETE");
+    userService.addUserRole(replicateRole);
+    String roleUid = userService.getUserRoleByName("ROLE_REPLICATE").getUid();
+    PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'" + roleUid + "'}]}]")
+        .content(HttpStatus.OK);
+
+    peter = userService.getUser(this.peter.getUid());
+    assertTrue(
+        peter
+            .getAllAuthorities()
+            .containsAll(Set.of("F_REPLICATE_USER", "F_USER_ADD", "F_USER_DELETE")));
+    switchContextToUser(this.peter);
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peter2','password':'Saf€sEcre1'}")
+            .content());
+
+    User peter2 = userService.getUserByUsername("peter2");
+
+    // Then
+    DELETE("/users/" + peter2.getUid()).content(OK);
   }
 
   @Test


### PR DESCRIPTION
* fix: bypass acl for user role deletion handler

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: d28da8c4667e599ef6a5b1d1d62e08b243e1edf2