### PR TITLE
Backport: fix: bypass acl for user role deletion handler (#21503)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -337,6 +337,14 @@ public interface UserService {
   void updateUserRole(UserRole userRole);
 
   /**
+   * Updates a UserRole.
+   *
+   * @param userRole the UserRole.
+   * @param userDetails the UserDetails to update with
+   */
+  void updateUserRole(UserRole userRole, UserDetails userDetails);
+
+  /**
    * Retrieves the UserRole with the given identifier.
    *
    * @param id the identifier of the UserRole to retrieve.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -506,6 +506,12 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
+  @Transactional
+  public void updateUserRole(UserRole userRole, UserDetails userDetails) {
+    userRoleStore.update(userRole, userDetails);
+  }
+
+  @Override
   @Transactional(readOnly = true)
   public UserRole getUserRole(String uid) {
     return userRoleStore.getByUid(uid);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
@@ -48,7 +48,11 @@ public class UserRoleDeletionHandler extends IdObjectDeletionHandler<UserRole> {
   private void deleteUser(User user) {
     for (UserRole role : user.getUserRoles()) {
       role.getMembers().remove(user);
-      userService.updateUserRole(role);
+
+      // Needs to bypass ACL to allow user deletion, without UserRole write access.
+      // We are just updating the membership/mapping here on the user side we have access to.
+      // See: https://dhis2.atlassian.net/browse/DHIS2-19693
+      userService.updateUserRole(role, new SystemUser());
     }
 
     user.setUserRoles(new HashSet<>());


### PR DESCRIPTION
* fix: bypass acl for user role deletion handler

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: d28da8c4667e599ef6a5b1d1d62e08b243e1edf2