### PR TITLE
feat: Prevent updating a CategoryCombo's categories when it has associated data [DHIS2-19942]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 
@@ -223,4 +224,14 @@ public interface DataValueService {
    * @return true, if any values exist, otherwise false
    */
   boolean dataValueExistsForDataElement(UID uid);
+
+  /**
+   * If a CategoryCombo is being updated, check whether it has any associated data, which may become
+   * inaccessible if new CategoryOptionCombos are created.
+   *
+   * @param entity existing entity
+   * @param newEntity new/updated entity
+   */
+  void checkNoDataValueBecomesInaccessible(CategoryCombo entity, CategoryCombo newEntity)
+      throws ConflictException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -36,6 +36,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,10 +44,12 @@ import org.hisp.dhis.audit.AuditOperationType;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.option.OptionService;
@@ -363,5 +366,17 @@ public class DefaultDataValueService implements DataValueService {
   @Override
   public boolean dataValueExistsForDataElement(@Nonnull UID uid) {
     return dataValueStore.dataValueExistsForDataElement(uid.getValue());
+  }
+
+  @Override
+  public void checkNoDataValueBecomesInaccessible(CategoryCombo entity, CategoryCombo newEntity)
+      throws ConflictException {
+
+    Set<String> oldCategories = IdentifiableObjectUtils.getUidsAsSet(entity.getCategories());
+    Set<String> newCategories = IdentifiableObjectUtils.getUidsAsSet(newEntity.getCategories());
+
+    if (!Objects.equals(oldCategories, newCategories) && dataValueExists(entity)) {
+      throw new ConflictException(ErrorCode.E1120);
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -369,13 +369,14 @@ public class DefaultDataValueService implements DataValueService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public void checkNoDataValueBecomesInaccessible(CategoryCombo entity, CategoryCombo newEntity)
       throws ConflictException {
 
     Set<String> oldCategories = IdentifiableObjectUtils.getUidsAsSet(entity.getCategories());
     Set<String> newCategories = IdentifiableObjectUtils.getUidsAsSet(newEntity.getCategories());
 
-    if (!Objects.equals(oldCategories, newCategories) && dataValueExists(entity)) {
+    if (!Objects.equals(oldCategories, newCategories) && dataValueStore.dataValueExists(entity)) {
       throw new ConflictException(ErrorCode.E1120);
     }
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonImportSummary.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/webapi/json/domain/JsonImportSummary.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.test.webapi.json.domain;
 
+import javax.annotation.Nullable;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 
@@ -52,6 +54,13 @@ public interface JsonImportSummary extends JsonObject {
 
   default JsonList<JsonTypeReport> getTypeReports() {
     return getList("typeReports", JsonTypeReport.class);
+  }
+
+  default <T extends IdentifiableObject> @Nullable JsonTypeReport getTypeReport(Class<T> clazz) {
+    return getList("typeReports", JsonTypeReport.class).stream()
+        .filter(tr -> tr.getString("klass").string().equals(clazz.getName()))
+        .findFirst()
+        .orElse(null);
   }
 
   default JsonImportCount getImportCount() {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -24,4 +24,4 @@ connection.pool.max_idle_time=25
 connection.pool.max_lifetime_seconds=30
 connection.pool.warn_max_age=28000
 
-use.local.dhis.conf=no
+use.local.dhis.conf=yes

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -24,4 +24,4 @@ connection.pool.max_idle_time=25
 connection.pool.max_lifetime_seconds=30
 connection.pool.warn_max_age=28000
 
-use.local.dhis.conf=yes
+use.local.dhis.conf=no

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -35,10 +35,12 @@ import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonImportSummary;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -84,15 +86,15 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
   @Test
   @DisplayName(
       "Importing an existing CategoryCombo, which has no data values, with an additional Category succeeds")
-  void importingCategoryComboNewCategoryTest() {
-    // Given an existing CategoryCombo exists with 2 Categories
+  void importingCategoryComboNewCategoryNoDataTest() {
+    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
     JsonImportSummary initialImport =
-        POST("/metadata", Body(getCatComboWithCategories()))
+        POST("/metadata", Body(metadataImport()))
             .content()
             .get("response")
             .as(JsonImportSummary.class);
     assertEquals("OK", initialImport.getStatus());
-    assertEquals(3, initialImport.getStats().getCreated());
+    assertEquals(13, initialImport.getStats().getCreated());
 
     // When importing the existing CategoryCombo with an additional Category
     // Then the import should succeed with the expected message & stats
@@ -106,41 +108,265 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertEquals(1, updateImport.getStats().getCreated());
   }
 
-  private String getCatComboWithCategories() {
+  @Test
+  @DisplayName(
+      "Importing an existing CategoryCombo, which has data values, with an additional Category fails")
+  void importingCategoryComboNewCategoryWitDataTest() {
+    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
+    JsonImportSummary initialImport =
+        POST("/metadata", Body(metadataImport()))
+            .content()
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals("OK", initialImport.getStatus());
+    assertEquals(13, initialImport.getStats().getCreated());
+
+    User currentUser = getCurrentUser();
+
+    // add org unit to user
+    PATCH("/users/" + currentUser.getUid(), Body(updateUserOrgUnit("OrgUnitUid1")))
+        .content(HttpStatus.OK);
+
+    // and data value exists with one of the COCs
+    POST("/dataValues", Body(getDataValue())).content(HttpStatus.CREATED);
+
+    // When importing the existing CategoryCombo with an additional Category
+    // Then the import should fail with the expected message & stats
+    JsonImportSummary updateImport =
+        POST("/metadata", Body(getCatComboWithAdditionalCategory()))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals("ERROR", updateImport.getStatus());
+    assertEquals(0, updateImport.getStats().getUpdated());
+    assertEquals(4, updateImport.getStats().getIgnored());
+    assertEquals(
+        "Update cannot be applied as it would make existing data values inaccessible",
+        updateImport
+            .getTypeReport(CategoryCombo.class)
+            .getObjectReports()
+            .get(0)
+            .getErrorReports()
+            .get(0)
+            .getMessage());
+  }
+
+  @Test
+  @DisplayName(
+      "Importing an existing CategoryCombo, which has data values, with its original Categories succeeds")
+  void importingCategoryComboNoChangeWitDataTest() {
+    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
+    JsonImportSummary initialImport =
+        POST("/metadata", Body(metadataImport()))
+            .content()
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals("OK", initialImport.getStatus());
+    assertEquals(13, initialImport.getStats().getCreated());
+
+    User currentUser = getCurrentUser();
+
+    // add org unit to user
+    PATCH("/users/" + currentUser.getUid(), Body(updateUserOrgUnit("OrgUnitUid1")))
+        .content(HttpStatus.OK);
+
+    // and data value exists with one of the COCs
+    POST("/dataValues", Body(getDataValue())).content(HttpStatus.CREATED);
+
+    // When importing the existing CategoryCombo with its original Categories
+    // Then the import should succeed with the expected message & stats
+    JsonImportSummary updateImport =
+        POST("/metadata", Body(metadataImport()))
+            .content(HttpStatus.OK)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals("OK", updateImport.getStatus());
+    assertEquals(13, updateImport.getStats().getUpdated());
+    assertEquals(0, updateImport.getStats().getIgnored());
+  }
+
+  private String updateUserOrgUnit(String orgUnit) {
+    return """
+        [
+          {
+            "op": "add",
+            "path": "/organisationUnits",
+            "value": [
+              {
+                "id": "%s"
+              }
+            ]
+          }
+        ]
+        """
+        .formatted(orgUnit);
+  }
+
+  private String getDataValue() {
     return """
       {
-          "categories": [
+          "dataElement": "DeUid000001",
+          "period": "20231101",
+          "orgUnit": "OrgUnitUid1",
+          "categoryOptionCombo": "CocUid00001",
+          "attributeOptionCombo": "HllvX50cXC0",
+          "value": "2000",
+          "followup": false
+      }
+      """;
+  }
+
+  private String metadataImport() {
+    return """
+      {
+          "organisationUnits":[
               {
-                  "id": "CategoUid01",
-                  "name": "cat 1",
-                  "shortName": "cat 1",
-                  "dataDimensionType": "DISAGGREGATION",
-                  "categoryOptions": []
-              },
-              {
-                  "id": "CategoUid02",
-                  "name": "cat 2",
-                  "shortName": "cat 2",
-                  "dataDimensionType": "DISAGGREGATION",
-                  "categoryOptions": []
+                  "id": "OrgUnitUid1",
+                  "name": "test org 1",
+                  "shortName": "test org 1",
+                  "openingDate": "2023-06-15"
               }
           ],
-          "categoryCombos": [
+          "dataElements":[
               {
-                  "id": "CatComUid01",
-                  "name": "cat combo 1",
-                  "dataDimensionType": "DISAGGREGATION",
-                  "categories": [
-                      {
-                          "id": "CategoUid01"
-                      },
-                      {
-                          "id": "CategoUid02"
-                      }
-                  ]
+                  "id": "DeUid000001",
+                  "aggregationType": "DEFAULT",
+                  "domainType": "AGGREGATE",
+                  "name": "test de 1 - central v1",
+                  "shortName": "test de 1 - central v1",
+                  "valueType": "TEXT"
               }
-          ]
-      }
+          ],
+           "categoryOptions": [
+               {
+                   "id": "CatOptUid01",
+                   "name": "cat opt 1",
+                   "shortName": "cat opt 1"
+               },
+               {
+                   "id": "CatOptUid02",
+                   "name": "cat opt 2",
+                   "shortName": "cat opt 2"
+               },
+               {
+                   "id": "CatOptUid03",
+                   "name": "cat opt 3",
+                   "shortName": "cat opt 3"
+               },
+               {
+                   "id": "CatOptUid04",
+                   "name": "cat opt 4",
+                   "shortName": "cat opt 4"
+               }
+           ],
+           "categories": [
+               {
+                   "id": "CategoUid01",
+                   "name": "cat 1",
+                   "shortName": "cat 1",
+                   "dataDimensionType": "DISAGGREGATION",
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid01"
+                       },
+                       {
+                           "id": "CatOptUid02"
+                       }
+                   ]
+               },
+               {
+                   "id": "CategoUid02",
+                   "name": "cat 2",
+                   "shortName": "cat 2",
+                   "dataDimensionType": "DISAGGREGATION",
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid03"
+                       },
+                       {
+                           "id": "CatOptUid04"
+                       }
+                   ]
+               }
+           ],
+           "categoryCombos": [
+               {
+                   "id": "CatComUid01",
+                   "name": "cat combo 1",
+                   "dataDimensionType": "DISAGGREGATION",
+                   "categories": [
+                       {
+                           "id": "CategoUid01"
+                       },
+                       {
+                           "id": "CategoUid02"
+                       }
+                   ]
+               }
+           ],
+           "categoryOptionCombos": [
+               {
+                   "name": "cat opt 1, cat opt 3",
+                   "id": "CocUid00001",
+                   "categoryCombo": {
+                       "id": "CatComUid01"
+                   },
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid01"
+                       },
+                       {
+                           "id": "CatOptUid03"
+                       }
+                   ]
+               },
+               {
+                   "name": "cat opt 1, cat opt 4",
+                   "id": "CocUid00002",
+                   "categoryCombo": {
+                       "id": "CatComUid01"
+                   },
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid01"
+                       },
+                       {
+                           "id": "CatOptUid04"
+                       }
+                   ]
+               },
+               {
+                   "name": "cat opt 2, cat opt 3",
+                   "id": "CocUid00003",
+                   "categoryCombo": {
+                       "id": "CatComUid01"
+                   },
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid02"
+                       },
+                       {
+                           "id": "CatOptUid03"
+                       }
+                   ]
+               },
+               {
+                   "name": "cat opt 2, cat opt 4",
+                   "id": "CocUid00004",
+                   "categoryCombo": {
+                       "id": "CatComUid01"
+                   },
+                   "categoryOptions": [
+                       {
+                           "id": "CatOptUid02"
+                       },
+                       {
+                           "id": "CatOptUid04"
+                       }
+                   ]
+               }
+           ]
+       }
       """;
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -87,7 +87,7 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
   @DisplayName(
       "Importing an existing CategoryCombo, which has no data values, with an additional Category succeeds")
   void importingCategoryComboNewCategoryNoDataTest() {
-    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
+    // Given existing metadata (including 1 CategoryCombo with 2 Categories)
     JsonImportSummary initialImport =
         POST("/metadata", Body(metadataImport()))
             .content()
@@ -112,7 +112,7 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
   @DisplayName(
       "Importing an existing CategoryCombo, which has data values, with an additional Category fails")
   void importingCategoryComboNewCategoryWitDataTest() {
-    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
+    // Given existing metadata (including 1 CategoryCombo with 2 Categories)
     JsonImportSummary initialImport =
         POST("/metadata", Body(metadataImport()))
             .content()
@@ -153,9 +153,9 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
 
   @Test
   @DisplayName(
-      "Importing an existing CategoryCombo, which has data values, with its original Categories succeeds")
+      "Importing an existing CategoryCombo, which has no data values, with its original Categories succeeds")
   void importingCategoryComboNoChangeWitDataTest() {
-    // Given existing metadata (including 1 CategoryCombo exists with 2 Categories)
+    // Given existing metadata (including 1 CategoryCombo with 2 Categories)
     JsonImportSummary initialImport =
         POST("/metadata", Body(metadataImport()))
             .content()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -29,18 +29,14 @@
  */
 package org.hisp.dhis.webapi.controller.category;
 
-import java.util.Objects;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionComboGenerateService;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.feedback.ConflictException;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
@@ -62,8 +58,8 @@ public class CategoryComboController
     extends AbstractCrudController<CategoryCombo, GetObjectListParams> {
 
   private final CategoryService categoryService;
-  private final CategoryOptionComboGenerateService categoryOptionComboGenerateService;
   private final DataValueService dataValueService;
+  private final CategoryOptionComboGenerateService categoryOptionComboGenerateService;
 
   @GetMapping("/{uid}/metadata")
   public ResponseEntity<MetadataExportParams> getDataSetWithDependencies(
@@ -87,24 +83,13 @@ public class CategoryComboController
   @Override
   protected void preUpdateEntity(CategoryCombo entity, CategoryCombo newEntity)
       throws ConflictException {
-    checkNoDataValueBecomesInaccessible(entity, newEntity);
+    dataValueService.checkNoDataValueBecomesInaccessible(entity, newEntity);
   }
 
   @Override
   protected void prePatchEntity(CategoryCombo entity, CategoryCombo newEntity)
       throws ConflictException {
-    checkNoDataValueBecomesInaccessible(entity, newEntity);
-  }
-
-  private void checkNoDataValueBecomesInaccessible(CategoryCombo entity, CategoryCombo newEntity)
-      throws ConflictException {
-
-    Set<String> oldCategories = IdentifiableObjectUtils.getUidsAsSet(entity.getCategories());
-    Set<String> newCategories = IdentifiableObjectUtils.getUidsAsSet(newEntity.getCategories());
-
-    if (!Objects.equals(oldCategories, newCategories) && dataValueService.dataValueExists(entity)) {
-      throw new ConflictException(ErrorCode.E1120);
-    }
+    dataValueService.checkNoDataValueBecomesInaccessible(entity, newEntity);
   }
 
   @Override


### PR DESCRIPTION
# Feature
We currently prevent updating an existing `CategoryCombo`s categories if there is any existing data associated with its `CategoryOptionCombo`s. This is only implemented on the endpoint `PUT /api/categoryCombo` though.

This change adds the same validation on the `POST /api/metadata` endpoint to bring the same behaviour for this use case.
- new validation check added to `CategoryComboObjectBundleHook`

# Testing
3 Integration tests added:
- allow updating `CategoryCombo` categories when it has no associated data
- allow updating `CategoryCombo` with its original categories when it has associated data
- prevent updating `CategoryCombo` categories when it has associated data

# Info
Moved the existing validation check out of the `CategoryComboController` to the `DataValueService` so it can be reused.
Originally wanted to move it to `CategoryService`, but cyclic references prevent this.