### PR TITLE
fix: Skip filters as columns

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryHelper.java
@@ -136,7 +136,7 @@ public class EnrollmentQueryHelper {
     if (!params.isOrganisationUnitMode(SELECTED) && !params.isOrganisationUnitMode(CHILDREN)) {
       Set<String> levels = new LinkedHashSet<>();
 
-      for (DimensionalItemObject itemObject : params.getDimensionOrFilterItems(ORGUNIT_DIM_ID)) {
+      for (DimensionalItemObject itemObject : params.getDimensionOptions(ORGUNIT_DIM_ID)) {
         String level = LEVEL_PREFIX + ((OrganisationUnit) itemObject).getLevel();
         levels.add(level);
       }


### PR DESCRIPTION
Small fix to avoid returning `filter` as columns, in the query/response.