### PR TITLE
fix: set default translations value for dashboarditem

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_23__set_default_value_for_dashboarditem_translations.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_23__set_default_value_for_dashboarditem_translations.sql
@@ -1,0 +1,2 @@
+update dashboarditem set translations = '[]'::jsonb where translations is null;
+alter table dashboarditem alter column translations set default '[]'::jsonb;


### PR DESCRIPTION
### Issue
- Execute Metadata sync on SL database got below error
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.hisp.dhis.common.TranslationProperty.getTranslations()" because "this.translations" is null
	at org.hisp.dhis.dashboard.DashboardItem.getTranslations(DashboardItem.java:534)
```
- Root cause is there are old records in database with `translations` value is `null`. This happens back when we first introduced the `translations` jsonb column and the migration script didn't set default value for existing records. 
- The newly saved translations have empty array as default value because in Java model object we always init an empty set.
`private Set<Translation> translations = new HashSet<>();`

<img width="616" height="106" alt="Screenshot 2025-08-10 at 9 21 17 PM" src="https://github.com/user-attachments/assets/8acf1ac3-3455-4e0c-b48d-13a3c47242f9" />


###  Fix
- Add migration script to set correct default value in database.

### Test
- Manual test by sending POST request to local instance

<img width="653" height="625" alt="Screenshot 2025-08-10 at 9 22 51 PM" src="https://github.com/user-attachments/assets/6a54d48d-0ec7-4ade-a286-f7ed9a6cf18c" />

