### PR TITLE
Backport: feat: add HEAD method to allowed PAT http methods (#21575)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenControllerTest.java
@@ -102,6 +102,8 @@ class ApiTokenControllerTest extends DhisControllerConvenienceTest {
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("GET"));
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("POST"));
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("PATCH"));
+    assertTrue(token.getMethodAllowedList().getAllowedMethods().contains("DELETE"));
+    assertTrue(token.getMethodAllowedList().getAllowedMethods().contains("HEAD"));
     assertTrue(
         apiToken1.getRefererAllowedList().getAllowedReferrers().contains("http://hostname1.com"));
     assertTrue(
@@ -348,7 +350,7 @@ class ApiTokenControllerTest extends DhisControllerConvenienceTest {
         POST(
             ApiTokenSchemaDescriptor.API_ENDPOINT + "/",
             "{'attributes':[{'type': 'IpAllowedList','allowedIps':['1.1.1.1','2.2.2.2','3.3.3.3']},"
-                + "{'type':'MethodAllowedList','allowedMethods':['POST','GET','PATCH']},"
+                + "{'type':'MethodAllowedList','allowedMethods':['POST','GET','PATCH','HEAD','DELETE']},"
                 + "{'type':'RefererAllowedList','allowedReferrers':['http://hostname3.com','http://hostname2.com','http://hostname1.com']}]}");
     return assertStatus(HttpStatus.CREATED, post);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/ApiTokenControllerTest.java
@@ -102,8 +102,8 @@ class ApiTokenControllerTest extends DhisControllerConvenienceTest {
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("GET"));
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("POST"));
     assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("PATCH"));
-    assertTrue(token.getMethodAllowedList().getAllowedMethods().contains("DELETE"));
-    assertTrue(token.getMethodAllowedList().getAllowedMethods().contains("HEAD"));
+    assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("DELETE"));
+    assertTrue(apiToken1.getMethodAllowedList().getAllowedMethods().contains("HEAD"));
     assertTrue(
         apiToken1.getRefererAllowedList().getAllowedReferrers().contains("http://hostname1.com"));
     assertTrue(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -75,7 +75,7 @@ public class ApiTokenController extends AbstractCrudController<ApiToken> {
       "Operation not supported on ApiToken";
 
   private static final List<String> VALID_METHODS =
-      List.of("GET", "POST", "PATCH", "PUT", "DELETE");
+      List.of("HEAD", "GET", "POST", "PATCH", "PUT", "DELETE");
 
   private final ApiTokenService apiTokenService;
 


### PR DESCRIPTION
* feat: add HEAD method to allowed PAT http methods

Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>

Backport of: 3bfbb06cc2cc3643449199fe8dea28f8233b3706