### PR TITLE
fix: don't serialize to full user objects from UserRole's members

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -41,7 +42,10 @@ import java.util.Set;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.schema.annotation.PropertyRange;
+import org.hisp.dhis.schema.annotation.PropertyTransformer;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 import org.hisp.dhis.security.Authorities;
 
 /**
@@ -118,7 +122,10 @@ public class UserRole extends BaseIdentifiableObject implements MetadataObject {
   }
 
   @JsonProperty
-  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
+  @OpenApi.Property(UserPropertyTransformer.UserDto[].class)
+  @JsonSerialize(contentUsing = UserPropertyTransformer.JacksonSerialize.class)
+  @JsonDeserialize(contentUsing = UserPropertyTransformer.JacksonDeserialize.class)
+  @PropertyTransformer(UserPropertyTransformer.class)
   @JacksonXmlElementWrapper(localName = "users", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "userObject", namespace = DxfNamespaces.DXF_2_0)
   public List<User> getUsers() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1102,4 +1102,23 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
     assertNull(userByUsername.getSecret());
   }
+
+  @Test
+  void testGetUserRoleUsersAreTransformed() {
+    UserRole role = createUserRole('X');
+    User user = makeUser("Y");
+    user.setEmail("y@y.org");
+    userService.addUser(user);
+    role.getMembers().add(user);
+    manager.save(role);
+
+    JsonObject userInRole =
+        GET("/userRoles/{id}?fields=users[*]", role.getUid())
+            .content(HttpStatus.OK)
+            .getArray("users")
+            .getObject(0);
+
+    assertFalse(userInRole.has("email"), "email should not be exposed");
+    assertEquals(user.getUid(), userInRole.getString("id").string());
+  }
 }


### PR DESCRIPTION
## Summary
Prevents the UserRole's members to be serialized into full User obejcts, and instead serializes them in to the UserDtos, similar to UserGroup's members?