### PR TITLE
fix: Use job creator to execute Metadata Sync jobs [DHIS2-19725]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -191,7 +191,7 @@ public enum JobType {
    *     (System User will not work).
    */
   public boolean isValidUserRequiredForJob() {
-    return this == HTML_PUSH_ANALYTICS || this == AGGREGATE_DATA_EXCHANGE;
+    return this == HTML_PUSH_ANALYTICS || this == AGGREGATE_DATA_EXCHANGE || this == META_DATA_SYNC;
   }
 
   /**


### PR DESCRIPTION
# Issue
Executing a `META_DATA_SYNC` job results in a user error (full error appended at end of PR):
```
INFO  org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] : Running preCreateBundle
WARN  org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] Process aborted after 0.006s: aborted after error: Unable to find org.hisp.dhis.user.User with id -1
ERROR org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] failed after 0.005s: Unable to find org.hisp.dhis.user.User with id -1
jakarta.persistence.EntityNotFoundException: Unable to find org.hisp.dhis.user.User with id -1
```

# Cause
May be similar to #20850. Removal of null user as superuser potentially. No `User` available to run the job.

# Fix
Make `META_DATA_SYNC` job automatically have the `executedBy` field saved as the creator of the job, which will be used for subsequent runs.

# Testing
Tests added to make sure the `executedBy` field is auto populated when created & updated.

# Full Error
```
INFO  org.hisp.dhis.dxf2.metadata.version.MetadataVersionDelegate [pool-5-thread-1] Remote server metadata version  URL: https://dev.im.dhis2.org/dv-sync-user-42-central/api/metadata/version/Version_4/data.gz, username: system
INFO  org.hisp.dhis.dxf2.metadata.sync.DefaultMetadataSyncService [pool-5-thread-1] Downloaded the metadata snapshot from remote and saved in Data Store for the version: MetadataVersion{importDate=null, type=ATOMIC, name='Version_4', hashCode='77d79981f55b88280cb29beaf9e2b06a'}
INFO  org.hisp.dhis.render.DefaultRenderService [pool-5-thread-1] Skipping unknown property 'system'.
INFO  org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] : Running preCreateBundle
WARN  org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] Process aborted after 0.006s: aborted after error: Unable to find org.hisp.dhis.user.User with id -1
ERROR org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] failed after 0.005s: Unable to find org.hisp.dhis.user.User with id -1
jakarta.persistence.EntityNotFoundException: Unable to find org.hisp.dhis.user.User with id -1
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl$JpaEntityNotFoundDelegate.handleEntityNotFound(EntityManagerFactoryBuilderImpl.java:177)
	at org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:216)
	at org.hibernate.event.internal.DefaultLoadEventListener.proxyOrLoad(DefaultLoadEventListener.java:327)
	at org.hibernate.event.internal.DefaultLoadEventListener.doOnLoad(DefaultLoadEventListener.java:108)
	at org.hibernate.event.internal.DefaultLoadEventListener.onLoad(DefaultLoadEventListener.java:74)
	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:118)
	at org.hibernate.internal.SessionImpl.fireLoadNoChecks(SessionImpl.java:1231)
	at org.hibernate.internal.SessionImpl.fireLoad(SessionImpl.java:1220)
	at org.hibernate.internal.SessionImpl.access$2100(SessionImpl.java:202)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.doGetReference(SessionImpl.java:2808)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.lambda$getReference$0(SessionImpl.java:2757)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.perform(SessionImpl.java:2781)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.getReference(SessionImpl.java:2757)
	at org.hibernate.internal.SessionImpl.getReference(SessionImpl.java:3504)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:320)
	at jdk.proxy3/jdk.proxy3.$Proxy165.getReference(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.preCreateBundleObject(DefaultMetadataImportService.java:285)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.lambda$preCreateBundle$7(DefaultMetadataImportService.java:276)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.preCreateBundle(DefaultMetadataImportService.java:276)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.lambda$importMetadata$0(DefaultMetadataImportService.java:104)
	at org.hisp.dhis.scheduling.JobProgress.lambda$runStage$4(JobProgress.java:494)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:529)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:490)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:474)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.importMetadata(DefaultMetadataImportService.java:104)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.importMetadata(DefaultMetadataImportService.java:90)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:380)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223)
	at jdk.proxy3/jdk.proxy3.$Proxy487.importMetadata(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.sync.MetadataSyncImportHandler.importMetadata(MetadataSyncImportHandler.java:97)
	at org.hisp.dhis.dxf2.metadata.sync.DefaultMetadataSyncService.doMetadataSync(DefaultMetadataSyncService.java:113)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.handleMetadataSync(MetadataSyncJob.java:193)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.handleMetadataSync(MetadataSyncJob.java:159)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.runSyncTask(MetadataSyncJob.java:142)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.lambda$execute$0(MetadataSyncJob.java:112)
	at org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:329)
	at org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:225)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.execute(MetadataSyncJob.java:108)
	at org.hisp.dhis.scheduling.JobScheduler.runDueJob(JobScheduler.java:233)
	at org.hisp.dhis.scheduling.JobScheduler.lambda$runIfDue$2(JobScheduler.java:200)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
ERROR org.hisp.dhis.dxf2.metadata.sync.MetadataSyncImportHandler [pool-5-thread-1] Exception occurred while trying to import the metadata. Unable to find org.hisp.dhis.user.User with id -1
jakarta.persistence.EntityNotFoundException: Unable to find org.hisp.dhis.user.User with id -1
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl$JpaEntityNotFoundDelegate.handleEntityNotFound(EntityManagerFactoryBuilderImpl.java:177)
	at org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:216)
	at org.hibernate.event.internal.DefaultLoadEventListener.proxyOrLoad(DefaultLoadEventListener.java:327)
	at org.hibernate.event.internal.DefaultLoadEventListener.doOnLoad(DefaultLoadEventListener.java:108)
	at org.hibernate.event.internal.DefaultLoadEventListener.onLoad(DefaultLoadEventListener.java:74)
	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:118)
	at org.hibernate.internal.SessionImpl.fireLoadNoChecks(SessionImpl.java:1231)
	at org.hibernate.internal.SessionImpl.fireLoad(SessionImpl.java:1220)
	at org.hibernate.internal.SessionImpl.access$2100(SessionImpl.java:202)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.doGetReference(SessionImpl.java:2808)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.lambda$getReference$0(SessionImpl.java:2757)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.perform(SessionImpl.java:2781)
	at org.hibernate.internal.SessionImpl$IdentifierLoadAccessImpl.getReference(SessionImpl.java:2757)
	at org.hibernate.internal.SessionImpl.getReference(SessionImpl.java:3504)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:320)
	at jdk.proxy3/jdk.proxy3.$Proxy165.getReference(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.preCreateBundleObject(DefaultMetadataImportService.java:285)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.lambda$preCreateBundle$7(DefaultMetadataImportService.java:276)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.preCreateBundle(DefaultMetadataImportService.java:276)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.lambda$importMetadata$0(DefaultMetadataImportService.java:104)
	at org.hisp.dhis.scheduling.JobProgress.lambda$runStage$4(JobProgress.java:494)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:529)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:490)
	at org.hisp.dhis.scheduling.JobProgress.runStage(JobProgress.java:474)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.importMetadata(DefaultMetadataImportService.java:104)
	at org.hisp.dhis.dxf2.metadata.DefaultMetadataImportService.importMetadata(DefaultMetadataImportService.java:90)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:380)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223)
	at jdk.proxy3/jdk.proxy3.$Proxy487.importMetadata(Unknown Source)
	at org.hisp.dhis.dxf2.metadata.sync.MetadataSyncImportHandler.importMetadata(MetadataSyncImportHandler.java:97)
	at org.hisp.dhis.dxf2.metadata.sync.DefaultMetadataSyncService.doMetadataSync(DefaultMetadataSyncService.java:113)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.handleMetadataSync(MetadataSyncJob.java:193)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.handleMetadataSync(MetadataSyncJob.java:159)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.runSyncTask(MetadataSyncJob.java:142)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.lambda$execute$0(MetadataSyncJob.java:112)
	at org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:329)
	at org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:225)
	at org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob.execute(MetadataSyncJob.java:108)
	at org.hisp.dhis.scheduling.JobScheduler.runDueJob(JobScheduler.java:233)
	at org.hisp.dhis.scheduling.JobScheduler.lambda$runIfDue$2(JobScheduler.java:200)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
WARN  org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] [META_DATA_SYNC RZfXlRPXWml] Process aborted after 1.922s: aborted after error: Exception occurred while trying to import the metadata. Unable to find org.hisp.dhis.user.User with id -1
ERROR org.hisp.dhis.system.notification.DefaultNotifier [pool-4-thread-1] Exception occurred while trying to import the metadata. Unable to find org.hisp.dhis.user.User with id -1
ERROR org.hisp.dhis.scheduling.RecordingJobProgress [pool-5-thread-1] [META_DATA_SYNC RZfXlRPXWml] failed after 1.92s: Exception occurred while trying to import the metadata. Unable to find org.hisp.dhis.user.User with id -1
INFO  org.hisp.dhis.dxf2.metadata.jobs.MetadataRetryContext [pool-5-thread-1] Now trying. Current count: 2
INFO  org.hisp.dhis.dxf2.metadata.jobs.MetadataRetryContext [pool-5-thread-1] Now trying. Current count: 3
INFO  org.hisp.dhis.dxf2.metadata.jobs.MetadataSyncJob [pool-5-thread-1] Metadata Sync failed! Sending mail to Admin
INFO  org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor [pool-5-thread-1] Failure mail will be sent with the following message: Following Exceptions were encountered while the scheduler run for metadata sync 

ERROR_CATEGORY : metadataSync
 ERROR_VALUE : Exception occurred while trying to import the metadata. Unable to find org.hisp.dhis.user.User with id -1
```