### PR TITLE
fix: Use job creator to execute Metadata Sync jobs (2.42)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -191,7 +191,7 @@ public enum JobType {
    *     (System User will not work).
    */
   public boolean isValidUserRequiredForJob() {
-    return this == HTML_PUSH_ANALYTICS || this == AGGREGATE_DATA_EXCHANGE;
+    return this == HTML_PUSH_ANALYTICS || this == AGGREGATE_DATA_EXCHANGE || this == META_DATA_SYNC;
   }
 
   /**

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerIntegrationTest.java
@@ -126,4 +126,70 @@ class JobConfigurationControllerIntegrationTest extends PostgresControllerIntegr
 
     assertEquals("M5zQapPyTZI", executedBy2);
   }
+
+  @Test
+  @DisplayName("META_DATA_SYNC job should have an executedBy value when job set up")
+  void metadataSyncJobHasExecutedByValueTest() {
+
+    // given a metadata sync job is set up
+    @Language("json5")
+    String job =
+        """
+        {
+             "name": "metadata-sync-job-1",
+             "jobType": "META_DATA_SYNC",
+             "cronExpression": "0 0 22 ? * *"
+         }
+        """;
+    String jobId = assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", job));
+
+    // when retrieving the job config
+    HttpResponse get = GET("/jobConfigurations/" + jobId);
+    assertEquals(HttpStatus.OK, get.status());
+    String executedBy = get.content().getString("executedBy").string();
+
+    // then the executedBy value should be that of the job creator
+    assertEquals("M5zQapPyTZI", executedBy);
+  }
+
+  @Test
+  @DisplayName(
+      "META_DATA_SYNC job should have an executedBy value when job is updated without that value")
+  void metadataSyncJobHasExecutedByValueOnUpdateTest() {
+    // given a metadata sync job is set up
+    @Language("json5")
+    String job =
+        """
+        {
+             "name": "metadata-sync-job-2",
+             "jobType": "META_DATA_SYNC",
+             "cronExpression": "0 0 21 ? * *"
+         }
+        """;
+    String jobId = assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", job));
+
+    HttpResponse get = GET("/jobConfigurations/" + jobId);
+    String executedBy = get.content().getString("executedBy").string();
+
+    // and the executedBy value is set
+    assertEquals("M5zQapPyTZI", executedBy);
+
+    // when that job is updated (e.g. new cron expression)
+    @Language("json5")
+    String jobUpdated =
+        """
+        {
+             "name": "metadata-sync-job-2",
+             "jobType": "META_DATA_SYNC",
+             "cronExpression": "0 0 20 ? * *"
+         }
+        """;
+    assertStatus(HttpStatus.OK, PUT("/jobConfigurations/" + jobId, jobUpdated));
+
+    // then the executedBy value should still be that of the job creator
+    HttpResponse get2 = GET("/jobConfigurations/" + jobId);
+    String executedBy2 = get2.content().getString("executedBy").string();
+
+    assertEquals("M5zQapPyTZI", executedBy2);
+  }
 }


### PR DESCRIPTION
port of #21608 