### PR TITLE
fix: allow deprecated TOTP secrets to be verified

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthUtils.java
@@ -168,8 +168,8 @@ public class TwoFactorAuthUtils {
 
     try {
       byte[] decodedSecretBytes = Base32.decode(secret);
-      if (decodedSecretBytes == null || (decodedSecretBytes.length != 20
-          && decodedSecretBytes.length != 10)) {
+      if (decodedSecretBytes == null
+          || (decodedSecretBytes.length != 20 && decodedSecretBytes.length != 10)) {
         log.warn("TOTP secret decoding failed, is null or invalid length");
         return false;
       }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthUtils.java
@@ -168,7 +168,8 @@ public class TwoFactorAuthUtils {
 
     try {
       byte[] decodedSecretBytes = Base32.decode(secret);
-      if (decodedSecretBytes == null || decodedSecretBytes.length != 20) {
+      if (decodedSecretBytes == null || (decodedSecretBytes.length != 20
+          && decodedSecretBytes.length != 10)) {
         log.warn("TOTP secret decoding failed, is null or invalid length");
         return false;
       }


### PR DESCRIPTION
## Summary
Fixes incompatibility with deprecated TOTP secrets, introduced after upgrade to 20 bytes secrets.
This fix allows pre 2.42.0 TOTP secrets to still be validated. 