### PR TITLE
fix: wrong and missing french and spanish translations for emails

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
@@ -1769,7 +1769,7 @@ respond_to_this_message=Responder a este mensaje
 email_restore_subject=Confirmaci\u00f3n de restauraci\u00f3n de cuenta de usuario en
 email_restore_1_1st_paragraph_before_application_title=Alguien, probablemente usted, nos ha pedido que
 email_restore_1_1st_paragraph_after_application_title=Cuenta de usuario
-email_restore_1_2nd_paragraph=Te han enviado dos correos-e, donde este es el primero. Por favor, siga el siguiente enlace. En el paso siguiente, se le pedir\u00e1 que ingrese un c\u00f3digo que le ha sido enviado en el otro correo-e.
+email_restore_1_2nd_paragraph=Por favor, siga el siguiente enlace para restaurar su cuenta.
 email_restore_1_3rd_paragraph=Debe completar el proceso de restauraci\u00f3n en 1 hora. Si no realiza ninguna acci\u00f3n, su cuenta no se restaurar\u00e1. Si no solicit\u00f3 esta restauraci\u00f3n, omita este mensaje.
 
 #-- Invite emails -------------------------------------------------------------#
@@ -1777,26 +1777,26 @@ email_restore_1_3rd_paragraph=Debe completar el proceso de restauraci\u00f3n en 
 email_invite_subject=Invitaci\u00f3n a crear una cuenta de usuario en
 email_invite_1_1st_paragraph_before_application_title=Se trata de una invitaci\u00f3n a
 email_invite_1_1st_paragraph_after_application_title=Cuenta de usuario
-email_invite_1_2nd_paragraph=Te han enviado dos correos-e, donde este es el primero. Por favor, siga el siguiente enlace. En el paso siguiente, se le pedir\u00e1 que ingrese un c\u00f3digo que le ha sido enviado en el otro correo-e.
+email_invite_1_2nd_paragraph=Por favor, siga el siguiente enlace para aceptar la invitaci\u00f3n y crear su cuenta.
 email_invite_1_3rd_paragraph=Debe responder a esta invitaci\u00f3n en un plazo de una semana. Si no realiza ninguna acci\u00f3n, la invitaci\u00f3n expirar\u00e1 en ese momento.
 
 #-- Verify email -------------------------------------------------------------#
 
-email_verify_1_1st_paragraph_before_application_title=This is a message to verify a
-email_verify_1_1st_paragraph_after_application_title=, user account email.
-email_verify_1_2nd_paragraph=Please click the link below to verify the email address of your account.
-email_verify_1_3rd_paragraph=You must respond to this email within one hour. If you take no action, the email address will not be verified.
-verify_email_subject=Verify email address
+email_verify_1_1st_paragraph_before_application_title=Ceci est un message pour v\u00e9rifier une adresse \u00e9lectronique
+email_verify_1_1st_paragraph_after_application_title=, correo electr\u00f3nico de la cuenta de usuario.
+email_verify_1_2nd_paragraph=Por favor, haga clic en el enlace de abajo para verificar la direcci\u00f3n de correo electr\u00f3nico de su cuenta.
+email_verify_1_3rd_paragraph=Debe responder a este correo electr\u00f3nico dentro de una hora. Si no realiza ninguna acci\u00f3n, la direcci\u00f3n de correo electr\u00f3nico no ser\u00e1 verificada.
+verify_email_subject=Verificar direcci\u00f3n de correo electr\u00f3nico.
 
 #-- 2FA code email -------------------------------------------------------------#
 
-email_2fa_subject=Your Two-Factor Authentication Code for
-email_2fa_1_greeting=Dear
-email_2fa_1_1st_paragraph_application_title=You have requested a two-factor authentication code to log into your account.
-email_2fa_1_2nd_paragraph=Your two-factor authentication code:
-email_2fa_1_3rd_paragraph=Please use this code within 15 minutes to log into your account.
-email_2fa_1_4th_paragraph=If you did not request this code, please contact your system administrator immediately to secure your account.
-email_2fa_1_ending=Thank you,
+email_2fa_subject=Su C\u00f3digo de Autenticaci\u00f3n de Dos Factores para
+email_2fa_1_greeting=Estimado
+email_2fa_1_1st_paragraph_application_title=Usted ha solicitado un c\u00f3digo de autenticaci\u00f3n de dos factores para iniciar sesi\u00f3n en su cuenta.
+email_2fa_1_2nd_paragraph=Su c\u00f3digo de autenticaci\u00f3n de dos factores:
+email_2fa_1_3rd_paragraph=Use este c\u00f3digo dentro de 15 minutos para iniciar sesi\u00f3n en su cuenta.
+email_2fa_1_4th_paragraph=Si no solicit\u00f3 este c\u00f3digo, p\u00f3ngase en contacto con su administrador del sistema de inmediato para asegurar su cuenta.
+email_2fa_1_ending=Gracias,
 
 #-- Cache strategy display strings --------------------------------------------#
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
@@ -1794,7 +1794,7 @@ email_2fa_subject=Su C\u00f3digo de Autenticaci\u00f3n de Dos Factores para
 email_2fa_1_greeting=Estimado
 email_2fa_1_1st_paragraph_application_title=Usted ha solicitado un c\u00f3digo de autenticaci\u00f3n de dos factores para iniciar sesi\u00f3n en su cuenta.
 email_2fa_1_2nd_paragraph=Su c\u00f3digo de autenticaci\u00f3n de dos factores:
-email_2fa_1_3rd_paragraph=Use este c\u00f3digo dentro de 15 minutos para iniciar sesi\u00f3n en su cuenta.
+email_2fa_1_3rd_paragraph=Use este c\u00f3digo en los pr\u00f3ximos 15 minutos para iniciar sesi\u00f3n en su cuenta.
 email_2fa_1_4th_paragraph=Si no solicit\u00f3 este c\u00f3digo, p\u00f3ngase en contacto con su administrador del sistema de inmediato para asegurar su cuenta.
 email_2fa_1_ending=Gracias,
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_fr.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_fr.properties
@@ -1769,7 +1769,7 @@ respond_to_this_message=R\u00e9pondre \u00e0 ce message
 email_restore_subject=Confirmation de r\u00e9activation de compte utilisateur \u00e0
 email_restore_1_1st_paragraph_before_application_title=Quelqu'un (probablement vous) nous a demande de r\u00e9activer votre
 email_restore_1_1st_paragraph_after_application_title=compte utilisateur.
-email_restore_1_2nd_paragraph=Deux emails vous ont \u00e9t\u00e9 envoy\u00e9s, dont ceci est le premier. Veuilez suivre le lien ci-dessous. Dans l'\u00e9tape suivante, on vous demandera de saisir le code qui vous a \u00e9t\u00e9 envoy\u00e9 dans l'autre mail.
+email_restore_1_2nd_paragraph=Veuillez suivre le lien ci-dessous pour restaurer votre compte.
 email_restore_1_3rd_paragraph=Vous devez compl\u00e9ter la r\u00e9activation de votre compte dans l'heure qui suit. Si vous ne prenez aucune action, alors votre compte ne sera pas r\u00e9activ\u00e9. Si vous n'avez pas demand\u00e9 cette d\u00e9marche, veuillez ignorer ce message.
 
 #-- Invite emails -------------------------------------------------------------#
@@ -1777,7 +1777,7 @@ email_restore_1_3rd_paragraph=Vous devez compl\u00e9ter la r\u00e9activation de 
 email_invite_subject=Invitation pour cr\u00e9er le compte utilisateur \u00e0
 email_invite_1_1st_paragraph_before_application_title=Ceci est une invitation pour cr\u00e9er un
 email_invite_1_1st_paragraph_after_application_title=compte utilisateur.
-email_invite_1_2nd_paragraph=Deux emails vous ont \u00e9t\u00e9 envoy\u00e9s, dont ceci est le premier. Veuilez suivre le lien ci-dessous. Dans l'\u00e9tape suivante, on vous demandera de saisir le code qui vous a \u00e9t\u00e9 envoy\u00e9 dans l'autre mail.
+email_invite_1_2nd_paragraph=Veuillez suivre le lien ci-dessous pour accepter l'invitation et cr\u00e9er votre compte.
 email_invite_1_3rd_paragraph=Vous devez r\u00e9pondre \u00e0 cette invitation dans les une semaine. Si vous ne prenez aucune action, l'invitation sera p\u00e9rim\u00e9e
 
 #-- Verify email -------------------------------------------------------------#


### PR DESCRIPTION
## Summary
Updates wrong translations and adds missing translations for French and Spanish.

Jira: [DHIS2-19912](https://dhis2.atlassian.net/browse/DHIS2-19912)

[DHIS2-19912]: https://dhis2.atlassian.net/browse/DHIS2-19912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ