### PR TITLE
fix: program notification recipients orgunit check

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -313,7 +313,7 @@ public interface UserDetails
     return isInUserHierarchy(orgUnitPath, getUserDataOrgUnitIds());
   }
 
-  default boolean isInUserHierarchy(
+  static boolean isInUserHierarchy(
       @CheckForNull String orgUnitPath, @Nonnull Set<String> orgUnitIds) {
     if (orgUnitPath == null) return false;
     for (String uid : orgUnitPath.split("/")) if (orgUnitIds.contains(uid)) return true;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -39,11 +39,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -451,19 +451,19 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
       return Set.of();
     }
 
-    return userGroup.getMembers().stream()
-        .filter(
-            user ->
-                user != null
-                    && !user.isDisabled()
-                    && Objects.requireNonNull(
-                            UserDetails.createUserDetails(user, true, true, null, null, null, true))
-                        .isInUserHierarchy(
-                            registration.getSource().getUid(),
-                            user.getOrganisationUnits().stream()
-                                .map(OrganisationUnit::getUid)
-                                .collect(toSet())))
-        .collect(toSet());
+    Set<User> set = new HashSet<>();
+    for (User user : userGroup.getMembers()) {
+      if (user != null
+          && !user.isDisabled()
+          && UserDetails.isInUserHierarchy(
+              registration.getSource().getPath(),
+              user.getOrganisationUnits().stream()
+                  .map(OrganisationUnit::getUid)
+                  .collect(toSet()))) {
+        set.add(user);
+      }
+    }
+    return set;
   }
 
   private void sendInternalDhisMessages(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -451,7 +451,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
       return Set.of();
     }
 
-    Set<User> set = new HashSet<>();
+    Set<User> recipients = new HashSet<>();
     for (User user : userGroup.getMembers()) {
       if (user != null
           && !user.isDisabled()
@@ -460,10 +460,10 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
               user.getOrganisationUnits().stream()
                   .map(OrganisationUnit::getUid)
                   .collect(toSet()))) {
-        set.add(user);
+        recipients.add(user);
       }
     }
-    return set;
+    return recipients;
   }
 
   private void sendInternalDhisMessages(

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
@@ -112,11 +112,15 @@ class DataSetNotificationServiceTest extends TestBase {
 
   private CompleteDataSetRegistration registrationA;
 
+  private CompleteDataSetRegistration registrationB;
+
   private NotificationMessage notificationMessage;
 
   private OrganisationUnit organisationUnitA;
 
   private OrganisationUnit organisationUnitB;
+
+  private OrganisationUnit organisationUnitC;
 
   private DataSet dataSetA;
 
@@ -192,8 +196,11 @@ class DataSetNotificationServiceTest extends TestBase {
 
     organisationUnitA = createOrganisationUnit('A');
     organisationUnitB = createOrganisationUnit('B');
+    organisationUnitC = createOrganisationUnit('C');
     organisationUnitA.setPhoneNumber(PHONE_NUMBER);
     organisationUnitB.setPhoneNumber(PHONE_NUMBER);
+
+    organisationUnitC.setParent(organisationUnitA);
 
     periodA = createPeriod(new MonthlyPeriodType(), getDate(2000, 1, 1), getDate(2000, 1, 31));
 
@@ -236,6 +243,19 @@ class DataSetNotificationServiceTest extends TestBase {
             new Date(),
             "",
             true);
+
+    registrationB =
+        new CompleteDataSetRegistration(
+            dataSetA,
+            periodA,
+            organisationUnitC,
+            categoryOptionCombo,
+            new Date(),
+            "",
+            new Date(),
+            "",
+            true);
+
     notificationMessage = new NotificationMessage("subject", "message");
     summary = new OutboundMessageResponseSummary();
     summary.setBatchStatus(OutboundMessageBatchStatus.COMPLETED);
@@ -390,7 +410,7 @@ class DataSetNotificationServiceTest extends TestBase {
     when(itr.hasNext()).thenReturn(true, false);
     when(itr.next()).thenReturn(emailMessageSender);
 
-    subject.sendCompleteDataSetNotifications(registrationA);
+    subject.sendCompleteDataSetNotifications(registrationB);
 
     verify(emailMessageSender, times(1))
         .sendMessageAsync(


### PR DESCRIPTION
## Summary
Fixes issue when the program notification recipients orgunit check fails due to recent change in PR #21122 
 ### Problem:
 When the registration's source orgunit has multiple levels, the check fails, because it's using the wrong input for the method. The check should have used the orgunit's path and not the UID.
 ### Fix:
 Use the orgunit's path as input to the `UserDetails.isInUserHierarchy()` method instead.
 
 ### Test:
 Updates the `DataSetNotificationServiceTest#testSendCompleteDataSetNotifications_shouldNotSendToDisabledUsers()` test to use a new registration that has an orgunit source with a parent that's in the user's orgunit list.
 

 ### JIRA: [DHIS2-19622](https://dhis2.atlassian.net/browse/DHIS2-19622)


[DHIS2-19622]: https://dhis2.atlassian.net/browse/DHIS2-19622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ