### PR TITLE
fix: allow image uploads with valid formats [DHIS2-19733]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -304,7 +304,7 @@ public class ValidationUtils {
   private static String validateImage(TrackerBundle bundle, String value) {
     FileResource fileResource = bundle.getPreheat().get(FileResource.class, value);
 
-    return Constant.VALID_IMAGE_FORMATS.contains(fileResource.getFormat())
+    return !Constant.VALID_IMAGE_FORMATS.contains(fileResource.getFormat())
         ? "File resource with uid '"
             + value
             + "' is using invalid image format "


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-19733

This PR fixes an issue where image uploads in the Capture app were failing due to overly strict format validation. Valid image formats (e.g. jpeg, png, gif, etc.) were being incorrectly rejected, preventing users from uploading image resources.

**Fix implemented**

- Updated validation logic to check against a single source of truth: Constant.VALID_IMAGE_FORMATS.
- Case-insensitive matching ensures both upper/lowercase variants of valid formats are accepted.
- Invalid formats (exe, dat, pdf, etc.) are still properly rejected.