### PR TITLE
fix: Event query with dimensions of type coordinate [DHIS2-19989]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -42,6 +42,7 @@ import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.apache.commons.lang3.math.NumberUtils.createDouble;
 import static org.apache.commons.lang3.math.NumberUtils.isCreatable;
@@ -351,10 +352,26 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    * query items second. Program indicator expressions are converted to SQL expressions. When
    * grouping with non-default analytics period boundaries, all periods are skipped in the group
    * clause, as non default boundaries is defining their own period groups within their where
-   * clause.
+   * clause. It removes columns aliases.
+   *
+   * @return the list of "group by" columns.
    */
   protected List<String> getGroupByColumnNames(EventQueryParams params, boolean isAggregated) {
-    return getSelectColumns(params, true, isAggregated);
+    List<String> columns = getSelectColumns(params, true, isAggregated);
+
+    return removeAliases(columns);
+  }
+
+  /**
+   * It removes the aliases from the list of given columns, if any.
+   *
+   * <p>ie: columnA as cA -> columnA
+   *
+   * @param columns the columns that may have aliases.
+   * @return the columns without aliases.
+   */
+  List<String> removeAliases(List<String> columns) {
+    return columns.stream().map(c -> substringBefore(c, " as ")).collect(toList());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -969,7 +969,8 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
-  void testgetGroupByColumnNamesWithoutAliases() {
+  void testGetGroupByColumnNamesWithoutAliases() {
+    // Given
     DataElement deA = createDataElement('A', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
     DimensionalObject periods =
         new BaseDimensionalObject(
@@ -996,8 +997,10 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
             .withSkipMeta(false)
             .build();
 
+    // When
     List<String> columns = eventSubject.getGroupByColumnNames(params, false);
 
+    // Then
     assertThat(columns, hasSize(3));
     assertThat(
         columns,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -952,6 +952,67 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
         select);
   }
 
+  @Test
+  void testRemoveAliases() {
+    // Given
+    List<String> columnsWithAliases = List.of("columnA as cA", "columnB", "columnC as cC", "");
+
+    // When
+    List<String> columnsWithNoAliases = eventSubject.removeAliases(columnsWithAliases);
+
+    // Then
+    assertTrue(columnsWithNoAliases.size() == columnsWithAliases.size());
+    assertTrue(columnsWithNoAliases.contains("columnA"));
+    assertTrue(columnsWithNoAliases.contains("columnB"));
+    assertTrue(columnsWithNoAliases.contains("columnC"));
+    assertTrue(columnsWithNoAliases.contains(""));
+  }
+
+  @Test
+  void testgetGroupByColumnNamesWithoutAliases() {
+    DataElement deA = createDataElement('A', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
+    DimensionalObject periods =
+        new BaseDimensionalObject(
+            DimensionalObject.PERIOD_DIM_ID,
+            DimensionType.PERIOD,
+            List.of(MonthlyPeriodType.getPeriodFromIsoString("201901")));
+
+    DimensionalObject orgUnits =
+        new BaseDimensionalObject(
+            DimensionalObject.ORGUNIT_DIM_ID,
+            DimensionType.ORGANISATION_UNIT,
+            "ouA",
+            List.of(createOrganisationUnit('A')));
+
+    QueryItem qiA = new QueryItem(deA, null, deA.getValueType(), deA.getAggregationType(), null);
+
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(periods)
+            .addDimension(orgUnits)
+            .addItem(qiA)
+            .withCoordinateFields(List.of(deA.getUid()))
+            .withSkipData(true)
+            .withSkipMeta(false)
+            .build();
+
+    List<String> columns = eventSubject.getGroupByColumnNames(params, false);
+
+    assertThat(columns, hasSize(3));
+    assertThat(
+        columns,
+        containsInAnyOrder(
+            "ax.\"pe\"",
+            "ax.\"ou\"",
+            "'[' || round(ST_X(ST_Centroid(\""
+                + deA.getUid()
+                + "_geom"
+                + "\"))::numeric, 6) || ',' || round(ST_Y(ST_Centroid(\""
+                + deA.getUid()
+                + "_geom"
+                + "\"))::numeric, 6) || ']'"));
+  }
+
   private QueryFilter buildQueryFilter(QueryOperator operator, String filter) {
     return new QueryFilter(operator, filter);
   }


### PR DESCRIPTION
Analytics events aggregate query with dimensions of type coordinate fails.

This PR fix the issue related to coordinates, but also fixes other cases where the `group by` takes `aliases` into consideration, which cases a SQL exception at PG level.