### PR TITLE
fix: revert prometheus upgrade breaking jvm metrics

### DIFF
--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -43,3 +43,5 @@ oidc.provider.dhis2.jwk_uri = http://web:8080/oauth2/jwks
 oidc.provider.dhis2.user_info_uri = http://web:8080/userinfo
 
 route.remote_servers_allowed = http://web:8080
+
+monitoring.jvm.enabled = on

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -213,7 +213,7 @@
     <!-- Monitoring -->
     <micrometer-spring-legacy.version>1.3.20</micrometer-spring-legacy.version>
     <micrometer.version>1.15.0</micrometer.version>
-    <prometheus-metrics-model.version>1.4.1</prometheus-metrics-model.version>
+    <prometheus-metrics-model.version>1.3.1</prometheus-metrics-model.version>
 
     <!-- Logging -->
     <log4j.version>2.25.1</log4j.version>


### PR DESCRIPTION
## Summary
Reverts a Prometheus library upgrade, that breaks the JVM metrics feature.
Also adds `monitoring.jvm.enabled = on`, to dhis.conf for the E2E server config, this will effectively catch this potential upgrade issue in the future by failing to start. Having it default on in the E2E server, should not affect the other tests.