### PR TITLE
fix: revert jetty upgrade breaking compilation [2.40]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -180,7 +180,7 @@
     <jsmpp.version>3.0.1</jsmpp.version>
     <json-path.version>2.9.0</json-path.version>
     <jsoup.version>1.21.1</jsoup.version>
-    <jetty.version>11.0.26</jetty.version>
+    <jetty.version>10.0.24</jetty.version>
 
     <!-- Div. utils -->
     <version.debezium>2.7.3.Final</version.debezium>


### PR DESCRIPTION
## Summary

Reverts an automatic `jetty` library update (from `10.0.24` to `11.0.26`).
The upgrade breaks compilation in the jetty module.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project dhis-web-embedded-jetty: Compilation failure: Compilation failure:
[ERROR] /Users/xxxxx/projects/dhis2-core/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/JettyEmbeddedCoreWeb.java:[93,9] no suitable constructor found for FilterHolder(org.springframework.web.filter.DelegatingFilterProxy)
[ERROR]     constructor org.eclipse.jetty.servlet.FilterHolder.FilterHolder(org.eclipse.jetty.servlet.Source) is not applicable
[ERROR]       (argument mismatch; org.springframework.web.filter.DelegatingFilterProxy cannot be converted to org.eclipse.jetty.servlet.Source)
[ERROR]     constructor org.eclipse.jetty.servlet.FilterHolder.FilterHolder(java.lang.Class<? extends jakarta.servlet.Filter>) is not applicable
[ERROR]       (argument mismatch; org.springframework.web.filter.DelegatingFilterProxy cannot be converted to java.lang.Class<? extends jakarta.servlet.Filter>)
[ERROR]     constructor org.eclipse.jetty.servlet.FilterHolder.FilterHolder(jakarta.servlet.Filter) is not applicable
[ERROR]       (argument mismatch; org.springframework.web.filter.DelegatingFilterProxy cannot be converted to jakarta.servlet.Filter)
[ERROR] /Users/xxxxx/projects/dhis2-core/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/JettyEmbeddedCoreWeb.java:[99,19] incompatible types: org.eclipse.jetty.server.handler.ContextHandler.Context cannot be converted to javax.servlet.ServletContext
[ERROR] /Users/xxxxx/projects/dhis2-core/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/JettyEmbeddedCoreWeb.java:[102,9] no suitable method found for addServlet(java.lang.String,java.lang.Class<org.hisp.dhis.web.embeddedjetty.GetAppMenuServlet>)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,java.lang.Class<? extends jakarta.servlet.Servlet>) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.GetAppMenuServlet> cannot be converted to java.lang.Class<? extends jakarta.servlet.Servlet>)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,jakarta.servlet.Servlet) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.GetAppMenuServlet> cannot be converted to jakarta.servlet.Servlet)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,java.lang.String) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.GetAppMenuServlet> cannot be converted to java.lang.String)
[ERROR] /Users/xxxxx/projects/dhis2-core/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/JettyEmbeddedCoreWeb.java:[105,12] no suitable method found for addServlet(java.lang.String,java.lang.Class<org.hisp.dhis.web.embeddedjetty.RootPageServlet>)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,java.lang.Class<? extends jakarta.servlet.Servlet>) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.RootPageServlet> cannot be converted to java.lang.Class<? extends jakarta.servlet.Servlet>)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,jakarta.servlet.Servlet) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.RootPageServlet> cannot be converted to jakarta.servlet.Servlet)
[ERROR]     method org.eclipse.jetty.server.handler.ContextHandler.StaticContext.addServlet(java.lang.String,java.lang.String) is not applicable
[ERROR]       (argument mismatch; java.lang.Class<org.hisp.dhis.web.embeddedjetty.RootPageServlet> cannot be converted to java.lang.String)
[ERROR] -> [Help 1]
``` 