### PR TITLE
perf: improve tracker field filtering performance DHIS2-19910

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,11 @@ node_modules
 **/rebel.xml
 .vscode
 .cursor
+.claude
+CLAUDE.local.md
 # ignore generated artifact directory
 docker/artifacts
 # ignore local docker override files
 docker-compose.override.yml
+# ignore JMH benchmark results
+jmh-result*.csv

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -148,7 +148,7 @@ public class FieldFilterService {
         .anyMatch(f -> f.toFullPath().equals(path));
   }
 
-  private static class IgnoreJsonSerializerRefinementAnnotationInspector
+  public static class IgnoreJsonSerializerRefinementAnnotationInspector
       extends JacksonAnnotationIntrospector {
     /**
      * Since the field filter will handle type refinement itself (to avoid recursive loops), we want

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -82,6 +82,10 @@
       <artifactId>spring-beans</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
@@ -130,6 +134,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.graphhopper.external</groupId>
+      <artifactId>jackson-datatype-jts</artifactId>
     </dependency>
     <dependency>
       <groupId>org.locationtech.jts</groupId>
@@ -194,6 +202,11 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-service-field-filtering</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -379,6 +379,10 @@ class EventQueryParams {
     return accessiblePrograms != null && accessibleProgramStages != null;
   }
 
+  public Set<UID> getEnrollments() {
+    return enrollments;
+  }
+
   public EventQueryParams setEnrollments(Set<UID> enrollments) {
     this.enrollments = enrollments;
     return this;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -87,7 +87,8 @@ public interface EventService {
    * TrackerIdSchemeParams}.
    */
   @Nonnull
-  Event getEvent(UID uid, @Nonnull TrackerIdSchemeParams idSchemeParams, EventFields fields)
+  Event getEvent(
+      @Nonnull UID uid, @Nonnull TrackerIdSchemeParams idSchemeParams, @Nonnull EventFields fields)
       throws NotFoundException;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/Fields.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/Fields.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Fields represent the fields a user wants to be returned from an API usually specified via the
+ * HTTP request parameter {@code fields}.
+ *
+ * <p>Fields ensures that
+ *
+ * <ul>
+ *   <li>children of an excluded field {@code test(field)==false} are excluded as well
+ *   <li>includesAll automatically includes children unless they are explicitly included/excluded
+ *   <li>children are automatically included unless they are explicitly included/excluded
+ * </ul>
+ */
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
+public final class Fields implements Predicate<String> {
+  public static final Fields ALL = all();
+  public static final Fields NONE = none();
+
+  /** True means "includes all except", whereas false means "includes only specified". */
+  private final boolean includesAll;
+
+  /**
+   * Fields are either fields to be excluded in case {@link #includesAll} is true or included in
+   * case {@link #includesAll} is false.
+   */
+  private final Set<String> fields;
+
+  /** Children define which of a {@link #fields} fields children should be included or excluded. */
+  private final Map<String, Fields> children;
+
+  /** Transformations declare how a field in {@link #fields} should be returned. */
+  private final Map<String, List<Transformation>> transformations;
+
+  /** Creates Fields which includes all fields and all of its children with no transformations. */
+  public static Fields all() {
+    return new Fields(true, Set.of(), Map.of(), Map.of());
+  }
+
+  /** Creates Fields which includes no fields. */
+  public static Fields none() {
+    return new Fields(false, Set.of(), Map.of(), Map.of());
+  }
+
+  /**
+   * Tests whether a field should be included in the result like JSON serialization.
+   *
+   * @param field the field name to test
+   * @return true if the field should be included, false otherwise
+   */
+  @Override
+  public boolean test(String field) {
+    return includesAll ? !fields.contains(field) : fields.contains(field);
+  }
+
+  /**
+   * Returns the fields specification for a child object.
+   *
+   * @param field the field name
+   * @return Fields specification for the child
+   */
+  @Nonnull
+  public Fields getChildren(String field) {
+    if (!test(field)) {
+      return Fields.NONE; // children of an excluded parent are excluded
+    }
+
+    // explicit specifications take precedence
+    // this handles cases like: fields=dataValues[value], fields=dataValues[!value],
+    // fields=dataValues[*]
+    return children.getOrDefault(field, Fields.ALL);
+  }
+
+  /**
+   * Tests whether the dot separated field path is included. Serialization filters should use the
+   * more performant {@link #test(String)}.
+   *
+   * <p>{@code fields.includes("group.group.code")} is like {@code
+   * fields.getChildren("group").getChildren("group").test("code")}
+   *
+   * @param dotPath dot separated field path
+   * @return true if the field should be included, false otherwise
+   */
+  public boolean includes(String dotPath) {
+    String[] segments = dotPath.split("\\.");
+    Fields current = this;
+    for (int i = 0; i < segments.length - 1; i++) {
+      current = current.getChildren(segments[i]);
+    }
+    String lastSegment = segments[segments.length - 1];
+    return current.test(lastSegment);
+  }
+
+  /**
+   * Returns the transformations for a field.
+   *
+   * @param field the field name
+   * @return transformation for the field if any
+   */
+  @Nonnull
+  public List<Transformation> getTransformations(String field) {
+    if (!test(field)) {
+      return List.of(); // field must be included for it to be transformed
+    }
+
+    return transformations.getOrDefault(field, List.of());
+  }
+
+  /**
+   * Represents a single field transformation like {@code isNotEmpty} or {@code rename} in {@code
+   * fields=dataSets~isNotEmpty~rename(hasDataSets)}.
+   *
+   * <p>Users are allowed to pass multiple arguments to transformers with {@code
+   * fields=field::rename(one;two;three)}. Since our transformers use at most one we'll only forward
+   * one to simplify their logic.
+   */
+  public record Transformation(
+      String name, FieldsTransformer.Function transformer, String argument) {}
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import static org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig.configureMapper;
+import static org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig.createJtsModule;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FieldsConfig {
+
+  @Bean
+  public ObjectMapper jsonFilterMapper(FieldsPropertyFilter fieldsPropertyFilter) {
+    // reuse the same configuration as the primary ObjectMapper bean adding field filter on top of
+    // it
+    ObjectMapper mapper = configureMapper(new ObjectMapper());
+    mapper.registerModule(createJtsModule());
+
+    SimpleModule module = new SimpleModule();
+    module.setMixInAnnotation(Object.class, FieldFilterMixin.class);
+    mapper.registerModule(module);
+
+    mapper.setAnnotationIntrospector(new IgnoreJsonSerializerRefinementAnnotationInspector());
+
+    // pre-configure the filter as its stateless. This means every ObjectWriter will already have
+    // the filter setup.
+    SimpleFilterProvider filterProvider =
+        new SimpleFilterProvider().addFilter(FieldsPropertyFilter.FILTER_ID, fieldsPropertyFilter);
+    mapper.setFilterProvider(filterProvider);
+
+    return mapper;
+  }
+
+  // this is copied from the current FieldFilterService#configureFieldFilterObjectMapper
+  // so this package does not depend on the fieldfiltering package
+  static class IgnoreJsonSerializerRefinementAnnotationInspector
+      extends JacksonAnnotationIntrospector {
+    /**
+     * Since the field filter will handle type refinement itself (to avoid recursive loops), we want
+     * to ignore any type refinement happening with @JsonSerialize(...). In the future we would want
+     * to remove all @JsonSerialize annotations and just use the field filters, but since we still
+     * have object mappers without field filtering we can't do this just yet.
+     */
+    @Override
+    public JavaType refineSerializationType(
+        MapperConfig<?> config, Annotated a, JavaType baseType) {
+      return baseType;
+    }
+  }
+
+  // This is used to avoid having to annotate every object with the filter annotation.
+  @JsonFilter(FieldsPropertyFilter.FILTER_ID)
+  interface FieldFilterMixin {}
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParser.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParser.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.common.collection.CollectionUtils;
+import org.hisp.dhis.schema.Schema;
+
+public class FieldsParser {
+  /** Fields token that includes all fields. */
+  private static final String TOKEN_ALL = "*";
+
+  public static final Function<Schema, Set<String>> PRESET_ALL = s -> Set.of(TOKEN_ALL);
+
+  private static final Pattern TOKEN_PATTERN =
+      Pattern.compile(
+"""
+          (?<COLONCOLON>::)|(?<TILDE>~)|(?<PIPE>\\|)|(?<BRACKETOPEN>\\[)|(?<BRACKETCLOSE>\\])|(?<PARENOPEN>\\()|(?<PARENCLOSE>\\))|(?<COMMA>,)|(?<SEMICOLON>;)|(?<BANG>!)|(?<NAME>(?:[^,\\[\\]()~|;:!]|:(?!:))+)
+"""
+              .trim());
+
+  private static final Map<String, TokenType> GROUP_TO_TOKEN;
+
+  static {
+    Map<String, TokenType> map = new HashMap<>();
+    map.put("NAME", TokenType.NAME);
+    map.put("COMMA", TokenType.COMMA);
+    map.put("COLONCOLON", TokenType.COLON_COLON);
+    map.put("TILDE", TokenType.TILDE);
+    map.put("PIPE", TokenType.PIPE);
+    map.put("BRACKETOPEN", TokenType.BRACKET_OPEN);
+    map.put("BRACKETCLOSE", TokenType.BRACKET_CLOSE);
+    map.put("PARENOPEN", TokenType.PAREN_OPEN);
+    map.put("PARENCLOSE", TokenType.PAREN_CLOSE);
+    map.put("SEMICOLON", TokenType.SEMICOLON);
+    map.put("BANG", TokenType.BANG);
+    GROUP_TO_TOKEN = Map.copyOf(map);
+  }
+
+  enum TokenType {
+    NAME,
+    COMMA,
+    COLON_COLON,
+    TILDE,
+    PIPE,
+    BRACKET_OPEN,
+    BRACKET_CLOSE,
+    PAREN_OPEN,
+    PAREN_CLOSE,
+    SEMICOLON,
+    BANG
+  }
+
+  record Token(TokenType type, String value, int start, int end) {}
+
+  /**
+   * Parse fields and expand presets using given {@code presets} functions. Presets cannot be
+   * excluded i.e. fields=!:simple is equivalent to fields=:simple.
+   *
+   * <p>Use {@link #parse(String)} to parse fields without expanding presets.
+   */
+  @Nonnull
+  public static Fields parse(
+      @Nonnull String input,
+      @Nonnull Schema schema,
+      @Nonnull BiFunction<Schema, String, Schema> getSchema,
+      @Nonnull Map<String, Function<Schema, Set<String>>> presets) {
+    FieldsAccumulator root = parseFields(input, new HashSet<>(presets.keySet()));
+    mapPresets(root, schema, getSchema, presets);
+    return map(root, root.includes.contains(TOKEN_ALL));
+  }
+
+  /**
+   * Parse fields without expanding presets. Presets will be treated like any other field name. The
+   * only exception is that presets cannot be excluded i.e. fields=!:simple is equivalent to
+   * fields=:simple.
+   *
+   * <p>Use {@link #parse(String, Schema, BiFunction, Map)} to register and expand presets.
+   */
+  @Nonnull
+  public static Fields parse(@Nonnull String input) {
+    FieldsAccumulator root = parseFields(input, new HashSet<>());
+    return map(root, root.includes.contains(TOKEN_ALL));
+  }
+
+  private static FieldsAccumulator parseFields(String input, Set<String> unexcludableTokens) {
+    List<Token> tokens = tokenize(input);
+    unexcludableTokens.add(TOKEN_ALL);
+
+    FieldsAccumulator root = new FieldsAccumulator();
+    Stack<FieldsAccumulator> stack = new Stack<>();
+    stack.push(root);
+
+    Parser parser = new Parser(unexcludableTokens);
+
+    for (Token token : tokens) {
+      switch (token.type) {
+        case BANG:
+          parser.isExclusion = true;
+          break;
+
+        case NAME:
+          if (parser.parsingTransformationParams) {
+            parser.transformationParams.add(token.value.trim());
+          } else if (parser.pendingTransformation != null) {
+            if (!parser.pendingTransformation.isEmpty()) {
+              parser.currentTransformation.add(new Transformation(parser.pendingTransformation));
+            }
+            parser.pendingTransformation = token.value.trim();
+          } else if (parser.currentField == null) {
+            parser.currentField = removeAllWhitespace(token.value);
+          } else {
+            parser.consumeCurrentField(stack.peek());
+            parser.currentField = removeAllWhitespace(token.value);
+          }
+          break;
+
+        case COLON_COLON, TILDE, PIPE:
+          if (parser.pendingTransformation != null && !parser.pendingTransformation.isEmpty()) {
+            parser.currentTransformation.add(new Transformation(parser.pendingTransformation));
+          }
+          parser.pendingTransformation = "";
+          break;
+
+        case PAREN_OPEN:
+          if (parser.pendingTransformation != null) {
+            parser.parsingTransformationParams = true;
+            parser.transformationParams.clear();
+          } else {
+            if (parser.currentField == null) {
+              throw new IllegalArgumentException(
+                  "Block must have a field name like orgUnits[code]");
+            }
+            String fieldName = parser.currentField;
+            parser.consumeCurrentField(stack.peek());
+            stack.push(stack.peek().getOrCreateChild(fieldName));
+          }
+          break;
+
+        case PAREN_CLOSE:
+          if (parser.parsingTransformationParams) {
+            parser.currentTransformation.add(
+                new Transformation(
+                    parser.pendingTransformation,
+                    parser.transformationParams.toArray(new String[0])));
+            parser.pendingTransformation = null;
+            parser.transformationParams.clear();
+            parser.parsingTransformationParams = false;
+          } else {
+            if (stack.size() == 1) {
+              throw new IllegalArgumentException("Unbalanced parens/brackets in input");
+            }
+            if (parser.currentField != null) {
+              parser.consumeCurrentField(stack.peek());
+            }
+            stack.pop();
+          }
+          break;
+
+        case BRACKET_OPEN:
+          if (parser.currentField == null) {
+            throw new IllegalArgumentException("Block must have a field name like orgUnits[code]");
+          }
+          String fieldName = parser.currentField;
+          parser.consumeCurrentField(stack.peek());
+          stack.push(stack.peek().getOrCreateChild(fieldName));
+          break;
+
+        case BRACKET_CLOSE:
+          if (stack.size() == 1) {
+            throw new IllegalArgumentException("Unbalanced parens/brackets in input");
+          }
+          if (parser.currentField != null) {
+            parser.consumeCurrentField(stack.peek());
+          }
+          stack.pop();
+          break;
+
+        case COMMA:
+          if (!parser.parsingTransformationParams && parser.currentField != null) {
+            parser.consumeCurrentField(stack.peek());
+          }
+          break;
+
+        case SEMICOLON:
+          break;
+      }
+    }
+
+    if (parser.currentField != null) {
+      parser.consumeCurrentField(stack.peek());
+    }
+
+    return root;
+  }
+
+  private static List<Token> tokenize(String input) {
+    List<Token> tokens = new ArrayList<>();
+    Matcher matcher = TOKEN_PATTERN.matcher(input);
+    while (matcher.find()) {
+      TokenType tokenType =
+          GROUP_TO_TOKEN.entrySet().stream()
+              .filter(entry -> matcher.group(entry.getKey()) != null)
+              .map(Map.Entry::getValue)
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Regex matched text '"
+                              + matcher.group()
+                              + "' at position "
+                              + matcher.start()
+                              + " but no named group captured it. This indicates a programmer error in the regex pattern or GROUP_TO_TOKEN mapping."));
+      tokens.add(new Token(tokenType, matcher.group(), matcher.start(), matcher.end()));
+    }
+
+    return tokens;
+  }
+
+  /**
+   * This is the behavior of the {@code FieldFilterParser} so we kept it for backwards
+   * compatibility.
+   */
+  private static String removeAllWhitespace(String fieldName) {
+    StringBuilder sb = new StringBuilder(fieldName.length());
+    for (int i = 0; i < fieldName.length(); i++) {
+      char c = fieldName.charAt(i);
+      if (!Character.isWhitespace(c)) {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+
+  private static class Parser {
+    /** {@code *} and presets cannot be excluded, {@code !} is ignored. */
+    final Set<String> unexcludableTokens;
+
+    String currentField = null;
+    List<Transformation> currentTransformation = new ArrayList<>();
+    boolean isExclusion = false;
+
+    String pendingTransformation = null;
+    List<String> transformationParams = new ArrayList<>();
+    boolean parsingTransformationParams = false;
+
+    Parser(Set<String> unexcludableTokens) {
+      this.unexcludableTokens = unexcludableTokens;
+    }
+
+    void consumeCurrentField(FieldsAccumulator accumulator) {
+      if (currentField != null && !currentField.isEmpty()) {
+        if (pendingTransformation != null && !pendingTransformation.isEmpty()) {
+          currentTransformation.add(new Transformation(pendingTransformation));
+        }
+        accumulator.add(
+            currentField, isExclusion, unexcludableTokens, new ArrayList<>(currentTransformation));
+      }
+      reset();
+    }
+
+    private void reset() {
+      currentField = null;
+      currentTransformation.clear();
+      isExclusion = false;
+      pendingTransformation = null;
+      transformationParams.clear();
+      parsingTransformationParams = false;
+    }
+  }
+
+  private static void mapPresets(
+      FieldsAccumulator acc,
+      Schema schema,
+      BiFunction<Schema, String, Schema> getSchema,
+      Map<String, Function<Schema, Set<String>>> presets) {
+    acc.includes =
+        acc.includes.stream()
+            .flatMap(
+                field -> presets.getOrDefault(field, s -> Set.of(field)).apply(schema).stream())
+            .collect(Collectors.toSet());
+
+    for (Entry<String, FieldsAccumulator> entry : acc.children.entrySet()) {
+      Schema parent = getSchema.apply(schema, entry.getKey());
+      if (parent == null) {
+        continue; // invalid field
+      }
+      mapPresets(entry.getValue(), parent, getSchema, presets);
+    }
+  }
+
+  /** Maps in depth-first search order each field and its children to {@link Fields}. */
+  private static Fields map(FieldsAccumulator acc, boolean includesAll) {
+    // fields with `[]` i.e. fields=dataValues[value] will have accumulated children processed here
+    Map<String, Fields> children = new HashMap<>();
+    for (Entry<String, FieldsAccumulator> entry : acc.children.entrySet()) {
+      // Don't process children of excluded parents as they will be excluded anyway
+      if (isFieldExcluded(entry.getKey(), acc, includesAll)) {
+        continue;
+      }
+
+      boolean includeChildren =
+          entry.getValue().includes.contains(TOKEN_ALL) // fields=dataValues[*] all are included
+              || entry
+                  .getValue()
+                  .includes
+                  .isEmpty(); // fields=dataValues[!value] all but value are included
+      children.put(entry.getKey(), map(entry.getValue(), includeChildren));
+    }
+    acc.includes.remove(TOKEN_ALL);
+
+    Set<String> fields = includesAll ? acc.excludes : new HashSet<>(acc.includes);
+    if (!includesAll) {
+      // exclusion has precedence over inclusion
+      fields.removeAll(acc.excludes);
+    }
+
+    Map<String, List<Fields.Transformation>> transformations =
+        mapTransformations(acc.transformations);
+
+    return new Fields(includesAll, fields, children, transformations);
+  }
+
+  private static boolean isFieldExcluded(
+      String fieldName, FieldsAccumulator acc, boolean includesAll) {
+    if (includesAll) {
+      return acc.excludes.contains(fieldName);
+    } else {
+      return acc.excludes.contains(fieldName) || !acc.includes.contains(fieldName);
+    }
+  }
+
+  private static Map<String, List<Fields.Transformation>> mapTransformations(
+      Map<String, List<Transformation>> transformations) {
+    validateTransformations(transformations);
+    return sortAndConvertTransformations(transformations);
+  }
+
+  private static void validateTransformations(Map<String, List<Transformation>> transformations) {
+    validateUnknownTransformations(transformations);
+    validateDuplicateTransformations(transformations);
+    validateTransformationArguments(transformations);
+  }
+
+  private static void validateUnknownTransformations(
+      Map<String, List<Transformation>> transformations) {
+    String unknown =
+        transformations.entrySet().stream()
+            .flatMap(e -> e.getValue().stream())
+            .map(t -> t.name)
+            .filter(n -> !FieldsTransformer.TRANSFORMERS.containsKey(n))
+            .collect(Collectors.joining(", "));
+    if (!unknown.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Invalid field transformer(s): "
+              + unknown
+              + ". Valid ones are: "
+              + FieldsTransformer.TRANSFORMERS.keySet());
+    }
+  }
+
+  private static void validateDuplicateTransformations(
+      Map<String, List<Transformation>> transformations) {
+    String duplicates =
+        transformations.entrySet().stream()
+            .map(
+                e -> {
+                  Set<String> transformers =
+                      CollectionUtils.findDuplicates(
+                          e.getValue().stream().map(t -> t.name).toList());
+                  if (!transformers.isEmpty()) {
+                    return "'" + e.getKey() + "' " + String.join(", ", transformers);
+                  }
+                  return null;
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(", "));
+    if (!duplicates.isEmpty()) {
+      throw new IllegalArgumentException("Duplicate transformers for fields: " + duplicates + ".");
+    }
+  }
+
+  private static void validateTransformationArguments(
+      Map<String, List<Transformation>> transformations) {
+    String errors =
+        transformations.entrySet().stream()
+            .flatMap(
+                e ->
+                    e.getValue().stream()
+                        .map(
+                            t ->
+                                FieldsTransformer.TRANSFORMERS_VALIDATOR
+                                    .getOrDefault(t.name, (name, f, a) -> null)
+                                    .validate(t.name, e.getKey(), t.arguments)))
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(", "));
+    if (!errors.isEmpty()) {
+      throw new IllegalArgumentException(errors);
+    }
+  }
+
+  private static Map<String, List<Fields.Transformation>> sortAndConvertTransformations(
+      Map<String, List<Transformation>> transformations) {
+    Map<String, List<Transformation>> sortedTransformations =
+        sortTransformationsByRenameRule(transformations);
+    return convertToFieldsTransformations(sortedTransformations);
+  }
+
+  /**
+   * Renaming must be the last transformation applied to a field, so we sort transformations
+   * accordingly.
+   */
+  private static Map<String, List<Transformation>> sortTransformationsByRenameRule(
+      Map<String, List<Transformation>> transformations) {
+    Map<String, List<Transformation>> sortedTransformations = new HashMap<>();
+    for (Entry<String, List<Transformation>> entry : transformations.entrySet()) {
+      List<Transformation> sorted =
+          entry.getValue().stream()
+              .sorted(
+                  (t1, t2) -> {
+                    boolean t1IsRename = "rename".equals(t1.name());
+                    boolean t2IsRename = "rename".equals(t2.name());
+                    if (t1IsRename && !t2IsRename) return 1;
+                    if (!t1IsRename && t2IsRename) return -1;
+                    return 0;
+                  })
+              .toList();
+      sortedTransformations.put(entry.getKey(), sorted);
+    }
+    return sortedTransformations;
+  }
+
+  /** Transformations only use one argument, if any so we only keep the first one. */
+  private static Map<String, List<Fields.Transformation>> convertToFieldsTransformations(
+      Map<String, List<Transformation>> sortedTransformations) {
+    Map<String, List<Fields.Transformation>> result = new HashMap<>(sortedTransformations.size());
+    for (Entry<String, List<Transformation>> entry : sortedTransformations.entrySet()) {
+      List<Fields.Transformation> ts =
+          entry.getValue().stream()
+              .map(
+                  t -> {
+                    String argument =
+                        (t.arguments == null || t.arguments.length == 0) ? null : t.arguments[0];
+                    return new Fields.Transformation(
+                        t.name, FieldsTransformer.TRANSFORMERS.get(t.name), argument);
+                  })
+              .toList();
+      result.put(entry.getKey(), ts);
+    }
+    return result;
+  }
+
+  /**
+   * Accumulates included and excluded field names as well as presets and * in a tree like structure
+   * representing the (nested) fields expressions.
+   */
+  private static final class FieldsAccumulator {
+    Set<String> includes = new HashSet<>();
+    final Set<String> excludes = new HashSet<>();
+    final Map<String, FieldsAccumulator> children = new HashMap<>();
+    final Map<String, List<Transformation>> transformations = new HashMap<>();
+
+    void add(
+        String field,
+        boolean isExclusion,
+        Set<String> unexcludableTokens,
+        List<Transformation> transformers) {
+      if (!isExclusion || unexcludableTokens.contains(field)) {
+        this.includes.add(field);
+      } else {
+        this.excludes.add(field);
+      }
+
+      if (!transformers.isEmpty()) {
+        this.transformations.put(field, transformers);
+      }
+    }
+
+    FieldsAccumulator getOrCreateChild(String field) {
+      return children.computeIfAbsent(field, k -> new FieldsAccumulator());
+    }
+  }
+
+  private record Transformation(String name, String... arguments) {
+    @Override
+    public @Nonnull String toString() {
+      return name + "(" + String.join(",", arguments) + ")";
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsPropertyFilter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * FieldsPropertyFilter is a stateless Jackson filter that serializes and transforms fields as
+ * declared in a {@code fields} parameter. The {@code fields} are passed into serialization via
+ * provider attributes.
+ *
+ * <p>This filter must be fast! Almost every DHIS2 endpoint supports field filtering. Make sure your
+ * change does not degrade performance using a benchmark (like {@code
+ * FieldFilterSerializationBenchmarkTest}) or performance test.
+ */
+@Component
+@RequiredArgsConstructor
+public class FieldsPropertyFilter extends SimpleBeanPropertyFilter {
+
+  public static final String FILTER_ID = "tracker-fields-filter";
+
+  /** Key under which fields are stored for filtering during serialization. */
+  public static final String FIELDS_ATTRIBUTE = "fields";
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void serializeAsField(
+      Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer)
+      throws Exception {
+    Fields current = (Fields) provider.getAttribute(FIELDS_ATTRIBUTE);
+
+    if (current == null) {
+      throw new IllegalStateException(
+          "No fields attribute found in SerializerProvider there must be a bug in field filtering.");
+    }
+
+    if (current.test(writer.getName())) {
+      Fields children = current.getChildren(writer.getName());
+      provider.setAttribute(FIELDS_ATTRIBUTE, children);
+
+      serialize(pojo, jgen, provider, writer, current);
+
+      provider.setAttribute(FIELDS_ATTRIBUTE, current);
+    } else if (!jgen.canOmitFields()) { // since 2.3
+      writer.serializeAsOmittedField(pojo, jgen, provider);
+    }
+  }
+
+  /**
+   * Serializes a field with optional transformations. Uses hybrid approach:
+   *
+   * <ol>
+   *   <li>objects are serialized/filtered directly if they do not need to be transformed
+   *   <li>objects are serialized/filtered to Jackson's {@code JsonNode} which is then mutated by
+   *       transformation(s)
+   * </ol>
+   *
+   * This means that objects are streamed to JSON with no intermediate in-memory representation if
+   * no transformations are needed. Transformations, however, come with the penalty of double
+   * (de)serialization. This approach is an improvement over the field filtering added in 2.38 where
+   * we always paid the cost of double (de)serialization. Some of the transformations need access to
+   * JSON type information. We could likely serialize/filter/transform the JSON stream if that would
+   * not be necessary.
+   */
+  private void serialize(
+      Object pojo,
+      JsonGenerator jgen,
+      SerializerProvider provider,
+      PropertyWriter writer,
+      Fields current)
+      throws Exception {
+    List<Fields.Transformation> transformations = current.getTransformations(writer.getName());
+    if (transformations.isEmpty()) {
+      writer.serializeAsField(pojo, jgen, provider);
+      return;
+    }
+
+    // serialize applying any filters and capture output in buffer for later transformations
+    TokenBuffer tokenBuffer = new TokenBuffer(objectMapper, false);
+    writer.serializeAsField(pojo, tokenBuffer, provider);
+    // create ObjectNode from buffer for transformations to mutate
+    JsonNode filteredFieldNode = objectMapper.readTree(tokenBuffer.asParser());
+    // transformations are applied on single-field object like {"fieldName": filteredValue}
+    String fieldName = filteredFieldNode.fieldNames().next();
+    JsonNode fieldValue = filteredFieldNode.get(fieldName);
+    ObjectNode result = objectMapper.createObjectNode();
+    result.set(fieldName, fieldValue);
+
+    for (Fields.Transformation transformation : transformations) {
+      transformation.transformer().transform(fieldName, result, transformation.argument());
+    }
+
+    // write the transformed result to the output stream (field name may have been changed by
+    // rename transformation)
+    String finalFieldName = result.fieldNames().next();
+    jgen.writeFieldName(finalFieldName);
+    jgen.writeTree(result.get(finalFieldName));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsTransformer.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link FieldsTransformer.Function} implement the {@code fields} transformations. Transformer
+ * functions work by mutating the {@link ObjectNode} field/value. They reuse most of the logic from
+ * {@link org.hisp.dhis.fieldfiltering.transformers}.
+ */
+public class FieldsTransformer {
+  public static final Map<String, Function> TRANSFORMERS =
+      Map.of(
+          "isEmpty",
+          FieldsTransformer::isEmpty,
+          "isNotEmpty",
+          FieldsTransformer::isNotEmpty,
+          "keyBy",
+          FieldsTransformer::keyBy,
+          "pluck",
+          FieldsTransformer::pluck,
+          "rename",
+          FieldsTransformer::rename,
+          "size",
+          FieldsTransformer::size);
+  public static final Map<String, Validator> TRANSFORMERS_VALIDATOR =
+      Map.of("rename", FieldsTransformer::requireOneArgument);
+
+  public interface Function {
+    void transform(@Nonnull String field, @Nonnull ObjectNode parent, @Nullable String argument);
+  }
+
+  /**
+   * Validates the argument(s) to a field transformer.
+   *
+   * <p>Return an error message if the argument does not conform to the transformer and {@code null}
+   * if it does.
+   */
+  public interface Validator {
+    @Nullable
+    String validate(
+        @Nonnull String transformer, @Nonnull String field, @Nullable String... arguments);
+  }
+
+  public static void isEmpty(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nullable String argument) {
+    JsonNode value = parent.get(field);
+
+    if (value.isArray()) {
+      parent.put(field, value.isEmpty());
+    }
+  }
+
+  public static void isNotEmpty(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nullable String argument) {
+    JsonNode value = parent.get(field);
+
+    if (value.isArray()) {
+      parent.put(field, !value.isEmpty());
+    }
+  }
+
+  public static void keyBy(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nullable String key) {
+    JsonNode value = parent.get(field);
+    if (!value.isArray()) {
+      return;
+    }
+
+    if (key == null) {
+      key = "id";
+    }
+
+    ObjectNode objectNode = ((ArrayNode) value).arrayNode().objectNode();
+
+    for (JsonNode node : value) {
+      if (node.isObject() && node.has(key)) {
+        String propertyName = node.get(key).asText();
+
+        if (!objectNode.has(propertyName) && StringUtils.hasText(propertyName)) {
+          objectNode.set(propertyName, node);
+        } else if (objectNode.has(propertyName)) {
+          JsonNode jsonNode = objectNode.get(propertyName);
+
+          if (jsonNode.isArray()) {
+            ((ArrayNode) jsonNode).add(node);
+          } else {
+            ArrayNode arrayNode = objectNode.arrayNode();
+            arrayNode.add(jsonNode);
+            arrayNode.add(node);
+
+            objectNode.set(propertyName, arrayNode);
+          }
+        }
+      }
+    }
+
+    parent.replace(field, objectNode);
+  }
+
+  public static void pluck(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nullable String pluckField) {
+    JsonNode value = parent.get(field);
+    if (!value.isArray()) {
+      return;
+    }
+
+    if (pluckField == null) {
+      pluckField = "id";
+    }
+
+    ArrayNode arrayNode = ((ArrayNode) value).arrayNode();
+
+    for (JsonNode node : value) {
+      if (node.isObject() && node.has(pluckField)) {
+        arrayNode.add(node.get(pluckField));
+      } else {
+        arrayNode.add(node);
+      }
+    }
+
+    parent.replace(field, arrayNode);
+  }
+
+  public static void rename(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nonnull String newField) {
+    JsonNode value = parent.get(field);
+
+    parent.remove(field);
+    parent.set(newField, value);
+  }
+
+  public static void size(
+      @Nonnull String field, @Nonnull ObjectNode parent, @Nullable String argument) {
+    JsonNode value = parent.get(field);
+
+    if (value.isArray()) {
+      parent.put(field, value.size());
+    } else if (value.isTextual()) {
+      parent.put(field, value.asText().length());
+    } else if (value.isInt()) {
+      parent.put(field, value.asInt());
+    } else if (value.isLong()) {
+      parent.put(field, value.asLong());
+    } else if (value.isDouble() || value.isFloat()) {
+      parent.put(field, value.asDouble());
+    }
+  }
+
+  public static String requireOneArgument(
+      @Nonnull String transformer, @Nonnull String field, @Nullable String... arguments) {
+    if (arguments == null) {
+      return transformer
+          + " applied to field "
+          + field
+          + " requires exactly one non-blank argument";
+    }
+    if (arguments.length != 1) {
+      return transformer
+          + " applied to field "
+          + field
+          + " requires exactly one non-blank argument";
+    }
+    if (arguments[0].isBlank()) {
+      return transformer
+          + " applied to field "
+          + field
+          + " requires exactly one non-blank argument";
+    }
+
+    return null;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/SchemaFieldsPresets.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/SchemaFieldsPresets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,14 +27,47 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker;
+package org.hisp.dhis.tracker.export.fieldfiltering;
 
-import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.springframework.stereotype.Component;
 
-/**
- * FieldsRequestParam represents the HTTP request parameter {@code fields}. This allows users to
- * specify the exact fields they want in the JSON response.
- */
-public interface FieldsRequestParam {
-  Fields getFields();
+/** {@link Schema} aware implementations of {@link org.hisp.dhis.fieldfiltering.FieldPreset}s. */
+@RequiredArgsConstructor
+@Component
+public class SchemaFieldsPresets {
+  private final SchemaService schemaService;
+
+  @Nonnull
+  public static Set<String> mapSimple(@Nonnull Schema schema) {
+    return schema.getProperties().stream()
+        .filter(p -> p.getPropertyType().isSimple())
+        .map(SchemaFieldsPresets::toFieldName)
+        .collect(Collectors.toSet());
+  }
+
+  @Nullable
+  public Schema getSchema(@Nonnull Schema schema, @Nonnull String field) {
+    Property property = schema.getProperty(field);
+
+    if (property == null) {
+      return null; // invalid field
+    }
+
+    if (property.isCollection()) {
+      return schemaService.getDynamicSchema(property.getItemKlass());
+    }
+    return schemaService.getDynamicSchema(property.getKlass());
+  }
+
+  private static String toFieldName(Property property) {
+    return property.isCollection() ? property.getCollectionName() : property.getName();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/fieldfiltering/package-info.java
@@ -1,0 +1,46 @@
+/**
+ * DHIS2 field filtering system for JSON API responses used by Tracker.
+ *
+ * <p>User input {@code fields=id,name,group[code]} flows through this pipeline:
+ *
+ * <pre>
+ * HTTP Request ─────────────────────────┐
+ * ?fields=id,name,group[code]           │
+ *                                       ▼
+ * ┌─────────────────┐    ┌───────────────────────────────── ┐
+ * │  FieldsConverter│    │        FieldsParser              │
+ * │  (Spring Web)   ├───►│ 1. Tokenize: [id][,][name]...    │
+ * │                 │    │ 2. Parse: Build tree structure   │
+ * │                 │    │ 3. Expand presets (:all, :simple)│
+ * └─────────────────┘    │ 4. Validate transformations      │
+ *                        └─────────────────┬────────────── ─┘
+ *                                          │
+ *                                          ▼ Fields object
+ * ┌─────────────────────────────────────────────────────────┐
+ * │              Jackson Serialization                      │
+ * │ ObjectMapper.writer()                                   │
+ * │   .withAttribute("fields", fields)                      │
+ * │   .writeValueAsString(object)                           │
+ * └─────────────────┬───────────────────────────────────────┘
+ *                   │
+ *                   ▼ For each object property
+ * ┌──────────────────────────────────────────────────────────┐
+ * │           FieldsPropertyFilter                           │
+ * │ 1. Test field inclusion: fields.test("name")             │
+ * │ 2. Get/set child filters: fields.getChildren("group")    │
+ * │ 3. Apply transformations (rename, size, etc.)            │
+ * │ 4. Stream or double-serialize when given transformations │
+ * └─────────────────┬────────────────────────────────────────┘
+ *                   │
+ *                   ▼
+ * Filtered JSON: {"id":"123","name":"Test","group":{"code":"ABC"}}
+ * </pre>
+ *
+ * Controllers use {@code @RequestParam Fields fields} or parameters which Spring converts via the
+ * {@code FieldsConverter}. Controllers return a {@code FilteredPage} or {@code FilteredEntity}
+ * which are processed by an {@code HttpMessageConverter} that then triggers the response
+ * serialization through the configured Jackson {@link
+ * org.hisp.dhis.tracker.export.fieldfiltering.FieldsConfig#jsonFilterMapper(FieldsPropertyFilter)}
+ * bean.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParserTest.java
@@ -1,0 +1,743 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.fieldfiltering;
+
+import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
+import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.schema.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests the {@link FieldsParser} and its backwards compatibility with the {@link FieldFilterParser}
+ * which tracker used previously. Some tests are ported over from {@code FieldFilterParserTest}.
+ * Comments indicate where the tests differ.
+ */
+class FieldsParserTest {
+
+  /**
+   * {@link Fields.Transformation} has a reference to a transformer function which makes it
+   * impossible to use {@code assertEquals} as lambdas are not equal even though they point to the
+   * same function. Using this record to make asserting easier.
+   */
+  record ExpectTransformation(String name, String argument) {}
+
+  record ExpectField(boolean included, String dotPath, ExpectTransformation... transformations) {}
+
+  @ParameterizedTest
+  @MethodSource("providerEqualBehavior")
+  void testTrackerParser(String input, List<ExpectField> expectFields) {
+    Fields fields = FieldsParser.parse(input);
+
+    assertFields(expectFields, fields);
+  }
+
+  @ParameterizedTest
+  @MethodSource("providerEqualBehavior")
+  void testCurrentParser(String input, List<ExpectField> expectFields) {
+    List<FieldPath> fieldPaths = FieldFilterParser.parse(input);
+
+    assertFields(expectFields, fieldPaths);
+  }
+
+  // Tests with a comment that looks like a method name are ported from FieldFilterParserTest to
+  // ensure the current and tracker parser behave the same. Some more tests were added.
+  static Stream<Arguments> providerEqualBehavior() {
+    return Stream.of(
+        // testDepth0Filters
+        Arguments.of(
+            "id, name,    abc",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "abc"))),
+
+        // testDepth1Filters
+        Arguments.of(
+            "id,name,group[id,name]",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+
+        // testDepthXFilters
+        Arguments.of(
+            "id,name,group[id,name],group[id,name,group[id,name,group[id,name]]]",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"),
+                new ExpectField(true, "group.group.id"),
+                new ExpectField(true, "group.group.name"),
+                new ExpectField(true, "group.group.group.id"),
+                new ExpectField(true, "group.group.group.name"))),
+
+        // testOnlyBlockFilters
+        Arguments.of(
+            "group[id,name]",
+            List.of(
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+
+        // missing closing brackets are ignored
+        Arguments.of(
+            "id,name,group[id,name],group[id,name,group[id,name,group[id,name[",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"),
+                new ExpectField(true, "group.group.id"),
+                new ExpectField(true, "group.group.name"),
+                new ExpectField(true, "group.group.group.id"),
+                new ExpectField(true, "group.group.group.name"))),
+
+        // () is treated like [] (might have special meaning in a transformer waiting on answer from
+        // platform)
+        Arguments.of(
+            "group(id,name)",
+            List.of(
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+
+        // brackets and parentheses can be mixed :joy:
+        Arguments.of(
+            "group(id,name]",
+            List.of(
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+        Arguments.of(
+            "group[id,name)",
+            List.of(
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+
+        // testMixedBlockSingleFields
+        Arguments.of(
+            "id,name,group[id,name],code",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"),
+                new ExpectField(true, "code"))),
+
+        // testIgnoreWhitespace
+        Arguments.of(
+            " id,name  , group[ id , name  ], code  ",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"),
+                new ExpectField(true, "code"))),
+
+        // ignore empty fields and blocks
+        Arguments.of(
+            " id, ,, group[ , , id ,  ], code  ,",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "code"))),
+
+        // testBlockSpreadOut
+        Arguments.of(
+            "id,group[id],name,group[name],code",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"),
+                new ExpectField(true, "code"))),
+
+        // this is the behavior of the org.hisp.dhis.fieldfiltering.FieldFilterParser
+        // I replicated it for backwards compatibility but am unsure if we want to trim whitespace
+        // inside of a field name
+        Arguments.of(
+            " id  ,name  code, gro  up [ id , name  ]  ",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "namecode"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.id"),
+                new ExpectField(true, "group.name"))),
+        Arguments.of(
+            "id,name,!code",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(false, "code"))),
+
+        // exclusion has higher precedence
+        // exclusion before inclusion
+        Arguments.of(
+            "!code,id,name,code",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(false, "code"))),
+
+        // exclusion after inclusion
+        Arguments.of(
+            "code,id,name,!code",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(false, "code"))),
+
+        // exclusion only affects its level
+        Arguments.of(
+            "id,name,!code,group[code]",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(false, "code"),
+                new ExpectField(true, "group"),
+                new ExpectField(true, "group.code"))),
+
+        // based on testParseWithPresetAndExclude without the presets which are tested separately
+        // below
+        Arguments.of(
+            "code,id,name,!code,group[!code,hello,code]",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "name"),
+                new ExpectField(false, "code"),
+                new ExpectField(true, "group"),
+                new ExpectField(false, "group.code"),
+                new ExpectField(true, "group.hello"))),
+
+        // adapted org.hisp.dhis.fieldfiltering.FieldFilterParser transformer tests as the tracker
+        // parser includes validation of args
+        // testParseWithTransformer1
+        Arguments.of(
+            "name::rename(a),id~rename(b),code|rename(c)",
+            List.of(
+                new ExpectField(true, "name", new ExpectTransformation("rename", "a")),
+                new ExpectField(true, "id", new ExpectTransformation("rename", "b")),
+                new ExpectField(true, "code", new ExpectTransformation("rename", "c")))),
+
+        // testParseWithTransformer2
+        Arguments.of(
+            "groups[name::rename(a)]",
+            List.of(
+                new ExpectField(true, "groups"),
+                new ExpectField(true, "groups.name", new ExpectTransformation("rename", "a")))),
+
+        // testParseWithTransformer3
+        Arguments.of(
+            "groups[name::rename(a), code~isNotEmpty()]",
+            List.of(
+                new ExpectField(true, "groups"),
+                new ExpectField(true, "groups.name", new ExpectTransformation("rename", "a")),
+                new ExpectField(
+                    true, "groups.code", new ExpectTransformation("isNotEmpty", null)))),
+
+        // testParseWithTransformer4
+        Arguments.of(
+            "name::rename(n),groups[name]",
+            List.of(
+                new ExpectField(true, "name", new ExpectTransformation("rename", "n")),
+                new ExpectField(true, "groups"),
+                new ExpectField(true, "groups.name"))),
+
+        // testParseWithTransformer5
+        Arguments.of(
+            "name::rename(n),groups::rename(g)[name::rename(n)]",
+            List.of(
+                new ExpectField(true, "name", new ExpectTransformation("rename", "n")),
+                new ExpectField(true, "groups", new ExpectTransformation("rename", "g")),
+                new ExpectField(true, "groups.name", new ExpectTransformation("rename", "n")))),
+
+        // testParseWithTransformer6
+        Arguments.of(
+            "name::rename(n),groups::rename(g)[name]",
+            List.of(
+                new ExpectField(true, "name", new ExpectTransformation("rename", "n")),
+                new ExpectField(true, "groups", new ExpectTransformation("rename", "g")),
+                new ExpectField(true, "groups.name"))),
+
+        // testParseWithTransformer7
+        Arguments.of(
+            "name::size,group::isEmpty",
+            List.of(
+                new ExpectField(true, "name", new ExpectTransformation("size", null)),
+                new ExpectField(true, "group", new ExpectTransformation("isEmpty", null)))),
+
+        // testParseWithTransformer8
+        Arguments.of(
+            "name::rename(n)",
+            List.of(new ExpectField(true, "name", new ExpectTransformation("rename", "n")))),
+
+        // testParseWithMultipleTransformers
+        Arguments.of(
+            "name::size::rename(n)",
+            List.of(
+                new ExpectField(
+                    true,
+                    "name",
+                    new ExpectTransformation("size", null),
+                    new ExpectTransformation("rename", "n")))),
+
+        // testMixedBlockWithExpectTransformation
+        Arguments.of(
+            "id,categoryCombo[categoryOptionCombos~size],displayName",
+            List.of(
+                new ExpectField(true, "id"),
+                new ExpectField(true, "categoryCombo"),
+                new ExpectField(
+                    true,
+                    "categoryCombo.categoryOptionCombos",
+                    new ExpectTransformation("size", null)),
+                new ExpectField(true, "displayName"))));
+  }
+
+  // The following tests show where the org.hisp.dhis.fieldfiltering.FieldFilterParser and tracker
+  // implementations differ. Some differences
+  // are due to an improved API in the tracker parser, some are due to what I think are bugs in
+  // org.hisp.dhis.fieldfiltering.FieldFilterParser.
+
+  // /api/organisationUnits?fields=dataSets[name],!dataSets will return an empty object
+  // The tracker parser clearly shows that excluding has precedence over inclusion.
+  // The org.hisp.dhis.fieldfiltering.FieldFilterParser does not as exclusions are handled in its
+  // FieldFilterService. This makes it
+  // confusion to read the expectations of org.hisp.dhis.fieldfiltering.FieldFilterParser.
+  @Test
+  void testTrackerParserIncludeChildOfExcludedParent() {
+    Fields fields = FieldsParser.parse("group[code],!group");
+
+    assertFields(
+        List.of(new ExpectField(false, "group"), new ExpectField(false, "group.code")), fields);
+  }
+
+  @Test
+  void testCurrentParserIncludeChildOfExcludedParent() {
+    List<FieldPath> fieldPaths = FieldFilterParser.parse("group[code],!group");
+
+    assertFields(
+        List.of(new ExpectField(false, "group"), new ExpectField(true, "group.code")), fieldPaths);
+  }
+
+  // this leads to an HTTP 500 instead of 400 in org.hisp.dhis.fieldfiltering.FieldFilterParser
+  @Test
+  void bugInCurrentParserUnbalancedClosingParen() {
+    assertThrows(
+        java.util.EmptyStackException.class, () -> FieldFilterParser.parse("group[name]]"));
+  }
+
+  @Test
+  void testTrackerParserWhitespaceInNestedFieldNames() {
+    Fields fields = FieldsParser.parse("relationships[f rom[trackedEntity[ org Unit ]]]");
+
+    assertFields(
+        List.of(
+            new ExpectField(true, "relationships"),
+            new ExpectField(true, "relationships.from"),
+            new ExpectField(true, "relationships.from.trackedEntity"),
+            new ExpectField(true, "relationships.from.trackedEntity.orgUnit"),
+            new ExpectField(false, "relationships.from.trackedEntity.trackedEntityType")),
+        fields);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // org.hisp.dhis.fieldfiltering.FieldFilterParser ignores this, I think this should be
+        // invalid
+        "[value]"
+      })
+  void testTrackerParserFailsOnBlockWithoutName(String input) {
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> FieldsParser.parse(input));
+
+    assertContains("Block must have a field name", exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // org.hisp.dhis.fieldfiltering.FieldFilterParser throws EmptyStackException which leads to
+        // a 500 error
+        "]",
+        ")",
+        "group[name]]",
+        "group[group[name)]),code",
+        "group[name))",
+        "group[name],id]",
+        "group[name],id)",
+      })
+  void testTrackerParserFailsOnUnbalancedClosingParen(String input) {
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> FieldsParser.parse(input));
+
+    assertContains("Unbalanced", exception.getMessage());
+  }
+
+  private static final Map<String, Function<Schema, Set<String>>> PRESETS =
+      Map.of(":all", FieldsParser.PRESET_ALL);
+
+  record Any() {}
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "*", ":all", "!*", "!:all",
+      })
+  void testTrackerParserGivenRootStar(String input) {
+    Schema schema = new Schema(Any.class, "any", "any");
+    Fields fields = FieldsParser.parse(input, schema, (s, f) -> schema, PRESETS);
+
+    assertFields(
+        List.of(
+            new ExpectField(true, "code"),
+            new ExpectField(true, "group"),
+            new ExpectField(true, "group.code"),
+            new ExpectField(true, "group.group.code")),
+        fields);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "*,!code",
+        ":all,!code",
+        "!*,!code",
+        "!:all,!code",
+      })
+  void testTrackerParserGivenRootStarAndExclusion(String input) {
+    Schema schema = new Schema(Any.class, "any", "any");
+    Fields fields = FieldsParser.parse(input, schema, (s, f) -> schema, PRESETS);
+
+    assertFields(
+        List.of(
+            new ExpectField(false, "code"),
+            new ExpectField(true, "group"),
+            new ExpectField(true, "group.code"),
+            new ExpectField(true, "group.group.code")),
+        fields);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "*,group[!code]",
+        ":all,group[!code]",
+        "!*,group[!code]",
+        "!:all,group[!code]",
+      })
+  void testTrackerParserGivenRootStarAndChildExclusion(String input) {
+    Schema schema = new Schema(Any.class, "any", "any");
+    Fields fields = FieldsParser.parse(input, schema, (s, f) -> schema, PRESETS);
+
+    assertFields(
+        List.of(
+            new ExpectField(true, "code"),
+            new ExpectField(true, "code.name"),
+            new ExpectField(true, "group"),
+            new ExpectField(false, "group.code"),
+            new ExpectField(false, "group.code.name")),
+        fields);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "code,group[*,!code],names[list[*]],names[list[!first]]",
+        "code,group[:all,!code],names[list[:all]],names[list[!first]]",
+        "code,group[!*,!code],names[list[!*]],names[list[!first]]",
+        "code,group[!:all,!code],names[list[!:all]],names[list[!first]]",
+      })
+  void testTrackerParserGivenChildStarAndChildExclusion(String input) {
+    Schema schema = new Schema(Any.class, "any", "any");
+    Fields fields = FieldsParser.parse(input, schema, (s, f) -> schema, PRESETS);
+
+    assertFields(
+        List.of(
+            new ExpectField(true, "code"),
+            new ExpectField(true, "code.name"),
+            new ExpectField(true, "group"),
+            new ExpectField(true, "group.name"),
+            new ExpectField(false, "group.code"),
+            new ExpectField(false, "group.code.name"),
+            new ExpectField(true, "names"),
+            new ExpectField(true, "names.list"),
+            new ExpectField(true, "names.list.second"),
+            new ExpectField(false, "names.list.first"),
+            new ExpectField(false, "names.list.first.deep")),
+        fields);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "!group",
+        "!group[]",
+        "!group[code]", // bug in current field filter NPE Cannot invoke
+        // "org.hisp.dhis.fieldfiltering.FieldPath.getPath()" because "fieldPath" is null. This
+        // implementation treats all 3 cases in the same way. We ignore the child in case 3. as
+        // children of excluded parents are not included anyway.
+      })
+  void testVariantsToExcludeAParent(String input) {
+    Fields fields = FieldsParser.parse(input);
+
+    assertFields(
+        List.of(
+            new ExpectField(false, "none"),
+            new ExpectField(false, "group"),
+            new ExpectField(false, "group.code"),
+            new ExpectField(false, "group.code.name")),
+        fields);
+  }
+
+  @Test
+  void testGetChildrenAlignsWithIncludes() {
+    Fields fields = FieldsParser.parse("relationships[!from]");
+
+    assertTrue(fields.test("relationships"));
+    assertFalse(fields.getChildren("relationships").test("from"));
+    assertTrue(fields.getChildren("relationships").test("to"));
+    assertFalse(fields.getChildren("relationships").getChildren("from").test("value"));
+
+    assertTrue(fields.includes("relationships"));
+    assertTrue(fields.includes("relationships.to"));
+    assertFalse(fields.includes("relationships.from"));
+    assertFalse(fields.includes("relationships.from.value"));
+  }
+
+  @Test
+  void testParserSortsTransformationsWithRenameLast() {
+    Fields fields = FieldsParser.parse("field::rename(newName)~isEmpty");
+
+    List<Fields.Transformation> actual = fields.getTransformations("field");
+
+    assertEquals(
+        List.of(
+            new ExpectTransformation("isEmpty", null),
+            new ExpectTransformation("rename", "newName")),
+        actual.stream().map(toExpectTransformation()).toList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"field1::rename", "field1::rename()", "field1::rename(first;second;third)"})
+  void testTrackerParserFailsOnMissingRequiredRenameTransformerArgument(String input) {
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> FieldsParser.parse(input));
+
+    assertContains("rename applied to field", exception.getMessage());
+  }
+
+  @Test
+  void testTrackerParserFailsOnDuplicateTransformers() {
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                FieldsParser.parse(
+                    "field1::isEmpty~isEmpty,field2::isNotEmpty,field3::size::size"));
+
+    assertContains("Duplicate transformers", exception.getMessage());
+  }
+
+  @Test
+  void testTrackerParserFailsOnUnknownTransformation() {
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> FieldsParser.parse("field1::unknown,field2~unknown2"));
+
+    assertStartsWith("Invalid field transformer(s):", exception.getMessage());
+  }
+
+  public static void assertFields(List<ExpectField> expectFields, Fields fields) {
+    for (ExpectField expectField : expectFields) {
+      assertField(expectField, fields);
+    }
+  }
+
+  /**
+   * Tests if the field represented by the full path as used by the current FieldFilterParser is
+   * included in the parsed fields predicate.
+   */
+  private static void assertField(ExpectField expected, Fields fields) {
+    String what = expected.included ? "includes" : "exclude";
+
+    assertEquals(
+        expected.included,
+        fields.includes(expected.dotPath),
+        "fields " + fields + " does not " + what + " " + expected.dotPath);
+    assertTransformations(expected, fields);
+  }
+
+  private static void assertTransformations(ExpectField expected, Fields fields) {
+    String[] segments = expected.dotPath.split("\\.");
+    Fields current = fields;
+    for (int i = 0; i < segments.length - 1; i++) {
+      current = current.getChildren(segments[i]);
+    }
+    String lastSegment = segments[segments.length - 1];
+    List<Fields.Transformation> actual = current.getTransformations(lastSegment);
+
+    if (expected.transformations.length == 0) {
+      assertIsEmpty(
+          actual == null ? List.of() : actual,
+          "Expected no transformations for field " + expected.dotPath);
+    } else {
+      List<ExpectTransformation> expectedTransformations = List.of(expected.transformations);
+      assertNotEmpty(actual, "Expected transformations for field " + expected.dotPath);
+      List<ExpectTransformation> actualTransformations =
+          actual.stream().map(toExpectTransformation()).toList();
+      assertEquals(
+          expectedTransformations,
+          actualTransformations,
+          "Transformations mismatch for field " + expected.dotPath);
+    }
+  }
+
+  private static Function<Fields.Transformation, ExpectTransformation> toExpectTransformation() {
+    return t -> new ExpectTransformation(t.name(), t.argument());
+  }
+
+  private static void assertFields(
+      List<FieldsParserTest.ExpectField> expectFields, List<FieldPath> fieldPaths) {
+    for (ExpectField expectField : expectFields) {
+      assertField(expectField, fieldPaths);
+    }
+  }
+
+  /**
+   * Tests if the field represented by the full path as used by the current FieldFilterParser is
+   * included in the parsed fields predicate.
+   */
+  private static void assertField(ExpectField expected, List<FieldPath> fieldPaths) {
+    String what = expected.included ? "include" : "exclude";
+    List<FieldPath> actual =
+        fieldPaths.stream().filter(fp -> expected.dotPath.equals(fp.toFullPath())).toList();
+    assertNotEmpty(
+        actual,
+        () ->
+            fieldPaths.stream().map(FieldPath::toFullPath).collect(Collectors.toSet())
+                + " should contain "
+                + expected.dotPath
+                + " and "
+                + what
+                + " it");
+
+    Predicate<FieldPath> predicate;
+    if (expected.included) {
+      // exclusion has higher precedence over inclusion, a field can thus only be considered
+      // included if there is not also an exclusion
+      assertFalse(
+          actual.stream().anyMatch(FieldPath::isExclude),
+          () ->
+              fieldPaths.stream().map(FieldPath::toFullPath).collect(Collectors.toSet())
+                  + " should includes "
+                  + expected.dotPath
+                  + " but it contains the path with an exclusion");
+      predicate = fp -> !fp.isExclude();
+    } else {
+      predicate = FieldPath::isExclude;
+    }
+    Optional<FieldPath> path = actual.stream().filter(predicate).findAny();
+    assertTrue(
+        path.isPresent(),
+        () ->
+            fieldPaths.stream().map(FieldPath::toFullPath).collect(Collectors.toSet())
+                + " should contain "
+                + expected.dotPath
+                + " and "
+                + what
+                + " it");
+
+    assertTransformations(expected, path.get());
+  }
+
+  private static void assertTransformations(ExpectField expected, FieldPath actual) {
+    if (expected.transformations.length == 0) {
+      assertIsEmpty(
+          actual.getTransformers(), "Expected no transformations for field " + expected.dotPath);
+    } else {
+      assertNotEmpty(
+          actual.getTransformers(),
+          "Expected transformations "
+              + Arrays.toString(expected.transformations)
+              + " for field "
+              + expected.dotPath);
+      List<ExpectTransformation> actualTransformations =
+          actual.getTransformers().stream()
+              .map(
+                  t ->
+                      new ExpectTransformation(
+                          t.getName(),
+                          (t.getParameters() == null || t.getParameters().isEmpty())
+                              ? null
+                              : t.getParameters().get(0).isEmpty()
+                                  ? null
+                                  : t.getParameters().get(0)))
+              .toList();
+      assertEquals(
+          List.of(expected.transformations),
+          actualTransformations,
+          "Transformations mismatch for field " + expected.dotPath);
+    }
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
@@ -110,7 +110,7 @@ public class JacksonObjectMapperConfig {
     return dataValueJsonMapper;
   }
 
-  @Bean("xmlMapper")
+  @Bean
   public ObjectMapper xmlMapper() {
     return xmlMapper;
   }
@@ -129,14 +129,19 @@ public class JacksonObjectMapperConfig {
   }
 
   static {
-    JtsModule jtsModule = new JtsModule(new GeometryFactory(new PrecisionModel(), 4326));
-    jtsModule.addSerializer(Geometry.class, new GeometrySerializer());
+    JtsModule jtsModule = createJtsModule();
     jsonMapper.registerModule(jtsModule);
     dataValueJsonMapper.registerModule(jtsModule);
     xmlMapper.registerModule(new JtsXmlModule());
   }
 
-  private static ObjectMapper configureMapper(ObjectMapper objectMapper) {
+  public static JtsModule createJtsModule() {
+    JtsModule jtsModule = new JtsModule(new GeometryFactory(new PrecisionModel(), 4326));
+    jtsModule.addSerializer(Geometry.class, new GeometrySerializer());
+    return jtsModule;
+  }
+
+  public static ObjectMapper configureMapper(ObjectMapper objectMapper) {
     return configureMapper(objectMapper, false);
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportFileTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportFileTest.java
@@ -333,8 +333,11 @@ public class TrackerExportFileTest extends TrackerApiTest {
                 .body()
                 .asByteArray());
 
-    JsonArray eventsJson =
-        JsonParser.parseString(s.get("events.json")).getAsJsonObject().getAsJsonArray("events");
+    assertTrue(
+        s.containsKey("events.json"),
+        "zip is expected to have the event JSON under entry events.json");
+    String json = s.get("events.json");
+    JsonArray eventsJson = JsonParser.parseString(json).getAsJsonObject().getAsJsonArray("events");
 
     assertJsonOneEventSize(eventsJson);
     assertEventJson(eventsJson);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -557,13 +557,19 @@ public class TrackerExportTest extends TrackerApiTest {
 
   @Test
   void whenGetEventsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
-    ApiResponse response =
-        trackerImportExportActions.getWithHeaders(
-            "events?events=" + event,
-            null,
-            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+    List<String> events =
+        trackerImportExportActions
+            .getWithHeaders(
+                "events?events=" + event,
+                null,
+                new Headers(new Header(HttpHeaders.ACCEPT, "text/html")))
+            .validate()
+            .statusCode(200)
+            .contentType("application/json;charset=utf-8")
+            .extract()
+            .jsonPath()
+            .getList("events.event.flatten()");
 
-    List<String> events = response.extractList("events.event.flatten()");
     assertEquals(
         List.of(event),
         events,
@@ -583,13 +589,19 @@ public class TrackerExportTest extends TrackerApiTest {
 
   @Test
   void whenGetTrackedEntitiesShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
-    ApiResponse response =
-        trackerImportExportActions.getWithHeaders(
-            "trackedEntities?trackedEntities=" + trackedEntityA,
-            null,
-            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+    List<String> trackedEntities =
+        trackerImportExportActions
+            .getWithHeaders(
+                "trackedEntities?trackedEntities=" + trackedEntityA,
+                null,
+                new Headers(new Header(HttpHeaders.ACCEPT, "text/html")))
+            .validate()
+            .statusCode(200)
+            .contentType("application/json;charset=utf-8")
+            .extract()
+            .jsonPath()
+            .getList("trackedEntities.trackedEntity.flatten()");
 
-    List<String> trackedEntities = response.extractList("trackedEntities.trackedEntity.flatten()");
     assertEquals(
         List.of(trackedEntityA),
         trackedEntities,
@@ -609,13 +621,19 @@ public class TrackerExportTest extends TrackerApiTest {
 
   @Test
   void whenGetEnrollmentsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
-    ApiResponse response =
-        trackerImportExportActions.getWithHeaders(
-            "enrollments?enrollments=" + enrollment,
-            null,
-            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+    List<String> enrollments =
+        trackerImportExportActions
+            .getWithHeaders(
+                "enrollments?enrollments=" + enrollment,
+                null,
+                new Headers(new Header(HttpHeaders.ACCEPT, "text/html")))
+            .validate()
+            .statusCode(200)
+            .contentType("application/json;charset=utf-8")
+            .extract()
+            .jsonPath()
+            .getList("enrollments.enrollment.flatten()");
 
-    List<String> enrollments = response.extractList("enrollments.enrollment.flatten()");
     assertEquals(
         List.of(enrollment),
         enrollments,
@@ -624,13 +642,19 @@ public class TrackerExportTest extends TrackerApiTest {
 
   @Test
   void whenGetRelationshipsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
-    ApiResponse response =
-        trackerImportExportActions.getWithHeaders(
-            "relationships?trackedEntity=" + trackedEntityA,
-            null,
-            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+    List<String> relationships =
+        trackerImportExportActions
+            .getWithHeaders(
+                "relationships?trackedEntity=" + trackedEntityA,
+                null,
+                new Headers(new Header(HttpHeaders.ACCEPT, "text/html")))
+            .validate()
+            .statusCode(200)
+            .contentType("application/json;charset=utf-8")
+            .extract()
+            .jsonPath()
+            .getList("relationships.relationship.flatten()");
 
-    List<String> relationships = response.extractList("relationships.relationship.flatten()");
     assertEquals(
         List.of(trackedEntityToTrackedEntityRelationship),
         relationships,

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -178,6 +178,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>test</scope>
@@ -424,6 +434,7 @@
             <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-hibernate</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-jdbc</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-setting</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.openjdk.jmh:jmh-generator-annprocess</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredNonTestScopedDependencies>
             <!-- compile dependency to get coverage in aggregate report -->
@@ -446,4 +457,32 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jmh</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.openjdk.jmh</groupId>
+                  <artifactId>jmh-generator-annprocess</artifactId>
+                  <version>${jmh.version}</version>
+                </path>
+                <path>
+                  <groupId>org.projectlombok</groupId>
+                  <artifactId>lombok</artifactId>
+                  <version>${lombok.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/MvcTestConfig.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.hisp.dhis.test.message.DefaultFakeMessageSender;
 import org.hisp.dhis.user.UserSettingsService;
+import org.hisp.dhis.webapi.fields.FieldsConverter;
 import org.hisp.dhis.webapi.mvc.CurrentSystemSettingsHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
@@ -56,6 +57,7 @@ import org.hisp.dhis.webapi.mvc.interceptor.AuthorityInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.SystemSettingsInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
+import org.hisp.dhis.webapi.mvc.messageconverter.FilteredPageHttpMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
@@ -117,9 +119,15 @@ public class MvcTestConfig implements WebMvcConfigurer {
   private CurrentSystemSettingsHandlerMethodArgumentResolver
       currentSystemSettingsHandlerMethodArgumentResolver;
 
+  @Autowired private FieldsConverter fieldsConverter;
+
   @Autowired
   @Qualifier("jsonMapper")
   private ObjectMapper jsonMapper;
+
+  @Qualifier("jsonFilterMapper")
+  @Autowired
+  private ObjectMapper jsonFilterMapper;
 
   @Autowired
   @Qualifier("xmlMapper")
@@ -259,6 +267,7 @@ public class MvcTestConfig implements WebMvcConfigurer {
             compression ->
                 converters.add(
                     new StreamingJsonRootMessageConverter(fieldFilterService, compression)));
+    converters.add(new FilteredPageHttpMessageConverter(jsonFilterMapper));
 
     converters.add(new StringHttpMessageConverter());
     converters.add(new ByteArrayHttpMessageConverter());
@@ -272,6 +281,7 @@ public class MvcTestConfig implements WebMvcConfigurer {
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new FieldPathConverter());
+    registry.addConverter(fieldsConverter);
   }
 
   @Bean

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/FieldFilterSerializationBenchmarkTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/FieldFilterSerializationBenchmarkTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsPropertyFilter;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JMH benchmark integrated with DHIS2 Spring testing infrastructure.
+ *
+ * <p>This approach combines JUnit test execution with JMH benchmarking, allowing full access to
+ * Spring services (based on: <a
+ * href="https://gist.github.com/msievers/ce80d343fc15c44bea6cbb741dde7e45">this gist</a>).
+ *
+ * <p><strong>Fork Configuration:</strong> This benchmark uses {@code @Fork(0)} to run in the same
+ * JVM as the test runner. While JMH typically recommends forking for isolation, this is necessary
+ * to preserve the Spring application context and dependency injection. The trade-off is acceptable
+ * because:
+ *
+ * <ul>
+ *   <li>All benchmarks run under the same conditions, so relative performance differences remain
+ *       valid
+ *   <li>Spring services are essential for realistic performance testing
+ *   <li>The magnitude of performance differences makes minor interference negligible
+ * </ul>
+ */
+@Tag("benchmark")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+public class FieldFilterSerializationBenchmarkTest extends H2ControllerIntegrationTestBase {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+    @Param({"25", "50", "100", "200", "400", "800"})
+    public int eventCount;
+
+    @Param({
+      "*", // serialize all so we can compare field filtering to pure Jackson serialization
+      "event", // serialize only a single String field so we reduce the actual data Jackson has to
+      // write and so our field filtering is what should dominate
+      "*,!relationships", // default fields of /tracker/events
+      "*,event~rename(foo)", // transformation with all fields
+      "event~rename(foo)" // transformation with single field
+    })
+    public String fields;
+
+    public List<Event> events;
+
+    // Spring services are injected from test instance
+    public static FieldFilterService fieldFilterService;
+    public static ObjectMapper objectMapper;
+    public static ObjectMapper filterMapper;
+    public static Authentication savedAuth;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      events = FieldFilterSerializationTest.createEvents(eventCount);
+
+      // JMH runs in separate threads, need to propagate SecurityContext
+      if (savedAuth != null) {
+        SecurityContextHolder.getContext().setAuthentication(savedAuth);
+      }
+    }
+  }
+
+  public static class FieldFilterBenchmarks {
+    @Benchmark
+    public void noFieldFiltering(BenchmarkState state, Blackhole bh)
+        throws JsonProcessingException {
+      bh.consume(BenchmarkState.objectMapper.writeValueAsString(state.events));
+    }
+
+    @Benchmark
+    public void currentFieldFiltering(BenchmarkState state, Blackhole bh)
+        throws JsonProcessingException {
+      List<FieldPath> filter = FieldFilterParser.parse(state.fields);
+      List<ObjectNode> objectNodes =
+          BenchmarkState.fieldFilterService.toObjectNodes(state.events, filter);
+      bh.consume(BenchmarkState.objectMapper.writeValueAsString(objectNodes));
+    }
+
+    @Benchmark
+    public void trackerFieldFiltering(BenchmarkState state, Blackhole bh)
+        throws JsonProcessingException {
+      Fields fields = FieldsParser.parse(state.fields);
+      bh.consume(
+          BenchmarkState.filterMapper
+              .writer()
+              .withAttribute(FieldsPropertyFilter.FIELDS_ATTRIBUTE, fields)
+              .writeValueAsString(state.events));
+    }
+  }
+
+  // Spring dependencies - accessed through test instance
+  @Autowired private FieldFilterService fieldFilterService;
+  @Autowired private ObjectMapper objectMapper;
+
+  @Qualifier("jsonFilterMapper")
+  @Autowired
+  private ObjectMapper filterMapper;
+
+  @Test
+  @Timeout(unit = TimeUnit.MINUTES, value = 200)
+  void executeJmhRunner() throws Exception {
+    // Inject Spring services into static benchmark state
+    BenchmarkState.fieldFilterService = this.fieldFilterService;
+    BenchmarkState.objectMapper = this.objectMapper;
+    BenchmarkState.filterMapper = this.filterMapper;
+    // Capture current authentication for propagation to benchmark threads
+    BenchmarkState.savedAuth = SecurityContextHolder.getContext().getAuthentication();
+
+    Options opt =
+        new OptionsBuilder()
+            .include(
+                "org.hisp.dhis.webapi.controller.tracker.FieldFilterSerializationBenchmarkTest.FieldFilterBenchmarks.*")
+            .shouldFailOnError(true)
+            .forks(0) // Run in same JVM to preserve Spring context
+            .mode(Mode.Throughput)
+            .timeUnit(TimeUnit.SECONDS)
+            .warmupIterations(3)
+            .warmupTime(TimeValue.seconds(5))
+            .measurementIterations(5)
+            .measurementTime(TimeValue.seconds(5))
+            .resultFormat(ResultFormatType.CSV)
+            .result("jmh-result.csv")
+            //            .addProfiler(AsyncProfiler.class,
+            //
+            // "libPath=linux-x64/libasyncProfiler.so;event=cpu;output=jfr,flamegraph;dir=target/profiler-output") // to profile: download and fix .so path https://github.com/async-profiler/async-profiler/
+            .build();
+
+    // add the events/s to the benchmark results to see the effect of the eventCount on the event
+    // throughput of each implementation
+    Collection<RunResult> results = new Runner(opt).run();
+    List<RunResult> sortedResults = sortResults(results);
+    addEventThroughputToCsv("jmh-result-enhanced.csv", sortedResults);
+  }
+
+  /**
+   * Sort results by fields parameter, eventCount and then benchmark method name. This makes
+   * comparison of the different implementations given the same benchmark parameters easier.
+   */
+  private List<RunResult> sortResults(Collection<RunResult> results) {
+    List<RunResult> sortedResults = new ArrayList<>(results);
+    sortedResults.sort(
+        Comparator.comparing((RunResult r) -> r.getParams().getParam("fields"))
+            .thenComparing(
+                (RunResult r) -> {
+                  String eventCountStr = r.getParams().getParam("eventCount");
+                  return eventCountStr != null ? Integer.parseInt(eventCountStr) : 0;
+                })
+            .thenComparing(
+                (RunResult r) -> {
+                  String benchmark = r.getParams().getBenchmark();
+                  return benchmark.substring(benchmark.lastIndexOf('.') + 1);
+                }));
+    return sortedResults;
+  }
+
+  private void addEventThroughputToCsv(String csvFilePath, Collection<RunResult> results) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(csvFilePath))) {
+      writeHeader(writer, results);
+
+      for (RunResult rr : results) {
+        writeDataRow(writer, rr);
+      }
+
+      System.out.println("Generated benchmark results: " + csvFilePath);
+    } catch (IOException e) {
+      System.err.println("Failed to write benchmark results CSV: " + e.getMessage());
+    }
+  }
+
+  private void writeHeader(BufferedWriter writer, Collection<RunResult> results)
+      throws IOException {
+    // Get parameter keys from first result
+    SortedSet<String> params =
+        results.isEmpty()
+            ? new TreeSet<>()
+            : new TreeSet<>(results.iterator().next().getParams().getParamsKeys());
+
+    writer.write(
+        "\"Benchmark\",\"Mode\",\"Threads\",\"Samples\",\"Score\",\"Score Error (99.9% CI)\",\"Unit\"");
+
+    for (String param : params) {
+      writer.write(",\"Param: " + param + "\"");
+    }
+
+    writer.write(",\"Events/s\",\"Events/s Error (99.9% CI)\"");
+    writer.newLine();
+  }
+
+  private void writeDataRow(BufferedWriter writer, RunResult rr) throws IOException {
+    BenchmarkParams params = rr.getParams();
+    Result result = rr.getPrimaryResult();
+
+    // Calculate events/s and events/s error
+    String eventCountStr = params.getParam("eventCount");
+    double eventsPerSec = 0;
+    double eventsPerSecError = 0;
+    if (eventCountStr != null) {
+      int eventCount = Integer.parseInt(eventCountStr);
+      eventsPerSec = result.getScore() * eventCount;
+      eventsPerSecError = result.getScoreError() * eventCount;
+    }
+
+    // Write CSV row
+    // method name instead of full package
+    String methodName = params.getBenchmark().substring(params.getBenchmark().lastIndexOf('.') + 1);
+    writer.write(csvQuote(methodName));
+    writer.write(",");
+    writer.write(csvQuote(params.getMode().shortLabel()));
+    writer.write(",");
+    writer.write(String.valueOf(params.getThreads()));
+    writer.write(",");
+    writer.write(String.valueOf(result.getSampleCount()));
+    writer.write(",");
+    writer.write(String.format("%f", result.getScore()));
+    writer.write(",");
+    writer.write(String.format("%f", result.getScoreError()));
+    writer.write(",");
+    writer.write(csvQuote(result.getScoreUnit()));
+
+    // Write parameter values (quote if contains comma)
+    for (String paramKey : params.getParamsKeys()) {
+      writer.write(",");
+      String paramValue = params.getParam(paramKey);
+      if (paramValue != null) {
+        // Quote if contains comma (for values like "*,!relationships")
+        if (paramValue.contains(",")) {
+          writer.write("\"" + paramValue + "\"");
+        } else {
+          writer.write(paramValue);
+        }
+      }
+    }
+
+    // Write events/s and events/s error
+    writer.write(",");
+    writer.write(String.format("%.2f", eventsPerSec));
+    writer.write(",");
+    writer.write(String.format("%.2f", eventsPerSecError));
+    writer.newLine();
+  }
+
+  private String csvQuote(String value) {
+    if (value.contains(",")
+        || value.contains(" ")
+        || value.contains("\n")
+        || value.contains("\r")
+        || value.contains("\"")) {
+      return "\"" + value.replaceAll("\"", "\"\"") + "\"";
+    } else {
+      return "\"" + value + "\"";
+    }
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/FieldFilterSerializationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/FieldFilterSerializationTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import static org.hisp.dhis.test.webapi.Assertions.assertNoDiff;
+import static org.hisp.dhis.webapi.fields.FieldsConverter.PRESETS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.jsontree.JsonDiff.Mode;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsPropertyFilter;
+import org.hisp.dhis.tracker.export.fieldfiltering.SchemaFieldsPresets;
+import org.hisp.dhis.webapi.controller.tracker.view.DataValue;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.Note;
+import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
+import org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem;
+import org.hisp.dhis.webapi.controller.tracker.view.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * This test ensures that simple POJOs like Tracker view classes can be serialized and field
+ * filtered to JSON by Jackson. This test makes sure the filters Spring/Jackson configuration works
+ * and that the tracker field filtering is backwards compatible with the current {@link
+ * FieldFilterParser} and {@link FieldFilterService}.
+ */
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FieldFilterSerializationTest extends H2ControllerIntegrationTestBase {
+  private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+  private static final Instant DATE = Instant.parse("2023-03-15T14:30:45Z");
+
+  @Autowired private FieldFilterService fieldFilterService;
+
+  // use primary ObjectMapper from JacksonObjectMapperConfig to serialize the current ObjectNode to
+  // a JSON string
+  @Autowired private ObjectMapper objectMapper;
+
+  // use the filter ObjectMapper from FieldsConfig to serialize, filter and transform an Object to a
+  // JSON string
+  @Qualifier("jsonFilterMapper")
+  @Autowired
+  private ObjectMapper filterMapper;
+
+  @Autowired private SchemaService schemaService;
+  @Autowired private SchemaFieldsPresets schemaFieldsPresets;
+
+  private List<Event> events;
+
+  private Schema eventSchema;
+
+  @BeforeAll
+  void setUp() {
+    events = createEvents(2);
+    eventSchema = schemaService.getDynamicSchema(events.get(0).getClass());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "*",
+        ":all",
+        "!*",
+        "!:all", // should this be invalid? the exclusion is ignored and the preset is applied
+        ":simple",
+        "!event",
+        "event,dataValues",
+        "event,!dataValues",
+        "!dataValues",
+        "!dataValues[]", // behaves like !dataValues
+        // "!dataValues[value]", // bug in current field filter NPE Cannot invoke
+        // "org.hisp.dhis.fieldfiltering.FieldPath.getPath()" because "fieldPath" is null
+        // behaves like !dataValues in tracker filter
+        "dataValues,!dataValues",
+        "!dataValues,dataValues",
+        // this is opening a block without a field is a 400 in tracker filter but ignored in the
+        // current one
+        // http://localhost:8080/api/organisationUnits?pageSize=1&fields=[id]
+        // "[value]",
+        "event,!dataValues,*",
+        "dataValues[!value]",
+        "dataValues, ,dataValues[!value], ",
+        "dataValues,dataValues[!value,value)",
+        "dataValues,dataValues[value]",
+        "*,dataValues[value]",
+        "dataValues[value]",
+        "dataValues[value",
+        "dataValues[dataElement,!value]",
+        "dataValues::rename(values)[dataElement,!value]",
+        "event,*,dataValues[!value]",
+        "event,dataValues[dataElement,value]",
+        "event,dataValues[*,!storedBy]",
+        "event,dataValues[:all,!storedBy]",
+        "event,dataValues[!*,!storedBy]",
+        "event,dataValues[:simple,!storedBy]",
+        "event,dataValues[:simple,!storedBy,:all]",
+        "event,dataValues[!:all,!storedBy]",
+        "*,!enrollment",
+        "relationships,relationships[from]",
+        "relationships[!from]",
+        "relationships[  ]",
+        "relationships[relationship,unknownfield]",
+        // The current filter returns all if that field while the tracker filter returns {} as the
+        // field
+        // does not exist. The current behavior makes no sense as this suggests to a user that their
+        // fields
+        // input was correct.
+        // "relationships[unknownfield]",
+        "relationships[!unknownfield]",
+        "relationships[f rom[trackedEntity[ org Unit ]",
+        "relationships[from[trackedEntity[ :simple ]",
+        // transformations
+        "dataValues~isEmpty",
+        "dataValues|isEmpty",
+        "dataValues::isEmpty",
+        "notes::isEmpty",
+        "event::isEmpty",
+        "dataValues::isNotEmpty",
+        "notes::isNotEmpty",
+        "event::isNotEmpty",
+        "dataValues|rename(hasDataValues)~isEmpty", // rename must be applied last
+        "notes[:all,value~rename(text)]",
+        "notes::size",
+        "event::size",
+        "relationships[bidirectional::size]",
+        "dataValues::pluck",
+        "dataValues::pluck(value)",
+        "event::pluck",
+        // tracker does not have the field id which the key defaults to so this leads to {}
+        "dataValues~keyBy[dataElement,value]",
+        "dataValues~keyBy(dataElement)[dataElement,value]",
+        "dataValues~keyBy(dataElement)[!value,:all]",
+        // filtering is done before the transformation so this leads to {} as the key is filtered
+        // out
+        "dataValues~keyBy(dataElement)[!dataElement]",
+        "event::keyBy",
+      })
+  void trackerFilterShouldMatchCurrentFilterOnSimplePojo(String fields)
+      throws JsonProcessingException {
+    String actualCurrent = serializeUsingCurrentFilter(events, fields);
+    String actualTracker = serializeUsingTrackerFilter(events, fields);
+
+    assertEquals(actualCurrent, actualTracker);
+  }
+
+  /**
+   * Test rename transformations where tracker filter maintains natural field order while current
+   * filter ({@link FieldFilterService}) does not.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"*,event::rename(nonEvent)", "event::rename(nonEvent)"})
+  void trackerFilterShouldMatchCurrentFilterIgnoringFieldOrder(String fields)
+      throws JsonProcessingException {
+    String actualCurrent = serializeUsingCurrentFilter(events, fields);
+    String actualTracker = serializeUsingTrackerFilter(events, fields);
+
+    // Use JsonDiff with LENIENT mode to ignore field order differences
+    assertNoDiff(actualCurrent, actualTracker, Mode.LENIENT);
+  }
+
+  private String serializeUsingCurrentFilter(List<Event> events, String fields)
+      throws JsonProcessingException {
+    List<FieldPath> filter = FieldFilterParser.parse(fields);
+    List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(events, filter);
+    return objectMapper.writeValueAsString(objectNodes);
+  }
+
+  private String serializeUsingTrackerFilter(List<Event> events, String fieldsInput)
+      throws JsonProcessingException {
+    Fields fields =
+        FieldsParser.parse(fieldsInput, eventSchema, schemaFieldsPresets::getSchema, PRESETS);
+    return filterMapper
+        .writer()
+        .withAttribute(FieldsPropertyFilter.FIELDS_ATTRIBUTE, fields)
+        .writeValueAsString(events);
+  }
+
+  static List<Event> createEvents(int n) {
+    List<Event> events = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      events.add(createEvent());
+    }
+    return events;
+  }
+
+  private static Event createEvent() {
+    return Event.builder()
+        .event(UID.generate())
+        .program(UID.generate().getValue())
+        .programStage(UID.generate().getValue())
+        .enrollment(UID.generate())
+        .trackedEntity(UID.generate())
+        .orgUnit(UID.generate().getValue())
+        .relationships(
+            List.of(
+                Relationship.builder()
+                    .relationship(UID.generate())
+                    .relationshipName("Mother-Child")
+                    .relationshipType(UID.generate().getValue())
+                    .createdAt(DATE)
+                    .bidirectional(false)
+                    .from(
+                        RelationshipItem.builder()
+                            .trackedEntity(
+                                RelationshipItem.TrackedEntity.builder()
+                                    .trackedEntity(UID.generate())
+                                    .trackedEntityType(UID.generate().getValue())
+                                    .createdAt(DATE)
+                                    .orgUnit(UID.generate().getValue())
+                                    .build())
+                            .build())
+                    .to(
+                        RelationshipItem.builder()
+                            .trackedEntity(
+                                RelationshipItem.TrackedEntity.builder()
+                                    .trackedEntity(UID.generate())
+                                    .trackedEntityType(UID.generate().getValue())
+                                    .createdAt(DATE)
+                                    .orgUnit(UID.generate().getValue())
+                                    .build())
+                            .build())
+                    .build(),
+                Relationship.builder()
+                    .relationship(UID.generate())
+                    .relationshipName("Sibling")
+                    .relationshipType(UID.generate().getValue())
+                    .createdAt(DATE)
+                    .bidirectional(true)
+                    .from(
+                        RelationshipItem.builder()
+                            .event(
+                                RelationshipItem.Event.builder()
+                                    .event(UID.generate())
+                                    .program(UID.generate().getValue())
+                                    .programStage(UID.generate().getValue())
+                                    .orgUnit(UID.generate().getValue())
+                                    .occurredAt(DATE)
+                                    .createdAt(DATE)
+                                    .build())
+                            .build())
+                    .to(
+                        RelationshipItem.builder()
+                            .enrollment(
+                                RelationshipItem.Enrollment.builder()
+                                    .enrollment(UID.generate())
+                                    .program(UID.generate().getValue())
+                                    .orgUnit(UID.generate().getValue())
+                                    .enrolledAt(DATE)
+                                    .createdAt(DATE)
+                                    .build())
+                            .build())
+                    .build()))
+        .scheduledAt(DATE)
+        .storedBy("fred")
+        .followUp(true)
+        .createdAt(DATE)
+        .attributeOptionCombo(UID.generate().getValue())
+        .attributeCategoryOptions(UID.generate().getValue())
+        .geometry(GEOMETRY_FACTORY.createPoint(new Coordinate(4, 12)))
+        .createdBy(
+            User.builder()
+                .uid(UID.generate().getValue())
+                .username("fred")
+                .displayName("Freddy")
+                .build())
+        .dataValues(
+            Set.of(
+                DataValue.builder()
+                    .dataElement(UID.generate().getValue())
+                    .value("14")
+                    .storedBy("alice")
+                    .build(),
+                DataValue.builder()
+                    .dataElement(UID.generate().getValue())
+                    .value("78")
+                    .storedBy("bob")
+                    .build()))
+        .notes(List.of(Note.builder().note(UID.generate()).value("lovely note").build()))
+        .build();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/SimpleBenchmarkExample.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/SimpleBenchmarkExample.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Simple JMH benchmark example to demonstrate working JMH setup in DHIS2.
+ *
+ * <p>This example shows how to: 1. Set up JMH benchmarks in the DHIS2 project structure 2. Use
+ * parameterized benchmarks 3. Create synthetic data for testing 4. Run benchmarks both in IDE and
+ * via Maven CLI
+ *
+ * <p>To run this benchmark: - In IDE: Ensure JMH profile is active, then run main() method - Maven
+ * CLI: mvn clean compile test-compile -Pjmh && java -cp "$(mvn dependency:build-classpath -q
+ * -Dmdep.outputFile=/dev/stdout -Pjmh):target/test-classes"
+ * org.hisp.dhis.webapi.controller.tracker.SimpleBenchmarkExample
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class SimpleBenchmarkExample {
+
+  @Param({"100", "1000", "10000"})
+  private int listSize;
+
+  private List<String> testData;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    testData = new ArrayList<>(listSize);
+    for (int i = 0; i < listSize; i++) {
+      testData.add("item-" + i);
+    }
+  }
+
+  @Benchmark
+  public int benchmarkArrayListIteration() {
+    int sum = 0;
+    for (String item : testData) {
+      sum += item.length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int benchmarkArrayListIndexAccess() {
+    int sum = 0;
+    for (int i = 0; i < testData.size(); i++) {
+      sum += testData.get(i).length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public long benchmarkStreamOperations() {
+    return testData.stream().mapToInt(String::length).sum();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt =
+        new OptionsBuilder()
+            .include(SimpleBenchmarkExample.class.getSimpleName())
+            .jvmArgs("-Xmx1g")
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/PageTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/PageTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -81,7 +80,8 @@ class PageTest {
             exportPage,
             "http://localhost/organisationUnits?page=1&pageSize=3&fields=displayName");
 
-    assertEquals(Map.of("fruits", fruits), page.getItems());
+    assertEquals("fruits", page.getKey());
+    assertEquals(fruits, page.getItems());
 
     assertEquals(1, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
@@ -105,7 +105,8 @@ class PageTest {
             exportPage,
             "http://localhost/organisationUnits?page=2&pageSize=3&fields=displayName");
 
-    assertEquals(Map.of("fruits", fruits), page.getItems());
+    assertEquals("fruits", page.getKey());
+    assertEquals(fruits, page.getItems());
 
     assertEquals(2, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
@@ -134,7 +135,8 @@ class PageTest {
             exportPage,
             "http://localhost/organisationUnits?page=1&pageSize=3&fields=displayName");
 
-    assertEquals(Map.of("fruits", List.of("apple", "banana", "cherry")), page.getItems());
+    assertEquals("fruits", page.getKey());
+    assertEquals(List.of("apple", "banana", "cherry"), page.getItems());
 
     assertEquals(1, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -155,11 +155,12 @@ class EnrollmentsExportControllerTest extends PostgresControllerIntegrationTestB
   void getEnrollmentByIdWithFields(BiFunction<Enrollment, String, JsonEnrollment> getEnrollment) {
     Enrollment enrollment = get(Enrollment.class, "TvctPPhpD8z");
 
-    JsonEnrollment jsonEnrollment = getEnrollment.apply(enrollment, "orgUnit,status");
+    JsonEnrollment jsonEnrollment =
+        getEnrollment.apply(enrollment, "orgUnit,status::rename(state)");
 
-    assertHasOnlyMembers(jsonEnrollment, "orgUnit", "status");
+    assertHasOnlyMembers(jsonEnrollment, "orgUnit", "state");
     assertEquals(enrollment.getOrganisationUnit().getUid(), jsonEnrollment.getOrgUnit());
-    assertEquals(enrollment.getStatus().toString(), jsonEnrollment.getStatus());
+    assertEquals(enrollment.getStatus().toString(), jsonEnrollment.getString("state").string());
   }
 
   @ParameterizedTest

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerUnitTest.java
@@ -68,8 +68,7 @@ class EnrollmentsExportControllerUnitTest {
 
     Exception exception =
         assertThrows(
-            IllegalStateException.class,
-            () -> new EnrollmentsExportController(enrollmentService, paramsMapper, null, null));
+            IllegalStateException.class, () -> new EnrollmentsExportController(enrollmentService));
 
     assertAll(
         () ->

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -34,9 +34,11 @@ import static org.hisp.dhis.security.Authorities.ALL;
 import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertPagerLink;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -363,6 +365,17 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
 
     assertIsEmpty(dataValueChangeLogs);
     assertIsEmpty(eventFieldChangeLogs);
+  }
+
+  @Test
+  void shouldGetEventChangeLogsWithSimpleFieldsFilter() {
+    JsonList<JsonEventChangeLog> changeLogs =
+        GET("/tracker/events/{id}/changeLogs?fields=:simple", event.getUid())
+            .content(HttpStatus.OK)
+            .getList("changeLogs", JsonEventChangeLog.class);
+
+    assertFalse(changeLogs.isEmpty(), "should have some change logs");
+    assertHasOnlyMembers(changeLogs.get(0), "createdAt", "type");
   }
 
   private void updateDataValue(String value) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -215,13 +215,13 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     switchContextToUser(user);
 
     JsonEvent jsonEvent =
-        GET("/tracker/events/{id}?fields=orgUnit,status", event.getUid())
+        GET("/tracker/events/{id}?fields=orgUnit,status::rename(state)", event.getUid())
             .content(HttpStatus.OK)
             .as(JsonEvent.class);
 
-    assertHasOnlyMembers(jsonEvent, "orgUnit", "status");
+    assertHasOnlyMembers(jsonEvent, "orgUnit", "state");
     assertEquals(event.getOrganisationUnit().getUid(), jsonEvent.getOrgUnit());
-    assertEquals(event.getStatus().toString(), jsonEvent.getStatus());
+    assertEquals(event.getStatus().toString(), jsonEvent.getString("state").string());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
@@ -68,7 +68,7 @@ class EventsExportControllerUnitTest {
     Exception exception =
         assertThrows(
             IllegalStateException.class,
-            () -> new EventsExportController(eventService, null, null, null, null, null, null));
+            () -> new EventsExportController(eventService, null, null, null));
 
     assertAll(
         () -> assertStartsWith("event controller supports ordering by", exception.getMessage()),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerUnitTest.java
@@ -51,8 +51,6 @@ class RelationshipsExportControllerUnitTest {
 
   @Mock private RelationshipService relationshipService;
 
-  @Mock private RelationshipRequestParamsMapper paramsMapper;
-
   @Test
   void shouldFailInstantiatingControllerIfAnyOrderableFieldIsUnsupported() {
     // pretend the service does not support 2 of the orderable fields the web advocates
@@ -67,7 +65,7 @@ class RelationshipsExportControllerUnitTest {
     Exception exception =
         assertThrows(
             IllegalStateException.class,
-            () -> new RelationshipsExportController(relationshipService, paramsMapper, null, null));
+            () -> new RelationshipsExportController(relationshipService));
 
     assertAll(
         () ->

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesChangeLogsControllerTest.java
@@ -33,14 +33,17 @@ import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -262,6 +265,17 @@ class TrackedEntitiesChangeLogsControllerTest extends PostgresControllerIntegrat
     List<JsonTrackedEntityChangeLog> changeLogs = getChangeLogs(trackedEntityAttribute);
 
     assertNumberOfChanges(0, changeLogs);
+  }
+
+  @Test
+  void shouldGetTrackedEntityChangeLogsWithSimpleFieldsFilter() {
+    JsonList<JsonTrackedEntityChangeLog> changeLogs =
+        GET("/tracker/trackedEntities/{id}/changeLogs?fields=:simple", trackedEntity.getUid())
+            .content(HttpStatus.OK)
+            .getList("changeLogs", JsonTrackedEntityChangeLog.class);
+
+    assertFalse(changeLogs.isEmpty(), "should have some change logs");
+    assertHasOnlyMembers(changeLogs.get(0), "createdAt", "type");
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -269,13 +269,15 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
     TrackedEntity te = get(TrackedEntity.class, "QS6w44flWAf");
 
     JsonTrackedEntity json =
-        GET("/tracker/trackedEntities/{id}?fields=trackedEntityType,orgUnit", te.getUid())
+        GET(
+                "/tracker/trackedEntities/{id}?fields=trackedEntityType,orgUnit::rename(org)",
+                te.getUid())
             .content(HttpStatus.OK)
             .as(JsonTrackedEntity.class);
 
-    assertHasOnlyMembers(json, "trackedEntityType", "orgUnit");
+    assertHasOnlyMembers(json, "trackedEntityType", "org");
     assertEquals(te.getTrackedEntityType().getUid(), json.getTrackedEntityType());
-    assertEquals(te.getOrganisationUnit().getUid(), json.getOrgUnit());
+    assertEquals(te.getOrganisationUnit().getUid(), json.getString("org").string());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
@@ -66,9 +66,7 @@ class TrackedEntitiesExportControllerUnitTest {
     Exception exception =
         assertThrows(
             IllegalStateException.class,
-            () ->
-                new TrackedEntitiesExportController(
-                    trackedEntityService, null, null, null, null, null));
+            () -> new TrackedEntitiesExportController(trackedEntityService, null, null, null));
 
     assertAll(
         () ->

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/fields/FieldsConverterTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/fields/FieldsConverterTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.fields;
+
+import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.SchemaFieldsPresets;
+import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/** Tests {@link FieldsConverter} handles repeated {@code fields} request parameters correctly. */
+class FieldsConverterTest {
+  private MockMvc mockMvc;
+  private SchemaService schemaService;
+
+  record ExpectField(boolean included, String dotPath) {}
+
+  static class ClassEntity {}
+
+  static class MethodEntity {}
+
+  @BeforeEach
+  void setUp() {
+    List<ExpectField> expected =
+        List.of(
+            new ExpectField(true, "attributes"),
+            new ExpectField(true, "attributes.attribute"),
+            new ExpectField(true, "attributes.value"),
+            new ExpectField(true, "deleted"));
+
+    DefaultFormattingConversionService formattingConversionService =
+        new DefaultFormattingConversionService();
+
+    Schema classSchema = new Schema(ClassEntity.class, "classEntity", "classEntities");
+    Schema methodSchema = new Schema(MethodEntity.class, "methodEntity", "methodEntities");
+    schemaService = mock(SchemaService.class);
+    when(schemaService.getDynamicSchema(ClassEntity.class)).thenReturn(classSchema);
+    when(schemaService.getDynamicSchema(MethodEntity.class)).thenReturn(methodSchema);
+
+    SchemaFieldsPresets schemaFieldsPresets = new SchemaFieldsPresets(schemaService);
+    formattingConversionService.addConverter(
+        new FieldsConverter(schemaService, schemaFieldsPresets));
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(
+                new FieldsController(expected), new NonAnnotatedFieldsController())
+            .setConversionService(formattingConversionService)
+            .build();
+  }
+
+  @Test
+  void shouldConvertFieldsGivenASingleRequestParameter() throws Exception {
+    mockMvc
+        .perform(get("/testFields").param("fields", "attributes[attribute,value],deleted"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(""));
+
+    verify(schemaService).getDynamicSchema(ClassEntity.class);
+  }
+
+  @Test
+  void shouldConvertFieldsGivenMultipleRequestParameters() throws Exception {
+    mockMvc
+        .perform(
+            get("/testFields")
+                .param("fields", "attributes[attribute]")
+                .param("fields", "attributes[value]")
+                .param("fields", "deleted"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(""));
+
+    verify(schemaService).getDynamicSchema(ClassEntity.class);
+  }
+
+  @Test
+  void shouldConvertFieldsUsingMethodLevelEntityType() throws Exception {
+    mockMvc
+        .perform(get("/testMethodFields").param("fields", "attributes[attribute,value],deleted"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(""));
+
+    verify(schemaService).getDynamicSchema(MethodEntity.class);
+  }
+
+  @Test
+  void shouldFailIfControllerClassAndMethodHaveNoEntityType() throws Exception {
+    mockMvc
+        .perform(
+            get("/testFieldsNotAnnotated").param("fields", "attributes[attribute,value],deleted"))
+        .andExpect(status().isOk())
+        .andExpect(
+            result -> {
+              String content = result.getResponse().getContentAsString();
+              assertContains("Cannot convert fields without @OpenApi.EntityType", content);
+            });
+  }
+
+  @Controller
+  @OpenApi.EntityType(ClassEntity.class)
+  @RequiredArgsConstructor
+  private static class FieldsController extends CrudControllerAdvice {
+    private final List<ExpectField> expected;
+
+    @GetMapping("/testFields")
+    public @ResponseBody String get(@RequestParam(defaultValue = "*") Fields fields) {
+      assertFields(expected, fields);
+      return "";
+    }
+
+    @GetMapping("/testMethodFields")
+    @OpenApi.EntityType(MethodEntity.class)
+    public @ResponseBody String getMethodLevel(@RequestParam(defaultValue = "*") Fields fields) {
+      assertFields(expected, fields);
+      return "";
+    }
+  }
+
+  @Controller
+  @RequiredArgsConstructor
+  private static class NonAnnotatedFieldsController extends CrudControllerAdvice {
+    @GetMapping("/testFieldsNotAnnotated")
+    public @ResponseBody String get(@RequestParam(defaultValue = "*") Fields fields) {
+      return "";
+    }
+  }
+
+  public static void assertFields(List<ExpectField> expectFields, Fields fields) {
+    for (ExpectField expectField : expectFields) {
+      assertField(expectField, fields);
+    }
+  }
+
+  /**
+   * Tests if the field represented by the full path as used by the current FieldFilterParser is
+   * included in the parsed fields predicate.
+   */
+  private static void assertField(ExpectField expected, Fields fields) {
+    String what = expected.included ? "includes" : "exclude";
+    assertEquals(
+        expected.included,
+        fields.includes(expected.dotPath),
+        "fields " + fields + " does not " + what + " " + expected.dotPath);
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestHandler.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/RequestHandler.java
@@ -29,24 +29,18 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
-import static org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler.getRequestURL;
 import static org.hisp.dhis.webapi.utils.HeaderUtils.X_CONTENT_TYPE_OPTIONS_VALUE;
 import static org.hisp.dhis.webapi.utils.HeaderUtils.X_XSS_PROTECTION_VALUE;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.FileResourceStream.Content;
 import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
-import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.utils.ResponseEntityUtils;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.CacheControl;
@@ -60,16 +54,8 @@ import org.springframework.stereotype.Component;
  * Handles common tracker requests like
  *
  * <ul>
- *   <li>serving `fields` filtered JSON
  *   <li>serving files and images given a {@link FileResourceStream}
  * </ul>
- *
- * <p>The tracker equivalent for serving `fields` filtered JSON is {@link
- * org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController#getObjectListInternal}. Tracker
- * can currently not reuse the {@link org.hisp.dhis.common.Pager} as not all tracker endpoints
- * support or should support getting totals. Tracker exporters also do not return totals by default.
- * Metadata does not allow disabling totals. This is the reason why we are not reusing the {@code
- * StreamingJsonRoot}.
  */
 @Component
 @RequiredArgsConstructor
@@ -78,8 +64,6 @@ public class RequestHandler {
       CacheControl.noCache().cachePrivate();
 
   private final DhisConfigurationProvider dhisConfig;
-
-  private final FieldFilterService fieldFilterService;
 
   public ResponseEntity<InputStreamResource> serve(
       HttpServletRequest request, FileResourceStream file)
@@ -109,32 +93,5 @@ public class RequestHandler {
             HttpHeaders.CONTENT_DISPOSITION, ResponseHeader.contentDispositionInline(file.name()))
         .contentLength(content.length())
         .body(new InputStreamResource(content.stream()));
-  }
-
-  public <T> ResponseEntity<Page<ObjectNode>> serve(
-      HttpServletRequest request,
-      String key,
-      org.hisp.dhis.tracker.Page<T> page,
-      FieldsRequestParam fieldParams) {
-    return ResponseEntity.ok()
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(
-            Page.withPager(
-                key,
-                page.withMappedItems(
-                    i -> fieldFilterService.toObjectNode(i, fieldParams.getFields())),
-                getRequestURL(request)));
-  }
-
-  public <T> ResponseEntity<Page<ObjectNode>> serve(
-      String key, List<T> items, FieldsRequestParam fieldsParam) {
-    List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(items, fieldsParam.getFields());
-    return ResponseEntity.ok()
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(Page.withoutPager(key, objectNodes));
-  }
-
-  public <T> ResponseEntity<ObjectNode> serve(T item, List<FieldPath> fields) {
-    return ResponseEntity.ok(fieldFilterService.toObjectNode(item, fields));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/PotentialDuplicateRequestParams.java
@@ -35,9 +35,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.deduplication.DeduplicationStatus;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
@@ -112,5 +112,5 @@ unnecessary fields from the JSON response and in some cases decrease the respons
 on how to use it.
 """)
   @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ChangeLogRequestParams.java
@@ -34,8 +34,8 @@ import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
@@ -83,7 +83,7 @@ unnecessary fields from the JSON response and in some cases decrease the respons
 [metadata field filter](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter)
 on how to use it.
 """)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
 """

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -38,14 +38,14 @@ import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
@@ -59,6 +59,7 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @NoArgsConstructor
 public class EnrollmentRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!events,!attributes";
+  static final Fields DEFAULT_FIELDS_PARAM_PARSED = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
 """
@@ -132,5 +133,5 @@ will take more time to return.**
   private boolean includeDeleted = false;
 
   @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = DEFAULT_FIELDS_PARAM_PARSED;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -31,10 +31,10 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler.getRequestURL;
 import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.EnrollmentRequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -44,27 +44,27 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentFields;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.webapi.controller.tracker.RequestHandler;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredPage;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.EntityType(Enrollment.class)
+@OpenApi.EntityType(org.hisp.dhis.webapi.controller.tracker.view.Enrollment.class)
 @OpenApi.Document(
-    entity = org.hisp.dhis.program.Enrollment.class,
+    entity = org.hisp.dhis.webapi.controller.tracker.view.Enrollment.class,
     classifiers = {"team:tracker", "purpose:data"})
 @RestController
 @RequestMapping("/api/tracker/enrollments")
@@ -77,21 +77,8 @@ class EnrollmentsExportController {
 
   private final EnrollmentService enrollmentService;
 
-  private final EnrollmentRequestParamsMapper paramsMapper;
-
-  private final RequestHandler requestHandler;
-
-  private final FieldFilterService fieldFilterService;
-
-  public EnrollmentsExportController(
-      EnrollmentService enrollmentService,
-      EnrollmentRequestParamsMapper paramsMapper,
-      RequestHandler requestHandler,
-      FieldFilterService fieldFilterService) {
+  public EnrollmentsExportController(EnrollmentService enrollmentService) {
     this.enrollmentService = enrollmentService;
-    this.paramsMapper = paramsMapper;
-    this.requestHandler = requestHandler;
-    this.fieldFilterService = fieldFilterService;
 
     assertUserOrderableFieldsAreSupported(
         "enrollment", EnrollmentMapper.ORDERABLE_FIELDS, enrollmentService.getOrderableFields());
@@ -104,11 +91,11 @@ class EnrollmentsExportController {
       // use the text/html Accept header to default to a Json response when a generic request comes
       // from a browser
       )
-  ResponseEntity<Page<ObjectNode>> getEnrollments(
+  FilteredPage<Enrollment> getEnrollments(
       EnrollmentRequestParams requestParams, HttpServletRequest request)
       throws BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);
-    EnrollmentOperationParams operationParams = paramsMapper.map(requestParams);
+    EnrollmentOperationParams operationParams = EnrollmentRequestParamsMapper.map(requestParams);
 
     if (requestParams.isPaging()) {
       PageParams pageParams =
@@ -120,7 +107,8 @@ class EnrollmentsExportController {
       org.hisp.dhis.tracker.Page<Enrollment> page =
           enrollmentsPage.withMappedItems(ENROLLMENT_MAPPER::map);
 
-      return requestHandler.serve(request, ENROLLMENTS, page, requestParams);
+      return new FilteredPage<>(
+          Page.withPager(ENROLLMENTS, page, getRequestURL(request)), requestParams.getFields());
     }
 
     List<Enrollment> enrollments =
@@ -128,24 +116,23 @@ class EnrollmentsExportController {
             .map(ENROLLMENT_MAPPER::map)
             .toList();
 
-    return requestHandler.serve(ENROLLMENTS, enrollments, requestParams);
+    return new FilteredPage<>(
+        Page.withoutPager(ENROLLMENTS, enrollments), requestParams.getFields());
   }
 
   @OpenApi.Response(OpenApi.EntityType.class)
   @GetMapping(value = "/{uid}")
-  public ResponseEntity<ObjectNode> getEnrollmentByUid(
+  public FilteredEntity<Enrollment> getEnrollmentByUid(
       @OpenApi.Param({UID.class, org.hisp.dhis.program.Enrollment.class}) @PathVariable UID uid,
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
-          List<FieldPath> fields)
+          Fields fields)
       throws NotFoundException {
     EnrollmentFields enrollmentFields =
-        EnrollmentFields.of(
-            f -> fieldFilterService.filterIncludes(Enrollment.class, fields, f),
-            FieldPath.FIELD_PATH_SEPARATOR);
+        EnrollmentFields.of(fields::includes, FieldPath.FIELD_PATH_SEPARATOR);
 
     Enrollment enrollment =
         ENROLLMENT_MAPPER.map(enrollmentService.getEnrollment(uid, enrollmentFields));
 
-    return requestHandler.serve(enrollment, fields);
+    return new FilteredEntity<>(enrollment, fields);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -42,8 +42,6 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -51,6 +49,8 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
@@ -69,6 +69,7 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @NoArgsConstructor
 public class EventRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
+  static final Fields DEFAULT_FIELDS_PARAM_PARSED = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
 """
@@ -178,5 +179,5 @@ will take more time to return.**
   private Set<UID> enrollments = new HashSet<>();
 
   @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = DEFAULT_FIELDS_PARAM_PARSED;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -40,14 +40,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -56,23 +54,21 @@ import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
-import org.springframework.stereotype.Component;
 
 /**
  * Maps query parameters from {@link EventsExportController} stored in {@link EventRequestParams} to
  * {@link EventOperationParams} which is used to fetch events from the DB.
  */
-@Component
-@RequiredArgsConstructor
 class EventRequestParamsMapper {
   private static final Set<String> ORDERABLE_FIELD_NAMES = EventMapper.ORDERABLE_FIELDS.keySet();
 
-  private final FieldFilterService fieldFilterService;
+  private EventRequestParamsMapper() {
+    throw new IllegalStateException("Utility class");
+  }
 
-  public EventOperationParams map(
+  public static EventOperationParams map(
       EventRequestParams eventRequestParams, TrackerIdSchemeParams idSchemeParams)
       throws BadRequestException {
     OrganisationUnitSelectionMode orgUnitMode =
@@ -143,10 +139,7 @@ class EventRequestParamsMapper {
             .includeDeleted(eventRequestParams.isIncludeDeleted())
             .fields(
                 EventFields.of(
-                    f ->
-                        fieldFilterService.filterIncludes(
-                            Event.class, eventRequestParams.getFields(), f),
-                    FieldPath.FIELD_PATH_SEPARATOR))
+                    eventRequestParams.getFields()::includes, FieldPath.FIELD_PATH_SEPARATOR))
             .idSchemeParams(idSchemeParams);
 
     mapOrderParam(builder, eventRequestParams.getOrder());
@@ -162,7 +155,8 @@ class EventRequestParamsMapper {
     }
   }
 
-  private void mapOrderParam(EventOperationParamsBuilder builder, List<OrderCriteria> orders) {
+  private static void mapOrderParam(
+      EventOperationParamsBuilder builder, List<OrderCriteria> orders) {
     if (orders == null || orders.isEmpty()) {
       return;
     }
@@ -176,7 +170,7 @@ class EventRequestParamsMapper {
     }
   }
 
-  private void mapDataElementFilterParam(
+  private static void mapDataElementFilterParam(
       EventOperationParamsBuilder builder, Map<UID, List<QueryFilter>> dataElementFilters) {
     if (dataElementFilters == null || dataElementFilters.isEmpty()) {
       return;
@@ -191,7 +185,7 @@ class EventRequestParamsMapper {
     }
   }
 
-  private void mapAttributeFilterParam(
+  private static void mapAttributeFilterParam(
       EventOperationParamsBuilder builder, Map<UID, List<QueryFilter>> attributeFilters) {
     if (attributeFilters == null || attributeFilters.isEmpty()) {
       return;
@@ -206,7 +200,7 @@ class EventRequestParamsMapper {
     }
   }
 
-  private void validateUpdateDurationParams(EventRequestParams eventRequestParams)
+  private static void validateUpdateDurationParams(EventRequestParams eventRequestParams)
       throws BadRequestException {
     if (eventRequestParams.getUpdatedWithin() != null
         && (eventRequestParams.getUpdatedAfter() != null

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParams.java
@@ -35,11 +35,11 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
 import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
@@ -51,6 +51,7 @@ import org.hisp.dhis.webapi.controller.tracker.PageRequestParams;
 public class RelationshipRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM =
       "relationship,relationshipType,createdAtClient,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
+  static final Fields DEFAULT_FIELDS_PARAM_PARSED = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
 """
@@ -96,7 +97,7 @@ will take more time to return.**
   private UID event;
 
   @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = DEFAULT_FIELDS_PARAM_PARSED;
 
   private boolean includeDeleted;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
@@ -38,34 +38,30 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.relationship.RelationshipFields;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams.RelationshipOperationParamsBuilder;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
-import org.springframework.stereotype.Component;
 
 /**
  * Maps operation parameters from {@link RelationshipsExportController} stored in {@link
  * RelationshipRequestParams} to {@link RelationshipOperationParams} which is used to fetch
  * relationships from the service.
  */
-@Component
-@RequiredArgsConstructor
 class RelationshipRequestParamsMapper {
   private static final Set<String> ORDERABLE_FIELD_NAMES =
       RelationshipMapper.ORDERABLE_FIELDS.keySet();
 
-  private final FieldFilterService fieldFilterService;
+  private RelationshipRequestParamsMapper() {
+    throw new IllegalStateException("Utility class");
+  }
 
-  public RelationshipOperationParams map(RelationshipRequestParams relationshipRequestParams)
+  public static RelationshipOperationParams map(RelationshipRequestParams relationshipRequestParams)
       throws BadRequestException {
     UID trackedEntity = relationshipRequestParams.getTrackedEntity();
 
@@ -95,15 +91,12 @@ class RelationshipRequestParamsMapper {
     return builder
         .fields(
             RelationshipFields.of(
-                f ->
-                    fieldFilterService.filterIncludes(
-                        Relationship.class, relationshipRequestParams.getFields(), f),
-                FieldPath.FIELD_PATH_SEPARATOR))
+                relationshipRequestParams.getFields()::includes, FieldPath.FIELD_PATH_SEPARATOR))
         .includeDeleted(relationshipRequestParams.isIncludeDeleted())
         .build();
   }
 
-  private TrackerType getTrackerType(UID trackedEntity, UID enrollment, UID event)
+  private static TrackerType getTrackerType(UID trackedEntity, UID enrollment, UID event)
       throws BadRequestException {
     if (Objects.nonNull(trackedEntity)) {
       return TRACKED_ENTITY;
@@ -116,11 +109,11 @@ class RelationshipRequestParamsMapper {
         "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.");
   }
 
-  private boolean hasMoreThanOneNotNull(Object... values) {
+  private static boolean hasMoreThanOneNotNull(Object... values) {
     return Stream.of(values).filter(Objects::nonNull).count() > 1;
   }
 
-  private void mapOrderParam(
+  private static void mapOrderParam(
       RelationshipOperationParamsBuilder builder, List<OrderCriteria> orders) {
     if (orders == null || orders.isEmpty()) {
       return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -32,10 +32,10 @@ package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler.getRequestURL;
 import static org.hisp.dhis.webapi.controller.tracker.export.relationship.RelationshipRequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -44,27 +44,27 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.PageParams;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
 import org.hisp.dhis.tracker.export.relationship.RelationshipFields;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
-import org.hisp.dhis.webapi.controller.tracker.RequestHandler;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredPage;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.EntityType(org.hisp.dhis.relationship.Relationship.class)
+@OpenApi.EntityType(org.hisp.dhis.webapi.controller.tracker.view.Relationship.class)
 @OpenApi.Document(
-    entity = org.hisp.dhis.relationship.Relationship.class,
+    entity = org.hisp.dhis.webapi.controller.tracker.view.Relationship.class,
     classifiers = {"team:tracker", "purpose:data"})
 @RestController
 @RequestMapping(produces = APPLICATION_JSON_VALUE, value = "/api/tracker/relationships")
@@ -78,21 +78,8 @@ class RelationshipsExportController {
 
   private final RelationshipService relationshipService;
 
-  private final RelationshipRequestParamsMapper mapper;
-
-  private final RequestHandler requestHandler;
-
-  private final FieldFilterService fieldFilterService;
-
-  public RelationshipsExportController(
-      RelationshipService relationshipService,
-      RelationshipRequestParamsMapper mapper,
-      RequestHandler requestHandler,
-      FieldFilterService fieldFilterService) {
+  public RelationshipsExportController(RelationshipService relationshipService) {
     this.relationshipService = relationshipService;
-    this.requestHandler = requestHandler;
-    this.mapper = mapper;
-    this.fieldFilterService = fieldFilterService;
 
     assertUserOrderableFieldsAreSupported(
         "relationship",
@@ -107,11 +94,12 @@ class RelationshipsExportController {
       // use the text/html Accept header to default to a Json response when a generic request comes
       // from a browser
       )
-  ResponseEntity<Page<ObjectNode>> getRelationships(
+  FilteredPage<Relationship> getRelationships(
       RelationshipRequestParams requestParams, HttpServletRequest request)
       throws NotFoundException, BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);
-    RelationshipOperationParams operationParams = mapper.map(requestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(requestParams);
 
     if (requestParams.isPaging()) {
       PageParams pageParams =
@@ -123,7 +111,8 @@ class RelationshipsExportController {
       org.hisp.dhis.tracker.Page<Relationship> page =
           relationshipsPage.withMappedItems(RELATIONSHIP_MAPPER::map);
 
-      return requestHandler.serve(request, RELATIONSHIPS, page, requestParams);
+      return new FilteredPage<>(
+          Page.withPager(RELATIONSHIPS, page, getRequestURL(request)), requestParams.getFields());
     }
 
     List<Relationship> relationships =
@@ -131,25 +120,24 @@ class RelationshipsExportController {
             .map(RELATIONSHIP_MAPPER::map)
             .toList();
 
-    return requestHandler.serve(RELATIONSHIPS, relationships, requestParams);
+    return new FilteredPage<>(
+        Page.withoutPager(RELATIONSHIPS, relationships), requestParams.getFields());
   }
 
   @GetMapping("/{uid}")
   @OpenApi.Response(Relationship.class)
-  ResponseEntity<ObjectNode> getRelationshipByUid(
+  FilteredEntity<Relationship> getRelationshipByUid(
       @OpenApi.Param({UID.class, org.hisp.dhis.relationship.Relationship.class}) @PathVariable
           UID uid,
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
-          List<FieldPath> fields)
+          Fields fields)
       throws NotFoundException, ForbiddenException {
     RelationshipFields relationshipFields =
-        RelationshipFields.of(
-            f -> fieldFilterService.filterIncludes(Relationship.class, fields, f),
-            FieldPath.FIELD_PATH_SEPARATOR);
+        RelationshipFields.of(fields::includes, FieldPath.FIELD_PATH_SEPARATOR);
 
     Relationship relationship =
         RELATIONSHIP_MAPPER.map(relationshipService.getRelationship(uid, relationshipFields));
 
-    return requestHandler.serve(relationship, fields);
+    return new FilteredEntity<>(relationship, fields);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validatePaginationParameters;
 import static org.hisp.dhis.webapi.controller.tracker.RequestParamsValidator.validateUnsupportedParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler.getRequestURL;
 import static org.hisp.dhis.webapi.controller.tracker.export.MappingErrors.ensureNoMappingErrors;
 import static org.hisp.dhis.webapi.controller.tracker.export.trackedentity.TrackedEntityRequestParams.DEFAULT_FIELDS_PARAM;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
@@ -41,7 +42,6 @@ import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_ZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_TEXT_CSV;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -56,13 +56,13 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLog;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
@@ -76,6 +76,8 @@ import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.MappingErrors;
 import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredPage;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -89,9 +91,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.EntityType(TrackedEntity.class)
+@OpenApi.EntityType(org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity.class)
 @OpenApi.Document(
-    entity = org.hisp.dhis.trackedentity.TrackedEntity.class,
+    entity = org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity.class,
     classifiers = {"team:tracker", "purpose:data"})
 @RestController
 @RequestMapping("/api/tracker/trackedEntities")
@@ -101,13 +103,13 @@ class TrackedEntitiesExportController {
   protected static final String TRACKED_ENTITIES = "trackedEntities";
 
   /**
-   * Fields we need to fetch from the DB to fulfill requests for CSV. CSV cannot be filtered using
-   * the {@link FieldFilterService} so <code>fields</code> query parameter is ignored when CSV is
-   * requested. Make sure this is kept in sync with the columns we promise to return in the CSV. See
-   * {@link CsvTrackedEntity}.
+   * Fields we need to fetch from the DB to fulfill requests for CSV. CSV cannot be filtered by
+   * field filtering so <code>fields</code> query parameter is ignored when CSV is requested. Make
+   * sure this is kept in sync with the columns we promise to return in the CSV. See {@link
+   * CsvTrackedEntity}.
    */
-  private static final List<FieldPath> CSV_FIELDS =
-      FieldFilterParser.parse(
+  private static final Fields CSV_FIELDS =
+      FieldsParser.parse(
           "trackedEntity,trackedEntityType,createdAt,createdAtClient,updatedAt,updatedAtClient,orgUnit,inactive,deleted,potentialDuplicate,geometry,storedBy,createdBy,updatedBy,attributes");
 
   private static final TrackedEntityMapper TRACKED_ENTITY_MAPPER =
@@ -124,28 +126,20 @@ class TrackedEntitiesExportController {
 
   private final TrackedEntityService trackedEntityService;
 
-  private final TrackedEntityRequestParamsMapper paramsMapper;
-
   private final CsvService<TrackedEntity> entityCsvService;
 
   private final RequestHandler requestHandler;
-
-  private final FieldFilterService fieldFilterService;
 
   private final TrackedEntityChangeLogService trackedEntityChangeLogService;
 
   public TrackedEntitiesExportController(
       TrackedEntityService trackedEntityService,
-      TrackedEntityRequestParamsMapper paramsMapper,
       CsvService<TrackedEntity> csvEventService,
       RequestHandler requestHandler,
-      FieldFilterService fieldFilterService,
       TrackedEntityChangeLogService trackedEntityChangeLogService) {
     this.trackedEntityService = trackedEntityService;
-    this.paramsMapper = paramsMapper;
     this.entityCsvService = csvEventService;
     this.requestHandler = requestHandler;
-    this.fieldFilterService = fieldFilterService;
     this.trackedEntityChangeLogService = trackedEntityChangeLogService;
 
     assertUserOrderableFieldsAreSupported(
@@ -161,14 +155,15 @@ class TrackedEntitiesExportController {
       // use the text/html Accept header to default to a Json response when a generic request comes
       // from a browser
       )
-  ResponseEntity<Page<ObjectNode>> getTrackedEntities(
+  FilteredPage<TrackedEntity> getTrackedEntities(
       TrackedEntityRequestParams requestParams,
       TrackerIdSchemeParams idSchemeParams,
       @CurrentUser UserDetails currentUser,
       HttpServletRequest request)
       throws BadRequestException, ForbiddenException, NotFoundException, WebMessageException {
     validatePaginationParameters(requestParams);
-    TrackedEntityOperationParams operationParams = paramsMapper.map(requestParams, currentUser);
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityRequestParamsMapper.map(requestParams, currentUser);
 
     if (requestParams.isPaging()) {
       PageParams pageParams =
@@ -183,7 +178,9 @@ class TrackedEntitiesExportController {
               i -> TRACKED_ENTITY_MAPPER.map(idSchemeParams, errors, i));
       ensureNoMappingErrors(errors);
 
-      return requestHandler.serve(request, TRACKED_ENTITIES, page, requestParams);
+      return new FilteredPage<>(
+          Page.withPager(TRACKED_ENTITIES, page, getRequestURL(request)),
+          requestParams.getFields());
     }
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
@@ -193,7 +190,8 @@ class TrackedEntitiesExportController {
             .toList();
     ensureNoMappingErrors(errors);
 
-    return requestHandler.serve(TRACKED_ENTITIES, trackedEntities, requestParams);
+    return new FilteredPage<>(
+        Page.withoutPager(TRACKED_ENTITIES, trackedEntities), requestParams.getFields());
   }
 
   @GetMapping(produces = {CONTENT_TYPE_CSV, CONTENT_TYPE_TEXT_CSV})
@@ -269,7 +267,7 @@ class TrackedEntitiesExportController {
       UserDetails currentUser)
       throws BadRequestException, ForbiddenException, NotFoundException, WebMessageException {
     TrackedEntityOperationParams operationParams =
-        paramsMapper.map(requestParams, CSV_FIELDS, currentUser);
+        TrackedEntityRequestParamsMapper.map(requestParams, CSV_FIELDS, currentUser);
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
     List<TrackedEntity> result =
@@ -282,18 +280,16 @@ class TrackedEntitiesExportController {
 
   @OpenApi.Response(OpenApi.EntityType.class)
   @GetMapping(value = "/{uid}")
-  ResponseEntity<ObjectNode> getTrackedEntityByUid(
+  public FilteredEntity<TrackedEntity> getTrackedEntityByUid(
       @OpenApi.Param({UID.class, org.hisp.dhis.trackedentity.TrackedEntity.class}) @PathVariable
           UID uid,
       @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
       @OpenApi.Param(value = String[].class) @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM)
-          List<FieldPath> fields,
+          Fields fields,
       TrackerIdSchemeParams idSchemeParams)
       throws ForbiddenException, NotFoundException, WebMessageException {
     TrackedEntityFields trackedEntityFields =
-        TrackedEntityFields.of(
-            f -> fieldFilterService.filterIncludes(TrackedEntity.class, fields, f),
-            FieldPath.FIELD_PATH_SEPARATOR);
+        TrackedEntityFields.of(fields::includes, FieldPath.FIELD_PATH_SEPARATOR);
     MappingErrors errors = new MappingErrors(idSchemeParams);
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.map(
@@ -302,7 +298,7 @@ class TrackedEntitiesExportController {
             trackedEntityService.getTrackedEntity(uid, program, trackedEntityFields));
     ensureNoMappingErrors(errors);
 
-    return ResponseEntity.ok(fieldFilterService.toObjectNode(trackedEntity, fields));
+    return new FilteredEntity<>(trackedEntity, fields);
   }
 
   @GetMapping(
@@ -316,9 +312,7 @@ class TrackedEntitiesExportController {
       @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program)
       throws IOException, ForbiddenException, NotFoundException, WebMessageException {
     TrackedEntityFields trackedEntityFields =
-        TrackedEntityFields.of(
-            f -> fieldFilterService.filterIncludes(TrackedEntity.class, CSV_FIELDS, f),
-            FieldPath.FIELD_PATH_SEPARATOR);
+        TrackedEntityFields.of(CSV_FIELDS::includes, FieldPath.FIELD_PATH_SEPARATOR);
 
     MappingErrors errors = new MappingErrors(idSchemeParams);
     TrackedEntity trackedEntity =
@@ -366,15 +360,17 @@ class TrackedEntitiesExportController {
         trackedEntityService.getFileResourceImage(trackedEntity, attribute, program, dimension));
   }
 
+  @OpenApi.EntityType(org.hisp.dhis.webapi.controller.tracker.view.TrackedEntityChangeLog.class)
   @OpenApi.Response(status = Status.OK, value = Page.class)
   @GetMapping("/{trackedEntity}/changeLogs")
-  ResponseEntity<Page<ObjectNode>> getTrackedEntityChangeLog(
-      @OpenApi.Param({UID.class, org.hisp.dhis.trackedentity.TrackedEntity.class}) @PathVariable
-          UID trackedEntity,
-      @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
-      ChangeLogRequestParams requestParams,
-      HttpServletRequest request)
-      throws NotFoundException, BadRequestException, ForbiddenException {
+  FilteredPage<org.hisp.dhis.webapi.controller.tracker.view.TrackedEntityChangeLog>
+      getTrackedEntityChangeLog(
+          @OpenApi.Param({UID.class, org.hisp.dhis.trackedentity.TrackedEntity.class}) @PathVariable
+              UID trackedEntity,
+          @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
+          ChangeLogRequestParams requestParams,
+          HttpServletRequest request)
+          throws NotFoundException, BadRequestException, ForbiddenException {
 
     TrackedEntityChangeLogOperationParams operationParams =
         ChangeLogRequestParamsMapper.map(
@@ -388,10 +384,11 @@ class TrackedEntitiesExportController {
         trackedEntityChangeLogService.getTrackedEntityChangeLog(
             trackedEntity, program, operationParams, pageParams);
 
-    return requestHandler.serve(
-        request,
-        "changeLogs",
-        page.withMappedItems(TRACKED_ENTITY_CHANGE_LOG_MAPPER::map),
-        requestParams);
+    org.hisp.dhis.tracker.Page<org.hisp.dhis.webapi.controller.tracker.view.TrackedEntityChangeLog>
+        mappedPage = page.withMappedItems(TRACKED_ENTITY_CHANGE_LOG_MAPPER::map);
+
+    return new FilteredPage<>(
+        Page.withPager("changeLogs", mappedPage, getRequestURL(request)),
+        requestParams.getFields());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
@@ -40,14 +40,14 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.FieldsRequestParam;
@@ -66,6 +66,7 @@ import org.hisp.dhis.webapi.webdomain.StartDateTime;
 @NoArgsConstructor
 public class TrackedEntityRequestParams implements PageRequestParams, FieldsRequestParam {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
+  static final Fields DEFAULT_FIELDS_PARAM_PARSED = FieldsParser.parse(DEFAULT_FIELDS_PARAM);
 
   @OpenApi.Description(
 """
@@ -181,5 +182,5 @@ will take more time to return.**
   private Boolean potentialDuplicate;
 
   @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+  private Fields fields = DEFAULT_FIELDS_PARAM_PARSED;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/FilteredEntity.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/FilteredEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,14 +27,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker;
+package org.hisp.dhis.webapi.controller.tracker.view;
 
 import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
 
 /**
- * FieldsRequestParam represents the HTTP request parameter {@code fields}. This allows users to
- * specify the exact fields they want in the JSON response.
+ * Wrapper that carries both a single entity and the Fields for field filtering. This allows the
+ * FilteredPageHttpMessageConverter to access both the entity data and the fields without using
+ * request attributes or ThreadLocal.
  */
-public interface FieldsRequestParam {
-  Fields getFields();
-}
+public record FilteredEntity<T>(T entity, Fields fields) {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/FilteredPage.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/FilteredPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,14 +27,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker;
+package org.hisp.dhis.webapi.controller.tracker.view;
 
 import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
 
 /**
- * FieldsRequestParam represents the HTTP request parameter {@code fields}. This allows users to
- * specify the exact fields they want in the JSON response.
+ * Wrapper that carries both a Page and the Fields for field filtering. This allows the
+ * FilteredPageHttpMessageConverter to access both the page data and the fields without using
+ * request attributes or ThreadLocal.
  */
-public interface FieldsRequestParam {
-  Fields getFields();
-}
+public record FilteredPage<T>(Page<T> page, Fields fields) {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/fields/FieldsConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/fields/FieldsConverter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.fields;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
+import org.hisp.dhis.tracker.export.fieldfiltering.SchemaFieldsPresets;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Spring converter that converts field filter strings to {@link Fields}. Works for both
+ * {@code @RequestParam} and properties within {@code @ModelAttribute} objects. Uses request context
+ * to determine the controller's {@link @OpenApi.EntityType} annotation to fetch the {@link Schema}.
+ * The {@link Schema} is needed to expand presets into fields.
+ */
+@Component
+@RequiredArgsConstructor
+public class FieldsConverter implements ConditionalGenericConverter {
+
+  private final SchemaService schemaService;
+  private final SchemaFieldsPresets schemaFieldsPresets;
+
+  public static final Map<String, Function<Schema, Set<String>>> PRESETS =
+      Map.of(":all", FieldsParser.PRESET_ALL, ":simple", SchemaFieldsPresets::mapSimple);
+
+  @Override
+  public boolean matches(@Nonnull TypeDescriptor sourceType, TypeDescriptor targetType) {
+    return Fields.class.equals(targetType.getResolvableType().resolve());
+  }
+
+  @Override
+  public Set<ConvertiblePair> getConvertibleTypes() {
+    return Set.of(
+        new ConvertiblePair(String.class, Fields.class),
+        new ConvertiblePair(String[].class, Fields.class));
+  }
+
+  @Override
+  public Object convert(
+      Object source, TypeDescriptor sourceType, @Nonnull TypeDescriptor targetType) {
+
+    String fieldsString;
+    if (sourceType.isArray()) {
+      /*
+       * Undo Spring's splitting of
+       * {@code fields=attributes[attribute,value],deleted} into
+       * <ul>
+       * <li>0 = "attributes[attribute"</li>
+       * <li>1 = "value]"</li>
+       * <li>2 = "deleted"</li>
+       * </ul>
+       * separating nested fields attribute and value.
+       */
+      fieldsString = String.join(",", (String[]) source);
+    } else {
+      fieldsString = (String) source;
+    }
+
+    Class<?> entityClass = getOpenApiEntityType();
+    if (entityClass == null) {
+      throw new IllegalArgumentException(
+          "Cannot convert fields without @OpenApi.EntityType annotation on the controller or method. "
+              + "Ensure controller or method has @OpenApi.EntityType annotation and conversion happens within web request context.");
+    }
+    Schema schema = schemaService.getDynamicSchema(entityClass);
+    if (schema == null) {
+      throw new IllegalArgumentException(
+          "No schema found for entity class "
+              + entityClass.getSimpleName()
+              + ". Ensure the entity class is properly configured in the schema service.");
+    }
+
+    return FieldsParser.parse(fieldsString, schema, schemaFieldsPresets::getSchema, PRESETS);
+  }
+
+  @Nullable
+  private Class<?> getOpenApiEntityType() {
+    RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+    if (requestAttributes == null) {
+      return null;
+    }
+
+    Object handler =
+        requestAttributes.getAttribute(
+            HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+    if (handler == null) {
+      return null;
+    }
+
+    if (handler instanceof org.springframework.web.method.HandlerMethod handlerMethod) {
+      OpenApi.EntityType methodEntityType =
+          handlerMethod.getMethodAnnotation(OpenApi.EntityType.class);
+      if (methodEntityType != null) {
+        return methodEntityType.value();
+      }
+
+      OpenApi.EntityType classEntityType =
+          handlerMethod.getBeanType().getAnnotation(OpenApi.EntityType.class);
+      return classEntityType != null ? classEntityType.value() : null;
+    } else {
+      OpenApi.EntityType entityType = handler.getClass().getAnnotation(OpenApi.EntityType.class);
+      return entityType != null ? entityType.value() : null;
+    }
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/FilteredPageHttpMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/FilteredPageHttpMessageConverter.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.mvc.messageconverter;
+
+import static org.hisp.dhis.webapi.utils.ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON_GZIP;
+import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON_ZIP;
+import static org.hisp.dhis.webapi.utils.ContextUtils.HEADER_CONTENT_DISPOSITION;
+import static org.hisp.dhis.webapi.utils.ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsPropertyFilter;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.FilteredPage;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.StreamingHttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/**
+ * HttpMessageConverter for trackers {@link FilteredPage} and {@link FilteredEntity} that handles
+ * streaming of field filtered JSON pages and entities directly to the HTTP response body's output
+ * stream. Supports compression variants (gzip, zip) based on media type for pages.
+ */
+@Component
+public class FilteredPageHttpMessageConverter extends AbstractHttpMessageConverter<Object> {
+
+  private static final org.springframework.http.MediaType MEDIA_TYPE_JSON_GZIP =
+      org.springframework.http.MediaType.valueOf(CONTENT_TYPE_JSON_GZIP);
+  private static final org.springframework.http.MediaType MEDIA_TYPE_JSON_ZIP =
+      org.springframework.http.MediaType.valueOf(CONTENT_TYPE_JSON_ZIP);
+
+  @Qualifier("jsonFilterMapper")
+  private final ObjectMapper filterMapper;
+
+  public FilteredPageHttpMessageConverter(
+      @Qualifier("jsonFilterMapper") ObjectMapper filterMapper) {
+    super(
+        org.springframework.http.MediaType.APPLICATION_JSON,
+        org.springframework.http.MediaType
+            .TEXT_HTML, // return JSON when a generic request comes from a browser
+        MEDIA_TYPE_JSON_GZIP,
+        MEDIA_TYPE_JSON_ZIP);
+    this.filterMapper = filterMapper;
+  }
+
+  @Override
+  protected boolean supports(@Nonnull Class<?> clazz) {
+    return FilteredPage.class.isAssignableFrom(clazz)
+        || FilteredEntity.class.isAssignableFrom(clazz);
+  }
+
+  @Nonnull
+  @Override
+  protected Object readInternal(@Nonnull Class<?> clazz, @Nonnull HttpInputMessage inputMessage)
+      throws HttpMessageNotReadableException {
+    throw new UnsupportedOperationException("Reading filtered objects is not supported");
+  }
+
+  @Override
+  protected void writeInternal(
+      @Nonnull Object filteredObject, @Nonnull HttpOutputMessage outputMessage)
+      throws IOException, HttpMessageNotWritableException {
+    setCompressionHeaders(filteredObject, outputMessage);
+    setContentType(outputMessage);
+
+    if (outputMessage instanceof StreamingHttpOutputMessage streamingHttpOutputMessage) {
+      writeStreaming(filteredObject, streamingHttpOutputMessage);
+    } else {
+      writeStandard(filteredObject, outputMessage);
+    }
+  }
+
+  private static void setCompressionHeaders(
+      Object filteredObject, HttpOutputMessage outputMessage) {
+    org.springframework.http.MediaType mediaType = outputMessage.getHeaders().getContentType();
+    if (MEDIA_TYPE_JSON_GZIP.isCompatibleWith(mediaType)
+        || MEDIA_TYPE_JSON_ZIP.isCompatibleWith(mediaType)) {
+      String filename = getFilename(filteredObject, mediaType);
+      outputMessage
+          .getHeaders()
+          .set(HEADER_CONTENT_DISPOSITION, "attachment; filename=" + filename);
+      outputMessage
+          .getHeaders()
+          .set(HEADER_CONTENT_TRANSFER_ENCODING, BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+    }
+  }
+
+  private static String getFilename(
+      Object filteredObject, org.springframework.http.MediaType mediaType) {
+    String baseName = getBaseName(filteredObject);
+
+    if (MEDIA_TYPE_JSON_GZIP.isCompatibleWith(mediaType)) {
+      return baseName + ".gz";
+    } else if (MEDIA_TYPE_JSON_ZIP.isCompatibleWith(mediaType)) {
+      return baseName + ".zip";
+    }
+    return baseName;
+  }
+
+  private static String getBaseName(Object filteredObject) {
+    if (filteredObject instanceof FilteredPage<?> filteredPage) {
+      return filteredPage.page().getKey() + ".json";
+    }
+
+    throw new UnsupportedOperationException("Only FilteredPage supports compressed responses");
+  }
+
+  private static void setContentType(HttpOutputMessage outputMessage) {
+    // Set content-type to application/json for text/html as that is what we return. Rely on
+    // Springs' default content negotiation otherwise.
+    MediaType contentType = outputMessage.getHeaders().getContentType();
+    if (MediaType.TEXT_HTML.isCompatibleWith(contentType)) {
+      outputMessage.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+    }
+  }
+
+  private void writeStreaming(Object filteredObject, StreamingHttpOutputMessage streamingMessage) {
+    streamingMessage.setBody(
+        outputStream ->
+            writeObjectToStream(
+                filteredObject, outputStream, streamingMessage.getHeaders().getContentType()));
+  }
+
+  private void writeStandard(Object filteredObject, HttpOutputMessage outputMessage)
+      throws IOException {
+    writeObjectToStream(
+        filteredObject, outputMessage.getBody(), outputMessage.getHeaders().getContentType());
+  }
+
+  private void writeObjectToStream(
+      Object filteredObject,
+      OutputStream outputStream,
+      org.springframework.http.MediaType mediaType)
+      throws IOException {
+    OutputStream targetStream = wrapStreamForCompression(filteredObject, outputStream, mediaType);
+
+    try {
+      if (filteredObject instanceof FilteredPage<?> filteredPage) {
+        writePageToStream(filteredPage, targetStream);
+      } else if (filteredObject instanceof FilteredEntity<?> filteredEntity) {
+        writeEntityToStream(filteredEntity, targetStream);
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported filtered object type: " + filteredObject.getClass());
+      }
+    } finally {
+      if (targetStream != outputStream) { // only close a stream we created
+        targetStream.close();
+      }
+    }
+  }
+
+  private OutputStream wrapStreamForCompression(
+      Object filteredObject, OutputStream original, MediaType mediaType) throws IOException {
+    if (MEDIA_TYPE_JSON_GZIP.isCompatibleWith(mediaType)) {
+      return new GZIPOutputStream(original);
+    } else if (MEDIA_TYPE_JSON_ZIP.isCompatibleWith(mediaType)) {
+      ZipOutputStream zip = new ZipOutputStream(original);
+      zip.putNextEntry(new ZipEntry(getBaseName(filteredObject)));
+      return zip;
+    }
+    return original;
+  }
+
+  private void writePageToStream(FilteredPage<?> filteredPage, OutputStream outputStream)
+      throws IOException {
+    Page<?> page = filteredPage.page();
+    Fields pageFields = createPageFields(filteredPage.fields());
+
+    ObjectWriter writer =
+        filterMapper.writer().withAttribute(FieldsPropertyFilter.FIELDS_ATTRIBUTE, pageFields);
+    try (JsonGenerator generator = writer.getFactory().createGenerator(outputStream)) {
+      writer.writeValue(generator, page);
+    }
+  }
+
+  /**
+   * Creates a fields wrapper equivalent to how the items are wrapped into a page. Users write the
+   * {@code fields} filter from the perspective of an item in the collection of the resource they
+   * are asking for. For example {@code /events?fields=event,orgUnit} while the response is actually
+   * an object with a {@code pager} and an {@code events} collection. We thus need to pretend the
+   * user sent {@code fields=events[event,orgUnit]}.
+   */
+  private static Fields createPageFields(Fields fields) {
+    return new Fields(
+        false,
+        Set.of("pager", "getDynamicItems"),
+        Map.of("pager", Fields.all(), "getDynamicItems", fields),
+        Map.of());
+  }
+
+  private void writeEntityToStream(FilteredEntity<?> filteredEntity, OutputStream outputStream)
+      throws IOException {
+    Object entity = filteredEntity.entity();
+    Fields fields = filteredEntity.fields();
+
+    ObjectWriter writer =
+        filterMapper.writer().withAttribute(FieldsPropertyFilter.FIELDS_ATTRIBUTE, fields);
+
+    try (JsonGenerator generator = writer.getFactory().createGenerator(outputStream)) {
+      writer.writeValue(generator, entity);
+    }
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.dxf2.metadata.MetadataExportService;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPathConverter;
 import org.hisp.dhis.node.NodeService;
+import org.hisp.dhis.webapi.fields.FieldsConverter;
 import org.hisp.dhis.webapi.mvc.CurrentSystemSettingsHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
@@ -54,6 +55,7 @@ import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.SystemSettingsInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.TrailingSlashInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
+import org.hisp.dhis.webapi.mvc.messageconverter.FilteredPageHttpMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
@@ -116,6 +118,8 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
   private CurrentSystemSettingsHandlerMethodArgumentResolver
       currentSystemSettingsHandlerMethodArgumentResolver;
 
+  @Autowired private FieldsConverter fieldsConverter;
+
   @Autowired private DefaultRequestInfoService requestInfoService;
 
   @Autowired private AuthorityInterceptor authorityInterceptor;
@@ -127,6 +131,10 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
   @Autowired
   @Qualifier("jsonMapper")
   private ObjectMapper jsonMapper;
+
+  @Qualifier("jsonFilterMapper")
+  @Autowired
+  private ObjectMapper jsonFilterMapper;
 
   @Autowired
   @Qualifier("xmlMapper")
@@ -225,6 +233,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
             compression ->
                 converters.add(
                     new StreamingJsonRootMessageConverter(fieldFilterService, compression)));
+    converters.add(new FilteredPageHttpMessageConverter(jsonFilterMapper));
 
     converters.add(new StringHttpMessageConverter(StandardCharsets.UTF_8));
     converters.add(new ByteArrayHttpMessageConverter());
@@ -238,6 +247,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
   @Override
   protected void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new FieldPathConverter());
+    registry.addConverter(fieldsConverter);
   }
 
   @Primary

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -41,9 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -54,50 +51,24 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.EnrollmentStatus;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageService;
-import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityFields;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
+import org.hisp.dhis.tracker.export.fieldfiltering.FieldsParser;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
-@MockitoSettings(strictness = Strictness.LENIENT) // common setup
-@ExtendWith(MockitoExtension.class)
 class EventRequestParamsMapperTest {
+
+  private static final UID ORGUNIT_UID = UID.generate();
 
   private static final UID DE_1_UID = UID.of("OBzmpRP6YUh");
 
@@ -109,83 +80,11 @@ class EventRequestParamsMapperTest {
 
   private static final UID PROGRAM_UID = UID.of("PlZSBEN7iZd");
 
-  @Mock private UserService userService;
-
-  @Mock private ProgramService programService;
-
-  @Mock private OrganisationUnitService organisationUnitService;
-
-  @Mock private ProgramStageService programStageService;
-
-  @Mock private AclService aclService;
-
-  @Mock private TrackedEntityService trackedEntityService;
-
-  @Mock private TrackedEntityAttributeService attributeService;
-
-  @Mock private DataElementService dataElementService;
-
-  @Mock private FieldFilterService fieldFilterService;
-
-  @InjectMocks private EventRequestParamsMapper mapper;
-
-  private Program program;
-
-  private OrganisationUnit orgUnit;
-
   private TrackerIdSchemeParams idSchemeParams;
 
   @BeforeEach
-  void setUp() throws ForbiddenException, NotFoundException {
-    User user = new User();
-
-    when(userService.getUserByUsername(null)).thenReturn(user);
-
-    program = new Program();
-    program.setUid(PROGRAM_UID.getValue());
-    when(programService.getProgram(PROGRAM_UID.getValue())).thenReturn(program);
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-
-    ProgramStage programStage = new ProgramStage();
-    programStage.setUid("PlZSBEN7iZd");
-    when(programStageService.getProgramStage("PlZSBEN7iZd")).thenReturn(programStage);
-    when(aclService.canDataRead(user, programStage)).thenReturn(true);
-
-    orgUnit = new OrganisationUnit();
-    when(organisationUnitService.getOrganisationUnit(any())).thenReturn(orgUnit);
-    when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
-
-    TrackedEntity trackedEntity = new TrackedEntity();
-    when(trackedEntityService.getTrackedEntity(
-            UID.of("qnR1RK4cTIZ"), null, TrackedEntityFields.none()))
-        .thenReturn(trackedEntity);
-    TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
-    tea1.setUid(TEA_1_UID.getValue());
-    TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
-    tea2.setUid(TEA_2_UID.getValue());
-    when(attributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1, tea2));
-    when(attributeService.getTrackedEntityAttribute(TEA_1_UID.getValue())).thenReturn(tea1);
-
-    DataElement de1 = new DataElement();
-    de1.setUid(DE_1_UID.getValue());
-    when(dataElementService.getDataElement(DE_1_UID.getValue())).thenReturn(de1);
-    DataElement de2 = new DataElement();
-    de2.setUid(DE_2_UID.getValue());
-    when(dataElementService.getDataElement(DE_2_UID.getValue())).thenReturn(de2);
-
+  void setUp() {
     idSchemeParams = TrackerIdSchemeParams.builder().build();
-  }
-
-  @Test
-  void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB() throws BadRequestException {
-    EventRequestParams eventRequestParams = new EventRequestParams();
-
-    mapper.map(eventRequestParams, idSchemeParams);
-
-    verifyNoInteractions(programService);
-    verifyNoInteractions(programStageService);
-    verifyNoInteractions(organisationUnitService);
-    verifyNoInteractions(trackedEntityService);
   }
 
   @Test
@@ -193,18 +92,18 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setProgram(PROGRAM_UID);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
-    assertEquals(UID.of(program), params.getProgram());
+    assertEquals(PROGRAM_UID, params.getProgram());
   }
 
   @Test
   void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setOrgUnit(UID.of(orgUnit));
+    eventRequestParams.setOrgUnit(ORGUNIT_UID);
     eventRequestParams.setOrgUnitMode(SELECTED);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(SELECTED, params.getOrgUnitMode());
   }
@@ -217,7 +116,8 @@ class EventRequestParamsMapperTest {
 
     BadRequestException exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
 
     assertStartsWith(
         "Only one parameter of 'programStatus' and 'enrollmentStatus'", exception.getMessage());
@@ -226,11 +126,11 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldReturnOrgUnitWhenCorrectOrgUnitMapped() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setOrgUnit(UID.of(orgUnit));
+    eventRequestParams.setOrgUnit(ORGUNIT_UID);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
-    assertEquals(UID.of(orgUnit), params.getOrgUnit());
+    assertEquals(ORGUNIT_UID, params.getOrgUnit());
   }
 
   @Test
@@ -238,7 +138,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setTrackedEntity(UID.of("qnR1RK4cTIZ"));
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(UID.of("qnR1RK4cTIZ"), params.getTrackedEntity());
   }
@@ -252,7 +152,7 @@ class EventRequestParamsMapperTest {
     EndDateTime occurredBefore = EndDateTime.of("2020-09-12");
     eventRequestParams.setOccurredBefore(occurredBefore);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(occurredAfter.toDate(), params.getOccurredAfter());
     assertEquals(occurredBefore.toDate(), params.getOccurredBefore());
@@ -267,7 +167,7 @@ class EventRequestParamsMapperTest {
     EndDateTime scheduledBefore = EndDateTime.of("2021-09-12");
     eventRequestParams.setScheduledBefore(scheduledBefore);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(scheduledAfter.toDate(), params.getScheduledAfter());
     assertEquals(scheduledBefore.toDate(), params.getScheduledBefore());
@@ -282,7 +182,7 @@ class EventRequestParamsMapperTest {
     EndDateTime updatedBefore = EndDateTime.of("2022-09-12");
     eventRequestParams.setUpdatedBefore(updatedBefore);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(updatedAfter.toDate(), params.getUpdatedAfter());
     assertEquals(updatedBefore.toDate(), params.getUpdatedBefore());
@@ -294,7 +194,7 @@ class EventRequestParamsMapperTest {
     String updatedWithin = "6m";
     eventRequestParams.setUpdatedWithin(updatedWithin);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(updatedWithin, params.getUpdatedWithin());
   }
@@ -312,7 +212,8 @@ class EventRequestParamsMapperTest {
 
     Exception exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
 
     assertEquals(
         "Last updated from and/or to and last updated duration cannot be specified simultaneously",
@@ -328,7 +229,7 @@ class EventRequestParamsMapperTest {
     StartDateTime enrolledAfter = StartDateTime.of("2022-02-01");
     eventRequestParams.setEnrollmentEnrolledAfter(enrolledAfter);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(enrolledBefore.toDate(), params.getEnrollmentEnrolledBefore());
     assertEquals(enrolledAfter.toDate(), params.getEnrollmentEnrolledAfter());
@@ -343,7 +244,7 @@ class EventRequestParamsMapperTest {
     StartDateTime enrolledAfter = StartDateTime.of("2022-02-01");
     eventRequestParams.setEnrollmentOccurredAfter(enrolledAfter);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(enrolledBefore.toDate(), params.getEnrollmentOccurredBefore());
     assertEquals(enrolledAfter.toDate(), params.getEnrollmentOccurredAfter());
@@ -355,7 +256,7 @@ class EventRequestParamsMapperTest {
 
     eventRequestParams.setEnrollments(Set.of(UID.of("NQnuK2kLm6e")));
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(Set.of(UID.of("NQnuK2kLm6e")), params.getEnrollments());
   }
@@ -365,7 +266,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setEvents(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"));
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(UID.of("XKrcfuM4Hcw", "M4pNmLabtXl"), params.getEvents());
   }
@@ -374,7 +275,7 @@ class EventRequestParamsMapperTest {
   void testMappingEventIsNull() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertIsEmpty(params.getEvents());
   }
@@ -385,7 +286,7 @@ class EventRequestParamsMapperTest {
     eventRequestParams.setAssignedUsers(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"));
     eventRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertContainsOnly(UID.of("IsdLBTOBzMi", "l5ab8q5skbB"), params.getAssignedUsers());
     assertEquals(AssignedUserSelectionMode.PROVIDED, params.getAssignedUserMode());
@@ -399,7 +300,8 @@ class EventRequestParamsMapperTest {
 
     Exception exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
     assertEquals(
         "Event UIDs and filters can not be specified at the same time", exception.getMessage());
   }
@@ -409,7 +311,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilter(DE_1_UID + ":eq:2," + DE_2_UID + ":like:foo");
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
@@ -427,7 +329,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilter(DE_1_UID + ":gt:10:lt:20");
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
@@ -444,7 +346,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilter(DE_1_UID.getValue());
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
     assertNotNull(dataElementFilters);
@@ -457,7 +359,7 @@ class EventRequestParamsMapperTest {
   void shouldMapDataElementFiltersToDefaultIfNoneSet() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> dataElementFilters = params.getDataElementFilters();
 
@@ -470,7 +372,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilterAttributes(TEA_1_UID + ":eq:2," + TEA_2_UID + ":like:foo");
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
@@ -488,7 +390,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilterAttributes(TEA_1_UID + ":gt:10:lt:20");
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
@@ -505,7 +407,7 @@ class EventRequestParamsMapperTest {
     EventRequestParams eventRequestParams = new EventRequestParams();
     eventRequestParams.setFilterAttributes(TEA_1_UID.getValue());
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
     assertNotNull(attributeFilters);
@@ -518,7 +420,7 @@ class EventRequestParamsMapperTest {
   void shouldMapAttributeFiltersToDefaultIfNoneSet() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     Map<UID, List<QueryFilter>> attributeFilters = params.getAttributeFilters();
 
@@ -533,7 +435,7 @@ class EventRequestParamsMapperTest {
         OrderCriteria.fromOrderString(
             "createdAt:asc,zGlzbfreTOH,programStage:desc,scheduledAt:asc"));
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(
         List.of(
@@ -552,7 +454,8 @@ class EventRequestParamsMapperTest {
 
     Exception exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () -> assertContains("unsupportedProperty1", exception.getMessage()));
@@ -561,9 +464,9 @@ class EventRequestParamsMapperTest {
   @Test
   void shouldMapSelectedOrgUnitModeWhenOrgUnitModeNotProvided() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setOrgUnit(UID.of(orgUnit));
+    eventRequestParams.setOrgUnit(ORGUNIT_UID);
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(SELECTED, params.getOrgUnitMode());
   }
@@ -573,7 +476,7 @@ class EventRequestParamsMapperTest {
       throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    EventOperationParams params = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams params = EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertEquals(ACCESSIBLE, params.getOrgUnitMode());
   }
@@ -584,15 +487,14 @@ class EventRequestParamsMapperTest {
       names = {"ACCESSIBLE", "CAPTURE"})
   void shouldFailWhenOrgUnitSuppliedAndOrgUnitModeCannotHaveOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-
     EventRequestParams eventRequestParams = new EventRequestParams();
-    eventRequestParams.setOrgUnit(UID.of(orgUnit));
+    eventRequestParams.setOrgUnit(ORGUNIT_UID);
     eventRequestParams.setOrgUnitMode(orgUnitMode);
 
     Exception exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
 
     assertStartsWith(
         "orgUnitMode " + orgUnitMode + " cannot be used with orgUnits.", exception.getMessage());
@@ -609,7 +511,8 @@ class EventRequestParamsMapperTest {
 
     Exception exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(eventRequestParams, idSchemeParams));
+            BadRequestException.class,
+            () -> EventRequestParamsMapper.map(eventRequestParams, idSchemeParams));
 
     assertStartsWith(
         "At least one org unit is required for orgUnitMode: " + orgUnitMode,
@@ -617,27 +520,25 @@ class EventRequestParamsMapperTest {
   }
 
   @Test
-  void shouldMapEventParamsTrueWhenFieldPathIncludeRelationships() throws BadRequestException {
+  void shouldMapAndIncludeRelationshipsIfInFields() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    List<FieldPath> fieldPaths = FieldFilterParser.parse("relationships");
-    eventRequestParams.setFields(fieldPaths);
-    when(fieldFilterService.filterIncludes(Event.class, fieldPaths, "relationships"))
-        .thenReturn(true);
+    Fields fields = FieldsParser.parse("relationships");
+    eventRequestParams.setFields(fields);
 
-    EventOperationParams eventOperationParams = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams eventOperationParams =
+        EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertTrue(eventOperationParams.getFields().isIncludesRelationships());
   }
 
   @Test
-  void shouldMapEventParamsFalseWhenFieldPathIncludeRelationships() throws BadRequestException {
+  void shouldMapAndIncludeRelationshipsIfNotInFields() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
-    List<FieldPath> fieldPaths = FieldFilterParser.parse("relationships");
-    eventRequestParams.setFields(fieldPaths);
-    when(fieldFilterService.filterIncludes(Event.class, fieldPaths, "relationships"))
-        .thenReturn(false);
+    Fields fields = FieldsParser.parse("event");
+    eventRequestParams.setFields(fields);
 
-    EventOperationParams eventOperationParams = mapper.map(eventRequestParams, idSchemeParams);
+    EventOperationParams eventOperationParams =
+        EventRequestParamsMapper.map(eventRequestParams, idSchemeParams);
 
     assertFalse(eventOperationParams.getFields().isIncludesRelationships());
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
@@ -38,34 +38,26 @@ import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class RelationshipRequestParamsMapperTest {
-  private RelationshipRequestParamsMapper mapper;
-
-  @BeforeEach
-  void setUp() {
-    FieldFilterService fieldFilterService = mock(FieldFilterService.class);
-    mapper = new RelationshipRequestParamsMapper(fieldFilterService);
-  }
 
   @Test
   void getIdentifierParamThrowsIfNoParamsIsSet() {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(relationshipRequestParams));
+        assertThrows(
+            BadRequestException.class,
+            () -> RelationshipRequestParamsMapper.map(relationshipRequestParams));
 
     assertEquals(
         "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
@@ -80,7 +72,9 @@ class RelationshipRequestParamsMapperTest {
     relationshipRequestParams.setEvent(UID.of("Hq3Kc6HK4OZ"));
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(relationshipRequestParams));
+        assertThrows(
+            BadRequestException.class,
+            () -> RelationshipRequestParamsMapper.map(relationshipRequestParams));
 
     assertEquals(
         "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
@@ -94,7 +88,9 @@ class RelationshipRequestParamsMapperTest {
     relationshipRequestParams.setEnrollment(UID.of("Hq3Kc6HK4OZ"));
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(relationshipRequestParams));
+        assertThrows(
+            BadRequestException.class,
+            () -> RelationshipRequestParamsMapper.map(relationshipRequestParams));
 
     assertEquals(
         "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
@@ -108,7 +104,9 @@ class RelationshipRequestParamsMapperTest {
     relationshipRequestParams.setEvent(UID.of("Hq3Kc6HK4OZ"));
 
     BadRequestException exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(relationshipRequestParams));
+        assertThrows(
+            BadRequestException.class,
+            () -> RelationshipRequestParamsMapper.map(relationshipRequestParams));
 
     assertEquals(
         "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
@@ -120,7 +118,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(UID.of("Hq3Kc6HK4OZ"), operationParams.getIdentifier());
   }
@@ -130,7 +129,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(TRACKED_ENTITY, operationParams.getType());
   }
@@ -140,7 +140,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setEnrollment(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(UID.of("Hq3Kc6HK4OZ"), operationParams.getIdentifier());
   }
@@ -150,7 +151,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setEnrollment(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(ENROLLMENT, operationParams.getType());
   }
@@ -160,7 +162,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setEvent(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(UID.of("Hq3Kc6HK4OZ"), operationParams.getIdentifier());
   }
@@ -170,7 +173,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setEvent(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(EVENT, operationParams.getType());
   }
@@ -181,7 +185,8 @@ class RelationshipRequestParamsMapperTest {
     relationshipRequestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
     relationshipRequestParams.setOrder(OrderCriteria.fromOrderString("createdAt:asc"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertEquals(List.of(new Order("created", SortDirection.ASC)), operationParams.getOrder());
   }
@@ -194,7 +199,9 @@ class RelationshipRequestParamsMapperTest {
         OrderCriteria.fromOrderString("unsupportedProperty1:asc,createdAt:asc"));
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(relationshipRequestParams));
+        assertThrows(
+            BadRequestException.class,
+            () -> RelationshipRequestParamsMapper.map(relationshipRequestParams));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () -> assertContains("unsupportedProperty1", exception.getMessage()));
@@ -205,7 +212,8 @@ class RelationshipRequestParamsMapperTest {
     RelationshipRequestParams relationshipRequestParams = new RelationshipRequestParams();
     relationshipRequestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
 
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    RelationshipOperationParams operationParams =
+        RelationshipRequestParamsMapper.map(relationshipRequestParams);
 
     assertIsEmpty(operationParams.getOrder());
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -50,9 +50,9 @@ import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.tracker.export.fieldfiltering.Fields;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserDetails;
@@ -61,12 +61,7 @@ import org.hisp.dhis.webapi.webdomain.EndDateTime;
 import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class TrackedEntityRequestParamsMapperTest {
   public static final UID TEA_1_UID = UID.of("TvjwTPToKHO");
 
@@ -77,10 +72,6 @@ class TrackedEntityRequestParamsMapperTest {
   private static final UID PROGRAM_STAGE_UID = UID.of("RpCr2u2pFqw");
 
   private static final UID TRACKED_ENTITY_TYPE_UID = UID.of("Dp8baZYrLtr");
-
-  @Mock private FieldFilterService fieldFilterService;
-
-  @InjectMocks private TrackedEntityRequestParamsMapper mapper;
 
   private TrackedEntityRequestParams trackedEntityRequestParams;
 
@@ -108,7 +99,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
-    final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    final TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertThat(params.getProgram(), is(PROGRAM_UID));
     assertThat(params.getProgramStage(), is(PROGRAM_STAGE_UID));
@@ -146,7 +138,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
-    final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    final TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertThat(params.getTrackedEntityType(), is(TRACKED_ENTITY_TYPE_UID));
     assertThat(params.getLastUpdatedStartDate(), is(trackedEntityRequestParams.getUpdatedAfter()));
@@ -174,7 +167,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setOrgUnitMode(CAPTURE);
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, Fields.ALL, user);
 
     assertEquals(CAPTURE, params.getOrgUnitMode());
   }
@@ -184,7 +178,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, Fields.ALL, user);
 
     assertEquals(ACCESSIBLE, params.getOrgUnitMode());
   }
@@ -196,7 +191,9 @@ class TrackedEntityRequestParamsMapperTest {
 
     BadRequestException exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
+            BadRequestException.class,
+            () ->
+                TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, Fields.ALL, user));
 
     assertStartsWith(
         "Only one parameter of 'programStatus' and 'enrollmentStatus'", exception.getMessage());
@@ -208,7 +205,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEnrollmentEnrolledAfter(startDate);
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertEquals(startDate.toDate(), params.getProgramEnrollmentStartDate());
   }
@@ -217,7 +215,8 @@ class TrackedEntityRequestParamsMapperTest {
   void testMappingProgram() throws BadRequestException {
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertEquals(PROGRAM_UID, params.getProgram());
   }
@@ -227,7 +226,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
     trackedEntityRequestParams.setProgramStage(PROGRAM_STAGE_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertEquals(PROGRAM_STAGE_UID, params.getProgramStage());
   }
@@ -235,7 +235,8 @@ class TrackedEntityRequestParamsMapperTest {
   @Test
   void testMappingTrackedEntityType() throws BadRequestException {
     trackedEntityRequestParams.setTrackedEntityType(TRACKED_ENTITY_TYPE_UID);
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertEquals(TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityType());
   }
@@ -246,7 +247,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setAssignedUserMode(AssignedUserSelectionMode.PROVIDED);
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertContainsOnly(
         UID.of("IsdLBTOBzMi", "l5ab8q5skbB"),
@@ -261,7 +263,9 @@ class TrackedEntityRequestParamsMapperTest {
 
     BadRequestException exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
+            BadRequestException.class,
+            () ->
+                TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, Fields.ALL, user));
 
     assertStartsWith("`program` must be defined when `programStatus`", exception.getMessage());
   }
@@ -273,7 +277,9 @@ class TrackedEntityRequestParamsMapperTest {
 
     BadRequestException exception =
         assertThrows(
-            BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null, user));
+            BadRequestException.class,
+            () ->
+                TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, Fields.ALL, user));
 
     assertStartsWith("`program` must be defined when `enrollmentStatus`", exception.getMessage());
   }
@@ -282,7 +288,9 @@ class TrackedEntityRequestParamsMapperTest {
   void shouldFailIfGivenStatusAndNotOccurredEventDates() {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+    assertThrows(
+        BadRequestException.class,
+        () -> TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -290,7 +298,9 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
     trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+    assertThrows(
+        BadRequestException.class,
+        () -> TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -298,7 +308,9 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-11-11"));
     trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
-    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+    assertThrows(
+        BadRequestException.class,
+        () -> TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
@@ -307,7 +319,8 @@ class TrackedEntityRequestParamsMapperTest {
         OrderCriteria.fromOrderString("createdAt:asc,zGlzbfreTOH,enrolledAt:desc"));
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertEquals(
         List.of(
@@ -321,7 +334,8 @@ class TrackedEntityRequestParamsMapperTest {
   void testMappingOrderParamsNoOrder() throws BadRequestException {
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
+    TrackedEntityOperationParams params =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user);
 
     assertIsEmpty(params.getOrder());
   }
@@ -332,7 +346,9 @@ class TrackedEntityRequestParamsMapperTest {
         OrderCriteria.fromOrderString("unsupportedProperty1:asc,enrolledAt:asc"));
 
     Exception exception =
-        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+        assertThrows(
+            BadRequestException.class,
+            () -> TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () -> assertContains("unsupportedProperty1", exception.getMessage()));
@@ -344,7 +360,8 @@ class TrackedEntityRequestParamsMapperTest {
     trackedEntityRequestParams.setFilter(TEA_1_UID + ":like:value1," + TEA_2_UID + ":like:value2");
     trackedEntityRequestParams.setProgram(PROGRAM_UID);
 
-    Map<UID, List<QueryFilter>> filters = mapper.map(trackedEntityRequestParams, user).getFilters();
+    Map<UID, List<QueryFilter>> filters =
+        TrackedEntityRequestParamsMapper.map(trackedEntityRequestParams, user).getFilters();
 
     assertEquals(
         Map.of(

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -231,6 +231,7 @@
     <easy-random.version>5.0.0</easy-random.version>
     <tree.version>0.2.5</tree.version>
     <h2.version>2.3.232</h2.version>
+    <jmh.version>1.37</jmh.version>
     <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
 
     <!-- Maven plugin versions -->
@@ -1724,7 +1725,18 @@
         <artifactId>minio</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
+        <scope>test</scope>
+      </dependency>
       <!-- Monitoring -->
       <dependency>
         <groupId>io.prometheus</groupId>
@@ -2395,7 +2407,7 @@ jasperreports.version=${jasperreports.version}
               <skipTests>${skipTests}</skipTests>
               <trimStackTrace>false</trimStackTrace>
               <argLine>@{argLine} ${surefireArgLine}</argLine>
-              <excludedGroups>integration,integrationH2</excludedGroups>
+              <excludedGroups>benchmark,integration,integrationH2</excludedGroups>
               <systemPropertyVariables>
                 <!-- Uncomment if you need to debug the log4j2 config itself -->
                 <!-- <log4j2.debug>true</log4j2.debug> -->
@@ -2421,6 +2433,7 @@ jasperreports.version=${jasperreports.version}
               <trimStackTrace>false</trimStackTrace>
               <argLine>@{argLine} ${surefireArgLine}</argLine>
               <groups>integration</groups>
+              <excludedGroups>benchmark</excludedGroups>
               <systemPropertyVariables>
                 <!-- Uncomment if you need to debug the log4j2 config itself -->
                 <!-- <log4j2.debug>true</log4j2.debug> -->
@@ -2446,6 +2459,7 @@ jasperreports.version=${jasperreports.version}
               <trimStackTrace>false</trimStackTrace>
               <argLine>@{argLine} ${surefireArgLine}</argLine>
               <groups>integrationH2</groups>
+              <excludedGroups>benchmark</excludedGroups>
               <systemPropertyVariables>
                 <!-- Uncomment if you need to debug the log4j2 config itself -->
                 <!-- <log4j2.debug>true</log4j2.debug> -->


### PR DESCRIPTION
## Background

[field filtering](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter) allows reducing the JSON response via the query parameter `fields`. The JSON response can also be changed using these [transformations](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_field_transformers). Field filtering is used by almost every endpoint in DHIS2. Tracker uses the same implementation as platform which was [re-implemented in 2.38](https://dhis2.atlassian.net/browse/TECH-650) using Jackson. It looks to me as if analytics still depends on the [previous field filter implementation](https://github.com/dhis2/dhis2-core/tree/master/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter) at least in some endpoint(s).

I ran a [Gatling](https://github.com/dhis2/performance-tests-gatling) performance tests locally with a single user making 100 requests against `/api/organisationUnits?fields=:all,!name,!id,!favorites,!translations,!children,!sharing` sequentially. I collected the following profile

[profile.html](https://github.com/user-attachments/files/22094934/profile.html)

If you select a thread processing an HTTP request and search (Ctrl+f) for `fieldfiltering` you'll find that 90% of CPU samples are dealing with it. This gets worse quickly if you increase the `pageSize` and thus the elements to be filtered. Field filtering outways time spent in the DB even though hibernate is making lots of requests to the DB (at least one per entity)!

To get a feel for the cost of field filtering I ran the above test against

1. dhis2/core:42.0 with no code changes
2. dhis2/core-dev:42.0 where I removed the field filtering feature, so no matter `fields` we serialize the entire object using Jackson

For our default `pageSize=50` we already pay ~20ms on field filtering even though 2. is at a disadvantage as it has to serialize more than 1. as there is no filtering.

<img width="1000" height="600" alt="analysis" src="https://github.com/user-attachments/assets/e4126171-6df4-451f-868b-b1a052b53342" />

The main reasons why the current implementation is slow are

1. The implementation is built around the full path of a field:

[FieldFilterService](https://github.com/dhis2/dhis2-core/blob/2151f37440c411b844ee59aa6c6a1420012f6dcb/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java#L250) turns `fields=:all,!name,!id,!favorites,!translations,!children,!sharing` into

```
paths = {ArrayList@31490}  size = 71
 0 = {FieldPath@31270} "FieldPath(name=parent, path=[], exclude=false, preset=false, transformers=[], fullPath=parent)"
 1 = {FieldPath@31415} "FieldPath(name=yearToDate, path=[queryMods], exclude=false, preset=false, transformers=[], fullPath=queryMods.yearToDate)"
 2 = {FieldPath@31272} "FieldPath(name=type, path=[], exclude=false, preset=false, transformers=[], fullPath=type)"
 3 = {FieldPath@31483} "FieldPath(name=minDate, path=[queryMods], exclude=false, preset=false, transformers=[], fullPath=queryMods.minDate)"
...
```

Our Jackson [FieldFilterSimpleBeanPropertyFilter](https://github.com/dhis2/dhis2-core/blob/a7c9affd49bbb02db3b48c2597e377f098bfb779/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java#L118-L150) is then called for every field on an object to decide whether it should be serialized. [FieldFilterSimpleBeanPropertyFilter](https://github.com/dhis2/dhis2-core/blob/a7c9affd49bbb02db3b48c2597e377f098bfb779/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java#L118-L150) builds the full path again and again for every field from Jacksons generator state. This involves lots of String splits, joins, StringBuilder operations like `insert(0` 😨.

To answer the question `should the field be include it or not?` we then iterate over all field paths (which can really be all or most of them with `fields=*`) and [String compare paths](https://github.com/dhis2/dhis2-core/blob/a7c9affd49bbb02db3b48c2597e377f098bfb779/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java#L109-L110).

2. We are using a post-processing approach:

We serialize the [Jackson filtered object to a Jackson JsonNode](https://github.com/dhis2/dhis2-core/blob/4b34f59a62e1ebb2c28d1f4e9fee3497587d093c/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java#L271) so we can then apply [transformations](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_field_transformers)

https://github.com/FasterXML/jackson-databind/blob/d4220ed27198847e13ce75d9bee805e028a100e0/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java#L3639
> Functionally similar to serializing value into token stream and parsing that stream back as tree model node, but more efficient as {@link TokenBuffer} is used to contain the intermediate representation instead of fully serialized contents.

The price of field transformations is also paid when users don't actually transform any fields. Remember [valueToTree](https://github.com/FasterXML/jackson-databind/blob/d4220ed27198847e13ce75d9bee805e028a100e0/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java#L3636-L3642) described above.

This is the flow of data until it reaches the HTTP body

`DHIS2 entity => Jackson property filter & serialize to a Jackson ObjectNode => serialized again in controllers/message converter to HTTP body`

So even though you find the words `stream` in some of the involved code we do not actually stream the entities to the HTTP body directly. We will create JSON in-memory representations first like in [StreamingJsonRoot.pager](https://github.com/dhis2/dhis2-core/blob/4b34f59a62e1ebb2c28d1f4e9fee3497587d093c/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/StreamingJsonRoot.java#L47-L48) which is then serialized in [StreamingJsonRootMessageConverter](https://github.com/dhis2/dhis2-core/blob/4b34f59a62e1ebb2c28d1f4e9fee3497587d093c/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/StreamingJsonRootMessageConverter.java#L62) when it comes to metadata. Endpoints returning a Jackson `ObjectNode` or any other type rely on Spring serializing to the HTTP body using the `ObjectMapper`.

3. (maybe minor) Not following [Jacksons advice](https://github.com/fasterxml/jackson-docs/wiki/presentation:-jackson-performance#basics-things-you-should-do-anyway) as we copy the heavy thread safe [ObjectMapper on every request](https://github.com/dhis2/dhis2-core/blob/4b34f59a62e1ebb2c28d1f4e9fee3497587d093c/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java#L258).

It is important we optimize this
* as it affects almost every endpoint
* even when users don't send us a `fields` parameter a default will be in place like this one in `/tracker/trackedEntities` [fields=*,!relationships,!enrollments,!events,!programOwners](https://github.com/dhis2/dhis2-core/blob/4b34f59a62e1ebb2c28d1f4e9fee3497587d093c/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java#L68)
* you could argue users rarely use a `pageSize` larger than the default of `50`. It still matters as we have deeply nested entities like tracked entity that can have lots of collections of nested entities which are not affected by the `pageSize`
* our apps like Capture make many API requests even in a single page. Try clicking your way to an event dashboard by selecting an orgUnit and program and you'll find ~80 API requests (the exact number of API requests is lower due to some being for static content or not field filtered)

## Improved implementation

This PR shows how we can improve what was [re-implemented in 2.38](https://dhis2.atlassian.net/browse/TECH-650) using Jackson. The essence is that for every field Jackson needs to know `should I include it or not?`. This is essentially a predicate `boolean test(String field)` which must be answered quickly.

How?

1. We build up a structure of predicates (`Fields`) that reflect the structure of the data being filtered. [in `FieldsParser`]
2. We use the fact that Jackson will traverse the object tree in depth-first order. [in `FieldsPropertyFilter`]
3. We store the current objects predicate tree in Jacksons context and reset it once Jackson is done with serializing that object. [in `FieldsPropertyFilter`]
6. We do still use the current approach of building up the intermediate `Jackson ObjectNode` but only for fields that are actually transformed. [in `FieldsPropertyFilter`]

Transformations (4.) could be further improved. Some transformations like `rename` can be done without creating intermediate `Jackson ObjectNode`. Others like `isEmpty` are more challenging as they need JSON type information which we do not have in the property filter unless we actually serialize. I did not go further with optimizing 4. as I am not sure many people even use transformations.

Benefits of new implementation

* faster response times
* less garbage as without transformation we truly stream our Java entities to the HTTP body

## Benchmark

Benchmark `FieldFilterSerializationBenchmarkTest` compares the throughput of the current and the proposed implementation. It also compares the presence of field filtering when no filtering occurs i.e. `fields=*` with pure Jackson serialization. The **operation** being benchmarked is the parsing of `fields` and the serialization of `List<Event>` to a JSON `String` which includes filtering and transforming events.

JMH advice is to fork the JVM to prevent interference between the runs. I have set `fork(0)` because of Spring/authentication. It took me a while to get Spring and JMH to work. So don't put too much faith into the exact numbers (I also ran this locally). Since our workload is static, same POJOs are serialized, I think that should be alright. The difference in magnitude should also be enough indication. I also ran a performance test locally against the application so we can more clearly see the impact on the response times.

### `fields=*` (overhead analysis)

We can calculate an overhead of the `field filter` feature/implementation by comparing the field filter implementations throughput with `fields=*` to pure Jackson serialization.

<img width="3550" height="2364" alt="benchmark_graph_star" src="https://github.com/user-attachments/assets/63dc8a88-0611-4789-8071-370f695118ec" />

These are the throughput values and the overhead i.e. `Overhead = (noFieldFiltering - xxxFieldFiltering) / noFieldFiltering`. The event count is the number of events serialized in the benchmarked operation.

|   Event Count | No Filtering (events/s)   | Better Filtering (events/s)   | Current Filtering (events/s)   | Better Overhead (%)   | Current Overhead (%)   | Better vs Current (x faster)   |
|--------------:|:--------------------------|:------------------------------|:-------------------------------|:----------------------|:-----------------------|:-------------------------------|
|            25 | 104,891                   | 63,939                        | 1,446                          | 39.0%                 | 98.6%                  | 44.2x                          |
|            50 | 84,331                    | 57,366                        | 1,504                          | 32.0%                 | 98.2%                  | 38.1x                          |
|           100 | 88,863                    | 53,817                        | 1,597                          | 39.4%                 | 98.2%                  | 33.7x                          |
|           200 | 91,592                    | 51,846                        | 1,637                          | 43.4%                 | 98.2%                  | 31.7x                          |
|           400 | 88,885                    | 55,407                        | 1,599                          | 37.7%                 | 98.2%                  | 34.6x                          |
|           800 | 91,857                    | 53,514                        | 1,694                          | 41.7%                 | 98.2%                  | 31.6x                          |

#### Allocations and GC

I ran the `fields=*` and `eventCount=50` benchmark from before with the async-profiler profiling allocations. In this run the proposed implementation processed 31x more events/s than the current implementation.

|   Event Count | No Filtering (events/s)   | Better Filtering (events/s)   | Current Filtering (events/s)   | Better Overhead (%)   | Current Overhead (%)   | Better vs Current (x faster)   |
|--------------:|:--------------------------|:------------------------------|:-------------------------------|:----------------------|:-----------------------|:-------------------------------|
|            50 | 71,569                    | 40,885                        | 1,333                          | 42.9%                 | 98.1%                  | 30.7x                          |

This was the allocation behavior:

  | Event Type                      | No Filtering   | Better         | Current       |
  |---------------------------------|----------------|----------------|---------------|
  | jdk.ObjectAllocationInNewTLAB   | 29,468 (592KB) | 16,756 (333KB) | 6,309 (120KB) |
  | jdk.ObjectAllocationOutsideTLAB | 0              | 0              | 0             |
  | jdk.GCHeapSummary               | 24 events      | 14 events      | 6 events      |

if we now compare the allocations per event

| Implementation | Total Allocs | Events/s | Duration | Total Events | Allocs/Event |
  |----------------|--------------|----------|----------|--------------|--------------|
  | Current        | 6,309        | 1,333    | 25s      | 33,325       | 0.189        |
  | Better         | 16,756       | 40,885   | 25s      | 1,022,125    | 0.016        |
  | No Filtering   | 29,468       | 71,569   | 25s      | 1,789,225    | 0.016        |

- Better implementation: 12x more allocation-efficient per event (0.016 vs 0.189)
- Better optimization: Achieves baseline allocation efficiency (same as no filtering) while maintaining filtering functionality
- The current implementation has less GC events which I would explain by it processing considerably less events

Allocation flamegraphs created using `jfrconv --alloc --total jfr-alloc.jfr alloc-flamegraph.html`:

- no field filtering [alloc-flamegraph.html](https://github.com/user-attachments/files/22166981/alloc-flamegraph.html)
- better field filtering [alloc-flamegraph.html](https://github.com/user-attachments/files/22166995/alloc-flamegraph.html)
- current field filtering [alloc-flamegraph.html](https://github.com/user-attachments/files/22167000/alloc-flamegraph.html)

You can see the current field filtering does lots of `String` manipulations. The better implementation shows allocations due to Jackson and date serialization which we can optimize further later on.

### `fields=*,!relationships`

|   Event Count | Better Filtering (events/s)   | Current Filtering (events/s)   | Performance Improvement   |
|--------------:|:------------------------------|:-------------------------------|:--------------------------|
|            25 | 188,110                       | 14,115                         | 13.3x                     |
|            50 | 185,000                       | 21,462                         | 8.6x                      |
|           100 | 172,609                       | 26,726                         | 6.5x                      |
|           200 | 165,711                       | 31,444                         | 5.3x                      |
|           400 | 171,590                       | 34,400                         | 5.0x                      |
|           800 | 165,264                       | 35,154                         | 4.7x                      |

### `fields=*,event~rename(foo)` (transformation)

From the results of serializing all fields with one renamed we can see

* The current implementation has similar throughput to `fields=*` as it always creates the intermediate `Jackson ObjectNode` in memory.
* You can see the transformation does affect the proposed implementation as it uses the same approach and creates an intermediate `Jackson ObjectNode` in memory. It still outperforms the current implementation as it will only create an `ObjectNode` for the node it actually transforms.

|   Event Count | Better Filtering (events/s)   | Current Filtering (events/s)   | Performance Improvement   |
|--------------:|:------------------------------|:-------------------------------|:--------------------------|
|            25 | 56,172                        | 1,461                          | 38.4x                     |
|            50 | 50,329                        | 1,521                          | 33.1x                     |
|           100 | 53,232                        | 1,657                          | 32.1x                     |
|           200 | 50,400                        | 1,584                          | 31.8x                     |
|           400 | 53,804                        | 1,588                          | 33.9x                     |
|           800 | 52,718                        | 1,659                          | 31.8x                     |

### `fields=event`

Filtering out all but a single string field with `fields=event` leads to

|   Event Count | Better Filtering (events/s)   | Current Filtering (events/s)   | Performance Improvement   |
|--------------:|:------------------------------|:-------------------------------|:--------------------------|
|            25 | 2,146,797                     | 95,280                         | 22.5x                     |
|            50 | 2,220,312                     | 162,887                        | 13.6x                     |
|           100 | 2,356,845                     | 248,318                        | 9.5x                      |
|           200 | 2,447,940                     | 343,439                        | 7.1x                      |
|           400 | 2,274,336                     | 416,872                        | 5.5x                      |
|           800 | 2,479,009                     | 445,075                        | 5.6x                      |

## HTTP API performance

I ran a [Gatling](https://github.com/dhis2/performance-tests-gatling) performance tests locally with a single user making 100 sequential HTTP requests against

1. dhis2/core-dev:42-47f0d4eae9 with no code changes
2. this PRs changes with the proposed implementation

I picked a slow request the Capture app makes as the target. Select a [Child Programme and orgUnit Ngelehun CHC](https://play.im.dhis2.org/stable-2-42-1/apps/capture#/?orgUnitId=DiszpKrYNg8&programId=IpHINAT79UW&selectedTemplateId=IpHINAT79UW-default). Capture app then makes request `https://play.im.dhis2.org/stable-2-42-1/api/42/tracker/trackedEntities?order=createdAt:desc&page=1&pageSize=15&orgUnits=DiszpKrYNg8&orgUnitMode=SELECTED&program=IpHINAT79UW&fields=:all,!relationships,programOwners[orgUnit,program]`.

The default `pageSize` on the Capture app page above is `15` with options `10, 15, 25, 50, 100`. This graph shows the difference in response times of `current - proposed`

<img width="1000" height="600" alt="analysis" src="https://github.com/user-attachments/assets/580aab39-6cee-4b3a-83e0-feb13a887a00" />

You can see from the CPU profile that field filtering does not play a big role anymore. Once you find (Ctrl+f) the thread handling `TrackedEntitiesExportController.getTrackedEntities`, you'll see that

1. [profile.html before](https://github.com/user-attachments/files/22119668/profile.html):
 ~42% of stacktrace samples are related to `fieldfiltering`
2. [profile.html after](https://github.com/user-attachments/files/22119739/profile.html): ~0.4% of stacktrace samples are related to `fieldfiltering`

### Caveat

The drastic improvement we see with the tracker API above will unlikely be seen with metadata. The reason is that tracker was calling the current field filter service for ever item individually

```java
  public <T> ResponseEntity<Page<ObjectNode>> serve(
      HttpServletRequest request,
      String key,
      org.hisp.dhis.tracker.Page<T> page,
      FieldsRequestParam fieldParams) {
    return ResponseEntity.ok()
        .contentType(MediaType.APPLICATION_JSON)
        .body(
            Page.withPager(
                key,
                page.withMappedItems(
                    i -> fieldFilterService.toObjectNode(i, fieldParams.getFields())),
                getRequestURL(request)));
```

Tracker now field filters the entire list of items at once in the `FilteredPageHttpMessageConverter`.

## Tests

* The proposed parser is unit tested using the same `fields` input strings used for the current implementation while asserting both `fields` outputs match.
* The JSON output of proposed fields filtering vs current implementation is also tested in `FieldFilterSerializationTest`. This tests the parsing, Jackson config and actual field filtering using the Jackson property filter.
* Tracker also has e2e tests and API tests (to which I added transformations). This ensures Spring/Jackson is properly configured.

## Misc changes

* Tracker controller's must be annotated with `@OpenApi.EntityType` and the actual type that is returned/filtered. This type is used to fetch the schema needed to provide preset `fields=:simple`. Double-checked with Jan that this is ok from the OpenAPI point of view 👌🏻 
* Added Spring converter `FilteredPageHttpMessageConverter` (similar to `StreamingJsonRootMessageConverter`) which does the filtering and serialization by streaming to the HTTP body. This is a dedicated converter for Trackers `Page`.

## Jackson and Thread Safety

The proposed field filtering implementation is **thread-safe**. `FieldsConfig` creates a singleton `ObjectMapper` bean. The `FilteredPageHttpMessageConverter` creates a new `ObjectWriter` with `withAttribute()` for each HTTP request, and Jackson's architecture ensures isolation between concurrent serializations.

**Why it's thread-safe:**
  * Singleton [ObjectMapper](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/ObjectMapper.html) (`jsonFilterMapper` bean) is thread-safe and [supposed to be reused](https://github.com/fasterxml/jackson-docs/wiki/presentation:-jackson-performance#basics-things-you-should-do-anyway).
  * Each request gets its own `ObjectWriter` instance via `filterMapper.writer().withAttribute()`
  * Jackson creates isolated `SerializerProvider` instances per serialization call
  * The `FieldsPropertyFilter.serializeAsField()` attribute modifications operate on per-call instances
  * No shared mutable state exists between concurrent requests

## Bugs/Behavior changes

1. unknown field

```http
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=bMcwwoVnbSR&
  occurredAfter=2024-01-01&
  occurredBefore=2024-12-31&
  fields=dataValues[unknown]
```

returned all fields which suggests the `fields` param is correct. For metadata it will only return the `dataValues.id`. That is inline with tracker vs metadata behavior of objects like `fields=dataValues`.

We now return an empty object like we do for

```http
### events with unknown parent
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=bMcwwoVnbSR&
  occurredAfter=2024-01-01&
  occurredBefore=2024-12-31&
  fields=unknown
```

or

```http
### events with unknown child
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/tracker/events?
  program=bMcwwoVnbSR&
  occurredAfter=2024-01-01&
  occurredBefore=2024-12-31&
  fields=dataValues[value,unknown]
```

which only returns `value`.

2. The following fail with an HTTP 500 which are now rejected with a 400

  | fields                   |
  |--------------------------|
  | ]                        |
  | )                        |
  | group[name]]             |                                                              | group[group[name)]),code |
  | group[name))             |
  | group[name],id]          |
  | group[name],id)          |

3. `fields=[value]` is ignored by the current field filter parser. This is now rejected so users get an HTTP 400

4.

```http
### excluding a field and its children
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/organisationUnits?
  pageSize=1&
  fields=:all,!parent

### excluding a field and its children
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/organisationUnits?
  pageSize=1&
  fields=:all,!parent[]

### NPE in current impl when given a child, which is now treated like the above
GET {{PROTOCOL}}://{{AUTH}}@{{HOST}}/api/organisationUnits?
  pageSize=1&
  fields=:all,!parent[name]
```

5. https://dhis2.atlassian.net/browse/DHIS2-19950 - this PR adds validations so requests described in the issue are rejected with a 400

### To Discuss For v43

* `fields=name  code` leads to field `namecode`. Do we want to/have to strip inner whitespace?
* `fields=!:all` will include all. The exclusion is ignored. I think we should reject excluding presets.

## Differences in tracker vs metadata

These field filter features do not work in tracker

* https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_field_transformers
  * `skipSharing`: because we don't even expose this parameter
  * `defaults`: because we don't even expose this parameter
  * put `attributeValue` onto root object: because tracker entities do not have them, they have their own `attributes` which have nothing to do with `attributeValues`
* only [presets](https://github.com/dhis2/dhis2-core/blob/4459605590f853d9f53870894f24a080271c8c84/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPreset.java#L38) `:all` and `:simple`

This behaves differently

* `dataSets.id` is shown for `fields=dataSets` for reference/complex objects like `dataSets` in metatada. `fields=relationships` means `fields=relationships[*]` for tracker. The reason is AFAIK that tracker does not use `Schemas`

## How to apply this to metadata

This PR only applies to tracker endpoints. How could we also use this for metadata? What steps could we take? Tracker does not use all of the field filter features.
