### PR TITLE
feat: Org unit TEA filter in enrollment aggregate [DHIS2-19938]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.substringBetween;
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.common.CteContext.ENROLLMENT_AGGR_BASE;
@@ -554,37 +553,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     return "select " + StringUtils.join(selectCols, ",") + " ";
-  }
-
-  /**
-   * This method switches or add a new prefix to the given column if needed. It takes into
-   * consideration columns used in functions as well as regular columns and columns with aliases.
-   *
-   * <p>ie:
-   *
-   * <ul>
-   *   <li>ax.value as "A03MvHHogjR" -> ax.value as "A03MvHHogjR"
-   *   <li>ev.value as "A03MvHHogjR" -> ev.value as "A03MvHHogjR"
-   *   <li>value as "A03MvHHogjR" -> ax.value as "A03MvHHogjR"
-   *   <li>count() as value -> count() as value"
-   *   <li>ST_Y(ax.geometry) -> ST_Y(ax.geometry)
-   * </ul>
-   *
-   * @param column to be prefixed.
-   * @return the prefixed column (if required).
-   */
-  String addEnrollmentPrefix(String column) {
-    String functionColumn = substringBetween(column, "(", ")");
-    boolean hasFunction = functionColumn != null;
-    boolean hasPrefix = column.contains("ax.") || column.contains("ev.");
-
-    if (!hasFunction && !hasPrefix) {
-      column = "ax." + column;
-    } else if (hasFunction && functionColumn.length() > 0 && !hasPrefix) {
-      column = column.replace(functionColumn, "ax." + functionColumn);
-    }
-
-    return column;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -933,6 +933,29 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
+  void testInFilterForEnrollmentsAggregate() {
+    // Given
+    QueryItem queryItem = mock(QueryItem.class);
+    QueryFilter queryFilter = new QueryFilter(IN, "A;B;C");
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withStartDate(new Date())
+            .withEndDate(new Date())
+            .withEndpointAction(AGGREGATE)
+            .withEndpointItem(ENROLLMENT)
+            .build();
+    when(queryItem.getItemName()).thenReturn("anyItem");
+    when(queryItem.getValueType()).thenReturn(ValueType.ORGANISATION_UNIT);
+    when(organisationUnitResolver.resolveOrgUnits(any(), any())).thenReturn("A;B;C");
+
+    // When
+    String sql = eventSubject.toSql(queryItem, queryFilter, params).trim();
+
+    // Then
+    assertEquals("ax.\"anyItem\" in ('A','B','C')", sql);
+  }
+
+  @Test
   void testGetSelectClauseForQueryEnrollments() {
     // Given
     Period period = new Period(THIS_YEAR);


### PR DESCRIPTION
The analytics enrollment aggregate endpoint needs to support filtering by TEA of type organization unit. This should be done for the `filter` and `dimension` params.

`filter=Jz9SFscXSHb:IN:ImspTQPwCqd`
`dimension=Jz9SFscXSHb:IN:ImspTQPwCqd`

These changes require a few checks in different places, which are all part of the same requirement.
To make it more readable and maintainable, I created the `EnrollmentOrgUnitFilterHandler` class, so all checks are concentrated in a single place.


Example of queries (DB 2.38 FE, E2E):

```
/api/analytics/enrollments/aggregate/rTOK3lv5A5G.json?dimension=Jz9SFscXSHb:IN:ImspTQPwCqd;USER_ORGUNIT;USER_ORGUNIT_GRANDCHILDREN;lc3eMKXaEfw;bL4ooGhyHRQ;LEVEL-H1KlN4QIauv;USER_ORGUNIT_CHILDREN;Vth0fbpFcsO;OU_GROUP-CXw2yu5fodb&filter=ou:USER_ORGUNIT,pe:LAST_10_YEARS&totalPages=false&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&relativePeriodDate=2025-07-01


/api/analytics/enrollments/aggregate/rTOK3lv5A5G.json?dimension=Jz9SFscXSHb&filter=Jz9SFscXSHb:IN:ImspTQPwCqd;USER_ORGUNIT;USER_ORGUNIT_GRANDCHILDREN;lc3eMKXaEfw;bL4ooGhyHRQ;LEVEL-H1KlN4QIauv;,pe:LAST_10_YEARS&totalPages=false&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&relativePeriodDate=2025-07-01
```