### PR TITLE
fix: escape routes once

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -343,7 +343,7 @@ public class RouteService {
 
     uriComponentsBuilder.path(getSubPath(route, subPath));
 
-    return uriComponentsBuilder.toUriString();
+    return uriComponentsBuilder.build().toUriString();
   }
 
   protected WebClient.RequestHeadersSpec<?> buildRequestSpec(


### PR DESCRIPTION
[DHIS2-20010](https://dhis2.atlassian.net/browse/DHIS2-20010)

Adds a solution suggested in the issue above -- before/after:

<img width="1866" height="1143" alt="route-fix-before" src="https://github.com/user-attachments/assets/adbb67fc-005b-4935-8265-0402e6d6619f" />

<img width="1866" height="1143" alt="route-fix-after" src="https://github.com/user-attachments/assets/f4330900-57c8-475c-a775-9c568ffdac30" />
