### PR TITLE
chore: Clean up data value import of period in test

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueMultiTextControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueMultiTextControllerTest.java
@@ -45,12 +45,15 @@ import org.hisp.dhis.test.webapi.json.domain.JsonImportConflict;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * Tests data value validation for {@link org.hisp.dhis.common.ValueType#MULTI_TEXT}.
  *
  * @author Jan Bernitt
  */
+@TestInstance(Lifecycle.PER_CLASS)
 class DataValueMultiTextControllerTest extends AbstractDataValueControllerTest {
   private String multiTextDataElementId;
 


### PR DESCRIPTION
# Issue
These integration tests started failing on GitHub only (which usually suggests it's a test order/data issue)
- `DataIntegrityPeriodsDistantPastControllerTest`
- `DataIntegrityPeriodsThreeYearFutureControllerTest`

# Cause
It seems that this test `DataValueMultiTextControllerTest#testPostJsonDataValueSet_MultiText_NoSuchOption` leaves a `Period` in the DB after it completes.
It looks like this results in unexpected results for the Data Integrity tests (if they run after `testPostJsonDataValueSet_MultiText_NoSuchOption`).

This test (`testPostJsonDataValueSet_MultiText_NoSuchOption`) ends up calling `HibernatePeriodStore#insertIsoPeriodInStatelessSession` which inserts a `Period` in a different session to that of the Spring test. This means that Spring isn't aware of this insert and doesn't roll it back after the test completes.
Our test cleanup doesn't catch it because the test uses `@Transactional`, so we let Spring clean up.

# Fix
There are 2 options that result in the `Period` being deleted after the test (getting the tests passing again):
1. Add `@TestInstance(Lifecycle.PER_CLASS)` to `DataValueMultiTextControllerTest`
- this results in the test clean up being done by our `SpringIntegrationTestExtension` and the DB tables are emptied

2. Remove `@Transactional` from `AbstractDataValueControllerTest`
- this results in the test clean up being done by our `SpringIntegrationTestExtension` and the DB tables are emptied

This PR goes with option 1 as it only effects 1 test class. Option 2 affects 4 test classes.

# Info
The exact reason why the tests started failing now is still unknown. Tests and code don't seem to have any recent changes.