### PR TITLE
chore: Add integrity check for null occurred date for single events [DHIS2-19614](2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -42,6 +42,7 @@ checks:
   - programs/programs_custom_data_entry_form_empty.yaml
   - programs/tracker_geometry_invalid_srid.yaml
   - program_indicators/program_indicators_without_expression.yaml
+  - tracker/single_events_null_occurred_date.yaml
   - program_rules/program_rules_no_action.yaml
   - program_rules/program_rules_without_condition.yaml
   - program_rules/program_rules_message_no_template.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -41,8 +41,8 @@ checks:
   - option_sets/option_groups_empty.yaml
   - programs/programs_custom_data_entry_form_empty.yaml
   - programs/tracker_geometry_invalid_srid.yaml
+  - programs/single_events_null_occurred_date.yaml
   - program_indicators/program_indicators_without_expression.yaml
-  - tracker/single_events_null_occurred_date.yaml
   - program_rules/program_rules_no_action.yaml
   - program_rules/program_rules_without_condition.yaml
   - program_rules/program_rules_message_no_template.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/programs/single_events_null_occurred_date.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/programs/single_events_null_occurred_date.yaml
@@ -27,8 +27,8 @@
 ---
 name: single_events_null_occurred_date
 description: Single events without an occurred date
-section: Tracker
-section_order: 1
+section: Programs
+section_order: 3
 summary_sql: >-
   WITH rs as (
   SELECT e.uid
@@ -72,9 +72,8 @@ recommendation: >-
   ensure that you have a backup of your database before running this command, 
   ensure that DHIS2 is not running, perform the change in a test environment first. 
   
-  After linking fixing the single event, 
-  restart DHIS2 and re-run the integrity check to ensure that the single event has an occurred date
-  and the integrity check no longer flags it.
+  After fixing the single event, restart DHIS2 and re-run the integrity check 
+  to ensure that the single event has an occurred date and the integrity check no longer flags it.
   
   Alternatively, if you know that the event is not needed or used, you can delete it.
   You can delete the single event using the following SQL command:
@@ -88,3 +87,4 @@ recommendation: >-
   
   If you are unsure how to proceed or encounter issues when either trying to fix or delete a single event, 
   please feel free to reach out on the DHIS2 Community of Practice forum at https://community.dhis2.org.
+is_slow: true

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/tracker/single_events_null_occurred_date.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/tracker/single_events_null_occurred_date.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2004-2025, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: single_events_null_occurred_date
+description: Single events without an occurred date
+section: Tracker
+section_order: 1
+summary_sql: >-
+  WITH rs as (
+  SELECT e.uid
+  FROM event e
+  INNER JOIN programstage ps ON ps.programstageid = e.programstageid
+  INNER JOIN program p ON p.programid = ps.programid
+  WHERE e.occurreddate IS NULL
+  AND p.type = 'WITHOUT_REGISTRATION'
+  )
+  SELECT COUNT(*) as value,
+  100.0 * COUNT(*) / NULLIF( (SELECT COUNT(*) from event),0) as percent
+  from rs;
+details_sql: >-
+  SELECT 
+    e.uid as uid,
+    e.uid as name,
+    'single event without occurred date' AS comment
+   FROM event e
+   INNER JOIN programstage ps ON ps.programstageid = e.programstageid
+   INNER JOIN program p ON p.programid = ps.programid
+   WHERE e.occurreddate IS NULL
+   AND p.type = 'WITHOUT_REGISTRATION';
+severity: SEVERE
+introduction: >
+  Single event cannot be scheduled, hence occurred date is mandatory. This was enforced by the system
+  but it is not enforced in the database. Starting from v43, the occurred date column for single events
+  will not accept null values. This check must pass in order to be able to upgrade to v43 and later.
+details_id_type: events
+recommendation: >-
+  You will need to either assign an occurred date to the single event or delete the single event.
+  
+  One way it so try to assign to occurreddate column a value getting it from scheduleddate or completeddate
+  or a manually inserted value:
+  
+  UPDATE singleevent
+  SET occurreddate = COALESCE(event.scheduleddate, event.completeddate, '2025-09-01 11:26:00')
+  WHERE uid = '<event_uid>';
+     
+  Be sure to replace `<event_uid>` with the UID of the single event you want to fix.
+  As is always the case with direct database manipulation, you should
+  ensure that you have a backup of your database before running this command, 
+  ensure that DHIS2 is not running, perform the change in a test environment first. 
+  
+  After linking fixing the single event, 
+  restart DHIS2 and re-run the integrity check to ensure that the single event has an occurred date
+  and the integrity check no longer flags it.
+  
+  Alternatively, if you know that the event is not needed or used, you can delete it.
+  You can delete the single event using the following SQL command:
+  
+  UPDATE event SET deleted = true WHERE uid = '<event_uid>';
+    
+  Replace `<event_uid>` with the UID of the single event you want to delete. 
+  Once you have run this command return to the Data Administration app and choose "Maintenance" 
+  and then tick "Permanently remove soft deleted events". Click "Perform maintenance" to 
+  permanently delete the soft-deleted events.
+  
+  If you are unsure how to proceed or encounter issues when either trying to fix or delete a single event, 
+  please feel free to reach out on the DHIS2 Community of Practice forum at https://community.dhis2.org.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -59,7 +59,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(89, checks.size());
+    assertEquals(90, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2125,6 +2125,7 @@ data_integrity.program_rules_message_no_template.name=Program rules actions whic
 data_integrity.program_rules_no_action.name=Program rules with no action.
 data_integrity.program_rules_no_expression.name=Program rules with no expression.
 data_integrity.program_rules_no_priority.name=Program rules with no priority
+data_integrity.single_events_null_occurred_date.name=Single events without an occurred date
 data_integrity.validation_rules_missing_value_strategy_null.name=All validation rule expressions should have a missing value strategy.
 data_integrity.dashboards_not_viewed_one_year.name=Dashboards which have not been actively viewed in the past 12 months
 data_integrity.maps_not_viewed_one_year.name=Maps which have not been viewed in the past 12 months

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegritySingleEventNullOccurredDateTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegritySingleEventNullOccurredDateTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import java.util.Date;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageService;
+import org.hisp.dhis.program.ProgramType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DataIntegritySingleEventNullOccurredDateTest extends AbstractDataIntegrityIntegrationTest {
+
+  @Autowired private ProgramService programService;
+
+  @Autowired private ProgramStageService programStageService;
+
+  private ProgramStage eventProgramStage;
+
+  private Program eventProgram;
+
+  private ProgramStage trackerProgramStage;
+
+  private Program trackerProgram;
+
+  private OrganisationUnit organisationUnit;
+
+  private static final String CHECK = "single_events_null_occurred_date";
+
+  private static final String DETAILS_ID_TYPE = "events";
+
+  @BeforeEach
+  void setup() {
+    trackerProgram = createProgram('B');
+    trackerProgram.setName("programB");
+    trackerProgram.setProgramType(ProgramType.WITH_REGISTRATION);
+    programService.addProgram(trackerProgram);
+
+    trackerProgramStage = createProgramStage('B', trackerProgram);
+    trackerProgramStage.setName("programStageB");
+    programStageService.saveProgramStage(trackerProgramStage);
+
+    eventProgram = createProgram('A');
+    eventProgram.setName("programA");
+    eventProgram.setProgramType(ProgramType.WITHOUT_REGISTRATION);
+    programService.addProgram(eventProgram);
+
+    eventProgramStage = createProgramStage('A', eventProgram);
+    eventProgramStage.setName("programStageA");
+    programStageService.saveProgramStage(eventProgramStage);
+
+    organisationUnit = createOrganisationUnit('A');
+    manager.save(organisationUnit);
+  }
+
+  @Test
+  void shouldFindNoIntegrityIssuesWhenThereIsTrackerEventWithoutOccurredDate() {
+    Enrollment enrollment = createEnrollment(trackerProgram, null, organisationUnit);
+    manager.save(enrollment);
+    Event trackerEvent = createEvent(trackerProgramStage, enrollment, organisationUnit);
+    manager.save(trackerEvent);
+    dbmsManager.clearSession();
+
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK, true);
+  }
+
+  @Test
+  void shouldFindNoIntegrityIssuesWhenThereIsNoSingleEventWithoutOccurredDate() {
+    Enrollment enrollment = createEnrollment(eventProgram, null, organisationUnit);
+    manager.save(enrollment);
+    Event singleEvent = createEvent(eventProgramStage, enrollment, organisationUnit);
+    singleEvent.setOccurredDate(new Date());
+    manager.save(singleEvent);
+    dbmsManager.clearSession();
+
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK, true);
+  }
+
+  @Test
+  void shouldFindIntegrityIssuesWhenThereIsSingleEventWithoutOccurredDate() {
+    Enrollment enrollment = createEnrollment(eventProgram, null, organisationUnit);
+    manager.save(enrollment);
+    Event singleEvent = createEvent(eventProgramStage, enrollment, organisationUnit);
+    singleEvent.setOccurredDate(new Date());
+    manager.save(singleEvent);
+    Event singleEventWithoutOccurredDate =
+        createEvent(eventProgramStage, enrollment, organisationUnit);
+    manager.save(singleEventWithoutOccurredDate);
+    dbmsManager.clearSession();
+
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE,
+        CHECK,
+        50,
+        singleEventWithoutOccurredDate.getUid(),
+        singleEventWithoutOccurredDate.getUid(),
+        "single event without occurred date",
+        true);
+  }
+}


### PR DESCRIPTION
Migration script in master is setting `occurreddate` in `singleevent` table as `not null`. In tracker importer there is already a validation to check that `occurredAt` for a single event (event from a program `WITHOUT_REGISTRATION`) is present but at the DB level the constraint is not there because `event` table contains both types of event and a tracker event (event from a program `WITH_REGISTRATION`) can be scheduled and can have a `null` `occurredAt`.
So, to make sure that the migration will succeed, we are creating an integrity check to make sure every single event has a value in the `occurreddate` column.

**This integrity check only makes sense in versions previous to v43 because there `event` table is present**