### PR TITLE
 fix: Use program owner instead of enrollment org unit [DHIS2-18338][2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/HibernatePotentialDuplicateStore.java
@@ -66,9 +66,11 @@ import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerStore;
 import org.hisp.dhis.tracker.export.trackedentity.HibernateTrackedEntityChangeLogStore;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLog;
 import org.hisp.dhis.user.CurrentUserUtil;
@@ -86,6 +88,8 @@ class HibernatePotentialDuplicateStore
 
   private final HibernateTrackedEntityChangeLogStore hibernateTrackedEntityChangeLogStore;
 
+  private final TrackedEntityProgramOwnerStore trackedEntityProgramOwnerStore;
+
   private final DhisConfigurationProvider config;
 
   public HibernatePotentialDuplicateStore(
@@ -95,10 +99,12 @@ class HibernatePotentialDuplicateStore
       AclService aclService,
       AuditManager auditManager,
       HibernateTrackedEntityChangeLogStore hibernateTrackedEntityChangeLogStore,
+      TrackedEntityProgramOwnerStore trackedEntityProgramOwnerStore,
       DhisConfigurationProvider config) {
     super(entityManager, jdbcTemplate, publisher, PotentialDuplicate.class, aclService, false);
     this.auditManager = auditManager;
     this.hibernateTrackedEntityChangeLogStore = hibernateTrackedEntityChangeLogStore;
+    this.trackedEntityProgramOwnerStore = trackedEntityProgramOwnerStore;
     this.config = config;
   }
 
@@ -290,6 +296,11 @@ class HibernatePotentialDuplicateStore
               UserInfoSnapshot.from(CurrentUserUtil.getCurrentUserDetails()));
           e.setLastUpdated(new Date());
           getSession().update(e);
+          TrackedEntityProgramOwner trackedEntityProgramOwner =
+              trackedEntityProgramOwnerStore.getTrackedEntityProgramOwner(
+                  duplicate, e.getProgram());
+          trackedEntityProgramOwner.setTrackedEntity(original);
+          trackedEntityProgramOwnerStore.update(trackedEntityProgramOwner);
         });
 
     // Flush to update records before we delete duplicate, or else it might

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -78,6 +78,7 @@ import org.hisp.dhis.test.utils.RelationshipUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventChangeLogService;
@@ -129,6 +130,8 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
   @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   private Date enrollmentDate;
 
@@ -193,6 +196,8 @@ class MaintenanceServiceTest extends PostgresIntegrationTestBase {
     manager.save(trackedEntityWithAssociations);
     manager.save(enrollmentWithTeAssociation);
     manager.save(enrollment);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntity, program, organisationUnit);
     event = new Event(enrollment, stageA);
     event.setUid(UID.generate().getValue());
     event.setOrganisationUnit(organisationUnit);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -67,6 +67,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.PageParams;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLog;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
@@ -95,6 +96,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
   @Autowired private TrackedEntityAttributeService trackedEntityAttributeService;
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   @Autowired private IdentifiableObjectManager manager;
 
@@ -131,6 +134,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     Enrollment enrollment2 = createEnrollment(program1, duplicate, orgUnit);
     manager.save(enrollment1);
     manager.save(enrollment2);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(original, program, orgUnit);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(duplicate, program1, orgUnit);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
     manager.update(original);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
@@ -79,6 +80,8 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private RelationshipService relationshipService;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   private TrackedEntityType trackedEntityType;
 
@@ -188,6 +191,14 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     manager.save(enrollment2);
     manager.save(enrollment3);
     manager.save(enrollment4);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        original, program, organisationUnit);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        duplicate, program, organisationUnit);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        control1, program, organisationUnit);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        control2, program, organisationUnit);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
     control1.getEnrollments().add(enrollment3);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -76,6 +76,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.event.EventFields;
 import org.hisp.dhis.tracker.export.relationship.RelationshipFields;
 import org.hisp.dhis.user.User;
@@ -93,6 +94,8 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   @Autowired protected UserService _userService;
 
   @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   private final Date incidentDate = new Date();
 
@@ -240,6 +243,8 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     enrollmentA = createEnrollment(programA, trackedEntityA, orgUnitA);
     manager.save(enrollmentA, false);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityA, programA, orgUnitA);
 
     relationshipA = new Relationship();
     relationshipA.setUid(CodeGenerator.generateUid());
@@ -265,13 +270,19 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
     enrollmentB = createEnrollment(programB, trackedEntityB, orgUnitB);
     manager.save(enrollmentB);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityB, programB, orgUnitB);
 
     enrollmentChildA = createEnrollment(programA, trackedEntityChildA, orgUnitChildA);
     manager.save(enrollmentChildA);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityChildA, programA, orgUnitChildA);
 
     enrollmentGrandchildA =
         createEnrollment(programA, trackedEntityGrandchildA, orgUnitGrandchildA);
     manager.save(enrollmentGrandchildA);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        trackedEntityGrandchildA, programA, orgUnitGrandchildA);
 
     injectSecurityContextUser(user);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.tracker.JsonPage;
 import org.hisp.dhis.webapi.controller.tracker.JsonPage.JsonPager;
@@ -64,6 +65,8 @@ import org.springframework.transaction.annotation.Transactional;
 class ProgramNotificationInstanceControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Autowired private ProgramNotificationInstanceService programNotificationInstanceService;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   private Enrollment enrollment;
 
@@ -94,6 +97,7 @@ class ProgramNotificationInstanceControllerTest extends PostgresControllerIntegr
     manager.save(trackedEntityA);
     enrollment = createEnrollment(prA, trackedEntityA, orgUnit);
     manager.save(enrollment);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(trackedEntityA, prA, orgUnit);
 
     enrollmentNotification1 = new ProgramNotificationInstance();
     enrollmentNotification1.setName("enrollment A notification 1");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -98,6 +98,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
@@ -156,6 +157,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
   @Autowired private EventService eventService;
 
   @Autowired private IncomingSmsService incomingSmsService;
+
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
   @Autowired
   @Qualifier("smsMessageSender")
@@ -866,6 +869,8 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     enrollment.setOccurredDate(new Date());
     enrollment.setStatus(EnrollmentStatus.ACTIVE);
     manager.save(enrollment);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
+        te, trackerProgram, te.getOrganisationUnit());
     return enrollment;
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportNoteControllerTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.webapi.controller.tracker.JsonNote;
@@ -56,11 +57,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestBase {
+  @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
+
   private User importUser;
 
   private Event event;
@@ -237,6 +241,7 @@ class TrackerImportNoteControllerTest extends PostgresControllerIntegrationTestB
     manager.save(enrollmentA, false);
     te.setEnrollments(Set.of(enrollmentA));
     manager.save(te, false);
+    trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(te, program, orgUnit);
     return enrollmentA;
   }
 }


### PR DESCRIPTION
When we fetched enrollments, we were checking user access against the enrollment’s org unit. That was a mistake, since that field just shows where the enrollment came from and isn’t meant for ACL checks.

I’ve fixed it so we now use the org unit owner to validate access instead.
