### PR TITLE
feat: add Configuration Key to override Doris connection.url

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -101,6 +101,12 @@ public enum ConfigurationKey {
   /** Database connection URL. */
   CONNECTION_URL("connection.url", "", false),
 
+  /**
+   * If present, overrides the connection.url value - useful when running Apache Doris in a
+   * container
+   */
+  DORIS_CATALOG_CONNECTION_URL("doris.catalog.connection.url", "", false),
+
   /** Analytics Database connection URL. */
   ANALYTICS_CONNECTION_URL("analytics.connection.url", "", false),
 

--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/init/AnalyticsDatabaseInit.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/init/AnalyticsDatabaseInit.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.db.SqlBuilderProvider;
 import org.hisp.dhis.db.model.Database;
 import org.hisp.dhis.db.setting.SqlBuilderSettings;
@@ -111,7 +112,10 @@ public class AnalyticsDatabaseInit {
    * transaction database as an external data source.
    */
   private void createDorisJdbcCatalog() {
-    String connectionUrl = config.getProperty(ConfigurationKey.CONNECTION_URL);
+    String connectionUrl =
+        StringUtils.firstNonBlank(
+            config.getProperty(ConfigurationKey.DORIS_CATALOG_CONNECTION_URL),
+            config.getProperty(ConfigurationKey.CONNECTION_URL));
     String username = config.getProperty(ConfigurationKey.CONNECTION_USERNAME);
     String password = config.getProperty(ConfigurationKey.CONNECTION_PASSWORD);
 


### PR DESCRIPTION
## Summary  
This PR introduces a new configuration key, `doris.catalog.connection.url`, which overrides the existing `connection.url` configuration. This is implemented to address connectivity issues for Apache Doris running in a Docker container environment when accessing PostgreSQL via `localhost`.

## Changes  
- Added a new configuration key `doris.catalog.connection.url` to customize the connection URL for the Doris catalog.
- Facilitated Doris catalog creation in containerized environments by allowing an alternative to the default `connection.url`.
- Ensured Apache Doris can connect to PostgreSQL using a specified URL when `localhost` is inaccessible due to container networking constraints.

### Example

Upon startup, the following Doris catalog is created:
```sql
CREATE CATALOG pg_local PROPERTIES (
  'type'        = 'jdbc',
  'user'        = 'dhis',
  'password'    = 'dhis',
  'jdbc_url'    = 'jdbc:postgresql://localhost:5432/e2e',
  'driver_class'= 'org.postgresql.Driver',
  'driver_url'  = 'postgresql.jar'
);
```
In scenarios where Apache Doris is containerized, connectivity issues occur as Doris cannot resolve `localhost:5432`. The new configuration key allows the use of an alternative URL, for example, `jdbc:postgresql://host.docker.internal:5432/e2e`, to ensure successful connections.