### PR TITLE
chore: Small updates and more tests for category validations

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/CategoryComboObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/CategoryComboObjectBundleHook.java
@@ -52,7 +52,7 @@ public class CategoryComboObjectBundleHook extends AbstractObjectBundleHook<Cate
   @Override
   public void validate(CategoryCombo combo, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
     checkIsValid(combo, addReports);
-    checkIfDataBecomesInaccessible(combo, bundle, addReports);
+    if (bundle.isPersisted(combo)) checkIfDataBecomesInaccessible(combo, bundle, addReports);
   }
 
   private void checkIfDataBecomesInaccessible(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -185,6 +185,21 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertEquals(0, updateImport.getStats().getIgnored());
   }
 
+  @Test
+  @DisplayName("Importing a new CategoryCombo with no Categories succeeds")
+  void importNewCategoryComboNoCategoriesTest() {
+    // When importing a new Category Combo with no Categories
+    JsonImportSummary importSummary =
+        POST("/metadata", Body(getCatComboWithoutCategory()))
+            .content()
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    // Then it shows as success & created
+    assertEquals("OK", importSummary.getStatus());
+    assertEquals(1, importSummary.getStats().getCreated());
+  }
+
   private String updateUserOrgUnit(String orgUnit) {
     return """
         [
@@ -416,5 +431,20 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
           ]
       }
       """;
+  }
+
+  private String getCatComboWithoutCategory() {
+    return """
+          {
+            "categoryCombos": [
+               {
+                 "id": "CatComUid11",
+                 "name": "cat combo 11",
+                 "dataDimensionType": "DISAGGREGATION",
+                 "categories": []
+               }
+             ]
+          }
+          """;
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonAttributeValue;
+import org.hisp.dhis.test.webapi.json.domain.JsonCategoryOptionCombo;
 import org.hisp.dhis.test.webapi.json.domain.JsonDataElement;
 import org.hisp.dhis.test.webapi.json.domain.JsonErrorReport;
 import org.hisp.dhis.test.webapi.json.domain.JsonIdentifiableObject;
@@ -887,6 +888,39 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
     GET("/categoryOptionCombos/CocUid000a2").content(HttpStatus.OK);
     GET("/categoryOptionCombos/CocUid000a3").content(HttpStatus.OK);
     GET("/categoryOptionCombos/CocUid000a4").content(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName(
+      "Updating CategoryOptionCombo ignoreApproval field should succeed when expected CategoryOptionCombos provided")
+  void updateCocsIgnoreApprovalTest() {
+    // Given category metadata exists
+    POST("/metadata", CAT_METADATA_IMPORT).content(HttpStatus.OK);
+
+    // And the ignoreApproval field is 'false'
+    assertFalse(
+        GET("/categoryOptionCombos/CocUid000a1")
+            .content(HttpStatus.OK)
+            .as(JsonCategoryOptionCombo.class)
+            .getIgnoreApproval());
+
+    // When importing (update) COCs with a new value for the field 'ignoreApproval'
+    JsonImportSummary report =
+        POST("/metadata", Path.of("metadata/category/update_cocs_ignore_approval.json"))
+            .contentUnchecked()
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    // Then the import is successful and the COCs show as updated
+    assertEquals("OK", report.getStatus());
+    assertEquals(4, report.getStats().getUpdated());
+
+    // And the new value of true is present
+    assertTrue(
+        GET("/categoryOptionCombos/CocUid000a1")
+            .content(HttpStatus.OK)
+            .as(JsonCategoryOptionCombo.class)
+            .getIgnoreApproval());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/category/update_cocs_ignore_approval.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/category/update_cocs_ignore_approval.json
@@ -1,0 +1,68 @@
+{
+  "categoryOptionCombos": [
+    {
+      "name": "cat opt a1, cat opt a3",
+      "id": "CocUid000a1",
+      "ignoreApproval": true,
+      "categoryCombo": {
+        "id": "CatComUida1"
+      },
+      "categoryOptions": [
+        {
+          "id": "CatOptUida1"
+        },
+        {
+          "id": "CatOptUida3"
+        }
+      ]
+    },
+    {
+      "name": "cat opt a1, cat opt a4",
+      "id": "CocUid000a2",
+      "ignoreApproval": true,
+      "categoryCombo": {
+        "id": "CatComUida1"
+      },
+      "categoryOptions": [
+        {
+          "id": "CatOptUida1"
+        },
+        {
+          "id": "CatOptUida4"
+        }
+      ]
+    },
+    {
+      "name": "cat opt a2, cat opt a3",
+      "id": "CocUid000a3",
+      "ignoreApproval": true,
+      "categoryCombo": {
+        "id": "CatComUida1"
+      },
+      "categoryOptions": [
+        {
+          "id": "CatOptUida2"
+        },
+        {
+          "id": "CatOptUida3"
+        }
+      ]
+    },
+    {
+      "name": "cat opt a2, cat opt a4",
+      "id": "CocUid000a4",
+      "ignoreApproval": true,
+      "categoryCombo": {
+        "id": "CatComUida1"
+      },
+      "categoryOptions": [
+        {
+          "id": "CatOptUida2"
+        },
+        {
+          "id": "CatOptUida4"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Found a couple of small improvements while testing locally.

Add a check so that new `CategoryCombo`'s are not needlessly checked for existing data
- it's not a big improvement but it might prevent other unknown import scenarios

New tests added:
- to confirm a `CategoryCombo` can be created with no `Categories`
- to confirm`CategoryOptionCombo`s can be updated (test updates `ignoreApproval` field)