### PR TITLE
fix: Validate ACL on event update [DHIS2-10900][2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -296,7 +296,8 @@ public class ServiceConfig {
         getCheckerByClass(EventGeometryCheck.class),
         getCheckerByClass(DataValueCheck.class),
         getCheckerByClass(FilteredDataValueCheck.class),
-        getCheckerByClass(ExpirationDaysCheck.class));
+        getCheckerByClass(ExpirationDaysCheck.class),
+        getCheckerByClass(UpdateProgramStageInstanceAclCheck.class));
   }
 
   @Bean


### PR DESCRIPTION
I'm adding the ACL validation when updating events, as it was missing.
We already have it in place when creating and deleting events.