### PR TITLE
fix: Check write permission to TET when importing TE [DHIS2-20132]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackerAccessManager.java
@@ -112,7 +112,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
     if (!aclService.canDataWrite(user, trackedEntityType)) {
       return List.of(
-          "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
+          "User has no data write access to tracked entity type: " + trackedEntityType.getUid());
     }
 
     List<Program> tetPrograms =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/acl/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/acl/TrackerAccessManagerTest.java
@@ -252,6 +252,23 @@ class TrackerAccessManagerTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void checkAccessPermissionForTeWhenNoWriteAccessToTet() {
+    programA.setPublicAccess(AccessStringHelper.FULL);
+    programA.setAccessLevel(AccessLevel.OPEN);
+    manager.update(programA);
+    User user = createUserWithAuth("user1").setOrganisationUnits(Sets.newHashSet(orgUnitB));
+    user.setTeiSearchOrganisationUnits(Sets.newHashSet(orgUnitA, orgUnitB));
+    UserDetails userDetails = UserDetails.fromUser(user);
+    trackedEntityType.getSharing().setPublicAccess(AccessStringHelper.DATA_READ);
+    manager.update(trackedEntityType);
+
+    assertNoErrors(trackerAccessManager.canRead(userDetails, trackedEntityA));
+    assertHasError(
+        trackerAccessManager.canWrite(userDetails, trackedEntityA),
+        "User has no data write access to tracked entity type");
+  }
+
+  @Test
   void checkAccessPermissionForEnrollmentInClosedProgram()
       throws ForbiddenException, BadRequestException, NotFoundException {
     programA.setPublicAccess(AccessStringHelper.FULL);


### PR DESCRIPTION
When creating a new TE, we verify the user has write access to the TET.
On the other hand, when updating or deleting that TE, the user currently needs read access only to the TET.

We should verify the user has write access in all those cases.