### PR TITLE
ci: exclude benchmark from jenkins DHIS2-19910 [42]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1948,6 +1948,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <excludedGroups>benchmark</excludedGroups>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
for now the [benchmark](https://github.com/dhis2/dhis2-core/pull/21761) is only run manually by devs. I did exclude the tag in all our maven test profiles which we use on github but forgot we also run on jenkins 😅 this excludes the tag by default. jenkins does a `mvn clean install` running all tests without the dedicated profiles. this is why this default should take effect. the profiles override the default so should also still work.