### PR TITLE
fix: disable e2e test postBasedOnSchema while investigating test failure

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.test.e2e.dto.schemas.SchemaProperty;
 import org.hisp.dhis.test.e2e.utils.DataGenerator;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,6 +86,7 @@ public class MetadataImportBasedOnSchemasTest extends ApiTest {
     schemasActions.validateObjectAgainstSchema(schema, firstObject).validate().statusCode(200);
   }
 
+  @Disabled("Disabled while investigating test failures")
   @ParameterizedTest(name = "POST to /{1}")
   @MethodSource("getSchemaEndpoints")
   public void postBasedOnSchema(String endpoint, String schema) {


### PR DESCRIPTION
Disable e2e test while investigating below error 


```
{
    "httpStatus": "Conflict",
    "httpStatusCode": 409,
    "status": "ERROR",
    "message": "One or more errors occurred, please see full details in import report.",
    "response": {
        "klass": "org.hisp.dhis.dataset.Section",
        "errorReports": [
            {
                "message": "Invalid UID `85r6xhxmfwr` for property `Section`",
                "args": [
                    "85r6xhxmfwr",
                    "Section"
                ],
                "mainKlass": "org.hisp.dhis.dataset.Section",
                "errorCode": "E4014",
                "errorProperties": [
                    "85r6xhxmfwr",
                    "Section"
                ]
            }
        ],
        "uid": "85r6xhxmfwr",
        "responseType": "ObjectReportWebMessageResponse"
    }
}
```