### PR TITLE
fix: remove analytics 0-partition tables on scheduled full update

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -101,7 +101,6 @@ public class ContinuousAnalyticsTableJob implements Job {
 
       AnalyticsTableUpdateParams params =
           AnalyticsTableUpdateParams.newBuilder()
-              .lastYears(parameters.getLastYears())
               .skipResourceTables(false)
               .skipOutliers(parameters.getSkipOutliers())
               .skipTableTypes(parameters.getSkipTableTypes())


### PR DESCRIPTION
## Summary

This PR fixes a [bug](https://dhis2.atlassian.net/browse/DHIS2-19473) in the Analytics table generation process, where a scheduled Full update would not remove the `LATEST_PARTITION` table generated by the scheduled partial update.
This would cause the Analytics query to return "duplicated" values, since the SQL query would pull data from the `LATEST_PARTITION` table and the regular table.

## Technical analysis and fix

The error is caused by this [line](https://github.com/dhis2/dhis2-core/blob/f07ccc7285ab713db9cf0867a03580be833bf541/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java#L223) in `AbstractJdbcTableManager.swapTable` function:

```
boolean skipMasterTable =
        params.isPartialUpdate() && tableExists && table.getTableType().isLatestPartition();
```

When `skipMasterTable` is true, the `swapTable` function does not drop the `LATEST_PARTITION` tables, but only operates on the parent table.

By removing the `lastYears` parameter from the `AnalyticsTableUpdateParams`, the `params.isPartialUpdate()` function return `false` and the full update is triggered.