### PR TITLE
fix: ColumnMapper references correct SqlBuilder class

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/util/ColumnMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/util/ColumnMapper.java
@@ -186,10 +186,6 @@ public class ColumnMapper {
     }
   }
 
-  public SqlBuilder getSqlBuilder() {
-    return sqlBuilder;
-  }
-
   /**
    * Returns a cast expression which includes a value filter for the given value type.
    *


### PR DESCRIPTION
## Summary
Fix a bug where configuring the SQL builder for `JdbcTrackedEntityAnalyticsTableManager` changed the `SqlBuilder` globally for all table managers. `ColumnMapper` is no longer a singleton so each `*TableManager` receives its own `ColumnMapper` instance with the correct `SqlBuilder` (e.g., `PostgreSqlBuilder` for TEA analytics).

## Background / Context
- `ColumnMapper` was implemented as a singleton.  
- `JdbcTrackedEntityAnalyticsTableManager` must always use `PostgreSqlBuilder` because tracked entity analytics do not use Doris or ClickHouse.  
- Because `ColumnMapper` was a singleton, setting `PostgreSqlBuilder` for the TEA manager unintentionally affected other `*TableManager` implementations.

## Changes
- Remove the singleton behavior from `ColumnMapper` so it is instantiated per `*TableManager`.  


