### PR TITLE
fix: Validate payload org unit when single event update [DHIS2-20173]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidator.java
@@ -78,14 +78,6 @@ class SecuritySingleEventValidator
             ? preheatEvent.getProgramStage()
             : bundle.getPreheat().getProgramStage(event.getProgramStage());
 
-    if (strategy.isUpdate()) {
-      checkOrgUnitInCaptureScope(
-          reporter,
-          event,
-          bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()),
-          bundle.getUser());
-    }
-
     CategoryOptionCombo categoryOptionCombo =
         bundle.getPreheat().getCategoryOptionCombo(event.getAttributeOptionCombo());
 
@@ -94,6 +86,11 @@ class SecuritySingleEventValidator
     checkWriteCategoryOptionComboAccess(reporter, event, categoryOptionCombo, bundle.getUser());
 
     if (strategy.isUpdate()) {
+      OrganisationUnit payloadOrgUnit = bundle.getPreheat().getOrganisationUnit(event.getOrgUnit());
+      if (!preheatEvent.getOrganisationUnit().getUid().equals(payloadOrgUnit.getUid())) {
+        checkOrgUnitInCaptureScope(reporter, event, payloadOrgUnit, bundle.getUser());
+      }
+
       checkCompletablePermission(reporter, event, preheatEvent, bundle.getUser());
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidator.java
@@ -77,6 +77,15 @@ class SecuritySingleEventValidator
         strategy.isUpdateOrDelete()
             ? preheatEvent.getProgramStage()
             : bundle.getPreheat().getProgramStage(event.getProgramStage());
+
+    if (strategy.isUpdate()) {
+      checkOrgUnitInCaptureScope(
+          reporter,
+          event,
+          bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()),
+          bundle.getUser());
+    }
+
     CategoryOptionCombo categoryOptionCombo =
         bundle.getPreheat().getCategoryOptionCombo(event.getAttributeOptionCombo());
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidatorTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1083;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1091;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1099;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
@@ -165,8 +166,9 @@ class SecuritySingleEventValidatorTest extends TestBase {
       value = TrackerImportStrategy.class,
       mode = EnumSource.Mode.INCLUDE,
       names = {"UPDATE", "DELETE"})
-  void shouldFailValidationWhenUserDoNotHaveOrgUnitInCaptureScoreForUpdateAndDeleteStrategy(
-      TrackerImportStrategy strategy) {
+  void
+      shouldFailValidationWhenUserDoesNotHaveDatabaseOrgUnitInCaptureScopeForUpdateAndDeleteStrategy(
+          TrackerImportStrategy strategy) {
     UID enrollmentUid = UID.generate();
     org.hisp.dhis.tracker.imports.domain.Event event =
         org.hisp.dhis.tracker.imports.domain.SingleEvent.builder()
@@ -180,6 +182,47 @@ class SecuritySingleEventValidatorTest extends TestBase {
     when(bundle.getStrategy(event)).thenReturn(strategy);
     SingleEvent preheatEvent = getEvent();
     when(preheat.getSingleEvent(event.getEvent())).thenReturn(preheatEvent);
+    lenient()
+        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
+        .thenReturn(organisationUnit);
+
+    validator.validate(reporter, bundle, event);
+
+    assertHasError(reporter, event, E1000);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TrackerImportStrategy.class,
+      mode = EnumSource.Mode.INCLUDE,
+      names = {"UPDATE"})
+  void shouldFailValidationWhenUserDoesNotHavePayloadOrgUnitInCaptureScopeForUpdateStrategy(
+      TrackerImportStrategy strategy) {
+    UID enrollmentUid = UID.generate();
+    org.hisp.dhis.tracker.imports.domain.Event event =
+        org.hisp.dhis.tracker.imports.domain.SingleEvent.builder()
+            .event(UID.generate())
+            .enrollment(enrollmentUid)
+            .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
+            .programStage(MetadataIdentifier.ofUid(PS_ID))
+            .program(MetadataIdentifier.ofUid(PROGRAM_ID))
+            .build();
+
+    User user = makeUser("B");
+    user.setOrganisationUnits(Set.of(organisationUnit));
+    UserDetails userDetails = UserDetails.fromUser(user);
+    when(bundle.getUser()).thenReturn(userDetails);
+
+    OrganisationUnit outOfScopeOrgUnit = createOrganisationUnit('B');
+    outOfScopeOrgUnit.setUid("ORG_UNIT_UID");
+    outOfScopeOrgUnit.updatePath();
+
+    when(bundle.getStrategy(event)).thenReturn(strategy);
+    SingleEvent preheatEvent = getEvent();
+    when(preheat.getSingleEvent(event.getEvent())).thenReturn(preheatEvent);
+    lenient()
+        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
+        .thenReturn(outOfScopeOrgUnit);
 
     validator.validate(reporter, bundle, event);
 
@@ -238,6 +281,9 @@ class SecuritySingleEventValidatorTest extends TestBase {
     when(preheat.getSingleEvent(event.getEvent())).thenReturn(preheatEvent);
     UserDetails userDetails = setUpUserWithOrgUnit();
     when(aclService.canDataWrite(userDetails, program)).thenReturn(false);
+    lenient()
+        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
+        .thenReturn(organisationUnit);
 
     validator.validate(reporter, bundle, event);
 
@@ -306,6 +352,9 @@ class SecuritySingleEventValidatorTest extends TestBase {
     UserDetails userDetails = setUpUserWithOrgUnit();
     when(aclService.canDataWrite(userDetails, program)).thenReturn(true);
     when(aclService.canDataWrite(userDetails, categoryOption)).thenReturn(false);
+    lenient()
+        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
+        .thenReturn(organisationUnit);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, E1099);
@@ -339,6 +388,9 @@ class SecuritySingleEventValidatorTest extends TestBase {
     UserDetails userDetails = setUpUserWithOrgUnit();
     when(aclService.canDataWrite(userDetails, program)).thenReturn(true);
     when(aclService.canDataWrite(userDetails, categoryOption)).thenReturn(true);
+    lenient()
+        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
+        .thenReturn(organisationUnit);
 
     validator.validate(reporter, bundle, event);
 
@@ -396,6 +448,7 @@ class SecuritySingleEventValidatorTest extends TestBase {
     when(preheat.getSingleEvent(event.getEvent())).thenReturn(preheatEvent);
 
     when(aclService.canDataWrite(user, program)).thenReturn(true);
+    when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit())).thenReturn(organisationUnit);
 
     validator.validate(reporter, bundle, event);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecuritySingleEventValidatorTest.java
@@ -220,9 +220,7 @@ class SecuritySingleEventValidatorTest extends TestBase {
     when(bundle.getStrategy(event)).thenReturn(strategy);
     SingleEvent preheatEvent = getEvent();
     when(preheat.getSingleEvent(event.getEvent())).thenReturn(preheatEvent);
-    lenient()
-        .when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit()))
-        .thenReturn(outOfScopeOrgUnit);
+    when(bundle.getPreheat().getOrganisationUnit(event.getOrgUnit())).thenReturn(outOfScopeOrgUnit);
 
     validator.validate(reporter, bundle, event);
 


### PR DESCRIPTION
When updating a single event, if the org unit is updated, we need to validate both the current org unit and the one in the payload. Currently, only the former is validated.