### PR TITLE
fix: make sure a failed POST of a DV with file does not leave parts behind [DHIS2-20190]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -212,7 +212,7 @@ public class DataValueController {
       return new WebMessage(Status.OK, HttpStatus.ACCEPTED)
           .setResponse(new FileResourceWebMessageResponse(fr));
     } catch (Exception ex) {
-      // in case we fail to save the FR delete the DV as well
+      // in case we fail to save the FR => delete the DV as well
       deleteDataValue(
           DataValueQueryParams.builder().de(de).co(co).cc(cc).cp(cp).pe(pe).ou(ou).build(),
           ds,


### PR DESCRIPTION
### Summary
Posting a file data value could fail storing the DV for example due to validation issues. This would leave the file resource behind. This PR fixes that by first storing the data value with a fresh UID, once that succeeds it file resource is created. This is so we avoid the complicated process of deleting an unwanted file resource. We rather delete an unwanted data value which is what is now happening should we fail to store the file resource.

### Manual Testing
See Jira

### Automatic Testing
A test case was added to confirm. 