### PR TITLE
fix: remove analytics 0-partition tables on scheduled full update [2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -101,7 +101,6 @@ public class ContinuousAnalyticsTableJob implements Job {
 
       AnalyticsTableUpdateParams params =
           AnalyticsTableUpdateParams.newBuilder()
-              .lastYears(parameters.getLastYears())
               .skipResourceTables(false)
               .skipOutliers(parameters.getSkipOutliers())
               .skipTableTypes(parameters.getSkipTableTypes())


### PR DESCRIPTION
Back-port from https://github.com/dhis2/dhis2-core/pull/21959