### PR TITLE
test: performance workflow improvements DHIS2-20175

### DIFF
--- a/.github/workflows/run-performance-tests.yml
+++ b/.github/workflows/run-performance-tests.yml
@@ -41,6 +41,11 @@ on:
         required: false
         default: ''
         type: string
+      prof_args:
+        description: 'Profiler arguments (enables profiling). Options: https://github.com/async-profiler/async-profiler/blob/master/docs/ProfilerOptions.md'
+        required: false
+        default: ''
+        type: string
       # Read https://github.com/dhis2/dhis2-core/blob/master/docker/DOCKERHUB.md on how we publish
       # DHIS2 Docker images
       dhis2_image_baseline:
@@ -96,6 +101,7 @@ jobs:
         DHIS2_IMAGE="${{ inputs.dhis2_image_baseline }}" \
         SIMULATION_CLASS="${{ inputs.simulation_class }}" \
         MVN_ARGS="${{ inputs.mvn_args }} -Dgatling.failOnError=false" \
+        PROF_ARGS="${{ inputs.prof_args }}" \
         DHIS2_DB_DUMP_URL="${{ inputs.dhis2_db_dump_url }}" \
         DHIS2_DB_IMAGE_SUFFIX="${{ inputs.dhis2_db_image_suffix }}" \
         ./run-simulation.sh
@@ -105,6 +111,7 @@ jobs:
         DHIS2_IMAGE="${{ inputs.dhis2_image_candidate }}" \
         SIMULATION_CLASS="${{ inputs.simulation_class }}" \
         MVN_ARGS="${{ inputs.mvn_args }}" \
+        PROF_ARGS="${{ inputs.prof_args }}" \
         DHIS2_DB_DUMP_URL="${{ inputs.dhis2_db_dump_url }}" \
         DHIS2_DB_IMAGE_SUFFIX="${{ inputs.dhis2_db_image_suffix }}" \
         ./run-simulation.sh
@@ -166,4 +173,7 @@ jobs:
         echo "  * \`simulation-run.txt\` - Test run metadata (indicates baseline/candidate)" >> $GITHUB_STEP_SUMMARY
         echo "  * \`simulation.log\` - Binary test data (response times, etc.)" >> $GITHUB_STEP_SUMMARY
         echo "  * \`simulation.csv\` - Parsed binary data in CSV format" >> $GITHUB_STEP_SUMMARY
+        echo "  * \`profile.html\` - Flamegraph visualization (if profiling enabled with prof_args)" >> $GITHUB_STEP_SUMMARY
+        echo "  * \`profile.jfr\` - JFR profiler data (if profiling enabled with prof_args)" >> $GITHUB_STEP_SUMMARY
+        echo "  * \`profile.collapsed\` - Collapsed stack traces (if profiling enabled with prof_args)" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/run-performance-tests.yml
+++ b/.github/workflows/run-performance-tests.yml
@@ -142,7 +142,27 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Performance tests completed comparing:" >> $GITHUB_STEP_SUMMARY
         echo "* **Baseline**: \`${{ inputs.dhis2_image_baseline }}\`" >> $GITHUB_STEP_SUMMARY
+
+        # Extract and display DHIS2 labels for baseline
+        OUTPUT=$(docker inspect -f '{{json .Config.Labels}}' "${{ inputs.dhis2_image_baseline }}" 2>/dev/null | \
+          jq -r 'to_entries | map(select(.key | startswith("DHIS2_"))) | sort_by(.key) | .[] | "  * **\(.key)**: `\(.value)`"')
+        if [ -z "$OUTPUT" ]; then
+          echo "  * Failed to find DHIS2 related metadata in Docker image" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
+        fi
+
         echo "* **Candidate**: \`${{ inputs.dhis2_image_candidate }}\`" >> $GITHUB_STEP_SUMMARY
+
+        # Extract and display DHIS2 labels for candidate
+        OUTPUT=$(docker inspect -f '{{json .Config.Labels}}' "${{ inputs.dhis2_image_candidate }}" 2>/dev/null | \
+          jq -r 'to_entries | map(select(.key | startswith("DHIS2_"))) | sort_by(.key) | .[] | "  * **\(.key)**: `\(.value)`"')
+        if [ -z "$OUTPUT" ]; then
+          echo "  * Failed to find DHIS2 related metadata in Docker image" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
+        fi
+
         echo "* **Simulation Class**: \`${{ inputs.simulation_class }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🖥️ Environment" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-performance-tests.yml
+++ b/.github/workflows/run-performance-tests.yml
@@ -140,7 +140,49 @@ jobs:
       run: |
         echo "## 🚀 Performance Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
+
+        # Build the command to reproduce this run
+        echo "### 🔄 Reproduce this run" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```sh' >> $GITHUB_STEP_SUMMARY
+        echo -n 'gh workflow run run-performance-tests.yml' >> $GITHUB_STEP_SUMMARY
+        echo ' \' >> $GITHUB_STEP_SUMMARY
+        echo "  --field perf_tests_git_ref=\"${{ inputs.perf_tests_git_ref }}\" \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --field simulation_class=\"${{ inputs.simulation_class }}\" \\" >> $GITHUB_STEP_SUMMARY
+
+        # Add optional fields only if they're not empty or not default
+        if [ -n "${{ inputs.mvn_args }}" ]; then
+          echo "  --field mvn_args=\"${{ inputs.mvn_args }}\" \\" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [ -n "${{ inputs.prof_args }}" ]; then
+          echo "  --field prof_args=\"${{ inputs.prof_args }}\" \\" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [ "${{ inputs.dhis2_image_baseline }}" != "dhis2/core-dev:latest" ]; then
+          echo "  --field dhis2_image_baseline=\"${{ inputs.dhis2_image_baseline }}\" \\" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "  --field dhis2_image_candidate=\"${{ inputs.dhis2_image_candidate }}\" \\" >> $GITHUB_STEP_SUMMARY
+
+        if [ -n "${{ inputs.dhis2_db_dump_url }}" ]; then
+          echo "  --field dhis2_db_dump_url=\"${{ inputs.dhis2_db_dump_url }}\" \\" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [ "${{ inputs.dhis2_db_image_suffix }}" != "sierra-leone-dev" ]; then
+          echo "  --field dhis2_db_image_suffix=\"${{ inputs.dhis2_db_image_suffix }}\" \\" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "  --ref ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### 📊 Test Configuration" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
         echo "Performance tests completed comparing:" >> $GITHUB_STEP_SUMMARY
+        echo "* **Simulation**" >> $GITHUB_STEP_SUMMARY
+        echo "  * **Class**: \`${{ inputs.simulation_class }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "  * **Git ref**: \`${{ inputs.perf_tests_git_ref }}\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Baseline**: \`${{ inputs.dhis2_image_baseline }}\`" >> $GITHUB_STEP_SUMMARY
 
         # Extract and display DHIS2 labels for baseline
@@ -162,8 +204,6 @@ jobs:
         else
           echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
         fi
-
-        echo "* **Simulation Class**: \`${{ inputs.simulation_class }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🖥️ Environment" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-performance-tests.yml
+++ b/.github/workflows/run-performance-tests.yml
@@ -1,11 +1,24 @@
 # Performance test workflow to compare a baseline against a candidate DHIS2 version
-# You can run the workflow using the GitHub CLI like so
+# You can run the workflow using the GitHub CLI like so:
+#
+# Basic example (required args only):
 # gh workflow run run-performance-tests.yml \
+# 	--field perf_tests_git_ref="master" \
+# 	--field simulation_class="org.hisp.dhis.test.tracker.TrackerTest" \
+# 	--field dhis2_image_candidate="dhis2/core-dev:latest"
+#
+# With custom baseline:
+# gh workflow run run-performance-tests.yml \
+# 	--field perf_tests_git_ref="master" \
 # 	--field simulation_class="org.hisp.dhis.test.tracker.TrackerTest" \
 # 	--field dhis2_image_baseline="dhis2/core:2.42.1" \
 # 	--field dhis2_image_candidate="dhis2/core-dev:latest"
 #
-# To use a specific database version, provide both dump URL and matching image suffix:
+# With specific database version:
+# gh workflow run run-performance-tests.yml \
+# 	--field perf_tests_git_ref="2.42.2" \
+# 	--field simulation_class="org.hisp.dhis.test.tracker.TrackerTest" \
+# 	--field dhis2_image_candidate="dhis2/core:2.42.2" \
 # 	--field dhis2_db_dump_url="https://databases.dhis2.org/sierra-leone/2.42.2/dhis2-db-sierra-leone.sql.gz" \
 # 	--field dhis2_db_image_suffix="sierra-leone-2.42.2"
 name: Performance tests
@@ -15,6 +28,10 @@ run-name: Performance test comparing ${{ inputs.dhis2_image_baseline }} to ${{ i
 on:
   workflow_dispatch:
     inputs:
+      perf_tests_git_ref:
+        description: 'Git ref (tag/branch/commit) to checkout dhis2-core performance tests'
+        required: true
+        type: string
       simulation_class:
         description: 'Fully qualified Gatling simulation class to run (e.g., org.hisp.dhis.test.TrackerTest)'
         required: true
@@ -57,6 +74,7 @@ jobs:
     - name: Checkout performance tests
       uses: actions/checkout@v5
       with:
+        ref: ${{ inputs.perf_tests_git_ref }}
         sparse-checkout: |
           dhis-2/dhis-test-performance
 

--- a/dhis-2/dhis-test-performance/README.md
+++ b/dhis-2/dhis-test-performance/README.md
@@ -20,8 +20,9 @@ Test results are saved to `target/gatling/<simulation-class>-<timestamp>/`:
 * `simulation.log` - Binary response times
 * `simulation.csv` - Response times (automated in CI only, [see below](#simulationcsv))
 * `simulation-run.txt` - Run metadata
-* `profile.html` - Flamegraph (when profiling enabled)
-* `profile.jfr` - JFR (Java flight recorder) profiling data (when profiling enabled)
+* `profile.html` - Flamegraph visualization (if profiling enabled with PROF_ARGS)
+* `profile.jfr` - JFR profiler data (if profiling enabled with PROF_ARGS)
+* `profile.collapsed` - Collapsed stack traces (if profiling enabled with PROF_ARGS)
 
 ### simulation.csv
 

--- a/dhis-2/dhis-test-performance/docker-compose.profile.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.profile.yml
@@ -38,7 +38,7 @@ services:
         else
           echo "async-profiler already installed"
         fi &&
-        chmod 777 /profiler-output
+        chmod 755 /profiler-output
       '
     volumes:
       - async-profiler:/usr/local

--- a/dhis-2/dhis-test-performance/docker-compose.profile.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.profile.yml
@@ -38,7 +38,7 @@ services:
         else
           echo "async-profiler already installed"
         fi &&
-        chmod 755 /profiler-output
+        chmod 777 /profiler-output
       '
     volumes:
       - async-profiler:/usr/local

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   # https://docs.dhis2.org/en/manage/reference/dhisconf.html
   web:
     image: "${DHIS2_IMAGE:-dhis2/core-dev:latest}"
+    cpus: 4
     mem_limit: 16gb
     environment:
       JAVA_OPTS:
@@ -45,6 +46,7 @@ services:
         POSTGRES_BASE_IMAGE: ghcr.io/baosystems/postgis:14-3.5
         DHIS2_DB_DUMP_URL: "${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/sierra-leone/dev/dhis2-db-sierra-leone.sql.gz}"
     image: localhost/dhis2-postgres:14-3.5-${DHIS2_DB_IMAGE_SUFFIX:-sierra-leone-dev}
+    cpus: 4
     mem_limit: 16gb
     shm_size: 256mb
     volumes:
@@ -65,7 +67,7 @@ services:
           'psql --quiet --host=127.0.0.1 --port=5432 --set=application_name=docker --command "/** docker healthcheck **/ SELECT ''ok''" > /dev/null',
         ]
       start_period: 120s
-      interval: 3s
+      interval: 5s
       timeout: 3s
       retries: 5
     ports:

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       args:
         POSTGRES_BASE_IMAGE: ghcr.io/baosystems/postgis:14-3.5
         DHIS2_DB_DUMP_URL: "${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/sierra-leone/dev/dhis2-db-sierra-leone.sql.gz}"
-    image: dhis2-postgres:14-3.5-${DHIS2_DB_IMAGE_SUFFIX:-sierra-leone-dev}
+    image: localhost/dhis2-postgres:14-3.5-${DHIS2_DB_IMAGE_SUFFIX:-sierra-leone-dev}
     mem_limit: 16gb
     shm_size: 256mb
     volumes:

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -42,9 +42,9 @@ services:
       context: ./docker
       dockerfile: Dockerfile.postgres
       args:
-        POSTGRES_BASE_IMAGE: postgis/postgis:13-3.5
+        POSTGRES_BASE_IMAGE: ghcr.io/baosystems/postgis:14-3.5
         DHIS2_DB_DUMP_URL: "${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/sierra-leone/dev/dhis2-db-sierra-leone.sql.gz}"
-    image: dhis2-postgres:13-3.5-${DHIS2_DB_IMAGE_SUFFIX:-sierra-leone-dev}
+    image: dhis2-postgres:14-3.5-${DHIS2_DB_IMAGE_SUFFIX:-sierra-leone-dev}
     mem_limit: 16gb
     shm_size: 256mb
     volumes:

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -48,7 +48,8 @@ services:
     mem_limit: 16gb
     shm_size: 256mb
     volumes:
-      - ./docker/postgresql.conf:/etc/postgresql.conf
+      - ./docker/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       POSTGRES_USER: &postgres_user dhis
       POSTGRES_DB: &postgres_db dhis

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -1,4 +1,4 @@
-ARG POSTGRES_BASE_IMAGE=postgis/postgis:13-3.5
+ARG POSTGRES_BASE_IMAGE=ghcr.io/baosystems/postgis:14-3.5
 ARG DHIS2_DB_DUMP_URL
 
 FROM busybox AS downloader

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -1,3 +1,5 @@
+# Dockerfile to build the DB dump into the Docker image essentially caching the DB dump using
+# Dockers image/layer caching. The dump will be restored on each container creation.
 ARG POSTGRES_BASE_IMAGE=ghcr.io/baosystems/postgis:14-3.5
 ARG DHIS2_DB_DUMP_URL
 

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Dockerfile to build the DB dump into the Docker image essentially caching the DB dump using
 # Dockers image/layer caching. The dump will be restored on each container creation.
 ARG POSTGRES_BASE_IMAGE=ghcr.io/baosystems/postgis:14-3.5

--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -4,6 +4,6 @@ connection.url = jdbc:postgresql://db/dhis
 connection.username = dhis
 connection.password = dhis
 
-system.update_notifications_enabled = 0ff
+system.update_notifications_enabled = off
 
 tracker.import.preheat.cache.enabled = off

--- a/dhis-2/dhis-test-performance/docker/log4j2.xml
+++ b/dhis-2/dhis-test-performance/docker/log4j2.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="10">
+    <!-- Stream logs:
+            docker compose logs -f web
+         Stream logs of a particuar package only:
+            docker compose logs -f web | grep org.hisp.dhis.monitoring.metrics
+         Show timestamps:
+            docker compose logs -t -f web
+    -->
+    <Properties>
+        <Property name="layout">%-5level %c [%t] %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${layout}" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!--
+            This config logs events
+
+            for Loggers declared in packages prefixed with "org.hisp.dhis" i.e. "org.hisp.dhis.security"
+            from level INFO to more severe (WARN, ERROR, ...)
+
+            any Logger declared in a package not prefixed with "org.hisp.dhis" and
+            without a Logger config defined here will log from level WARN to more severe.
+
+            Adapt this config as you see fit.
+
+            Please check https://logging.apache.org/log4j/2.x/manual/configuration.html
+        -->
+        <Logger name="org.hisp.dhis" level="INFO" additivity="true"/>
+
+        <Root level="WARN">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -135,10 +135,12 @@ post_process_profiler_data() {
 
   local title="$SIMULATION_CLASS on $DHIS2_IMAGE (async-profiler $PROF_ARGS)"
   # generate flamegraph and collapsed stack traces using jfrconv from async-profiler
+  # shellcheck disable=SC2086
   docker compose exec --workdir /profiler-output web \
-    jfrconv "$jfrconv_flags" --dot --title "$title" profile.jfr profile.html
+    jfrconv $jfrconv_flags --dot --title "$title" profile.jfr profile.html
+  # shellcheck disable=SC2086
   docker compose exec --workdir /profiler-output web \
-    jfrconv "$jfrconv_flags" --dot profile.jfr profile.collapsed
+    jfrconv $jfrconv_flags --dot profile.jfr profile.collapsed
 
   docker compose cp web:/profiler-output/. "$gatling_dir/"
 
@@ -152,12 +154,14 @@ prepare_database() {
 
 start_profiler() {
   if [ -n "$PROF_ARGS" ]; then
+    # shellcheck disable=SC2086
     docker compose exec --workdir /profiler-output web asprof start $PROF_ARGS -f profile.jfr 1 > /dev/null
   fi
 }
 
 run_simulation() {
   echo "Running $SIMULATION_CLASS..."
+  # shellcheck disable=SC2086
   mvn gatling:test \
     -Dgatling.simulationClass="$SIMULATION_CLASS" \
     $MVN_ARGS

--- a/dhis-2/dhis-test-performance/src/test/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.test.tracker;
 
+import static io.gatling.javaapi.core.CoreDsl.StringBody;
 import static io.gatling.javaapi.core.CoreDsl.constantConcurrentUsers;
 import static io.gatling.javaapi.core.CoreDsl.details;
 import static io.gatling.javaapi.core.CoreDsl.exec;
@@ -52,7 +53,6 @@ public class TrackerTest extends Simulation {
         http.baseUrl("http://localhost:8080")
             .acceptHeader("application/json")
             .maxConnectionsPerHost(100)
-            .basicAuth("admin", "district")
             .header("Content-Type", "application/json")
             .userAgentHeader("Gatling/Performance Test")
             .warmUp(
@@ -74,6 +74,11 @@ public class TrackerTest extends Simulation {
 
     scenario =
         scenario
+            .exec(
+                http("Login")
+                    .post("/api/auth/login")
+                    .body(StringBody("{\"username\":\"admin\",\"password\":\"district\"}"))
+                    .check(status().is(200)))
             .repeat(Integer.parseInt(repeat))
             .on(
                 exec(http("Go to first page of program " + program)


### PR DESCRIPTION
* We used basic auth in our performance tests so far. This meant hashing showed up in our CPU profiles as we did that on every request. That is not how users should interact with our API though. Capture will login and use a cookie with the sessionid. Use the approach like in [AuthenticationControllerTest](https://github.com/dhis2/dhis2-core/blob/ed0fcc164296e2936bd9b9d6d7713ced6b762a46/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java#L80) and let Gatling handle the JSESSIONID cookie. Gatling detects `Set-Cookie` headers automatically in the response to login.
* Allow running specific performance tests via git tag in GitHub workflow using arg `perf_tests_git_ref`
* Allow profiling in GitHub workflow using arg `prof_args`
* Add hard CPU limits to performance test containers so db and web containers are more isolated
* Fix log4j2.xml configuration for performance tests as I accidentally committed it as a directory 🤦🏻
* Use more up to date PostgreSQL version https://www.postgresql.org/support/versioning
* Fix postgres.conf location as it was not in the default location (and not configured to look elsewhere)
* Fix typo in dhis-2/dhis-test-performance/docker/dhis.conf
* Simplify container startup wait logic using `docker compose --wait`
* Remove Docker pull warnings by using `image: localhost/...` for the DB image. The DB image is purely a local image
* Use bao image for ARM architecture support like we do in [core](https://github.com/dhis2/dhis2-core/blob/adf6409477479ec816b2973683806cc3dd3ad8c7/docker-compose.yml#L16) to fix https://github.com/dhis2/dhis2-core/pull/22080#issuecomment-3353762775
* Describe the purpose of `Dockerfile.postgres` which for now is just caching the DB dump
* Pull mutable Docker images like `dhis2/core-dev:master`, `dhis2/core-dev:latest`, `dhis2/core-pr:<pr number>` so they are up to date. This is necessary as our self-hosted runner is not ephemeral so images are cached
* Add DHIS2 Docker image labels we add to our images like `DHIS2_BUILD_REVISION` to the job summary. This is especially important for all the mutable images
* Add a command to re-run the workflow with the same parameters to a job summary

## Sample run

Tested these changes with

```sh
gh workflow run run-performance-tests.yml \
        --field perf_tests_git_ref="DHIS2-20175" \
        --field simulation_class="org.hisp.dhis.test.tracker.TrackerTest" \
        --field prof_args="-e cpu" \
        --field dhis2_image_baseline="dhis2/core:2.42.2" \
        --field dhis2_image_candidate="dhis2/core-dev:master" \
        --field dhis2_db_dump_url="https://databases.dhis2.org/sierra-leone/2.42.2/dhis2-db-sierra-leone.sql.gz" \
        --field dhis2_db_image_suffix="sierra-leone-2.42.2" \
        --ref DHIS2-20175
```

results are in https://github.com/dhis2/dhis2-core/actions/runs/18185378283

## Gatling references on auth

- https://docs.gatling.io/reference/script/protocols/http/helpers/
- https://docs.gatling.io/guides/use-cases/basic-auth/
- https://gatling.io/blog/gatling-credentials
- https://community.gatling.io/t/is-set-cookie-saved-automatically-by-gatling-session/8042