### PR TITLE
fix: Hard coded endDate in period generation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
@@ -94,7 +94,7 @@ public class DatePeriodResourceTable
         // dynamic solution
         // instead of
         // fixing the date
-        Date endDate = new Cal( 2025, 1, 1, true ).time();
+        Date endDate = new Cal( 2035, 1, 1, true ).time();
 
         List<Period> dailyPeriods = new DailyPeriodType().generatePeriods( startDate, endDate );
 


### PR DESCRIPTION
This is just a "fix", to extend the period date generation.
As this release version is out of support, we decided to apply a minimal change by just increasing the period allowance, until they are able to upgrade DHIS2 to a bug free version, which starts in a patch version of 2.36.

