### PR TITLE
fix: Continuous Analytics fails to process datavalues in new periods

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTableService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTableService.java
@@ -52,4 +52,7 @@ public interface ResourceTableService {
 
   /** Drop all SQL views. */
   void dropAllSqlViews(JobProgress progress);
+
+  /** Update the period resource table with any new periods that have been created. */
+  void updatePeriodResourceTable();
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableUpdateParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableUpdateParams.java
@@ -65,6 +65,9 @@ public class AnalyticsTableUpdateParams {
   /** Indicates whether to skip update of analytics tables, outliers stats columns. */
   private final boolean skipOutliers;
 
+  /** Indicates whether to refresh the period resource table before analytics table update. */
+  private final boolean refreshPeriodResourceTable;
+
   /** Analytics table types to skip. */
   @Builder.Default private final Set<AnalyticsTableType> skipTableTypes = new HashSet<>();
 
@@ -138,6 +141,7 @@ public class AnalyticsTableUpdateParams {
     return MoreObjects.toStringHelper(this)
         .add("last years", lastYears)
         .add("skip resource tables", skipResourceTables)
+        .add("refresh period resource table", refreshPeriodResourceTable)
         .add("skip table types", skipTableTypes)
         .add("skip programs", skipPrograms)
         .add("skip outliers statistics", skipOutliers)
@@ -178,6 +182,9 @@ public class AnalyticsTableUpdateParams {
   }
 
   public AnalyticsTableUpdateParams withLatestPartition() {
-    return this.toBuilder().lastYears(AnalyticsTablePartition.LATEST_PARTITION).build();
+    return this.toBuilder()
+        .lastYears(AnalyticsTablePartition.LATEST_PARTITION)
+        .refreshPeriodResourceTable(true)
+        .build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -107,6 +107,16 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
       }
     }
 
+    if (params.isRefreshPeriodResourceTable() && params.isLatestUpdate()) {
+      log.info("Refreshing period resource table with new periods");
+      resourceTableService.updatePeriodResourceTable();
+
+      if (settings.isAnalyticsDatabase()) {
+        log.info("Replicating period resource table in analytics database");
+        resourceTableService.replicateAnalyticsResourceTables();
+      }
+    }
+
     if (!params.isLatestUpdate() && settings.isAnalyticsDatabase()) {
       if (!skipTypes.containsAll(Set.of(EVENT, ENROLLMENT, TRACKED_ENTITY_INSTANCE))) {
         log.info("Replicating tracked entity attribute value table");

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -287,4 +287,12 @@ public class DefaultResourceTableService implements ResourceTableService {
     progress.startingStage("Drop SQL views", nonQueryViews.size(), SKIP_ITEM);
     progress.runStage(nonQueryViews, SqlView::getViewName, sqlViewService::dropViewTable);
   }
+
+  @Override
+  @Transactional
+  public void updatePeriodResourceTable() {
+    Logged logged = analyticsTableSettings.getTableLogged();
+    ResourceTable table = new PeriodResourceTable(logged, periodService.getAllPeriods());
+    resourceTableStore.generateResourceTable(table);
+  }
 }


### PR DESCRIPTION
## Problem

Continuous Analytics was failing to process datavalues for future dates and open periods. The `analytics_rs_periodstructure` resource table only contained
periods that existed during the last full resource table generation. 
When datavalues were added for newly created periods, the INSERT query's JOIN with
  `analytics_rs_periodstructure` would fail, skipping these values.

## Solution

Added a `refreshPeriodResourceTable` parameter to `AnalyticsTableUpdateParams` that automatically triggers a period resource table refresh during latest
partition updates (continuous analytics).

Fixes DHIS2-18417