### PR TITLE
fix: add translation for categoryOption.displayName

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -418,6 +418,14 @@ public class CategoryOption extends BaseMetadataObject
     return translations.getTranslation("NAME", name);
   }
 
+  @JsonProperty
+  @Sortable(whenPersisted = false)
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @Translatable(propertyName = "formName", key = "FORM_NAME")
+  public String getDisplayFormName() {
+    return translations.getTranslation("FORM_NAME", getFormName());
+  }
+
   @Override
   @JsonProperty
   @JacksonXmlElementWrapper(localName = "translations", namespace = DxfNamespaces.DXF_2_0)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryOptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryOptionControllerTest.java
@@ -144,8 +144,8 @@ class CategoryOptionControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  @DisplayName("Should save and get translation for CategoryOption formName")
-  void testCategoryOptionFormNameTranslation() {
+  @DisplayName("Should return displayFormName in the payload")
+  void testCategoryOptionFormName() {
     // Create a category option with formName
     String coId =
         assertStatus(
@@ -154,33 +154,7 @@ class CategoryOptionControllerTest extends H2ControllerIntegrationTestBase {
                 "/categoryOptions/",
                 "{'name':'Test Category Option', 'shortName':'TCO', 'formName':'Test Form'}"));
 
-    // Verify initial state - no translations
-    JsonArray translations =
-        GET("/categoryOptions/{id}/translations", coId).content().getArray("translations");
-    assertTrue(translations.isEmpty());
-
-    // Add translation for formName
-    PUT(
-            "/categoryOptions/" + coId + "/translations",
-            "{'translations': [{'locale':'fr', 'property':'FORM_NAME', 'value':'Formulaire de Test'}]}")
-        .content(HttpStatus.NO_CONTENT);
-
-    // Verify translation was saved
-    translations =
-        GET("/categoryOptions/{id}/translations", coId).content().getArray("translations");
-    assertEquals(1, translations.size());
-    JsonObject translation = translations.getObject(0);
-    assertEquals("fr", translation.getString("locale").string());
-    assertEquals("FORM_NAME", translation.getString("property").string());
-    assertEquals("Formulaire de Test", translation.getString("value").string());
-
-    // Verify displayFormName returns translated value when locale is set
-    JsonObject categoryOption =
-        GET("/categoryOptions/{id}?locale=fr", coId).content().as(JsonObject.class);
-    assertEquals("Formulaire de Test", categoryOption.getString("displayFormName").string());
-
-    // Verify displayFormName returns original formName when no locale is set
-    categoryOption = GET("/categoryOptions/{id}", coId).content().as(JsonObject.class);
+    JsonObject categoryOption = GET("/categoryOptions/{id}", coId).content().as(JsonObject.class);
     assertEquals("Test Form", categoryOption.getString("displayFormName").string());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryOptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryOptionControllerTest.java
@@ -166,7 +166,8 @@ class CategoryOptionControllerTest extends H2ControllerIntegrationTestBase {
         .content(HttpStatus.NO_CONTENT);
 
     // Verify translation was saved
-    translations = GET("/categoryOptions/{id}/translations", coId).content().getArray("translations");
+    translations =
+        GET("/categoryOptions/{id}/translations", coId).content().getArray("translations");
     assertEquals(1, translations.size());
     JsonObject translation = translations.getObject(0);
     assertEquals("fr", translation.getString("locale").string());


### PR DESCRIPTION
### Issue
- During annotation migration, method `getDisplayFormName()` was missing

### Fix
- Add back the method

### Test
- Add controller test to verify the change