### PR TITLE
fix: data export AOC filters [DHIS2-20284]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
@@ -161,7 +161,7 @@ public class IdentifiableObjectUtils {
    */
   public static <T extends IdentifiableObject> List<Long> getIdentifiers(Collection<T> objects) {
     return objects != null
-        ? objects.stream().map(o -> o.getId()).collect(Collectors.toList())
+        ? objects.stream().map(PrimaryKeyObject::getId).distinct().toList()
         : null;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStoreParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStoreParams.java
@@ -32,8 +32,10 @@ package org.hisp.dhis.datavalue;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import lombok.Getter;
@@ -91,9 +93,9 @@ public class DataExportStoreParams {
 
   private Set<OrganisationUnitGroup> organisationUnitGroups = new HashSet<>();
 
-  private Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
+  private List<CategoryOptionCombo> categoryOptionCombos = new ArrayList<>();
 
-  private Set<CategoryOptionCombo> attributeOptionCombos = new HashSet<>();
+  private List<CategoryOptionCombo> attributeOptionCombos = new ArrayList<>();
 
   private Set<CategoryOption> coDimensionConstraints;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultCompleteDataSetRegistrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultCompleteDataSetRegistrationService.java
@@ -224,7 +224,7 @@ public class DefaultCompleteDataSetRegistrationService
       DataExportStoreParams params = new DataExportStoreParams();
       params.setDataElementOperands(dataSet.getCompulsoryDataElementOperands());
       params.setPeriods(Set.of(period));
-      params.setAttributeOptionCombos(Set.of(attributeOptionCombo));
+      params.setAttributeOptionCombos(List.of(attributeOptionCombo));
       params.setOrganisationUnits(Set.of(organisationUnit));
 
       Map<Long, Map<Long, Set<Long>>> dataPresent = new HashMap<>();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
@@ -183,7 +183,7 @@ public class HibernateDataExportStore implements DataExportStore {
         AND ou.hierarchylevel >= :minLevel
         AND ou.path LIKE ANY(:path)
         AND dv.categoryoptioncomboid = ANY(:coc)
-        AND dv.categoryoptioncomboid = ANY(:aoc)
+        AND dv.attributeoptioncomboid = ANY(:aoc)
         AND dv.lastupdated >= :lastUpdated
         AND dv.deleted = :deleted
         -- access check below must be 1 line for erasure
@@ -240,7 +240,7 @@ public class HibernateDataExportStore implements DataExportStore {
   private static Long[] getIds(Collection<? extends IdentifiableObject> objects) {
     return objects == null || objects.isEmpty()
         ? null
-        : objects.stream().map(IdentifiableObject::getId).toArray(Long[]::new);
+        : objects.stream().map(IdentifiableObject::getId).distinct().toArray(Long[]::new);
   }
 
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
@@ -38,7 +38,6 @@ import static org.hisp.dhis.datavalue.DataExportStore.EncodeType.DE;
 import static org.hisp.dhis.datavalue.DataExportStore.EncodeType.OU;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -214,7 +213,7 @@ public class DefaultDataExportService implements DataExportService {
                 .setPeriods(params.getPeriods())
                 .setStartDate(params.getStartDate())
                 .setEndDate(params.getEndDate())
-                .setAttributeOptionCombos(Sets.newHashSet(aoc))
+                .setAttributeOptionCombos(List.of(aoc))
                 .setOrderByOrgUnitPath(true)
                 .setOrderByPeriod(true);
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationRunner.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationRunner.java
@@ -471,7 +471,7 @@ public class DataValidationRunner {
       params.setCogDimensionConstraints(context.getCogDimensionConstraints());
 
       if (context.getAttributeCombo() != null) {
-        params.setAttributeOptionCombos(Sets.newHashSet(context.getAttributeCombo()));
+        params.setAttributeOptionCombos(List.of(context.getAttributeCombo()));
       }
 
       List<DeflatedDataValue> dataValues = dataValueService.getDeflatedDataValues(params);


### PR DESCRIPTION
### Summary
2 issues:
* a type in the SQL: `dv.categoryoptioncomboid` => `dv.attributeoptioncomboid` for a AOC filter caused it to match on `categoryoptioncomboid`
* AOC filters internally use a `Set<CategoryOptionCombo>` but that means for COCs/AOCs that use same CC with same COs (for some reason) one gets eliminated from the set as `equals` has the odd implementation of CC+COs being equal (and which we cannot change ATM)