### PR TITLE
Fix: mapViews metadata sync or import fails with ConstraintViolationException due to duplicate key [DHIS2-20266]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -321,6 +321,12 @@ public class DefaultMetadataImportService implements MetadataImportService {
     }
   }
 
+  /**
+   * Filters out MapView objects that are already referenced by Map objects in the bundle to prevent
+   * conflicts during import.
+   *
+   * @param bundleParams The ObjectBundleParams containing the objects to be imported.
+   */
   private void filterConflictingMapViews(ObjectBundleParams bundleParams) {
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> objects =
         bundleParams.getObjects();
@@ -331,13 +337,11 @@ public class DefaultMetadataImportService implements MetadataImportService {
       Set<String> mapViewIdsInMap = new HashSet<>();
 
       for (IdentifiableObject mapObj : mapObjects) {
-        if (mapObj instanceof org.hisp.dhis.mapping.Map) {
-          org.hisp.dhis.mapping.Map map = (org.hisp.dhis.mapping.Map) mapObj;
-          List<org.hisp.dhis.mapping.MapView> mapViews = map.getMapViews();
-          if (mapViews != null) {
-            for (org.hisp.dhis.mapping.MapView mapView : mapViews) {
-              mapViewIdsInMap.add(mapView.getUid());
-            }
+        org.hisp.dhis.mapping.Map map = (org.hisp.dhis.mapping.Map) mapObj;
+        List<org.hisp.dhis.mapping.MapView> mapViews = map.getMapViews();
+        if (mapViews != null) {
+          for (org.hisp.dhis.mapping.MapView mapView : mapViews) {
+            mapViewIdsInMap.add(mapView.getUid());
           }
         }
       }


### PR DESCRIPTION
Jira report: [Map synchronization and import fails with ConstraintViolationException due to duplicate key](https://dhis2.atlassian.net/browse/DHIS2-20266)

When importing metadata of Map and mapView type, be it via import or via metadata sync, a `org.hibernate.exception.ConstraintViolationException` exception can occur when the _Map_ metadata include in its _mapViews_ field any of the objects in the standalone _mapView_ metadata.  This causes a duplicated key issue:
```
org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "mapview_uid_key"
  Detail: Key (uid)=(....) already exists.
  ```

A filterConflictingMapViews method is added to the import service to remove from the _mapView_ metadata object the items used by the _Map_ metadata.
