### PR TITLE
fix: remove hibernate.allow_update_outside_transaction override TECH-1517

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -180,9 +180,6 @@ public class HibernateConfig {
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
-    // TODO: this is anti-pattern and should be turn off
-    properties.put("hibernate.allow_update_outside_transaction", "true");
-
     return properties;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -140,9 +140,6 @@ class DataStatisticsServiceTest extends PostgresIntegrationTestBase {
         "update singleevent set lastupdated = ? where eventid = ?",
         Timestamp.from(olderThanSevenDays),
         eventIds.get(2));
-
-    entityManager.flush();
-    entityManager.clear();
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -47,7 +47,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class FileResourceCleanUpJobTest extends PostgresIntegrationTestBase {
 
   @Autowired private FileResourceCleanUpJob cleanUpJob;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -188,9 +188,6 @@ class ProgramRuleServiceTest extends PostgresIntegrationTestBase {
     programRuleService.updateProgramRule(ruleB);
     programRuleService.updateProgramRule(ruleC);
 
-    entityManager.clear();
-    entityManager.flush();
-
     List<String> dataElementsPresentInProgramRules =
         programRuleActonService.getDataElementsPresentInProgramRuleActions();
 
@@ -244,9 +241,6 @@ class ProgramRuleServiceTest extends PostgresIntegrationTestBase {
     programRuleService.updateProgramRule(ruleA);
     programRuleService.updateProgramRule(ruleB);
     programRuleService.updateProgramRule(ruleC);
-
-    entityManager.clear();
-    entityManager.flush();
 
     List<String> trackedEntityAttributesPresentInProgramRules =
         programRuleActonService.getTrackedEntityAttributesPresentInProgramRuleActions();
@@ -346,9 +340,6 @@ class ProgramRuleServiceTest extends PostgresIntegrationTestBase {
     programRuleService.updateProgramRule(ruleD);
     programRuleService.updateProgramRule(ruleG);
     programRuleService.updateProgramRule(ruleF);
-
-    entityManager.clear();
-    entityManager.flush();
 
     List<ProgramRule> rules =
         programRuleService.getProgramRulesByActionTypes(


### PR DESCRIPTION
Removes the `hibernate.allow_update_outside_transaction=true` override that was added in [#14626](https://github.com/dhis2/dhis2-core/pull/14626) (the JPA-annotation mapping migration). That PR explicitly listed turning it off as follow-up work, since JPA does not allow `session.update` or `session.flush` outside of a transaction.

We discussed this setting in a backend meeting a while back and agreed it is dangerous to leave at `true`: it silently allows writes to bypass transaction boundaries, which masks real bugs, can leave the DB in inconsistent states under partial failures, and violates the JPA spec. Hibernate's own javadoc says "Since version 5.2 Hibernate conforms with the JPA specification and does not allow anymore to flush any update out of a transaction boundary."

Removing the line restores Hibernate 5.6's default (`false`), which causes `flush`, `executeUpdate`, locking, and procedure calls to throw `TransactionRequiredException` when invoked without an active transaction.

Three integration tests were flushing outside a transaction and were masked by the override:

* `DataStatisticsServiceTest`: `entityManager.flush()` in `@BeforeAll`. Spring's `@Transactional` doesn't wrap `@BeforeAll` (only `@Test` and `@BeforeEach`). The flush had nothing to flush since the side effects (`hibernateDataStatisticsStore.save`, `testSetup.importMetadata`, `jdbc.update`) had already been committed via service-level transactions or auto-commit. Removed.
* `ProgramRuleServiceTest`: three test methods called `entityManager.clear(); entityManager.flush();` in non-transactional class context. The order is wrong (`clear` before `flush` would discard pending writes) but harmless previously since each service call committed in its own tx. Removed.
* `FileResourceCleanUpJobTest`: `entityManager.flush()` in `createFileResource()`. The test directly drives `fileResourceStore.save(...)` (a Hibernate store, not a transactional service), so it now needs class-level `@Transactional` to provide a tx for the flush.
