### PR TITLE
test: cleanup docker containers on workflow cancellation [DHIS2-19797]

### DIFF
--- a/.github/workflows/performance-tests-compare.yml
+++ b/.github/workflows/performance-tests-compare.yml
@@ -127,9 +127,10 @@ jobs:
         sparse-checkout: |
           dhis-2/dhis-test-performance
 
-    # run-simulation.sh should cleanup after itself, this is to ensure the self-hosted runner is clean in case it did not.
+    # Backup cleanup before run: a previous job on this self-hosted runner may have left
+    # containers behind if its EXIT trap was killed before finishing.
     - name: Cleanup containers
-      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes
+      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes --remove-orphans
 
     - name: Clean target directory
       run: mvn clean
@@ -213,6 +214,14 @@ jobs:
         export REPORT_SUFFIX="candidate"
 
         ./run-simulation.sh
+
+    # Backup cleanup on cancellation: GitHub sends SIGTERM then SIGKILL after a short grace
+    # period, which can interrupt run-simulation.sh's EXIT trap mid-teardown. This step runs
+    # as a separate process with its own grace window to ensure containers and volumes are
+    # removed.
+    - name: Cleanup containers on cancellation
+      if: cancelled()
+      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes --remove-orphans
 
     - name: Upload Gatling report
       if: always()

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -101,9 +101,10 @@ jobs:
         sparse-checkout: |
           dhis-2/dhis-test-performance
 
-    # run-simulation.sh should cleanup after itself, this is to ensure the self-hosted runner is clean in case it did not.
+    # Backup cleanup before run: a previous job on this self-hosted runner may have left
+    # containers behind if its EXIT trap was killed before finishing.
     - name: Cleanup containers
-      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes
+      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes --remove-orphans
 
     - name: Clean target directory
       run: mvn clean
@@ -137,6 +138,14 @@ jobs:
         export REPORT_SUFFIX="${{ inputs.test_name }}"
 
         ./run-simulation.sh
+
+    # Backup cleanup on cancellation: GitHub sends SIGTERM then SIGKILL after a short grace
+    # period, which can interrupt run-simulation.sh's EXIT trap mid-teardown. This step runs
+    # as a separate process with its own grace window to ensure containers and volumes are
+    # removed.
+    - name: Cleanup containers on cancellation
+      if: cancelled()
+      run: docker compose --file docker-compose.yml --file docker-compose.profile.yml down --volumes --remove-orphans
 
     - name: Upload Gatling report
       if: always()

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -167,7 +167,7 @@ cleanup() {
   if [ -n "$PROF_ARGS" ]; then
     compose_files+=("-f" "docker-compose.profile.yml")
   fi
-  docker compose "${compose_files[@]}" down --volumes 2>/dev/null || true
+  docker compose "${compose_files[@]}" down --volumes --remove-orphans 2>/dev/null || true
 
   # Show output summary for the main (non-warmup) run
   if [ -n "$LAST_RUN_DIR" ] && [ -d "$LAST_RUN_DIR" ]; then
@@ -264,7 +264,7 @@ start_containers() {
   start_time=$(date +%s)
 
   # shellcheck disable=SC2086
-  docker compose $compose_args down --volumes
+  docker compose $compose_args down --volumes --remove-orphans
 
   # shellcheck disable=SC2086
   if ! docker compose $compose_args up --detach --wait --wait-timeout "$HEALTHCHECK_TIMEOUT"; then


### PR DESCRIPTION
Cleanup containers and volumes when a performance-test workflow is cancelled, so the self-hosted runner doesn't accumulate leftovers between runs.

* Add a post-run cleanup step gated on `if: cancelled()`. Needed because GitHub sends `SIGTERM` then `SIGKILL` after a short grace period, which can interrupt `run-simulation.sh`'s `EXIT` trap mid-teardown.
* Add `--remove-orphans` to the existing pre-run cleanup and to `run-simulation.sh`'s own teardown calls.

## Verification

* [Completing run](https://github.com/dhis2/dhis2-core/actions/runs/25324266675) (`TrackerTest`, default settings) — finished successfully, the cancellation step was correctly skipped.
* [Cancelled run](https://github.com/dhis2/dhis2-core/actions/runs/25324283355) (same, cancelled mid-simulation) — the new `Cleanup containers on cancellation` step ran and tore down the `web-healthcheck`, `web`, and `db` containers plus the network, confirming that the in-script `EXIT` trap had been killed before completing.
