### PR TITLE
disable e2e metadata test to investigate failures

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.hisp.dhis.test.e2e.utils.DataGenerator;
 import org.hisp.dhis.test.e2e.utils.SharingUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -184,6 +185,7 @@ class MetadataImportTest extends ApiTest {
         .body("shortName", equalTo("ANC 1st visit_m update"));
   }
 
+  @Disabled("Started failing intermittently in GitHub, April 2026")
   @ParameterizedTest(name = "withImportStrategy[{0}]")
   @CsvSource({"CREATE, ignored, 409", "CREATE_AND_UPDATE, updated, 200"})
   void shouldUpdateExistingMetadata(


### PR DESCRIPTION
started failing intermittently on GitHub