### PR TITLE
perf: skip audit JMS pipeline when no consumer exists DHIS2-21271

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -129,11 +129,6 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrix.java
@@ -29,9 +29,8 @@
  */
 package org.hisp.dhis.artemis.audit.configuration;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
+import java.util.Set;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
@@ -42,25 +41,22 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class AuditMatrix {
-  private Map<AuditScope, Map<AuditType, Boolean>> matrix;
+  private final Map<AuditScope, Set<AuditType>> matrix;
 
   public AuditMatrix(AuditMatrixConfigurer auditMatrixConfigurer) {
-    checkNotNull(auditMatrixConfigurer);
-
-    matrix = auditMatrixConfigurer.configure();
+    this.matrix = auditMatrixConfigurer.configure();
   }
 
   public boolean isEnabled(Audit audit) {
-    return matrix.get(audit.getAuditScope()).getOrDefault(audit.getAuditType(), false);
+    return matrix.get(audit.getAuditScope()).contains(audit.getAuditType());
   }
 
   public boolean isEnabled(AuditScope auditScope, AuditType auditType) {
-    return matrix.get(auditScope).getOrDefault(auditType, false);
+    return matrix.get(auditScope).contains(auditType);
   }
 
   public boolean isReadEnabled() {
-    final AuditScope[] auditScopes = AuditScope.values();
-    for (AuditScope auditScope : auditScopes) {
+    for (AuditScope auditScope : AuditScope.values()) {
       if (isEnabled(auditScope, AuditType.READ)) {
         return true;
       }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurer.java
@@ -29,14 +29,20 @@
  */
 package org.hisp.dhis.artemis.audit.configuration;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.lang3.ArrayUtils;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.artemis.config.ArtemisConfigData;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.external.conf.ConfigurationKey;
@@ -54,15 +60,14 @@ import org.springframework.stereotype.Component;
  *
  * <p>audit.tracker=CREATE;READ;UPDATE;DELETE
  *
- * <p>Misspelled entries are ignored, and the specific type is set to false. Missing {@see
- * AuditScope} are replaced with all-false types. To disable Auditing completely, simply do not
- * declare any audit.* property in dhis.conf
- *
  * @author Luciano Fiandesio
  */
 @Component
+@RequiredArgsConstructor
 public class AuditMatrixConfigurer {
   private final DhisConfigurationProvider config;
+
+  private final ArtemisConfigData artemisConfig;
 
   private static final String PROPERTY_PREFIX = "audit.";
 
@@ -70,47 +75,94 @@ public class AuditMatrixConfigurer {
 
   /**
    * Default Audit configuration: CREATE, UPDATE, DELETE, and SECURITY operations are audited by
-   * default. Other Audit types have to be explicitly enabled by the user
+   * default. Other Audit types have to be explicitly enabled by the user.
    */
-  private static final Map<AuditType, Boolean> DEFAULT_AUDIT_CONFIGURATION =
-      ImmutableMap.<AuditType, Boolean>builder()
-          .put(AuditType.CREATE, true)
-          .put(AuditType.UPDATE, true)
-          .put(AuditType.DELETE, true)
-          .put(AuditType.READ, false)
-          .put(AuditType.SEARCH, false)
-          .put(AuditType.SECURITY, true)
-          .build();
+  private static final Set<AuditType> DEFAULT_AUDIT_CONFIGURATION =
+      Collections.unmodifiableSet(
+          EnumSet.of(AuditType.CREATE, AuditType.UPDATE, AuditType.DELETE, AuditType.SECURITY));
 
-  public AuditMatrixConfigurer(DhisConfigurationProvider dhisConfigurationProvider) {
-    checkNotNull(dhisConfigurationProvider);
+  public Map<AuditScope, Set<AuditType>> configure() {
+    Map<AuditScope, Set<AuditType>> matrix = new EnumMap<>(AuditScope.class);
 
-    this.config = dhisConfigurationProvider;
-  }
-
-  public Map<AuditScope, Map<AuditType, Boolean>> configure() {
-    Map<AuditScope, Map<AuditType, Boolean>> matrix = new HashMap<>();
-
-    for (AuditScope value : AuditScope.values()) {
+    for (AuditScope scope : AuditScope.values()) {
       Optional<ConfigurationKey> confKey =
-          ConfigurationKey.getByKey(PROPERTY_PREFIX + value.name().toLowerCase());
+          ConfigurationKey.getByKey(PROPERTY_PREFIX + scope.name().toLowerCase());
 
       if (confKey.isPresent() && !StringUtils.isEmpty(config.getProperty(confKey.get()))) {
-        String[] configuredTypes = config.getProperty(confKey.get()).split(AUDIT_TYPE_STRING_SEPAR);
-
-        Map<AuditType, Boolean> matrixAuditTypes = new HashMap<>();
-
-        for (AuditType auditType : AuditType.values()) {
-          matrixAuditTypes.put(auditType, ArrayUtils.contains(configuredTypes, auditType.name()));
-        }
-
-        matrix.put(value, matrixAuditTypes);
-
+        matrix.put(scope, parseAuditTypes(scope, config.getProperty(confKey.get())));
       } else {
-        matrix.put(value, DEFAULT_AUDIT_CONFIGURATION);
+        matrix.put(scope, DEFAULT_AUDIT_CONFIGURATION);
       }
     }
 
+    disableScopesWithNoConsumer(matrix);
+
     return matrix;
+  }
+
+  private static Set<AuditType> parseAuditTypes(AuditScope scope, String configuredTypesString) {
+    Set<AuditType> auditTypes = EnumSet.noneOf(AuditType.class);
+    List<String> invalid = new ArrayList<>();
+    for (String token : configuredTypesString.split(AUDIT_TYPE_STRING_SEPAR)) {
+      String trimmed = token.trim();
+      // DISABLED is not an AuditType enum value but is documented as a way to disable a scope
+      // (e.g. audit.tracker=DISABLED). It worked by accident before: the old code iterated all
+      // AuditType values checking if each was in the input, and since "DISABLED" matched none,
+      // every type got false. We preserve this behavior explicitly.
+      if (trimmed.isEmpty() || "DISABLED".equals(trimmed)) {
+        continue;
+      }
+      try {
+        auditTypes.add(AuditType.valueOf(trimmed));
+      } catch (IllegalArgumentException e) {
+        invalid.add(trimmed);
+      }
+    }
+
+    if (!invalid.isEmpty()) {
+      String validTypes =
+          Arrays.stream(AuditType.values()).map(AuditType::name).collect(Collectors.joining(", "));
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid audit type(s) %s in config audit.%s. Valid types are: %s, DISABLED",
+              invalid, scope.name().toLowerCase(), validTypes));
+    }
+
+    return auditTypes;
+  }
+
+  /**
+   * Disables audit scopes that have no consumer in embedded Artemis mode to avoid the per-entity
+   * JMS pipeline (entity serialization, JSON serialization, publish, consume, deserialize) running
+   * only to discard every message. When both sinks (logger and database) are off for a scope and no
+   * external consumer can connect to the embedded broker, the pipeline has no consumer.
+   */
+  private void disableScopesWithNoConsumer(Map<AuditScope, Set<AuditType>> matrix) {
+    if (!artemisConfig.isEmbedded() || config.isEnabled(ConfigurationKey.AUDIT_DATABASE)) {
+      return;
+    }
+
+    for (AuditScope scope : AuditScope.values()) {
+      if (!isLoggerEnabled(scope)) {
+        matrix.put(scope, Set.of());
+      }
+    }
+  }
+
+  /**
+   * Checks if audit logging is enabled for a scope. This must match the logic in each scope's
+   * consumer. TrackerAuditConsumer uses a hardcoded fallback of "off" for audit.logger instead of
+   * the key's built-in default of "on". When audit.logger was flipped from off to on
+   * (https://github.com/dhis2/dhis2-core/pull/8785) TrackerAuditConsumer was not updated, so it
+   * diverges from other consumers when audit.logger is absent from dhis.conf.
+   *
+   * @see org.hisp.dhis.audit.consumers.TrackerAuditConsumer
+   */
+  private boolean isLoggerEnabled(AuditScope scope) {
+    if (scope == AuditScope.TRACKER) {
+      return Objects.equals(
+          config.getPropertyOrDefault(ConfigurationKey.AUDIT_LOGGER, "off"), "on");
+    }
+    return config.isEnabled(ConfigurationKey.AUDIT_LOGGER);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -48,6 +48,7 @@ import org.hibernate.event.spi.PostUpdateEvent;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.HibernateProxy;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -71,6 +72,8 @@ public abstract class AbstractHibernateListener {
 
   protected final AuditObjectFactory objectFactory;
 
+  private final AuditMatrix auditMatrix;
+
   private final UsernameSupplier usernameSupplier;
 
   private final SchemaService schemaService;
@@ -78,15 +81,18 @@ public abstract class AbstractHibernateListener {
   protected AbstractHibernateListener(
       AuditManager auditManager,
       AuditObjectFactory objectFactory,
+      AuditMatrix auditMatrix,
       UsernameSupplier usernameSupplier,
       SchemaService schemaService) {
     checkNotNull(auditManager);
     checkNotNull(objectFactory);
+    checkNotNull(auditMatrix);
     checkNotNull(usernameSupplier);
     checkNotNull(schemaService);
 
     this.auditManager = auditManager;
     this.objectFactory = objectFactory;
+    this.auditMatrix = auditMatrix;
     this.usernameSupplier = usernameSupplier;
     this.schemaService = schemaService;
   }
@@ -97,10 +103,10 @@ public abstract class AbstractHibernateListener {
       Auditable auditable =
           AnnotationUtils.getAnnotation(HibernateProxyUtils.getRealClass(object), Auditable.class);
 
-      boolean shouldAudit =
+      boolean isAuditableEventType =
           Arrays.stream(auditable.eventType()).anyMatch(s -> s.contains("all") || s.contains(type));
 
-      if (shouldAudit) {
+      if (isAuditableEventType && auditMatrix.isEnabled(auditable.scope(), getAuditType())) {
         return Optional.of(auditable);
       }
     }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostDeleteAuditListener.java
@@ -37,6 +37,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.AuditableEntity;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -53,9 +54,10 @@ public class PostDeleteAuditListener extends AbstractHibernateListener
   public PostDeleteAuditListener(
       AuditManager auditManager,
       AuditObjectFactory auditObjectFactory,
+      AuditMatrix auditMatrix,
       UsernameSupplier userNameSupplier,
       SchemaService schemaService) {
-    super(auditManager, auditObjectFactory, userNameSupplier, schemaService);
+    super(auditManager, auditObjectFactory, auditMatrix, userNameSupplier, schemaService);
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostInsertAuditListener.java
@@ -37,6 +37,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.AuditableEntity;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -53,9 +54,10 @@ public class PostInsertAuditListener extends AbstractHibernateListener
   public PostInsertAuditListener(
       AuditManager auditManager,
       AuditObjectFactory auditObjectFactory,
+      AuditMatrix auditMatrix,
       UsernameSupplier userNameSupplier,
       SchemaService schemaService) {
-    super(auditManager, auditObjectFactory, userNameSupplier, schemaService);
+    super(auditManager, auditObjectFactory, auditMatrix, userNameSupplier, schemaService);
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostLoadAuditListener.java
@@ -35,6 +35,7 @@ import org.hibernate.event.spi.PostLoadEventListener;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.AuditableEntity;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -50,9 +51,10 @@ public class PostLoadAuditListener extends AbstractHibernateListener
   public PostLoadAuditListener(
       AuditManager auditManager,
       AuditObjectFactory auditObjectFactory,
+      AuditMatrix auditMatrix,
       UsernameSupplier userNameSupplier,
       SchemaService schemaService) {
-    super(auditManager, auditObjectFactory, userNameSupplier, schemaService);
+    super(auditManager, auditObjectFactory, auditMatrix, userNameSupplier, schemaService);
   }
 
   AuditType getAuditType() {

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/PostUpdateAuditListener.java
@@ -37,6 +37,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.Audit;
 import org.hisp.dhis.artemis.audit.AuditManager;
 import org.hisp.dhis.artemis.audit.AuditableEntity;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.audit.AuditType;
@@ -53,9 +54,10 @@ public class PostUpdateAuditListener extends AbstractHibernateListener
   public PostUpdateAuditListener(
       AuditManager auditManager,
       AuditObjectFactory auditObjectFactory,
+      AuditMatrix auditMatrix,
       UsernameSupplier userNameSupplier,
       SchemaService schemaService) {
-    super(auditManager, auditObjectFactory, userNameSupplier, schemaService);
+    super(auditManager, auditObjectFactory, auditMatrix, userNameSupplier, schemaService);
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -29,23 +29,23 @@
  */
 package org.hisp.dhis.artemis.audit.configuration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.audit.AuditScope.AGGREGATE;
 import static org.hisp.dhis.audit.AuditScope.METADATA;
 import static org.hisp.dhis.audit.AuditScope.TRACKER;
 import static org.hisp.dhis.audit.AuditType.CREATE;
 import static org.hisp.dhis.audit.AuditType.DELETE;
 import static org.hisp.dhis.audit.AuditType.READ;
-import static org.hisp.dhis.audit.AuditType.SEARCH;
 import static org.hisp.dhis.audit.AuditType.SECURITY;
 import static org.hisp.dhis.audit.AuditType.UPDATE;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.artemis.config.ArtemisConfigData;
+import org.hisp.dhis.artemis.config.ArtemisMode;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.AuditType;
 import org.hisp.dhis.external.conf.ConfigurationKey;
@@ -55,122 +55,170 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * @author Luciano Fiandesio
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AuditMatrixConfigurerTest {
   @Mock private DhisConfigurationProvider config;
 
+  private ArtemisConfigData artemisConfig;
+
   private AuditMatrixConfigurer subject;
 
-  private Map<AuditScope, Map<AuditType, Boolean>> matrix;
+  private Map<AuditScope, Set<AuditType>> matrix;
 
   @BeforeEach
   public void setUp() {
-    this.subject = new AuditMatrixConfigurer(config);
+    artemisConfig = new ArtemisConfigData();
+    artemisConfig.setMode(ArtemisMode.EMBEDDED);
+    // lenient because configure() iterates all scopes calling getProperty() and isEnabled()
+    // with different ConfigurationKey args, but tests only stub the ones relevant to each case
+    this.subject = new AuditMatrixConfigurer(config, artemisConfig);
   }
 
   @Test
   void verifyConfigurationForMatrixIsIngested() {
+    enableDatabaseSink();
     when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX)).thenReturn("READ;");
+    when(config.getProperty(ConfigurationKey.AUDIT_AGGREGATE_MATRIX))
+        .thenReturn("CREATE;UPDATE;DELETE");
     when(config.getProperty(ConfigurationKey.AUDIT_TRACKER_MATRIX))
         .thenReturn("CREATE;READ;UPDATE;DELETE");
-    when(config.getProperty(ConfigurationKey.AUDIT_AGGREGATE_MATRIX))
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(READ), matrix.get(METADATA));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE), matrix.get(AGGREGATE));
+    assertEquals(Set.of(CREATE, READ, UPDATE, DELETE), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyDisabledAsOnlyValue() {
+    when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX)).thenReturn("DISABLED");
+    when(config.getProperty(ConfigurationKey.AUDIT_AGGREGATE_MATRIX)).thenReturn("DISABLED");
+    when(config.getProperty(ConfigurationKey.AUDIT_TRACKER_MATRIX)).thenReturn("DISABLED");
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(), matrix.get(METADATA));
+    assertEquals(Set.of(), matrix.get(AGGREGATE));
+    assertEquals(Set.of(), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyDisabledCombinedWithValidTypesEnablesTypes() {
+    enableDatabaseSink();
+    when(config.getProperty(ConfigurationKey.AUDIT_TRACKER_MATRIX))
+        .thenReturn("DISABLED;CREATE;UPDATE");
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyInvalidConfigurationThrows() {
+    when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX)).thenReturn("READX;UPDATE");
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> this.subject.configure());
+    assertTrue(ex.getMessage().contains("READX"));
+    assertTrue(ex.getMessage().contains("audit.metadata"));
+  }
+
+  @Test
+  void verifyWhitespaceInConfigIsTrimmed() {
+    enableLoggerSink();
+    when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX))
+        .thenReturn(" CREATE ; UPDATE ; DELETE ");
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE, DELETE), matrix.get(METADATA));
+  }
+
+  @Test
+  void verifyDefaultConfigDisablesTrackerInEmbeddedMode() {
+    // audit.logger absent from dhis.conf: defaults to "on" so isEnabled() returns true.
+    // TrackerAuditConsumer uses getPropertyOrDefault(AUDIT_LOGGER, "off") which returns "off"
+    // since the property is absent. Metadata/aggregate have logger on, tracker has it off.
+    enableLoggerSink();
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(METADATA));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(AGGREGATE));
+    assertEquals(Set.of(), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyTrackerEnabledWhenDatabaseSinkIsOn() {
+    enableDatabaseSink();
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(METADATA));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(AGGREGATE));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyTrackerEnabledWhenLoggerSetInConfig() {
+    // audit.logger=on explicitly set in dhis.conf: both isEnabled() and
+    // getPropertyOrDefault(AUDIT_LOGGER, "off") return "on", so tracker logger is enabled
+    enableLoggerSink();
+    when(config.getPropertyOrDefault(ConfigurationKey.AUDIT_LOGGER, "off")).thenReturn("on");
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(METADATA));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(AGGREGATE));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifySinksOffKeepsAllScopesEnabledInNativeMode() {
+    // sinks off but external consumers can connect in native mode
+    artemisConfig.setMode(ArtemisMode.NATIVE);
+    subject = new AuditMatrixConfigurer(config, artemisConfig);
+
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(METADATA));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(AGGREGATE));
+    assertEquals(Set.of(CREATE, UPDATE, DELETE, SECURITY), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifySinksOffDisablesAllScopesInEmbeddedMode() {
+    matrix = this.subject.configure();
+
+    assertEquals(Set.of(), matrix.get(METADATA));
+    assertEquals(Set.of(), matrix.get(AGGREGATE));
+    assertEquals(Set.of(), matrix.get(TRACKER));
+  }
+
+  @Test
+  void verifyExplicitMatrixOverriddenWhenSinksOffInEmbeddedMode() {
+    when(config.getProperty(ConfigurationKey.AUDIT_TRACKER_MATRIX))
         .thenReturn("CREATE;UPDATE;DELETE");
 
     matrix = this.subject.configure();
 
-    assertThat(matrix.get(METADATA).keySet(), hasSize(6));
-    assertMatrixEnabled(METADATA, READ);
-    assertMatrixDisabled(METADATA, CREATE, UPDATE, DELETE);
-
-    assertThat(matrix.get(TRACKER).keySet(), hasSize(6));
-    assertMatrixDisabled(TRACKER, SEARCH, SECURITY);
-    assertMatrixEnabled(TRACKER, CREATE, UPDATE, DELETE, READ);
-
-    assertThat(matrix.get(AGGREGATE).keySet(), hasSize(6));
-    assertMatrixDisabled(AGGREGATE, READ, SECURITY, SEARCH);
-    assertMatrixEnabled(AGGREGATE, CREATE, UPDATE, DELETE);
+    // explicitly configured but both sinks off + embedded = no consumer, so disabled
+    assertEquals(Set.of(), matrix.get(TRACKER));
   }
 
-  @Test
-  void allDisabled() {
-    when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX)).thenReturn("DISABLED");
-    when(config.getProperty(ConfigurationKey.AUDIT_TRACKER_MATRIX)).thenReturn("DISABLED");
-    when(config.getProperty(ConfigurationKey.AUDIT_AGGREGATE_MATRIX)).thenReturn("DISABLED");
-
-    matrix = this.subject.configure();
-
-    assertMatrixAllDisabled(METADATA);
-    assertMatrixAllDisabled(TRACKER);
-    assertMatrixAllDisabled(AGGREGATE);
+  private void enableLoggerSink() {
+    when(config.isEnabled(ConfigurationKey.AUDIT_LOGGER)).thenReturn(true);
   }
 
-  @Test
-  void verifyInvalidConfigurationIsIgnored() {
-    when(config.getProperty(ConfigurationKey.AUDIT_METADATA_MATRIX)).thenReturn("READX;UPDATE");
-
-    matrix = this.subject.configure();
-    assertThat(matrix.get(METADATA).keySet(), hasSize(6));
-    assertAllFalseBut(matrix.get(METADATA), UPDATE);
-  }
-
-  @Test
-  void verifyDefaultAuditingConfiguration() {
-    matrix = this.subject.configure();
-    assertMatrixDisabled(METADATA, READ);
-    assertMatrixEnabled(METADATA, CREATE);
-    assertMatrixEnabled(METADATA, UPDATE);
-    assertMatrixEnabled(METADATA, DELETE);
-
-    assertMatrixDisabled(TRACKER, READ);
-    assertMatrixEnabled(TRACKER, CREATE);
-    assertMatrixEnabled(TRACKER, UPDATE);
-    assertMatrixEnabled(TRACKER, DELETE);
-
-    assertMatrixDisabled(AGGREGATE, READ);
-    assertMatrixEnabled(AGGREGATE, CREATE);
-    assertMatrixEnabled(AGGREGATE, UPDATE);
-    assertMatrixEnabled(AGGREGATE, DELETE);
-  }
-
-  private void assertAllFalseBut(
-      Map<AuditType, Boolean> auditTypeBooleanMap, AuditType trueAuditType) {
-    for (AuditType auditType : auditTypeBooleanMap.keySet()) {
-      if (!auditType.name().equals(trueAuditType.name())) {
-        assertFalse(auditTypeBooleanMap.get(auditType));
-      } else {
-        assertTrue(auditTypeBooleanMap.get(auditType));
-      }
-    }
-  }
-
-  private void assertMatrixEnabled(AuditScope auditScope, AuditType... auditTypes) {
-    for (AuditType auditType : auditTypes) {
-      assertThat(
-          "Expecting true for audit type: " + auditType.name(),
-          matrix.get(auditScope).get(auditType),
-          is(true));
-    }
-  }
-
-  private void assertMatrixDisabled(AuditScope auditScope, AuditType... auditTypes) {
-    for (AuditType auditType : auditTypes) {
-      assertThat(
-          "Expecting false for audit type: " + auditType.name(),
-          matrix.get(auditScope).get(auditType),
-          is(false));
-    }
-  }
-
-  private void assertMatrixAllDisabled(AuditScope auditScope) {
-    for (AuditType auditType : AuditType.values()) {
-      assertThat(
-          "Expecting false for audit type: " + auditType.name(),
-          matrix.get(auditScope).get(auditType),
-          is(false));
-    }
+  private void enableDatabaseSink() {
+    when(config.isEnabled(ConfigurationKey.AUDIT_DATABASE)).thenReturn(true);
   }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/AuditHibernateListenerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/listener/AuditHibernateListenerTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hisp.dhis.artemis.audit.AuditManager;
+import org.hisp.dhis.artemis.audit.configuration.AuditMatrix;
 import org.hisp.dhis.artemis.audit.legacy.AuditObjectFactory;
 import org.hisp.dhis.artemis.config.UsernameSupplier;
 import org.hisp.dhis.schema.Property;
@@ -58,6 +59,8 @@ public class AuditHibernateListenerTest {
   @Mock private AuditManager auditManager;
 
   @Mock private AuditObjectFactory objectFactory;
+
+  @Mock private AuditMatrix auditMatrix;
 
   @Mock private UsernameSupplier usernameSupplier;
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -11,9 +11,9 @@ audit.in_memory-queue.enabled=off;
 metadata.audit.persist=on
 tracker.audit.persist=on
 aggregate.audit.persist=on
-audit.metadata=CREATE_UPDATE_DELETE
-audit.tracker=CREATE_UPDATE_DELETE
-audit.aggregate=CREATE_UPDATE_DELETE
+audit.metadata=CREATE;UPDATE;DELETE
+audit.tracker=CREATE;UPDATE;DELETE
+audit.aggregate=CREATE;UPDATE;DELETE
 
 db.pool.type=hikari
 connection.pool.timeout=5000


### PR DESCRIPTION
Every Hibernate INSERT/UPDATE/DELETE on a `@Auditable` entity triggers a per-entity audit pipeline:

```
Hibernate listener -> createAuditEntry() -> AuditManager.send() -> JSON serialize -> JMS publish
    -> Artemis broker -> AuditConsumer -> JSON deserialize -> logger? -> database?
```

Each scope has its own consumer (`TrackerAuditConsumer`, `MetadataAuditConsumer`, `AggregateAuditConsumer`).

With default configuration both sinks are off for tracker and the broker is embedded with only an [in-VM acceptor](https://activemq.apache.org/components/artemis/documentation/latest/embedding-activemq.html) (`vm://0`), so no external consumers can connect. Every message is discarded. This has been the case [since Oct 2021](https://github.com/dhis2/dhis2-core/commit/b72e0275015270ad974e3f9e466d08cb476610b7).

### Default configuration

| Config | Default | Effect on tracker |
|---|---|---|
| `system.audit.enabled` | `on` | Kill switch: if off, no Hibernate listeners are registered, no audit pipeline runs for any scope |
| `artemis.mode` | `EMBEDDED` | Only [in-VM acceptor](https://activemq.apache.org/components/artemis/documentation/latest/embedding-activemq.html), no external consumers |
| `audit.logger` | `on` | But tracker consumer [overrides fallback to off](https://github.com/dhis2/dhis2-core/blob/d025f817fe9c/dhis-2/dhis-services/dhis-service-audit-consumer/src/main/java/org/hisp/dhis/audit/consumers/TrackerAuditConsumer.java#L57-L58) |
| `audit.database` | [`off`](https://github.com/dhis2/dhis2-core/blob/d025f817fe9c/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java#L610) | Off for all scopes |
| `audit.tracker` | (empty) | Falls back to CREATE/UPDATE/DELETE/SECURITY enabled |

Result: the audit matrix allows tracker events through, but no consumer processes them.

### Changes

1. **Skip audit pipeline when no consumer exists.** In embedded Artemis mode, if both sinks (logger and database) are off for a scope, `AuditMatrixConfigurer` disables that scope at startup. With default configuration this disables tracker (both sinks off) while leaving metadata and aggregate enabled (logger on). Applies to any scope, not just tracker.
2. **Early matrix check in Hibernate listeners.** The listeners now check `AuditMatrix.isEnabled(scope, type)` before `createAuditEntry()` (schema lookup, entity state serialization). Previously the check only happened inside `AuditManager.send()`, after the expensive work. `AuditManager.send()` retains its check because it is also called directly from non-Hibernate code paths (`RouteService`, `JdbcMaintenanceStore`, `HibernatePotentialDuplicateStore`).

Users who need tracker audit can enable it the same way as before via `audit.database=on` (or `audit.logger=on`) in dhis.conf.

## Performance

Import throughput increased by ~61% (3.2 to 5.2 req/s) and import time reduced by ~38% (56s to 35s).

Load profile, 4 concurrent import users, Sierra Leone DB.

### CPU profile (import only)

* [Baseline](https://github.com/dhis2/dhis2-core/actions/runs/24077771287) (`dhis2/core-pr:23511`, post DHIS2-21248)
* [This PR](https://github.com/dhis2/dhis2-core/actions/runs/24199033238)

| | Total samples | Audit/JMS samples | Audit/JMS % |
|---|---|---|---|
| Baseline | 18,067 | 10,290 | 56.9% |
| This PR | 8,694 | 195 | 2.2% |

### HTTP (Gatling)

* [Baseline](https://github.com/dhis2/dhis2-core/actions/runs/24200642214) (`dhis2/core-dev:master`)
* [This PR](https://github.com/dhis2/dhis2-core/actions/runs/24235770426)

#### Import throughput

| | Duration | Throughput |
|---|---|---|
| Baseline | 55.9s | 3.22 req/s |
| This PR | 34.7s | 5.19 req/s |
| **Change** | **-38%** | **+61%** |

#### Import P95 latency (ms)

| Request | Baseline | This PR | Change |
|---|---|---|---|
| MNCH import | 2,512 | 2,121 | -16% |
| Child Programme import | 1,110 | 983 | -11% |
| ANC import | 899 | 783 | -13% |

## Audit configuration history

How the tracker audit pipeline ended up doing wasted work with default configuration:

| Date | Author | Change | `audit.logger` | tracker logger | `audit.database` | Tracker pipeline useful? |
|---|---|---|---|---|---|---|
| Jun 2020 | Morten | [PR #5706](https://github.com/dhis2/dhis2-core/pull/5706): added `audit.logger` and `audit.database` | off | off (fallback=off, same as global) | on | yes (database on) |
| Sep 2021 | Morten | [PR #8785](https://github.com/dhis2/dhis2-core/pull/8785): added dhis-audit.log, flipped logger to on | **on** | off (fallback unchanged, now diverges) | on | yes (database on) |
| Oct 2021 | Morten | [`b72e027`](https://github.com/dhis2/dhis2-core/commit/b72e0275015270ad974e3f9e466d08cb476610b7): flipped database to off | on | off | **off** | **no** |

## Config oddities

**`DISABLED` is not a real audit type.** The [docs](https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-master/audit.html) show `audit.tracker=DISABLED` as a way to disable auditing for a scope. But `DISABLED` is not an `AuditType` enum value. It worked by accident: the old code iterated all `AuditType` values and checked if each was in the user's input. Since `"DISABLED"` matched none of them, every type got `false`. Any unrecognized string (e.g. `audit.tracker=BANANA`) would have had the same effect. This PR preserves `DISABLED` explicitly to not break existing configs, but now rejects other unrecognized values.

**No way to disable a single scope.** Setting `audit.tracker=` (empty) falls back to the default (CREATE/UPDATE/DELETE enabled). The only way to disable just tracker was `audit.tracker=DISABLED`. There is no first-class "disable this scope" mechanism in the config.

## Should audit scopes have separate sink configs?

Currently sink config is global (`audit.logger`, `audit.database`) but `TrackerAuditConsumer` hardcodes a different logger default than other consumers. This PR works around that by replicating the hardcoded fallback logic in `AuditMatrixConfigurer.isLoggerEnabled()`. A cleaner model would be per-scope sink config:

```properties
# what to audit (existing)
audit.tracker = CREATE;UPDATE;DELETE

# where to send it (new, replaces global audit.logger/audit.database)
audit.tracker.logger = off
audit.tracker.database = off
audit.metadata.logger = on
audit.metadata.database = off
```

This would remove the need for hardcoded overrides in individual consumers and make the configuration explicit per scope.

More broadly, it is not clear what guarantees the audit system provides. The default setup uses non-persistent JMS messages (`DeliveryMode.NON_PERSISTENT`) over an embedded Artemis broker. If the JVM crashes, entities are already committed to the database (listeners fire post-commit) but audit messages in the broker may be lost. This means the audit system is best-effort by design: there can be persisted entities with no audit trace. If audit is meant to provide a reliable record, the architecture needs rethinking.
