### PR TITLE
chore: remove experimental analytics sql engine enabled flag

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -779,15 +779,6 @@ public non-sealed interface SystemSettings extends Settings {
   }
 
   /**
-   * @since 2.42
-   * @return true if the experimental analytics query engine should be used for analytics queries.
-   *     This engine is only required when using ClickHouse or Doris as the analytics database.
-   */
-  default boolean getUseExperimentalAnalyticsQueryEngine() {
-    return asBoolean("experimentalAnalyticsSqlEngineEnabled", true);
-  }
-
-  /**
    * @since 2.40
    * @return if true, the analytics event tables are created with a centroid value for each Data
    *     Element or TEA of type OU or ougeometry

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -1617,6 +1617,11 @@ public class EventQueryParams extends DataQueryParams {
       return this;
     }
 
+    public Builder removeItemFilters() {
+      this.params.itemFilters.clear();
+      return this;
+    }
+
     public Builder addItemFilter(QueryItem item) {
       this.params.itemFilters.add(item);
       return this;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -2032,7 +2032,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
     if (needsOptimizedCtes(params, cteContext)) {
       // 3.7 : Add shadow CTEs for optimized query
-      addShadowCtes(params, cteContext, selectColumns);
+      addShadowCtes(params, cteContext, selectColumns, maxLimit);
     }
 
     return sb.build();
@@ -2101,10 +2101,12 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    * @param selectColumns The list of columns computed for the main SELECT statement. This is used
    *     when computing the main {@code top_enrollments} CTE to ensure that any missing column is
    *     used in the shadow CTEs.
+   * @param maxLimit
    */
-  void addShadowCtes(EventQueryParams params, CteContext cteContext, List<String> selectColumns) {
+  void addShadowCtes(
+      EventQueryParams params, CteContext cteContext, List<String> selectColumns, int maxLimit) {
 
-    addTopEnrollmentsCte(params, cteContext, selectColumns);
+    addTopEnrollmentsCte(params, cteContext, selectColumns, maxLimit);
     addShadowEnrollmentTableCte(params, cteContext);
     addShadowEventTableCte(params, cteContext);
   }
@@ -2143,7 +2145,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    *     to ensure correct ordering in the final SQL query.
    */
   void addTopEnrollmentsCte(
-      EventQueryParams params, CteContext cteContext, List<String> selectColumns) {
+      EventQueryParams params, CteContext cteContext, List<String> selectColumns, int maxLimit) {
     SelectBuilder topEnrollments = new SelectBuilder();
     Map<String, String> formulaAliases = getFormulaColumnAliases();
 
@@ -2191,7 +2193,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     topEnrollments.where(Condition.raw(getWhereClause(params)));
 
     // Apply pagination
-    addPagingToBuilder(topEnrollments, params);
+    addPagingToBuilder(topEnrollments, params, maxLimit);
 
     // Add to CTE context with special name and type
     cteContext.addShadowCte("top_enrollments", topEnrollments.build(), TOP_ENROLLMENTS);
@@ -2382,17 +2384,17 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     return enrollmentColumns;
   }
 
-  private void addPagingToBuilder(SelectBuilder builder, EventQueryParams params) {
+  private void addPagingToBuilder(SelectBuilder builder, EventQueryParams params, int maxLimit) {
     if (params.isPaging()) {
       if (params.isTotalPages()) {
-        builder.limitWithMax(params.getPageSizeWithDefault(), 5000).offset(params.getOffset());
+        builder.limitWithMax(params.getPageSizeWithDefault(), maxLimit).offset(params.getOffset());
       } else {
         builder
-            .limitWithMaxPlusOne(params.getPageSizeWithDefault(), 5000)
+            .limitWithMaxPlusOne(params.getPageSizeWithDefault(), maxLimit)
             .offset(params.getOffset());
       }
-    } else {
-      builder.limitPlusOne(5000);
+    } else if (maxLimit > 0) {
+      builder.limitPlusOne(maxLimit);
     }
   }
 
@@ -2561,19 +2563,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     if (params.isSorting()) {
       builder.orderBy(getCteAwareSortClause(cteContext, params));
     }
-
-    // Paging with max limit of 5000
-    if (params.isPaging()) {
-      if (params.isTotalPages()) {
-        builder.limitWithMax(params.getPageSizeWithDefault(), maxLimit).offset(params.getOffset());
-      } else {
-        builder
-            .limitWithMaxPlusOne(params.getPageSizeWithDefault(), maxLimit)
-            .offset(params.getOffset());
-      }
-    } else {
-      builder.limitPlusOne(5000);
-    }
+    addPagingToBuilder(builder, params, maxLimit);
   }
 
   private void addCteJoins(SelectBuilder builder, CteContext cteContext) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -89,7 +89,6 @@ import static org.hisp.dhis.common.ValueType.REFERENCE;
 import static org.hisp.dhis.commons.collection.ListUtils.union;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
-import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_DATABASE;
 import static org.hisp.dhis.feedback.ErrorCode.E7149;
 import static org.hisp.dhis.system.util.MathUtils.getRoundedObject;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
@@ -871,9 +870,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    */
   protected String getAdditionalQueryItemWhereClause(
       EventQueryParams params, String existingWhereClause) {
-    if (!useExperimentalAnalyticsQueryEngine()) {
-      return StringUtils.EMPTY;
-    }
 
     String queryItemFilterClause = getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
 
@@ -1936,21 +1932,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         .flatMap(column -> ColumnUtils.splitColumns(column).stream())
         .distinct()
         .toList();
-  }
-
-  /**
-   * Determines if the experimental analytics query engine should be used. The experimental
-   * analytics query engine is used when the analytics database is set to Doris or when the setting
-   * is enabled. When the experimental analytics query engine is used, all enrollment and event
-   * queries are constructed using CTE (Common Table Expressions) instead of subqueries.
-   *
-   * @return true if the experimental analytics query engine should be used, false otherwise.
-   */
-  protected boolean useExperimentalAnalyticsQueryEngine() {
-    String analyticsDatabase = config.getPropertyOrDefault(ANALYTICS_DATABASE, "").trim();
-    return "doris".equalsIgnoreCase(analyticsDatabase)
-        || "clickhouse".equalsIgnoreCase(analyticsDatabase)
-        || this.settingsService.getCurrentSettings().getUseExperimentalAnalyticsQueryEngine();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -61,11 +61,6 @@ import static org.hisp.dhis.analytics.common.CteDefinition.CteType.TOP_ENROLLMEN
 import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
 import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManager.RepeatableStateStatus.NON_REPEATABLE;
 import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManager.RepeatableStateStatus.REPEATABLE;
-import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.hasEnrollmentOrgUnitFilter;
-import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.isAggregateEnrollment;
-import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getHeaderColumns;
-import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getOrgUnitLevelColumns;
-import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getPeriodColumns;
 import static org.hisp.dhis.analytics.event.data.OrgUnitTableJoiner.joinOrgUnitTables;
 import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_CODE_COLUMN;
 import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_NAME_COLUMN;
@@ -150,7 +145,6 @@ import org.hisp.dhis.analytics.table.util.ColumnMapper;
 import org.hisp.dhis.analytics.util.sql.ColumnUtils;
 import org.hisp.dhis.analytics.util.sql.Condition;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
-import org.hisp.dhis.analytics.util.sql.SqlConditionJoiner;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -289,29 +283,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   static final String COLUMN_ENROLLMENT_GEOMETRY_GEOJSON =
       String.format(
           "ST_AsGeoJSON(%s)", EnrollmentAnalyticsColumnName.ENROLLMENT_GEOMETRY_COLUMN_NAME);
-
-  /**
-   * Returns a SQL paging clause.
-   *
-   * @param params the {@link EventQueryParams}.
-   * @param maxLimit the configurable max limit of records.
-   */
-  protected String getPagingClause(EventQueryParams params, int maxLimit) {
-    String sql = "";
-
-    if (params.isPaging()) {
-      int limit =
-          params.isTotalPages()
-              ? params.getPageSizeWithDefault()
-              : params.getPageSizeWithDefault() + 1;
-
-      sql += LIMIT + " " + limit + " offset " + params.getOffset();
-    } else if (maxLimit > 0) {
-      sql += LIMIT + " " + (maxLimit + 1);
-    }
-
-    return sql;
-  }
 
   /**
    * Returns a SQL sort clause.
@@ -1239,84 +1210,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   }
 
   /**
-   * Template method that generates a SQL query for retrieving events or enrollments.
-   *
-   * @param params the {@link EventQueryParams} to drive the query generation.
-   * @param maxLimit max number of records to return.
-   * @return a SQL query.
-   */
-  protected String getAggregatedEnrollmentsSql(EventQueryParams params, int maxLimit) {
-    String sql = getSelectClause(params);
-
-    sql += getFromClause(params);
-
-    sql += getWhereClause(params);
-
-    sql += getSortClause(params);
-
-    sql += getPagingClause(params, maxLimit);
-
-    return sql;
-  }
-
-  /**
-   * Template method that generates a SQL query for retrieving aggregated enrollments.
-   *
-   * @param headers the {@link List<GridHeader>} to drive the query generation.
-   * @param params the {@link EventQueryParams} to drive the query generation.
-   * @return a SQL query.
-   */
-  protected String getAggregatedEnrollmentsSql(List<GridHeader> headers, EventQueryParams params) {
-    String sql = getSelectClause(params);
-
-    sql += getFromClause(params);
-
-    String whereClause = getWhereClause(params);
-    String filterWhereClause = getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
-
-    String headerColumns = String.join(",", getHeaderColumns(headers, sql, sqlBuilder));
-    String periodColumns = String.join(",", getPeriodColumns(params));
-    String orgUnitColumns = String.join(",", getOrgUnitLevelColumns(params));
-
-    if (isBlank(orgUnitColumns) && !isAggregateEnrollment(params)) {
-      orgUnitColumns = ORGUNIT_DIM_ID;
-    }
-
-    List<String> list = Arrays.asList(orgUnitColumns, periodColumns, headerColumns);
-    String columns =
-        list.stream().filter(StringUtils::isNotBlank).collect(Collectors.joining(", "));
-
-    String join = EMPTY;
-    if (hasEnrollmentOrgUnitFilter(params)) {
-      join =
-          " join analytics_event_"
-              + params.getProgram().getUid()
-              + " ev on ev.enrollment = ax.enrollment "
-              + whereClause
-              + " and ev.eventstatus != 'SCHEDULE'"; // We work only with non-scheduled events.
-    } else {
-      sql += SqlConditionJoiner.joinSqlConditions(whereClause, filterWhereClause);
-    }
-
-    sql =
-        "select count(distinct "
-            + OUTER_SQL_ALIAS
-            + ".enrollment) as "
-            + COL_VALUE
-            + ", "
-            + columns
-            + " from ("
-            + sql
-            + join
-            + ") "
-            + OUTER_SQL_ALIAS
-            + " group by "
-            + columns;
-
-    return sql;
-  }
-
-  /**
    * Adds a value from the given row set to the grid.
    *
    * @param grid the {@link Grid}.
@@ -2027,13 +1920,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       QueryItem item, EventQueryParams params) {
     return organisationUnitResolver.buildStageOuCteContext(item, params);
   }
-
-  /**
-   * Returns a select SQL clause for the given query.
-   *
-   * @param params the {@link EventQueryParams}.
-   */
-  protected abstract String getSelectClause(EventQueryParams params);
 
   /** Returns the column name associated with the CTE */
   protected abstract String getColumnWithCte(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
@@ -55,7 +55,7 @@ import org.hisp.dhis.program.AnalyticsType;
 import org.springframework.stereotype.Component;
 
 @Component
-class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
+public class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
 
   public EventTimeFieldSqlRenderer(SqlBuilder sqlBuilder) {
     super(sqlBuilder);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -370,6 +370,10 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     return count;
   }
 
+  private String addFiltersToWhereClause(EventQueryParams params) {
+    return getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
+  }
+
   /**
    * Returns a from SQL clause for the given analytics table partition.
    *
@@ -529,11 +533,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     // ---------------------------------------------------------------------
-    // Query items and filters
-    // ---------------------------------------------------------------------
-    sql += getQueryItemsAndFiltersWhereClause(params, hlp);
-
-    // ---------------------------------------------------------------------
     // Filter expression
     // ---------------------------------------------------------------------
 
@@ -593,10 +592,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     return sql;
-  }
-
-  private String addFiltersToWhereClause(EventQueryParams params) {
-    return getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -68,6 +68,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -197,15 +198,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   public void getEnrollments(EventQueryParams params, Grid grid, int maxLimit) {
     String sql;
     if (params.isAggregatedEnrollments()) {
-      sql =
-          useExperimentalAnalyticsQueryEngine()
-              ? buildAggregatedEnrollmentQueryWithCte(grid.getHeaders(), params)
-              : getAggregatedEnrollmentsSql(grid.getHeaders(), params);
+      sql = buildAggregatedEnrollmentQueryWithCte(grid.getHeaders(), params);
     } else {
-      sql =
-          useExperimentalAnalyticsQueryEngine()
-              ? buildAnalyticsQuery(params, maxLimit)
-              : getAggregatedEnrollmentsSql(params, maxLimit);
+      sql = buildAnalyticsQuery(params, maxLimit);
     }
     if (params.analyzeOnly()) {
       withExceptionHandling(
@@ -536,9 +531,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     // ---------------------------------------------------------------------
     // Query items and filters
     // ---------------------------------------------------------------------
-    if (!useExperimentalAnalyticsQueryEngine()) {
-      sql += getQueryItemsAndFiltersWhereClause(params, hlp);
-    }
+    sql += getQueryItemsAndFiltersWhereClause(params, hlp);
 
     // ---------------------------------------------------------------------
     // Filter expression
@@ -1206,14 +1199,37 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   }
 
   private String getBaseAggregationWhereClause(EventQueryParams params) {
-    if (!params.hasTimeDateRanges()) {
-      return getWhereClause(params);
+    EventQueryParams sanitizedParams = withoutProgramStageItems(params);
+    Set<QueryItem> aggregateEventDateFilters =
+        new LinkedHashSet<>(getAggregateEventDateFilters(params));
+
+    if (!aggregateEventDateFilters.isEmpty()) {
+      sanitizedParams =
+          withoutQueryItems(sanitizedParams, item -> aggregateEventDateFilters.contains(item));
     }
 
-    EventQueryParams sanitizedParams =
-        new EventQueryParams.Builder(params).withoutTimeDateRanges(EVENT_TIME_FIELDS).build();
+    if (sanitizedParams.hasTimeDateRanges()) {
+      sanitizedParams =
+          new EventQueryParams.Builder(sanitizedParams)
+              .withoutTimeDateRanges(EVENT_TIME_FIELDS)
+              .build();
+    }
 
     return getWhereClause(sanitizedParams);
+  }
+
+  private EventQueryParams withoutQueryItems(
+      EventQueryParams params, Predicate<QueryItem> predicate) {
+    EventQueryParams.Builder builder = new EventQueryParams.Builder(params);
+    List<QueryItem> filteredItems = params.getItems().stream().filter(predicate.negate()).toList();
+    List<QueryItem> filteredItemFilters =
+        params.getItemFilters().stream().filter(predicate.negate()).toList();
+
+    builder.removeItems().removeItemFilters();
+    filteredItems.forEach(builder::addItem);
+    filteredItemFilters.forEach(builder::addItemFilter);
+
+    return builder.build();
   }
 
   private boolean usesAggregateEventJoin(EventQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
 import static org.hisp.dhis.analytics.common.CteUtils.computeKey;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParam.StaticDimension.PROGRAM_STATUS;
-import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.hasEnrollmentOrgUnitFilter;
 import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.isAggregateEnrollment;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getHeaderColumns;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getOrgUnitLevelColumns;
@@ -110,7 +109,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueStatus;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
@@ -592,22 +590,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     return sql;
-  }
-
-  @Override
-  protected String getSelectClause(EventQueryParams params) {
-    List<String> selectCols =
-        ListUtils.distinctUnion(
-            params.isAggregatedEnrollments() ? List.of("enrollment") : getStandardColumns(params),
-            getSelectColumns(params, false));
-
-    // Needs event prefix as we will join with the event table for filtering DataElement of type
-    // Org. Unit.
-    if (hasEnrollmentOrgUnitFilter(params)) {
-      selectCols = selectCols.stream().map(this::addEnrollmentPrefix).toList();
-    }
-
-    return "select " + StringUtils.join(selectCols, ",") + " ";
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -1194,7 +1194,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   }
 
   private String getBaseAggregationWhereClause(EventQueryParams params) {
-    EventQueryParams sanitizedParams = withoutProgramStageItems(params);
+    EventQueryParams sanitizedParams =
+        EventPeriodUtils.sanitizeTimeFiltersForStageDateItems(params);
+    sanitizedParams = withoutProgramStageItems(sanitizedParams);
     Set<QueryItem> aggregateEventDateFilters =
         new LinkedHashSet<>(getAggregateEventDateFilters(params));
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -170,10 +170,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
 
   @Override
   public Grid getEvents(EventQueryParams params, Grid grid, int maxLimit) {
-    String sql =
-        useExperimentalAnalyticsQueryEngine()
-            ? buildAnalyticsQuery(params, maxLimit)
-            : getAggregatedEnrollmentsSql(params, maxLimit);
+    String sql = buildAnalyticsQuery(params, maxLimit);
     if (params.analyzeOnly()) {
       withExceptionHandling(
           () -> executionPlanStore.addExecutionPlan(params.getExplainOrderId(), sql));
@@ -701,9 +698,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
     // Query items and filters
     // ---------------------------------------------------------------------
 
-    if (!useExperimentalAnalyticsQueryEngine()) {
-      sql += getQueryItemsAndFiltersWhereClause(params, hlp);
-    }
+    sql += getQueryItemsAndFiltersWhereClause(params, hlp);
 
     sql += getOptionFilter(params, hlp);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -96,7 +96,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryRuntimeException;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -360,21 +359,6 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
   // -------------------------------------------------------------------------
   // Supportive methods
   // -------------------------------------------------------------------------
-
-  /**
-   * Returns a select SQL clause for the given query.
-   *
-   * @param params the {@link EventQueryParams}.
-   */
-  @Override
-  protected String getSelectClause(EventQueryParams params) {
-    List<String> standardColumns = getStandardColumns(params);
-
-    List<String> selectCols =
-        ListUtils.distinctUnion(standardColumns, getSelectColumns(params, false));
-
-    return "select " + StringUtils.join(selectCols, ",") + " ";
-  }
 
   @Override
   protected String getColumnWithCte(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -694,12 +694,6 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
               + "' ";
     }
 
-    // ---------------------------------------------------------------------
-    // Query items and filters
-    // ---------------------------------------------------------------------
-
-    sql += getQueryItemsAndFiltersWhereClause(params, hlp);
-
     sql += getOptionFilter(params, hlp);
 
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
@@ -570,7 +570,7 @@ public class DefaultProgramIndicatorSubqueryBuilder implements ProgramIndicatorS
               SUBQUERY_TABLE_ALIAS, relationshipType, programIndicator.getAnalyticsType());
     } else {
       if (AnalyticsType.ENROLLMENT == outerSqlEntity) {
-        condition = useExperimentalAnalyticsQueryEngine() ? "" : "enrollment = ax.enrollment";
+        condition = "";
       } else {
         if (AnalyticsType.EVENT == programIndicator.getAnalyticsType()) {
           condition = "event = ax.event";
@@ -593,10 +593,6 @@ public class DefaultProgramIndicatorSubqueryBuilder implements ProgramIndicatorS
         earliestStartDate,
         latestDate,
         SUBQUERY_TABLE_ALIAS);
-  }
-
-  protected boolean useExperimentalAnalyticsQueryEngine() {
-    return this.settingsService.getCurrentSettings().getUseExperimentalAnalyticsQueryEngine();
   }
 
   private String findKeyForAlias(String alias, CteContext cteContext) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/EventQueryParamsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/EventQueryParamsUtils.java
@@ -48,25 +48,29 @@ public class EventQueryParamsUtils {
   }
 
   /**
-   * Remove program stage items from EventQueryParams. This method creates a copy of the
-   * EventQueryParams instance and filters out QueryItems with hasProgramStage == true.
+   * Remove program stage items and item filters from EventQueryParams. This method creates a copy
+   * of the EventQueryParams instance and filters out QueryItems with hasProgramStage == true from
+   * both collections.
    *
    * @param params event query params
    * @return list of program stage items
    */
   public static EventQueryParams withoutProgramStageItems(EventQueryParams params) {
-    // Create a copy of the EventQueryParams instance
     EventQueryParams.Builder builder = new EventQueryParams.Builder(params);
 
-    // Filter out QueryItems with hasProgramStage == true
     List<QueryItem> filteredItems =
         params.getItems().stream().filter(item -> !item.hasProgramStage()).toList();
+    List<QueryItem> filteredItemFilters =
+        params.getItemFilters().stream().filter(item -> !item.hasProgramStage()).toList();
 
-    // Clear the current items and itemFilters in the builder
-    builder.removeItems(); // Clears the items
+    builder.removeItems().removeItemFilters();
 
     for (QueryItem item : filteredItems) {
       builder.addItem(item);
+    }
+
+    for (QueryItem item : filteredItemFilters) {
+      builder.addItemFilter(item);
     }
 
     return builder.build();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -219,7 +219,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
         .when(config.getPropertyOrDefault(ConfigurationKey.ANALYTICS_DATABASE, ""))
         .thenReturn("postgresql");
     lenient().when(systemSettingsService.getCurrentSettings()).thenReturn(systemSettings);
-    lenient().when(systemSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(false);
 
     ColumnMapper columnMapper = new ColumnMapper(sqlBuilder, systemSettingsService);
     QueryItemFilterBuilder filterBuilder =
@@ -1582,7 +1581,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Test
   void testGetEventCountIncludesStageDateFiltersForExperimentalEngine() {
-    when(systemSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
     when(jdbcTemplate.queryForObject(any(String.class), eq(Long.class))).thenReturn(1L);
 
     ProgramStage ps = createProgramStage('A', programA);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -46,12 +46,10 @@ import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.common.QueryOperator.NIEQ;
 import static org.hisp.dhis.common.QueryOperator.NILIKE;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
-import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointItem.ENROLLMENT;
 import static org.hisp.dhis.common.ValueType.BOOLEAN;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
-import static org.hisp.dhis.period.RelativePeriodEnum.THIS_YEAR;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 import static org.hisp.dhis.test.TestBase.createDataElement;
 import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
@@ -125,9 +123,7 @@ import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.period.PeriodTypeEnum;
-import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
@@ -195,8 +191,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
 
   private JdbcEventAnalyticsManager eventSubject;
 
-  private JdbcEnrollmentAnalyticsManager enrollmentSubject;
-
   private Program programA;
 
   private DataElement dataElementA;
@@ -237,24 +231,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
             null,
             piDisagQueryGenerator,
             eventTimeFieldSqlRenderer,
-            executionPlanStore,
-            systemSettingsService,
-            config,
-            sqlBuilder,
-            organisationUnitResolver,
-            columnMapper,
-            filterBuilder,
-            stageQuerySqlFacade,
-            new DateFieldPeriodBucketColumnResolver(new PostgreSqlAnalyticsSqlBuilder()));
-
-    enrollmentSubject =
-        new JdbcEnrollmentAnalyticsManager(
-            jdbcTemplate,
-            programIndicatorService,
-            programIndicatorSubqueryBuilder,
-            null,
-            piDisagQueryGenerator,
-            enrollmentTimeFieldSqlRenderer,
             executionPlanStore,
             systemSettingsService,
             config,
@@ -825,29 +801,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
-  void testMissingPsiGeometryInDefaultCoordinatesFieldInSqlSelectClause() {
-    EventQueryParams params =
-        getEventQueryParamsForCoordinateFieldsTest(
-            List.of("enrollmentgeometry", "tegeometry", "ougeometry"));
-
-    String whereClause = this.eventSubject.getSelectClause(params);
-
-    assertThat(
-        whereClause,
-        containsString("coalesce(ax.\"enrollmentgeometry\",ax.\"tegeometry\",ax.\"ougeometry\")"));
-  }
-
-  @Test
-  void testValidExplicitCoordinatesFieldInSqlSelectClause() {
-    EventQueryParams params =
-        getEventQueryParamsForCoordinateFieldsTest(List.of("ougeometry", "eventgeometry"));
-
-    String whereClause = this.eventSubject.getSelectClause(params);
-
-    assertThat(whereClause, containsString("coalesce(ax.\"ougeometry\",ax.\"eventgeometry\")"));
-  }
-
-  @Test
   void testGetCoalesceReturnsDefaultColumnNameWhenCoordinateFieldIsEmpty() {
     String sql =
         this.eventSubject.getCoalesce(
@@ -1115,24 +1068,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
-  void testGetSelectClauseForAggregatedEnrollments() {
-    // Given
-    PeriodDimension period = PeriodDimension.of(THIS_YEAR);
-    period.getPeriod().setPeriodType(new YearlyPeriodType());
-    EventQueryParams params =
-        new EventQueryParams.Builder()
-            .withProgram(createProgram('A'))
-            .withEndpointAction(AGGREGATE)
-            .withEndpointItem(ENROLLMENT)
-            .withPeriods(List.of(period), PeriodTypeEnum.YEARLY.getName())
-            .build();
-    // When
-    String select = enrollmentSubject.getSelectClause(params);
-    // Then
-    assertEquals("select enrollment,Yearly ", select);
-  }
-
-  @Test
   void testItemsInFilterAreQuotedForOrganisationUnit() {
     // Given
     QueryItem queryItem = mock(QueryItem.class);
@@ -1175,25 +1110,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
 
     // Then
     assertEquals("ax.\"12345678\" in ('A','B','C')", sql);
-  }
-
-  @Test
-  void testGetSelectClauseForQueryEnrollments() {
-    // Given
-    PeriodDimension period = PeriodDimension.of(THIS_YEAR);
-    EventQueryParams params =
-        new EventQueryParams.Builder()
-            .withProgram(createProgram('A'))
-            .withEndpointAction(QUERY)
-            .withEndpointItem(ENROLLMENT)
-            .withPeriods(List.of(period), PeriodTypeEnum.YEARLY.getName())
-            .build();
-    // When
-    String select = enrollmentSubject.getSelectClause(params);
-    // Then
-    assertEquals(
-        "select enrollment,trackedentity,enrollmentdate,occurreddate,storedby,createdbydisplayname,lastupdatedbydisplayname,lastupdated,created,completeddate,ST_AsGeoJSON(enrollmentgeometry),longitude,latitude,ouname,ounamehierarchy,oucode,enrollmentstatus,ax.\"yearly\" ",
-        select);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.program.EnrollmentStatus.ACTIVE;
 import static org.hisp.dhis.program.EnrollmentStatus.COMPLETED;
 import static org.hisp.dhis.test.TestBase.createPeriodDimensions;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +53,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -71,6 +73,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.ClickHouseAnalyticsSqlBuilder;
@@ -142,7 +145,6 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
   public void setUp() {
     when(jdbcTemplate.queryForRowSet(anyString())).thenReturn(this.rowSet);
     when(systemSettingsService.getCurrentSettings()).thenReturn(systemSettings);
-    when(systemSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
     when(systemSettings.getOrgUnitCentroidsInEventsAnalytics()).thenReturn(false);
     when(config.getPropertyOrDefault(ANALYTICS_DATABASE, "")).thenReturn("postgresql");
     when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
@@ -332,6 +334,59 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
 
     // The filter CTE should use the ev_occurreddate alias for the date column
     assertThat(generatedSql, containsString("ev_occurreddate"));
+  }
+
+  @Test
+  void verifyAggregateEnrollmentStageOrgUnitFilterStaysInFilterCte() {
+    DataElement orgUnitDataElement =
+        org.hisp.dhis.test.TestBase.createDataElement(
+            'O', ValueType.ORGANISATION_UNIT, AggregationType.NONE);
+    orgUnitDataElement.setUid("n1rtSHYf6O6");
+
+    QueryItem queryItem =
+        new QueryItem(
+            orgUnitDataElement,
+            programA,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            orgUnitDataElement.getAggregationType(),
+            null);
+    queryItem.setProgram(programA);
+    queryItem.setProgramStage(programStage);
+    queryItem.addFilter(new QueryFilter(IN, "ImspTQPwCqd"));
+
+    when(organisationUnitResolver.resolveOrgUnits(any(QueryFilter.class), anyList()))
+        .thenReturn("ImspTQPwCqd");
+
+    EventQueryParams.Builder params = createRequestParamsBuilder();
+    params.withEndpointAction(AGGREGATE);
+    params.addItemFilter(queryItem);
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(new GridHeader("value", "Value", ValueType.NUMBER, false, false));
+
+    subject.getEnrollments(params.build(), grid, 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String baseCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("enrollment_aggr_base as ("),
+            generatedSql.indexOf("select count(eb.enrollment) as value"));
+
+    assertThat(
+        generatedSql,
+        containsString(
+            noEof(
+                """
+                latest_events_%s as (
+                select enrollment, ev_n1rtSHYf6O6
+                from
+                """
+                    .formatted(programStage.getUid()))));
+    assertThat(generatedSql, containsString("\"n1rtSHYf6O6\" in ('ImspTQPwCqd')"));
+    assertThat(baseCteSql, containsString("inner join latest_events_" + programStage.getUid()));
+    assertThat(baseCteSql, not(containsString("and \"n1rtSHYf6O6\" in ('ImspTQPwCqd')")));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -32,16 +32,22 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME;
 import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.OU_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionConstants.OPTION_SEP;
+import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.IN;
+import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
 import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_DATABASE;
 import static org.hisp.dhis.program.EnrollmentStatus.ACTIVE;
 import static org.hisp.dhis.program.EnrollmentStatus.COMPLETED;
 import static org.hisp.dhis.test.TestBase.createPeriodDimensions;
+import static org.hisp.dhis.test.TestBase.createProgram;
+import static org.hisp.dhis.test.TestBase.createProgramIndicator;
+import static org.hisp.dhis.test.TestBase.getDate;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -81,10 +87,16 @@ import org.hisp.dhis.db.sql.DorisAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
 import org.hisp.dhis.period.PeriodDimension;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
+import org.hisp.dhis.relationship.RelationshipConstraint;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.test.random.BeanRandomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -128,6 +140,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
   @Mock private PiDisagInfoInitializer piDisagInfoInitializer;
 
   @Mock private PiDisagQueryGenerator piDisagQueryGenerator;
+
+  private final BeanRandomizer rnd = BeanRandomizer.create();
 
   private QueryItemFilterBuilder filterBuilder;
 
@@ -708,6 +722,7 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     DefaultProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder =
         new DefaultProgramIndicatorSubqueryBuilder(
             programIndicatorService, systemSettingsService, builder, dataElementService);
+    programIndicatorSubqueryBuilder.init();
     ColumnMapper columnMapper = new ColumnMapper(builder, systemSettingsService);
     filterBuilder = new QueryItemFilterBuilder(organisationUnitResolver, builder);
     EnrollmentTimeFieldSqlRenderer timeFieldRenderer = new EnrollmentTimeFieldSqlRenderer(builder);
@@ -764,6 +779,310 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
         containsString("(completeddate >= '2022-09-01' and completeddate < '2023-09-01')"));
     assertThat(generatedSql, not(containsString("enrollmentdate >= '2022-09-01'")));
     assertThat(generatedSql, not(containsString("occurreddate >= '2022-09-01'")));
+  }
+
+  @Test
+  void verifyWithProgramAndStartEndDate() {
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams())
+            .withStartDate(getDate(2017, 1, 1))
+            .withEndDate(getDate(2017, 12, 31))
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 0);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, containsString("enrollmentdate >= '2017-01-01'"));
+    assertThat(generatedSql, containsString("enrollmentdate < '2018-01-01'"));
+    assertThat(generatedSql, containsString("ax.\"uidlevel1\" = 'ouabcdefghA'"));
+  }
+
+  @Test
+  void verifyWithLastUpdatedTimeField() {
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams())
+            .withStartDate(getDate(2017, 1, 1))
+            .withEndDate(getDate(2017, 12, 31))
+            .withTimeField(TimeField.LAST_UPDATED.name())
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, containsString("lastupdated >= '2017-01-01'"));
+    assertThat(generatedSql, containsString("lastupdated < '2018-01-01'"));
+  }
+
+  @Test
+  void verifyWithProgramStageAndNumericDataElement() {
+    verifyWithProgramStageAndDataElement(ValueType.NUMBER);
+  }
+
+  @Test
+  void verifyWithProgramStageAndTextDataElement() {
+    verifyWithProgramStageAndDataElement(ValueType.TEXT);
+  }
+
+  private void verifyWithProgramStageAndDataElement(ValueType valueType) {
+    EventQueryParams params = createRequestParams(this.programStage, valueType);
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String stageUid = programStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    // CTE for the stage data element
+    assertThat(
+        generatedSql,
+        containsString(
+            noEof(
+                """
+                %s_%s_0 as ( select enrollment, "%s" as value,
+                row_number() over ( partition by enrollment order by occurreddate desc, created desc ) as rn
+                from analytics_event_%s where eventstatus != 'SCHEDULE' and ps = '%s' )
+                """
+                    .formatted(stageUid, deUid, deUid, programA.getUid(), stageUid))));
+
+    // Value projected as stage.de alias
+    assertThat(generatedSql, containsString("as \"" + stageUid + "." + deUid + "\""));
+
+    // Stage filter in WHERE
+    assertThat(generatedSql, containsString("and ps = '" + stageUid + "'"));
+  }
+
+  @Test
+  void verifyWithRepeatableProgramStageAndNumericDataElement() {
+    verifyWithRepeatableProgramStageAndDataElement(ValueType.NUMBER);
+  }
+
+  @Test
+  void verifyWithRepeatableProgramStageAndTextDataElement() {
+    verifyWithRepeatableProgramStageAndDataElement(ValueType.TEXT);
+  }
+
+  private void verifyWithRepeatableProgramStageAndDataElement(ValueType valueType) {
+    EventQueryParams params = createRequestParams(repeatableProgramStage, valueType);
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String stageUid = repeatableProgramStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    // CTE includes eventstatus for repeatable stage
+    assertThat(
+        generatedSql,
+        containsString(
+            noEof(
+                """
+                %s_%s_0 as ( select enrollment, "%s" as value, eventstatus,
+                row_number() over ( partition by enrollment order by occurreddate desc, created desc ) as rn
+                from analytics_event_%s where eventstatus != 'SCHEDULE' and ps = '%s' )
+                """
+                    .formatted(stageUid, deUid, deUid, programA.getUid(), stageUid))));
+
+    // Existence CTE
+    assertThat(
+        generatedSql,
+        containsString(
+            noEof(
+                """
+                select distinct enrollment from analytics_event_%s
+                where eventstatus != 'SCHEDULE' and ps = '%s'
+                """
+                    .formatted(programA.getUid(), stageUid))));
+
+    // SELECT projections for repeatable stage
+    assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + "\""));
+    assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + ".exists\""));
+    assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + ".status\""));
+  }
+
+  @Test
+  void verifyWithProgramStageAndTextualDataElementAndFilter() {
+    verifyWithProgramStageAndDataElementAndFilter(ValueType.TEXT);
+  }
+
+  @Test
+  void verifyWithProgramStageAndNumericDataElementAndFilter() {
+    verifyWithProgramStageAndDataElementAndFilter(ValueType.NUMBER);
+  }
+
+  private void verifyWithProgramStageAndDataElementAndFilter(ValueType valueType) {
+    EventQueryParams params = createRequestParamsWithFilter(programStage, valueType);
+
+    subject.getEnrollments(params, new ListGrid(), 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String stageUid = programStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    // Filter pushed into CTE
+    assertThat(
+        generatedSql,
+        containsString(
+            noEof(
+                """
+                %s_%s_0 as ( select enrollment, "%s" as value,
+                row_number() over ( partition by enrollment order by occurreddate desc, created desc ) as rn
+                from analytics_event_%s where eventstatus != 'SCHEDULE' and ps = '%s' and "%s" > '10' )
+                """
+                    .formatted(stageUid, deUid, deUid, programA.getUid(), stageUid, deUid))));
+
+    // Inner join (not left join) because filter exists
+    assertThat(generatedSql, containsString("inner join " + stageUid + "_" + deUid + "_0"));
+  }
+
+  @Test
+  void verifyGetEventsWithProgramStatusParam() {
+    mockEmptyRowSet();
+    EventQueryParams params = createRequestParamsWithStatusesForEnrollmentQuery();
+
+    subject.getEnrollments(params, new ListGrid(), 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    assertThat(sql.getValue(), containsString("enrollmentstatus in ('ACTIVE','COMPLETED')"));
+  }
+
+  @Test
+  void verifyGetEnrollmentsWithMissingValueEqFilter() {
+    String stageUid = programStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    // CTE without filter (NV stays in WHERE)
+    String cte =
+        noEof(
+            """
+            %s_%s_0 as ( select enrollment, "%s" as value,
+            row_number() over ( partition by enrollment order by occurreddate desc, created desc ) as rn
+            from analytics_event_%s where eventstatus != 'SCHEDULE' and ps = '%s' )
+            """
+                .formatted(stageUid, deUid, deUid, programA.getUid(), stageUid));
+
+    testIt(
+        EQ,
+        NV,
+        List.of(
+            capturedSql -> assertThat(capturedSql, containsString(cte)),
+            capturedSql -> assertThat(capturedSql, containsString("value is NULL"))));
+  }
+
+  @Test
+  void verifyGetEnrollmentsWithMissingValueNeqFilter() {
+    String stageUid = programStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    String cte =
+        noEof(
+            """
+            %s_%s_0 as ( select enrollment, "%s" as value,
+            row_number() over ( partition by enrollment order by occurreddate desc, created desc ) as rn
+            from analytics_event_%s where eventstatus != 'SCHEDULE' and ps = '%s' )
+            """
+                .formatted(stageUid, deUid, deUid, programA.getUid(), stageUid));
+
+    testIt(
+        NEQ,
+        NV,
+        List.of(
+            capturedSql -> assertThat(capturedSql, containsString(cte)),
+            capturedSql -> assertThat(capturedSql, containsString("value is not NULL"))));
+  }
+
+  @Test
+  void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTrackedEntity() {
+    ProgramIndicator programIndicatorA = createProgramIndicator('A', programA, "", "");
+
+    RelationshipType relationshipTypeA = createRelationshipType();
+
+    EventQueryParams.Builder params =
+        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
+            .withStartDate(getDate(2015, 1, 1))
+            .withEndDate(getDate(2017, 4, 8));
+
+    when(programIndicatorService.getAnalyticsSql(
+            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
+        .thenReturn("distinct event");
+
+    subject.getEnrollments(params.build(), new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, containsString("value as " + programIndicatorA.getUid()));
+    assertThat(generatedSql, containsString("enrollmentdate >= '2015-01-01'"));
+    assertThat(generatedSql, containsString("enrollmentdate < '2017-04-09'"));
+  }
+
+  @Test
+  void verifyWithProgramIndicatorAndRelationshipTypeDifferentConstraint() {
+    ProgramIndicator programIndicatorA = createProgramIndicator('A', programA, "", "");
+
+    RelationshipType relationshipTypeA =
+        createRelationshipType(RelationshipEntity.PROGRAM_INSTANCE);
+
+    EventQueryParams.Builder params =
+        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
+            .withStartDate(getDate(2015, 1, 1))
+            .withEndDate(getDate(2017, 4, 8));
+
+    when(programIndicatorService.getAnalyticsSql(
+            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
+        .thenReturn("distinct event");
+
+    subject.getEnrollments(params.build(), new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, containsString("value as " + programIndicatorA.getUid()));
+    assertThat(generatedSql, containsString("enrollmentdate >= '2015-01-01'"));
+  }
+
+  @Test
+  void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTrackedEntity2() {
+    Program programB = createProgram('B');
+    ProgramIndicator programIndicatorA = createProgramIndicator('A', programB, "", "");
+
+    RelationshipType relationshipTypeA = createRelationshipType();
+
+    EventQueryParams.Builder params =
+        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
+            .withStartDate(getDate(2015, 1, 1))
+            .withEndDate(getDate(2017, 4, 8));
+
+    when(programIndicatorService.getAnalyticsSql(
+            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
+        .thenReturn("distinct event");
+
+    subject.getEnrollments(params.build(), new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, containsString("value as " + programIndicatorA.getUid()));
+    assertThat(generatedSql, containsString("enrollmentdate >= '2015-01-01'"));
+  }
+
+  private RelationshipType createRelationshipType(RelationshipEntity toConstraint) {
+    RelationshipType relationshipTypeA = rnd.nextObject(RelationshipType.class);
+
+    RelationshipConstraint from = new RelationshipConstraint();
+    from.setRelationshipEntity(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
+
+    RelationshipConstraint to = new RelationshipConstraint();
+    to.setRelationshipEntity(toConstraint);
+
+    relationshipTypeA.setFromConstraint(from);
+    relationshipTypeA.setToConstraint(to);
+    return relationshipTypeA;
+  }
+
+  private RelationshipType createRelationshipType() {
+    return createRelationshipType(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
   }
 
   private EventQueryParams createAggregateEnrollmentWithStageDateParams() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -302,6 +302,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     // But outer SELECT should NOT alias them with stage UID prefix
     assertThat(generatedSql, not(containsString(programStage.getUid() + ".ouname")));
     assertThat(generatedSql, not(containsString(programStage.getUid() + ".oucode")));
+    // Stage-specific filtering must stay on the event-side CTE, not leak to the enrollment alias
+    assertThat(generatedSql, not(containsString("ax.\"ps\"")));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -324,7 +324,11 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     subject.getEnrollments(params, grid, 10000);
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
-    String generatedSql = sql.getValue();
+    String generatedSql = noEof(sql.getValue());
+    String baseCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("enrollment_aggr_base as ("),
+            generatedSql.indexOf("select count(eb.enrollment) as value"));
 
     // The SQL should contain a per-stage filter CTE
     assertThat(generatedSql, containsString("latest_events_" + programStage.getUid()));
@@ -336,6 +340,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
 
     // The filter CTE should use the ev_occurreddate alias for the date column
     assertThat(generatedSql, containsString("ev_occurreddate"));
+    // Stage event-date periods must not leak into the base enrollment-date filter
+    assertThat(baseCteSql, not(containsString("enrollmentdate >=")));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -32,35 +32,17 @@ package org.hisp.dhis.analytics.event.data;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
-import static org.hisp.dhis.analytics.DataType.NUMERIC;
-import static org.hisp.dhis.analytics.QueryKey.NV;
-import static org.hisp.dhis.common.DimensionConstants.OPTION_SEP;
-import static org.hisp.dhis.common.QueryOperator.EQ;
-import static org.hisp.dhis.common.QueryOperator.IN;
-import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_DATABASE;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.test.TestBase.createProgram;
-import static org.hisp.dhis.test.TestBase.createProgramIndicator;
-import static org.hisp.dhis.test.TestBase.getDate;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.function.Consumer;
-import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programindicator.DefaultProgramIndicatorSubqueryBuilder;
@@ -74,25 +56,17 @@ import org.hisp.dhis.analytics.event.data.stage.StageQuerySqlFacade;
 import org.hisp.dhis.analytics.table.util.ColumnMapper;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
-import org.hisp.dhis.relationship.RelationshipConstraint;
-import org.hisp.dhis.relationship.RelationshipEntity;
-import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.system.grid.ListGrid;
-import org.hisp.dhis.test.random.BeanRandomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -150,15 +124,6 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
   @Captor private ArgumentCaptor<String> sql;
 
-  private static final String DEFAULT_COLUMNS =
-      """
-      enrollment,trackedentity,enrollmentdate,occurreddate,storedby,createdbydisplayname,\
-      lastupdatedbydisplayname,lastupdated,created,completeddate,\
-      ST_AsGeoJSON(enrollmentgeometry),longitude,latitude,ouname,ounamehierarchy,\
-      oucode,enrollmentstatus""";
-
-  private final BeanRandomizer rnd = BeanRandomizer.create();
-
   @BeforeEach
   void setUp() {
     when(jdbcTemplate.queryForRowSet(anyString())).thenReturn(this.rowSet);
@@ -200,51 +165,6 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
-  void verifyWithProgramAndStartEndDate() {
-    EventQueryParams params =
-        new EventQueryParams.Builder(createRequestParams())
-            .withStartDate(getDate(2017, 1, 1))
-            .withEndDate(getDate(2017, 12, 31))
-            .build();
-
-    Grid grid = new ListGrid();
-    int unlimited = 0;
-
-    subject.getEnrollments(params, grid, unlimited);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
-            + getTable(programA.getUid())
-            + " as ax where (((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA') ";
-
-    assertSql(sql.getValue(), expected);
-    assertTrue(grid.hasLastDataRow());
-  }
-
-  @Test
-  void verifyWithLastUpdatedTimeField() {
-    EventQueryParams params =
-        new EventQueryParams.Builder(createRequestParams())
-            .withStartDate(getDate(2017, 1, 1))
-            .withEndDate(getDate(2017, 12, 31))
-            .withTimeField(TimeField.LAST_UPDATED.name())
-            .build();
-
-    subject.getEnrollments(params, new ListGrid(), 10000);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
-            + getTable(programA.getUid())
-            + " as ax where (((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA') limit 10001";
-
-    assertSql(sql.getValue(), expected);
-  }
-
-  @Test
   void verifySortsByCreatedDescending() {
     EventQueryParams params =
         new EventQueryParams.Builder(createRequestParams())
@@ -256,187 +176,6 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     assertThat(sql.getValue(), containsString("order by \"created\" desc nulls last"));
-  }
-
-  @Test
-  void verifyWithRepeatableProgramStageAndNumericDataElement() {
-    verifyWithRepeatableProgramStageAndDataElement(ValueType.NUMBER);
-  }
-
-  @Test
-  void verifyWithRepeatableProgramStageAndTextDataElement() {
-    verifyWithRepeatableProgramStageAndDataElement(ValueType.TEXT);
-  }
-
-  @Test
-  void verifyWithProgramStageAndTextDataElement() {
-    verifyWithProgramStageAndDataElement(ValueType.TEXT);
-  }
-
-  @Test
-  void verifyWithProgramStageAndNumericDataElement() {
-    verifyWithProgramStageAndDataElement(ValueType.NUMBER);
-  }
-
-  private void verifyWithProgramStageAndDataElement(ValueType valueType) {
-    EventQueryParams params = createRequestParams(this.programStage, valueType);
-
-    subject.getEnrollments(params, new ListGrid(), 100);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    if (valueType == ValueType.NUMBER) {
-      subSelect = subSelect + " as \"fWIAEtYVEGk\"";
-    }
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\","
-            + subSelect
-            + "  from "
-            + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA') "
-            + "and ps = '"
-            + programStage.getUid()
-            + "' limit 101";
-
-    assertSql(sql.getValue(), expected);
-  }
-
-  private void verifyWithRepeatableProgramStageAndDataElement(ValueType valueType) {
-    EventQueryParams params = createRequestParams(repeatableProgramStage, valueType);
-
-    subject.getEnrollments(params, new ListGrid(), 100);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String programUid = repeatableProgramStage.getProgram().getUid();
-
-    String programStageUid = repeatableProgramStage.getUid();
-
-    String dataElementUid = dataElementA.getUid();
-
-    String expected =
-        "select "
-            + DEFAULT_COLUMNS
-            + ",ax.\"quarterly\",ax.\"ou\","
-            + "(select \""
-            + dataElementUid
-            + "\" from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + repeatableProgramStage.getUid()
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + "\", exists ((select \""
-            + dataElementUid
-            + "\" "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 )) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + ".exists\""
-            + ",(select eventstatus "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + ".status\"  "
-            + "from analytics_enrollment_"
-            + programUid
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA') "
-            + "and ps = '"
-            + programStageUid
-            + "' limit 101";
-
-    assertEquals(expected, sql.getValue());
-  }
-
-  @Test
-  void verifyWithProgramStageAndTextualDataElementAndFilter() {
-    EventQueryParams params = createRequestParamsWithFilter(programStage, ValueType.TEXT);
-
-    subject.getEnrollments(params, new ListGrid(), 10000);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\","
-            + subSelect
-            + "  from "
-            + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA') "
-            + "and ps = '"
-            + programStage.getUid()
-            + "' and "
-            + subSelect
-            + " > '10' limit 10001";
-
-    assertSql(sql.getValue(), expected);
-  }
-
-  @Test
-  void verifyGetEventsWithProgramStatusParam() {
-    mockEmptyRowSet();
-
-    EventQueryParams params = createRequestParamsWithStatusesForEnrollmentQuery();
-
-    subject.getEnrollments(params, new ListGrid(), 10000);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
-            + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA')"
-            + " and enrollmentstatus in ('ACTIVE','COMPLETED') limit 10001";
-
-    assertSql(sql.getValue(), expected);
   }
 
   @Test
@@ -465,339 +204,9 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     assertDoesNotThrow(() -> subject.getEnrollments(params, new ListGrid(), 10000));
   }
 
-  @Test
-  void verifyWithProgramStageAndNumericDataElementAndFilter2() {
-    EventQueryParams params = createRequestParamsWithFilter(programStage, ValueType.NUMBER);
-
-    subject.getEnrollments(params, new ListGrid(), 10000);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\","
-            + subSelect
-            + " as \"fWIAEtYVEGk\""
-            + "  from "
-            + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA') "
-            + "and ps = '"
-            + programStage.getUid()
-            + "' and "
-            + subSelect
-            + " > '10' limit 10001";
-
-    assertSql(sql.getValue(), expected);
-  }
-
-  @Test
-  void verifyGetEnrollmentsWithMissingValueEqFilter() {
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String expected = subSelect + " is null";
-
-    testIt(
-        EQ,
-        NV,
-        Collections.singleton((capturedSql) -> assertThat(capturedSql, containsString(expected))));
-  }
-
-  @Test
-  void verifyGetEnrollmentsWithMissingValueNeqFilter() {
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String expected = subSelect + " is not null";
-    testIt(
-        NEQ,
-        NV,
-        Collections.singleton((capturedSql) -> assertThat(capturedSql, containsString(expected))));
-  }
-
-  @Test
-  void verifyGetEnrollmentsWithMissingValueAndNumericValuesInFilter() {
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String numericValues = String.join(OPTION_SEP, "10", "11", "12");
-    String expected =
-        "("
-            + subSelect
-            + " in ("
-            + String.join(",", numericValues.split(OPTION_SEP))
-            + ") or ("
-            + subSelect
-            + " is null and exists("
-            + subSelect
-            + ")))";
-    testIt(
-        IN,
-        numericValues + OPTION_SEP + NV,
-        Collections.singleton((capturedSql) -> assertThat(capturedSql, containsString(expected))));
-  }
-
-  @Test
-  void verifyGetEnrollmentsWithoutMissingValueAndNumericValuesInFilter() {
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String numericValues = String.join(OPTION_SEP, "10", "11", "12");
-    String expected = subSelect + " in (" + String.join(",", numericValues.split(OPTION_SEP)) + ")";
-    testIt(
-        IN,
-        numericValues,
-        Collections.singleton((capturedSql) -> assertThat(capturedSql, containsString(expected))));
-  }
-
-  @Test
-  void verifyGetEnrollmentsWithOnlyMissingValueInFilter() {
-    String subSelect =
-        "(select \"fWIAEtYVEGk\" from analytics_event_"
-            + programA.getUid()
-            + " where analytics_event_"
-            + programA.getUid()
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programA.getUid()
-            + ".enrollment = ax.enrollment and \"fWIAEtYVEGk\" is not null and ps = '"
-            + programStage.getUid()
-            + "' order by occurreddate desc, created desc  limit 1 )";
-
-    String expected = subSelect + " is null";
-    String unexpected = "(" + subSelect + " in (";
-    testIt(
-        IN,
-        NV,
-        List.of(
-            (capturedSql) -> assertThat(capturedSql, containsString(expected)),
-            (capturedSql) -> assertThat(capturedSql, not(containsString(unexpected)))));
-  }
-
-  private void testIt(
-      QueryOperator operator, String filter, Collection<Consumer<String>> assertions) {
-    subject.getEnrollments(
-        createRequestParamsWithFilter(programStage, ValueType.INTEGER, operator, filter),
-        new ListGrid(),
-        10000);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    assertions.forEach(consumer -> consumer.accept(sql.getValue()));
-  }
-
-  @Test
-  void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTrackedEntity() {
-    Date startDate = getDate(2015, 1, 1);
-    Date endDate = getDate(2017, 4, 8);
-
-    String piSubquery = "distinct event";
-
-    ProgramIndicator programIndicatorA = createProgramIndicator('A', programA, "", "");
-
-    RelationshipType relationshipTypeA = createRelationshipType();
-
-    EventQueryParams.Builder params =
-        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
-            .withStartDate(startDate)
-            .withEndDate(endDate);
-
-    when(programIndicatorService.getAnalyticsSql(
-            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
-        .thenReturn(piSubquery);
-
-    subject.getEnrollments(params.build(), new ListGrid(), 100);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
-            + piSubquery
-            + ") FROM analytics_event_"
-            + programA.getUid().toLowerCase()
-            + " as subax WHERE  "
-            + "subax.trackedentity in (select te.uid from trackedentity te "
-            + "left join relationshipitem ri on te.trackedentityid = ri.trackedentityid  "
-            + "left join relationship r on r.from_relationshipitemid = ri.relationshipitemid "
-            + "left join relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
-            + "left join relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "left join trackedentity te2 on te2.trackedentityid = ri2.trackedentityid "
-            + "WHERE rty.relationshiptypeid = "
-            + relationshipTypeA.getId()
-            + " and te2.uid = ax.trackedentity )) as \""
-            + programIndicatorA.getUid()
-            + "\"  "
-            + "from analytics_enrollment_"
-            + programA.getUid()
-            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA') limit 101";
-
-    assertSql(sql.getValue(), expected);
-  }
-
-  @Test
-  void verifyWithProgramIndicatorAndRelationshipTypeDifferentConstraint() {
-    Date startDate = getDate(2015, 1, 1);
-    Date endDate = getDate(2017, 4, 8);
-
-    String piSubquery = "distinct event";
-
-    ProgramIndicator programIndicatorA = createProgramIndicator('A', programA, "", "");
-
-    RelationshipType relationshipTypeA =
-        createRelationshipType(RelationshipEntity.PROGRAM_INSTANCE);
-
-    EventQueryParams.Builder params =
-        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
-            .withStartDate(startDate)
-            .withEndDate(endDate);
-
-    when(programIndicatorService.getAnalyticsSql(
-            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
-        .thenReturn(piSubquery);
-
-    subject.getEnrollments(params.build(), new ListGrid(), 100);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
-            + piSubquery
-            + ") FROM analytics_event_"
-            + programA.getUid().toLowerCase()
-            + " as subax WHERE "
-            + " subax.trackedentity in (select te.uid from trackedentity te "
-            + "left join relationshipitem ri on te.trackedentityid = ri.trackedentityid  "
-            + "left join relationship r on r.from_relationshipitemid = ri.relationshipitemid "
-            + "left join relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
-            + "left join relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "left join enrollment en2 on en2.enrollmentid = ri2.enrollmentid WHERE rty.relationshiptypeid "
-            + "= "
-            + relationshipTypeA.getId()
-            + " and en2.uid = ax.enrollment ))"
-            + " as \""
-            + programIndicatorA.getUid()
-            + "\"  "
-            + "from analytics_enrollment_"
-            + programA.getUid()
-            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA') limit 101";
-
-    assertSql(sql.getValue(), expected);
-  }
-
   @Override
   String getTableName() {
     return "analytics_enrollment";
-  }
-
-  private RelationshipType createRelationshipType(RelationshipEntity toConstraint) {
-    RelationshipType relationshipTypeA = rnd.nextObject(RelationshipType.class);
-
-    RelationshipConstraint from = new RelationshipConstraint();
-    from.setRelationshipEntity(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
-
-    RelationshipConstraint to = new RelationshipConstraint();
-    to.setRelationshipEntity(toConstraint);
-
-    relationshipTypeA.setFromConstraint(from);
-    relationshipTypeA.setToConstraint(to);
-    return relationshipTypeA;
-  }
-
-  private RelationshipType createRelationshipType() {
-    return createRelationshipType(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
-  }
-
-  private void assertSql(String actual, String expected) {
-    assertThat(actual, is("select " + DEFAULT_COLUMNS + "," + expected));
-  }
-
-  @Test
-  void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTrackedEntity2() {
-    Date startDate = getDate(2015, 1, 1);
-    Date endDate = getDate(2017, 4, 8);
-    Program programB = createProgram('B');
-    String piSubquery = "distinct event";
-
-    ProgramIndicator programIndicatorA = createProgramIndicator('A', programB, "", "");
-
-    RelationshipType relationshipTypeA = createRelationshipType();
-
-    EventQueryParams.Builder params =
-        new EventQueryParams.Builder(createRequestParams(programIndicatorA, relationshipTypeA))
-            .withStartDate(startDate)
-            .withEndDate(endDate);
-
-    when(programIndicatorService.getAnalyticsSql(
-            "", NUMERIC, programIndicatorA, getDate(2000, 1, 1), getDate(2017, 4, 8), "subax"))
-        .thenReturn(piSubquery);
-
-    subject.getEnrollments(params.build(), new ListGrid(), 100);
-
-    verify(jdbcTemplate).queryForRowSet(sql.capture());
-
-    String expected =
-        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
-            + piSubquery
-            + ") FROM analytics_event_"
-            + programB.getUid().toLowerCase()
-            + " as subax WHERE  "
-            + "subax.trackedentity in (select te.uid from trackedentity te "
-            + "left join relationshipitem ri on te.trackedentityid = ri.trackedentityid  "
-            + "left join relationship r on r.from_relationshipitemid = ri.relationshipitemid "
-            + "left join relationshipitem ri2 on r.to_relationshipitemid = ri2.relationshipitemid "
-            + "left join relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid "
-            + "left join trackedentity te2 on te2.trackedentityid = ri2.trackedentityid "
-            + "WHERE rty.relationshiptypeid = "
-            + relationshipTypeA.getId()
-            + " and te2.uid = ax.trackedentity )) as \""
-            + programIndicatorA.getUid()
-            + "\"  "
-            + "from analytics_enrollment_"
-            + programA.getUid()
-            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA') limit 101";
-
-    assertSql(sql.getValue(), expected);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -162,18 +162,18 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   private PostgreSqlAnalyticsSqlBuilder analyticsSqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
 
   private static final String BASE_COLUMNS =
-      "event,ps,occurreddate,storedby,"
-          + "createdbydisplayname,lastupdatedbydisplayname,"
-          + "lastupdated,created,completeddate,scheduleddate";
+      "ax.event, ax.ps, ax.occurreddate, ax.storedby, "
+          + "ax.createdbydisplayname, ax.lastupdatedbydisplayname, "
+          + "ax.lastupdated, ax.created, ax.completeddate, ax.scheduleddate";
 
   private static final String REGISTRATION_COLUMNS =
-      ",enrollmentdate,enrollmentoccurreddate,trackedentity,enrollment";
+      ", ax.enrollmentdate, ax.enrollmentoccurreddate, ax.trackedentity, ax.enrollment";
 
   private static final String GEO_AND_OU_COLUMNS =
-      ",ST_AsGeoJSON(coalesce(ax.\"eventgeometry\",ax.\"enrollmentgeometry\","
-          + "ax.\"tegeometry\",ax.\"ougeometry\"), 6) as geometry,"
-          + "ST_AsGeoJSON(coalesce(ax.enrollmentgeometry), 6) as enrollmentgeometry,"
-          + "longitude,latitude,ouname,ounamehierarchy,oucode,enrollmentstatus,eventstatus";
+      ", ST_AsGeoJSON(coalesce(ax.\"eventgeometry\", ax.\"enrollmentgeometry\", "
+          + "ax.\"tegeometry\", ax.\"ougeometry\"), 6) as geometry, "
+          + "ST_AsGeoJSON(coalesce(ax.enrollmentgeometry), 6) as enrollmentgeometry, "
+          + "ax.longitude, ax.latitude, ax.ouname, ax.ounamehierarchy, ax.oucode, ax.enrollmentstatus, ax.eventstatus";
 
   private static final String DEFAULT_COLUMNS_WITH_REGISTRATION =
       BASE_COLUMNS + REGISTRATION_COLUMNS + GEO_AND_OU_COLUMNS;
@@ -205,9 +205,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "select "
             + DEFAULT_COLUMNS_WITHOUT_REGISTRATION
-            + ",ax.\"quarterly\",ax.\"ou\"  from "
+            + ", ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 5001";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -263,13 +263,13 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "select "
             + DEFAULT_COLUMNS_WITH_REGISTRATION
-            + ",ax.\"quarterly\",ax.\"ou\",\""
+            + ", ax.\"quarterly\", ax.\"ou\", ax.\""
             + dataElement.getUid()
             + "_name"
-            + "\"  from "
+            + "\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
-            + " limit 101";
+            + " limit 5001";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -286,9 +286,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
+        "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') ";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 5001";
 
     assertSql(expected, sql.getValue());
     assertTrue(grid.hasLastDataRow());
@@ -503,11 +503,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
+        "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 101";
+            + "' limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -521,11 +521,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 101";
+            + "' limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -540,11 +540,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
+            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -558,10 +558,10 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
+        "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
-            + " and enrollmentstatus in ('ACTIVE','COMPLETED') and eventstatus in ('SCHEDULE') limit 101";
+            + " and enrollmentstatus in ('ACTIVE','COMPLETED') and eventstatus in ('SCHEDULE') limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -575,11 +575,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ps.\"quarterly\",ax.\"ou\"  from "
+        "ps.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
-            + " as ax left join analytics_rs_dateperiodstructure as ps on cast(ax.\"scheduleddate\" as date) = ps.\"dateperiod\" "
+            + " as ax "
             + "where (ps.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" "
-            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 101";
+            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -593,11 +593,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\"  from "
+        "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
             + " as ax "
             + "where ((( ax.\"lastupdated\" >= '2000-01-01' and ax.\"lastupdated\" < '2000-04-01') )) and ax.\"uidlevel1\" "
-            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 101";
+            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -679,11 +679,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 101";
+            + "' limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -698,11 +698,11 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
+            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 5001";
 
     assertSql(expected, sql.getValue());
   }
@@ -1232,7 +1232,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   private void assertSql(String expected, String actual) {
-    expected = "select " + DEFAULT_COLUMNS_WITH_REGISTRATION + "," + expected;
+    expected = "select " + DEFAULT_COLUMNS_WITH_REGISTRATION + ", " + expected;
 
     assertThat(actual, is(expected));
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -196,7 +196,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + DEFAULT_COLUMNS_WITHOUT_REGISTRATION
             + ", ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 5001";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -258,7 +258,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + "\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
-            + " limit 5001";
+            + " limit 101";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -277,7 +277,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 5001";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')";
 
     assertSql(expected, sql.getValue());
     assertTrue(grid.hasLastDataRow());
@@ -496,7 +496,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 5001";
+            + "' limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -514,7 +514,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 5001";
+            + "' limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -533,7 +533,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 5001";
+            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -550,7 +550,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
         "ax.\"quarterly\", ax.\"ou\" from "
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
-            + " and enrollmentstatus in ('ACTIVE','COMPLETED') and eventstatus in ('SCHEDULE') limit 5001";
+            + " and enrollmentstatus in ('ACTIVE','COMPLETED') and eventstatus in ('SCHEDULE') limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -568,7 +568,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax "
             + "where (ps.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" "
-            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 5001";
+            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -586,7 +586,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax "
             + "where ((( ax.\"lastupdated\" >= '2000-01-01' and ax.\"lastupdated\" < '2000-04-01') )) and ax.\"uidlevel1\" "
-            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 5001";
+            + "in ('ouabcdefghA') and enrollmentstatus in ('ACTIVE','COMPLETED') limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -672,7 +672,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' limit 5001";
+            + "' limit 101";
 
     assertSql(expected, sql.getValue());
   }
@@ -691,7 +691,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + getTable(programA.getUid())
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 5001";
+            + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
     assertSql(expected, sql.getValue());
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -36,11 +36,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.analytics.QueryKey.NV;
-import static org.hisp.dhis.common.DimensionConstants.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionConstants.OPTION_SEP;
-import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
-import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.common.QueryOperator.NEQ;
@@ -51,8 +47,6 @@ import static org.hisp.dhis.test.TestBase.createDataElement;
 import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.TestBase.createOrganisationUnitGroup;
 import static org.hisp.dhis.test.TestBase.createPeriodDimensions;
-import static org.hisp.dhis.test.TestBase.createProgram;
-import static org.hisp.dhis.test.TestBase.createProgramIndicator;
 import static org.hisp.dhis.test.TestBase.getDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,8 +62,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
-import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
@@ -102,11 +94,8 @@ import org.hisp.dhis.db.sql.ClickHouseAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.DorisAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.period.PeriodTypeEnum;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.setting.SystemSettings;
@@ -862,59 +851,6 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
 
     assertThat(params.isAggregationType(AggregationType.LAST), is(true));
     assertThat(sql.getValue(), containsString(subquery));
-  }
-
-  @Test
-  void verifySortClauseHandlesProgramIndicators() {
-    Program program = createProgram('P');
-    ProgramIndicator piA = createProgramIndicator('A', program, ".", ".");
-    piA.setUid("TLKx7vllb1I");
-
-    ProgramIndicator piB = createProgramIndicator('B', program, ".", ".");
-    piA.setUid("CCKx3gllb2P");
-
-    OrganisationUnit ouA = createOrganisationUnit('A');
-    List<PeriodDimension> periods = createPeriodDimensions("201501");
-
-    DataElement deA = createDataElement('A');
-    deA.setUid("ZE4cgllb2P");
-
-    DataQueryParams params =
-        DataQueryParams.newBuilder()
-            .withDataType(DataType.NUMERIC)
-            .withTableName("analytics")
-            .withPeriodType(PeriodTypeEnum.QUARTERLY.getName())
-            .withAggregationType(
-                AnalyticsAggregationType.fromAggregationType(AggregationType.DEFAULT))
-            .addDimension(
-                new BaseDimensionalObject(
-                    DATA_X_DIM_ID, DimensionType.PROGRAM_INDICATOR, getList(piA, piB)))
-            .addFilter(
-                new BaseDimensionalObject(
-                    ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, getList(ouA)))
-            .addDimension(new BaseDimensionalObject(PERIOD_DIM_ID, DimensionType.DATA_X, periods))
-            .addDimension(new BaseDimensionalObject(PERIOD_DIM_ID, DimensionType.PERIOD, periods))
-            .build();
-
-    EventQueryParams.Builder eventQueryParamsBuilder =
-        new EventQueryParams.Builder(params)
-            .withProgram(program)
-            .addAscSortItem(new QueryItem(piA))
-            .addDescSortItem(new QueryItem(piB))
-            .addAscSortItem(new QueryItem(deA));
-
-    String sql = subject.getAggregatedEnrollmentsSql(eventQueryParamsBuilder.build(), 100);
-
-    assertThat(
-        sql,
-        containsString(
-            "order by \""
-                + piA.getUid()
-                + "\" asc nulls last,\""
-                + deA.getUid()
-                + "\" asc nulls last,\""
-                + piB.getUid()
-                + "\""));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -416,7 +416,6 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void verifyExperimentalQueryDoesNotDuplicateStageSpecificDateCondition() {
     mockEmptyRowSet();
-    when(mockSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
 
     QueryItem stageEventDateItem =
         new QueryItem(
@@ -458,7 +457,6 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void verifyExperimentalQueryKeepsScheduledDateWithStageSpecificEventDate() {
     mockEmptyRowSet();
-    when(mockSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
 
     QueryItem stageEventDateItem =
         new QueryItem(
@@ -776,7 +774,6 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void verifyExperimentalAggregatedEventQueryIncludesStageDateFilters() {
     mockEmptyRowSet();
-    when(mockSettings.getUseExperimentalAnalyticsQueryEngine()).thenReturn(true);
     when(piDisagInfoInitializer.getParamsWithDisaggregationInfo(any(EventQueryParams.class)))
         .thenAnswer(i -> i.getArguments()[0]);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -45,15 +45,12 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.setting.SystemSettings;
-import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.test.random.BeanRandomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -78,18 +75,13 @@ class ProgramIndicatorSubqueryBuilderTest {
 
   @Mock private ProgramIndicatorService programIndicatorService;
 
-  @Mock private SystemSettingsService systemSettingsService;
-
   @InjectMocks private DefaultProgramIndicatorSubqueryBuilder subject;
-
-  @Spy private SystemSettings systemSettings;
 
   @BeforeEach
   void setUp() {
     program = createProgram('A');
     startDate = getDate(2018, 1, 1);
     endDate = getDate(2018, 6, 30);
-    when(systemSettingsService.getCurrentSettings()).thenReturn(systemSettings);
   }
 
   @Test
@@ -109,7 +101,7 @@ class ProgramIndicatorSubqueryBuilderTest {
         is(
             "(SELECT avg (distinct event) FROM analytics_event_"
                 + program.getUid().toLowerCase()
-                + " as subax WHERE enrollment = ax.enrollment)"));
+                + " as subax)"));
   }
 
   /** Verifies that the join after WHERE is changing when outer join is type EVENT. */
@@ -150,7 +142,7 @@ class ProgramIndicatorSubqueryBuilderTest {
         is(
             "(SELECT avg (distinct event) FROM analytics_event_"
                 + program.getUid().toLowerCase()
-                + " as subax WHERE enrollment = ax.enrollment)"));
+                + " as subax)"));
   }
 
   @Test
@@ -211,6 +203,6 @@ class ProgramIndicatorSubqueryBuilderTest {
         is(
             "(SELECT avg (distinct event) FROM analytics_event_"
                 + program.getUid().toLowerCase()
-                + " as subax WHERE enrollment = ax.enrollment AND (a = b))"));
+                + " as subax WHERE (a = b))"));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/EventQueryParamsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/EventQueryParamsUtilsTest.java
@@ -40,28 +40,38 @@ import org.junit.jupiter.api.Test;
 class EventQueryParamsUtilsTest {
   @Test
   void testWithoutProgramStageItems() {
-    // Create mock QueryItems
     QueryItem item1 = mock(QueryItem.class);
     QueryItem item2 = mock(QueryItem.class);
     QueryItem item3 = mock(QueryItem.class);
+    QueryItem filter1 = mock(QueryItem.class);
+    QueryItem filter2 = mock(QueryItem.class);
 
-    // Set behavior for hasProgramStage()
-    when(item1.hasProgramStage()).thenReturn(false); // This item should be retained
-    when(item2.hasProgramStage()).thenReturn(true); // This item should be removed
-    when(item3.hasProgramStage()).thenReturn(false); // This item should be retained
+    when(item1.hasProgramStage()).thenReturn(false);
+    when(item2.hasProgramStage()).thenReturn(true);
+    when(item3.hasProgramStage()).thenReturn(false);
+    when(filter1.hasProgramStage()).thenReturn(false);
+    when(filter2.hasProgramStage()).thenReturn(true);
 
-    // Create an EventQueryParams instance with these items
     EventQueryParams originalParams =
-        new EventQueryParams.Builder().addItem(item1).addItem(item2).addItem(item3).build();
+        new EventQueryParams.Builder()
+            .addItem(item1)
+            .addItem(item2)
+            .addItem(item3)
+            .addItemFilter(filter1)
+            .addItemFilter(filter2)
+            .build();
 
-    // Apply the method under test
     EventQueryParams resultParams = EventQueryParamsUtils.withoutProgramStageItems(originalParams);
 
-    // Assert the resulting params contain only the filtered items
     List<QueryItem> resultItems = resultParams.getItems();
     assertEquals(2, resultItems.size());
     assertTrue(resultItems.contains(item1));
     assertTrue(resultItems.contains(item3));
     assertFalse(resultItems.contains(item2));
+
+    List<QueryItem> resultItemFilters = resultParams.getItemFilters();
+    assertEquals(1, resultItemFilters.size());
+    assertTrue(resultItemFilters.contains(filter1));
+    assertFalse(resultItemFilters.contains(filter2));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -125,7 +125,6 @@ import org.hisp.dhis.parser.expression.function.VectorStddevSamp;
 import org.hisp.dhis.parser.expression.function.VectorSum;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -151,8 +150,6 @@ public class DefaultExpressionService implements ExpressionService {
   private final IdentifiableObjectManager idObjectManager;
 
   private final I18nManager i18nManager;
-
-  private final SystemSettingsService settingsService;
 
   private final SqlBuilder sqlBuilder;
 
@@ -257,8 +254,7 @@ public class DefaultExpressionService implements ExpressionService {
       IdentifiableObjectManager idObjectManager,
       I18nManager i18nManager,
       CacheProvider cacheProvider,
-      SqlBuilder sqlBuilder,
-      SystemSettingsService settingService) {
+      SqlBuilder sqlBuilder) {
     checkNotNull(expressionStore);
     checkNotNull(constantService);
     checkNotNull(dimensionService);
@@ -266,7 +262,6 @@ public class DefaultExpressionService implements ExpressionService {
     checkNotNull(i18nManager);
     checkNotNull(cacheProvider);
     checkNotNull(sqlBuilder);
-    checkNotNull(settingService);
 
     this.expressionStore = expressionStore;
     this.constantService = constantService;
@@ -275,7 +270,6 @@ public class DefaultExpressionService implements ExpressionService {
     this.i18nManager = i18nManager;
     this.constantMapCache = cacheProvider.createAllConstantsCache();
     this.sqlBuilder = sqlBuilder;
-    this.settingsService = settingService;
   }
 
   // -------------------------------------------------------------------------
@@ -710,8 +704,6 @@ public class DefaultExpressionService implements ExpressionService {
         .info(params.getExpressionInfo())
         .state(initialParsingState)
         .sqlBuilder(sqlBuilder)
-        .useExperimentalSqlEngine(
-            this.settingsService.getCurrentSettings().getUseExperimentalAnalyticsQueryEngine())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -68,7 +68,6 @@ import org.hisp.dhis.parser.expression.ExpressionItemMethod;
 import org.hisp.dhis.parser.expression.ExpressionState;
 import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.parser.expression.literal.SqlLiteral;
-import org.hisp.dhis.setting.SystemSettingsService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -96,8 +95,6 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
 
   private final SqlBuilder sqlBuilder;
 
-  private final SystemSettingsService settingsService;
-
   @Getter private final ImmutableMap<Integer, ExpressionItem> programIndicatorItems;
 
   public DefaultProgramIndicatorService(
@@ -110,8 +107,7 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
       DimensionService dimensionService,
       I18nManager i18nManager,
       CacheProvider cacheProvider,
-      SqlBuilder sqlBuilder,
-      SystemSettingsService settingsService) {
+      SqlBuilder sqlBuilder) {
     checkNotNull(programIndicatorStore);
     checkNotNull(programIndicatorGroupStore);
     checkNotNull(programStageService);
@@ -121,7 +117,6 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
     checkNotNull(i18nManager);
     checkNotNull(cacheProvider);
     checkNotNull(sqlBuilder);
-    checkNotNull(settingsService);
 
     this.programIndicatorStore = programIndicatorStore;
     this.programIndicatorGroupStore = programIndicatorGroupStore;
@@ -132,8 +127,6 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
     this.i18nManager = i18nManager;
     this.analyticsSqlCache = cacheProvider.createAnalyticsSqlCache();
     this.sqlBuilder = sqlBuilder;
-    this.settingsService = settingsService;
-
     this.programIndicatorItems = new ExpressionMapBuilder().getExpressionItemMap();
   }
 
@@ -462,8 +455,6 @@ public class DefaultProgramIndicatorService implements ProgramIndicatorService {
         .params(params)
         .progParams(progParams)
         .sqlBuilder(sqlBuilder)
-        .useExperimentalSqlEngine(
-            this.settingsService.getCurrentSettings().getUseExperimentalAnalyticsQueryEngine())
         .state(ExpressionState.builder().replaceNulls(replaceNulls).build())
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
@@ -106,7 +106,7 @@ public class ProgramItemStageElement extends ProgramExpressionItem {
     ProgramIndicator programIndicator = progParams.getProgramIndicator();
     AnalyticsType analyticsType = programIndicator.getAnalyticsType();
     // no need to emit a placeholder for event analytics
-    if (!visitor.isUseExperimentalSqlEngine() || AnalyticsType.EVENT == analyticsType) {
+    if (AnalyticsType.EVENT == analyticsType) {
       return getSqlLegacy(ctx, visitor);
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
@@ -102,7 +102,8 @@ public abstract class ProgramCountFunction extends ProgramExpressionItem {
 
   @Override
   public final Object getSql(ExprContext ctx, CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
+    if (visitor.getProgParams().getProgramIndicator().getAnalyticsType()
+        != org.hisp.dhis.program.AnalyticsType.ENROLLMENT) {
       return getSqlLegacy(ctx, visitor);
     }
     validateCountFunctionArgs(ctx);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
@@ -44,9 +44,6 @@ public class vCreationDate extends ProgramDateVariable {
 
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
-      return getSqlLegacy(visitor);
-    }
     ProgramExpressionParams params = visitor.getProgParams();
 
     if (params != null
@@ -58,22 +55,5 @@ public class vCreationDate extends ProgramDateVariable {
       // For Event analytics or other contexts, return the direct column name
       return "created";
     }
-  }
-
-  public Object getSqlLegacy(CommonExpressionVisitor visitor) {
-    ProgramExpressionParams params = visitor.getProgParams();
-
-    if (AnalyticsType.ENROLLMENT == params.getProgramIndicator().getAnalyticsType()) {
-      return visitor
-          .getStatementBuilder()
-          .getProgramIndicatorEventColumnSql(
-              null,
-              "created",
-              params.getReportingStartDate(),
-              params.getReportingEndDate(),
-              params.getProgramIndicator());
-    }
-
-    return "created";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
@@ -45,10 +45,6 @@ public class vDueDate extends ProgramDateVariable {
 
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
-      return getSqlLegacy(visitor);
-    }
-
     ProgramExpressionParams params = visitor.getProgParams();
 
     if (params != null
@@ -60,22 +56,5 @@ public class vDueDate extends ProgramDateVariable {
       // For Event analytics context (or others), return the direct column name "scheduleddate"
       return "scheduleddate";
     }
-  }
-
-  public Object getSqlLegacy(CommonExpressionVisitor visitor) {
-    ProgramExpressionParams params = visitor.getProgParams();
-
-    if (AnalyticsType.EVENT == params.getProgramIndicator().getAnalyticsType()) {
-      return "scheduleddate";
-    }
-
-    return visitor
-        .getStatementBuilder()
-        .getProgramIndicatorEventColumnSql(
-            null,
-            "scheduleddate",
-            params.getReportingStartDate(),
-            params.getReportingEndDate(),
-            params.getProgramIndicator());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
@@ -45,9 +45,6 @@ public class vEventDate extends ProgramDateVariable {
 
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
-      return getSqlLegacy(visitor);
-    }
     ProgramExpressionParams params = visitor.getProgParams();
 
     if (params != null
@@ -59,37 +56,5 @@ public class vEventDate extends ProgramDateVariable {
       // For Event analytics or other contexts, return the direct column name
       return "occurreddate";
     }
-  }
-
-  public Object getSqlLegacy(CommonExpressionVisitor visitor) {
-    ProgramExpressionParams params = visitor.getProgParams();
-
-    if (AnalyticsType.ENROLLMENT == params.getProgramIndicator().getAnalyticsType()) {
-      String sqlStatement =
-          visitor
-              .getStatementBuilder()
-              .getProgramIndicatorEventColumnSql(
-                  null,
-                  "occurreddate",
-                  params.getReportingStartDate(),
-                  params.getReportingEndDate(),
-                  params.getProgramIndicator());
-
-      return maybeAppendEventStatusFilterIntoWhere(sqlStatement);
-    }
-
-    return "occurreddate";
-  }
-
-  private String maybeAppendEventStatusFilterIntoWhere(String sqlStatement) {
-    int index = sqlStatement.indexOf("order by occurreddate");
-
-    if (index == -1) {
-      return sqlStatement;
-    }
-
-    return sqlStatement.substring(0, index)
-        + " and eventstatus IN ('COMPLETED', 'ACTIVE') "
-        + sqlStatement.substring(index);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
@@ -45,9 +45,6 @@ public class vEventStatus implements ProgramVariable {
 
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
-      return getSql2(visitor);
-    }
     ProgramExpressionParams params = visitor.getProgParams();
 
     if (params != null
@@ -63,18 +60,5 @@ public class vEventStatus implements ProgramVariable {
   @Override
   public Object defaultVariableValue() {
     return "COMPLETED";
-  }
-
-  public Object getSql2(CommonExpressionVisitor visitor) {
-    ProgramExpressionParams params = visitor.getProgParams();
-
-    return visitor
-        .getStatementBuilder()
-        .getProgramIndicatorEventColumnSql(
-            null,
-            "eventstatus",
-            params.getReportingStartDate(),
-            params.getReportingEndDate(),
-            params.getProgramIndicator());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vScheduledDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vScheduledDate.java
@@ -45,9 +45,6 @@ public class vScheduledDate extends ProgramDateVariable {
 
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    if (!visitor.isUseExperimentalSqlEngine()) {
-      return getSqlLegacy(visitor);
-    }
     ProgramExpressionParams params = visitor.getProgParams();
 
     if (params != null
@@ -59,38 +56,5 @@ public class vScheduledDate extends ProgramDateVariable {
       // For Event analytics or other contexts, return the direct column name
       return "scheduleddate";
     }
-  }
-
-  public Object getSqlLegacy(CommonExpressionVisitor visitor) {
-
-    ProgramExpressionParams params = visitor.getProgParams();
-
-    if (AnalyticsType.ENROLLMENT == params.getProgramIndicator().getAnalyticsType()) {
-      String sqlStatement =
-          visitor
-              .getStatementBuilder()
-              .getProgramIndicatorEventColumnSql(
-                  null,
-                  "scheduleddate",
-                  params.getReportingStartDate(),
-                  params.getReportingEndDate(),
-                  params.getProgramIndicator());
-
-      return maybeAppendEventStatusFilterIntoWhere(sqlStatement);
-    }
-
-    return "scheduleddate";
-  }
-
-  private String maybeAppendEventStatusFilterIntoWhere(String sqlStatement) {
-    int index = sqlStatement.indexOf("order by occurreddate");
-
-    if (index == -1) {
-      return sqlStatement;
-    }
-
-    return sqlStatement.substring(0, index)
-        + " and eventstatus = 'SCHEDULE' "
-        + sqlStatement.substring(index);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -262,8 +262,7 @@ class ExpressionServiceTest extends TestBase {
             idObjectManager,
             i18nManager,
             cacheProvider,
-            sqlBuilder,
-            settingsService);
+            sqlBuilder);
 
     categoryOptionA = new CategoryOption("Under 5");
     categoryOptionB = new CategoryOption("Over 5");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -45,6 +45,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -323,15 +325,11 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
 
     String sql = test("d2:count(#{ProgrmStagA.DataElmentA})");
     assertThat(
-        normalize(sql),
+        sql,
         is(
-            normalize(
-                "(select count(\"DataElmentA\") "
-                    + "from analytics_event_Program000A "
-                    + "where analytics_event_Program000A.enrollment = ax.enrollment "
-                    + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                    + "and occurreddate < cast( '2021-01-01' as date ) "
-                    + "and ps = 'ProgrmStagA')")));
+            "__D2FUNC__(func='count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='d03b8b7191fdc0e9146c5f03870b78b1befeae9d', pi='"
+                + programIndicator.getUid()
+                + "')__"));
   }
 
   @Test
@@ -343,15 +341,11 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
 
     String sql = test("d2:count(#{ProgrmStagA.DataElmentA})");
     assertThat(
-        normalize(sql),
+        sql,
         is(
-            normalize(
-                "(select count(\"DataElmentA\") "
-                    + "from analytics_event_Program000A "
-                    + "where analytics_event_Program000A.enrollment = ax.enrollment "
-                    + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                    + "and occurreddate >= cast( '2020-01-01' as date ) "
-                    + "and ps = 'ProgrmStagA')")));
+            "__D2FUNC__(func='count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='a303e79630018c6d90cf0bcb5a3429826381defd', pi='"
+                + programIndicator.getUid()
+                + "')__"));
   }
 
   @Test
@@ -363,15 +357,11 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
 
     String sql = test("d2:count(#{ProgrmStagA.DataElmentA})");
     assertThat(
-        normalize(sql),
+        sql,
         is(
-            normalize(
-                "(select count(\"DataElmentA\") "
-                    + "from analytics_event_Program000A "
-                    + "where analytics_event_Program000A.enrollment = ax.enrollment "
-                    + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                    + "and occurreddate < cast( '2021-01-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) "
-                    + "and ps = 'ProgrmStagA')")));
+            "__D2FUNC__(func='count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='f8b0c7db011ecc2256bb6bece7513471174905fc', pi='"
+                + programIndicator.getUid()
+                + "')__"));
   }
 
   @Test
@@ -453,6 +443,64 @@ class ProgramSqlGeneratorFunctionsTest extends TestBase {
                     + "where analytics_event_Program000A.enrollment = ax.enrollment "
                     + "and \"DataElmentA\" is not null and \"DataElmentA\" = 'ABC' "
                     + "and ps = 'ProgrmStagA')")));
+  }
+
+  @Test
+  void testEnrollmentCountIfConditionUsesPlaceholder() {
+    programIndicator.setAnalyticsType(ENROLLMENT);
+    when(programStageService.getProgramStage(programStageA.getUid())).thenReturn(programStageA);
+    when(idObjectManager.get(DataElement.class, dataElementA.getUid())).thenReturn(dataElementA);
+
+    String sql = test("d2:countIfCondition(#{ProgrmStagA.DataElmentA},'>5')");
+
+    String encodedCondition =
+        Base64.getEncoder().encodeToString("'>5'".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(
+        sql,
+        is(
+            "__D2FUNC__(func='countIfCondition', ps='ProgrmStagA', de='DataElmentA', argType='condLit64', arg64='"
+                + encodedCondition
+                + "', hash='noboundaries', pi='"
+                + programIndicator.getUid()
+                + "')__"));
+  }
+
+  @Test
+  void testEnrollmentCountIfValueUsesPlaceholder() {
+    programIndicator.setAnalyticsType(ENROLLMENT);
+    when(programStageService.getProgramStage(programStageA.getUid())).thenReturn(programStageA);
+    when(idObjectManager.get(DataElement.class, dataElementA.getUid())).thenReturn(dataElementA);
+
+    String sql = test("d2:countIfValue(#{ProgrmStagA.DataElmentA},55)");
+
+    String encodedValueSql =
+        Base64.getEncoder().encodeToString("55.0".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(
+        sql,
+        is(
+            "__D2FUNC__(func='countIfValue', ps='ProgrmStagA', de='DataElmentA', argType='val64', arg64='"
+                + encodedValueSql
+                + "', hash='noboundaries', pi='"
+                + programIndicator.getUid()
+                + "')__"));
+  }
+
+  @Test
+  void testEnrollmentCountUsesPlaceholder() {
+    programIndicator.setAnalyticsType(ENROLLMENT);
+    when(programStageService.getProgramStage(programStageA.getUid())).thenReturn(programStageA);
+    when(idObjectManager.get(DataElement.class, dataElementA.getUid())).thenReturn(dataElementA);
+
+    String sql = test("d2:count(#{ProgrmStagA.DataElmentA})");
+
+    assertThat(
+        sql,
+        is(
+            "__D2FUNC__(func='count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='noboundaries', pi='"
+                + programIndicator.getUid()
+                + "')__"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -122,11 +122,9 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
     assertThat(
         sql,
         is(
-            "(select created from analytics_event_"
-                + enrollmentIndicator.getProgram().getUid()
-                + " where analytics_event_"
-                + enrollmentIndicator.getProgram().getUid()
-                + ".enrollment = ax.enrollment and created is not null order by occurreddate desc limit 1 )"));
+            "FUNC_CTE_VAR( type='vCreationDate', column='created', piUid='"
+                + enrollmentIndicator.getUid()
+                + "', psUid='null', offset='0')"));
   }
 
   @Test
@@ -162,6 +160,17 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
   }
 
   @Test
+  void testDueDateForEnrollment() {
+    String sql = castString(test("V{due_date}", new DefaultLiteral(), enrollmentIndicator));
+    assertThat(
+        sql,
+        is(
+            "FUNC_CTE_VAR( type='vDueDate', column='scheduleddate', piUid='"
+                + enrollmentIndicator.getUid()
+                + "', psUid='null', offset='0')"));
+  }
+
+  @Test
   void testEnrollmentCount() {
     String sql = castString(test("V{enrollment_count}", new DefaultLiteral(), eventIndicator));
     assertThat(sql, is("distinct enrollment"));
@@ -192,9 +201,42 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
   }
 
   @Test
+  void testExecutionDateForEnrollment() {
+    String sql = castString(test("V{execution_date}", new DefaultLiteral(), enrollmentIndicator));
+    assertThat(
+        sql,
+        is(
+            "FUNC_CTE_VAR( type='vEventDate', column='occurreddate', piUid='"
+                + enrollmentIndicator.getUid()
+                + "', psUid='null', offset='0')"));
+  }
+
+  @Test
   void testEventDate() {
     String sql = castString(test("V{event_date}", new DefaultLiteral(), eventIndicator));
     assertThat(sql, is("occurreddate"));
+  }
+
+  @Test
+  void testEventDateForEnrollment() {
+    String sql = castString(test("V{event_date}", new DefaultLiteral(), enrollmentIndicator));
+    assertThat(
+        sql,
+        is(
+            "FUNC_CTE_VAR( type='vEventDate', column='occurreddate', piUid='"
+                + enrollmentIndicator.getUid()
+                + "', psUid='null', offset='0')"));
+  }
+
+  @Test
+  void testEventStatusForEnrollment() {
+    String sql = castString(test("V{event_status}", new DefaultLiteral(), enrollmentIndicator));
+    assertThat(
+        sql,
+        is(
+            "FUNC_CTE_VAR( type='vEventStatus', column='eventstatus', piUid='"
+                + enrollmentIndicator.getUid()
+                + "', psUid='null', offset='0')"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/dataitem/ProgramItemStageElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/dataitem/ProgramItemStageElementTest.java
@@ -97,7 +97,6 @@ class ProgramItemStageElementTest extends TestBase {
 
     when(visitor.getProgParams()).thenReturn(progParams);
     when(visitor.getState()).thenReturn(expressionState);
-    when(visitor.isUseExperimentalSqlEngine()).thenReturn(true);
 
     startDate = dateFormat.parse("2024-01-01");
     endDate = dateFormat.parse("2024-12-31");

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -102,11 +102,10 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(149, keys.size());
+    assertEquals(148, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));
-    assertTrue(keys.contains("experimentalAnalyticsSqlEngineEnabled"));
     assertTrue(keys.contains("notifierGistOverview"));
     assertTrue(keys.contains("keyCustomTranslationsEnabled"));
     assertTrue(keys.contains(("keyCustomColor")));

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -81,8 +81,6 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
 
   private SqlBuilder sqlBuilder;
 
-  private boolean useExperimentalSqlEngine;
-
   /**
    * A {@link Supplier} object that can return a {@link I18n} instance when needed. This is done
    * because retrieving a {@link I18n} instance can be expensive and is not needed for most parsing
@@ -132,7 +130,6 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
       ProgramStageService programStageService,
       TrackedEntityAttributeService attributeService,
       SqlBuilder sqlBuilder,
-      boolean useExperimentalSqlEngine,
       Supplier<I18n> i18nSupplier,
       Map<String, Constant> constantMap,
       Map<Integer, ExpressionItem> itemMap,
@@ -152,7 +149,6 @@ public class CommonExpressionVisitor extends AntlrExpressionVisitor {
     this.programStageService = programStageService;
     this.attributeService = attributeService;
     this.sqlBuilder = sqlBuilder;
-    this.useExperimentalSqlEngine = useExperimentalSqlEngine;
     this.i18nSupplier = i18nSupplier;
     this.constantMap = constantMap != null ? constantMap : new HashMap<>();
     this.itemMap = itemMap;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
@@ -31,13 +31,17 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
@@ -187,16 +191,8 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     String enrollmentSql =
         getSqlEnrollment(
             "d2:condition( \"d2:hasValue(#{ProgrmStagA.DataElmentA})\", 1+4, d2:zpvc(#{Program000B.DataElmentB}) )");
-    assertTrue(
-        enrollmentSql.contains(
-            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
-                + piB.getUid()
-                + "')"));
-    assertTrue(
-        enrollmentSql.contains(
-            "__PSDE_CTE_PLACEHOLDER__(psUid='Program000B', deUid='DataElmentB', offset='0', boundaryHash='noboundaries', piUid='"
-                + piB.getUid()
-                + "')"));
+    assertPlaceholder(enrollmentSql, "ProgrmStagA", "DataElmentA", "0", piB.getUid());
+    assertPlaceholder(enrollmentSql, "Program000B", "DataElmentB", "0", piB.getUid());
   }
 
   @Test
@@ -204,11 +200,13 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         normalizeSql(getSql("d2:count(#{ProgrmStagA.DataElmentA})")));
-    assertEquals(
-        "__D2FUNC__(func='d2:count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='noboundaries', pi='"
-            + piB.getUid()
-            + "')__",
-        normalizeSql(getSqlEnrollment("d2:count(#{ProgrmStagA.DataElmentA})")));
+    assertD2Func(
+        normalizeSql(getSqlEnrollment("d2:count(#{ProgrmStagA.DataElmentA})")),
+        "count",
+        "ProgrmStagA",
+        "DataElmentA",
+        "none",
+        piB.getUid());
   }
 
   @Test
@@ -224,10 +222,8 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         normalizeSql(
             getSqlEnrollment(
                 "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, \" >= #{Program000B.DataElmentB}\")"));
-    assertTrue(
-        enrollmentSql.startsWith(
-            "__D2FUNC__(func='d2:countIfCondition', ps='ProgrmStagA', de='DataElmentA'"));
-    assertTrue(enrollmentSql.contains("pi='" + piB.getUid() + "')__"));
+    assertD2Func(
+        enrollmentSql, "countIfCondition", "ProgrmStagA", "DataElmentA", "condLit64", piB.getUid());
   }
 
   @Test
@@ -237,10 +233,8 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         normalizeSql(getSql("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)")));
     String enrollmentSql =
         normalizeSql(getSqlEnrollment("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)"));
-    assertTrue(
-        enrollmentSql.startsWith(
-            "__D2FUNC__(func='d2:countIfValue', ps='ProgrmStagA', de='DataElmentA'"));
-    assertTrue(enrollmentSql.contains("pi='" + piB.getUid() + "')__"));
+    assertD2Func(
+        enrollmentSql, "countIfValue", "ProgrmStagA", "DataElmentA", "val64", piB.getUid());
   }
 
   @Test
@@ -248,12 +242,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))",
         getSql("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertTrue(
-        getSqlEnrollment("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"),
+        "ProgrmStagA",
+        "DataElmentD",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -261,12 +255,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end is not null)",
         getSql("d2:hasValue(#{ProgrmStagA.DataElmentA})"));
-    assertTrue(
-        getSqlEnrollment("d2:hasValue(#{ProgrmStagA.DataElmentA})")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:hasValue(#{ProgrmStagA.DataElmentA})"),
+        "ProgrmStagA",
+        "DataElmentA",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -286,12 +280,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(extract(epoch from (cast(occurreddate as timestamp) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as timestamp))) / 60)",
         getSql("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertTrue(
-        getSqlEnrollment("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"),
+        "ProgrmStagA",
+        "DataElmentD",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -312,12 +306,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         "((date_part('year',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date)))) * 12 "
             + "+ date_part('month',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))))",
         getSql("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertTrue(
-        getSqlEnrollment("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"),
+        "ProgrmStagA",
+        "DataElmentD",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -329,12 +323,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "coalesce(case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end >= 0 then 1 else 0 end, 0)",
         getSql("d2:oizp(#{ProgrmStagA.DataElmentA})"));
-    assertTrue(
-        getSqlEnrollment("d2:oizp(#{ProgrmStagA.DataElmentA})")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:oizp(#{ProgrmStagA.DataElmentA})"),
+        "ProgrmStagA",
+        "DataElmentA",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -375,12 +369,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "((cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date)) / 7)",
         getSql("d2:weeksBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
-    assertTrue(
-        getSqlEnrollment("d2:weeksBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:weeksBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"),
+        "ProgrmStagA",
+        "DataElmentD",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -390,11 +384,32 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         getSql("d2:yearsBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
     var enrol =
         getSqlEnrollment("d2:yearsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)");
-    assertTrue(
-        enrol.contains(
-            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
-                + piB.getUid()
-                + "')"));
+    assertPlaceholder(enrol, "ProgrmStagA", "DataElmentD", "0", piB.getUid());
+  }
+
+  /**
+   * Parses a SQL string containing {@code __PSDE_CTE_PLACEHOLDER__(...)} tokens and asserts that a
+   * placeholder with the given psUid, deUid, offset and piUid exists. The boundaryHash is asserted
+   * to be non-null (its value is non-deterministic across test runs).
+   */
+  private static void assertPlaceholder(
+      String sql, String psUid, String deUid, String offset, String piUid) {
+    Pattern pattern = Pattern.compile("__PSDE_CTE_PLACEHOLDER__\\(([^)]+)\\)");
+    Matcher matcher = pattern.matcher(sql);
+    while (matcher.find()) {
+      Map<String, String> fields = parsePlaceholderFields(matcher.group(1));
+      if (psUid.equals(fields.get("psUid"))
+          && deUid.equals(fields.get("deUid"))
+          && offset.equals(fields.get("offset"))
+          && piUid.equals(fields.get("piUid"))) {
+        assertNotNull(fields.get("boundaryHash"), "boundaryHash should not be null");
+        return;
+      }
+    }
+    fail(
+        String.format(
+            "No __PSDE_CTE_PLACEHOLDER__ found with psUid='%s', deUid='%s', offset='%s', piUid='%s' in:%n%s",
+            psUid, deUid, offset, piUid, sql));
   }
 
   @Test
@@ -402,12 +417,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "greatest(0,coalesce(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end::numeric,0) + 5::numeric)",
         getSql("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"));
-    assertTrue(
-        getSqlEnrollment("d2:zing(#{ProgrmStagA.DataElmentA} + 5)")
-            .contains(
-                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
-                    + piB.getUid()
-                    + "')"));
+    assertPlaceholder(
+        getSqlEnrollment("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"),
+        "ProgrmStagA",
+        "DataElmentA",
+        "0",
+        piB.getUid());
   }
 
   @Test
@@ -418,19 +433,48 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         getSql("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagA.DataElmentB})"));
     String enrollmentSql =
         getSqlEnrollment("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagB.DataElmentB})");
-    assertTrue(
-        enrollmentSql.contains(
-            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
-                + piB.getUid()
-                + "')"));
-    assertTrue(
-        enrollmentSql.contains(
-            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagB', deUid='DataElmentB', offset='0', boundaryHash='noboundaries', piUid='"
-                + piB.getUid()
-                + "')"));
+    assertPlaceholder(enrollmentSql, "ProgrmStagA", "DataElmentA", "0", piB.getUid());
+    assertPlaceholder(enrollmentSql, "ProgrmStagB", "DataElmentB", "0", piB.getUid());
   }
 
   private String normalizeSql(String sql) {
     return sql.replaceAll("\\s+", " ").trim();
+  }
+
+  /**
+   * Parses a SQL string containing {@code __D2FUNC__(...)__} tokens and asserts that a placeholder
+   * with the given func, ps, de, argType and pi exists. The hash is asserted to be non-null (its
+   * value is non-deterministic across test runs).
+   */
+  private static void assertD2Func(
+      String sql, String func, String ps, String de, String argType, String piUid) {
+    Pattern pattern = Pattern.compile("__D2FUNC__\\(([^)]+)\\)__");
+    Matcher matcher = pattern.matcher(sql);
+    while (matcher.find()) {
+      Map<String, String> fields = parsePlaceholderFields(matcher.group(1));
+      if (func.equals(fields.get("func"))
+          && ps.equals(fields.get("ps"))
+          && de.equals(fields.get("de"))
+          && argType.equals(fields.get("argType"))
+          && piUid.equals(fields.get("pi"))) {
+        assertNotNull(fields.get("hash"), "hash should not be null");
+        return;
+      }
+    }
+    fail(
+        String.format(
+            "No __D2FUNC__ found with func='%s', ps='%s', de='%s', argType='%s', pi='%s' in:%n%s",
+            func, ps, de, argType, piUid, sql));
+  }
+
+  /** Parses {@code key='value', key='value'} pairs from a placeholder body. */
+  private static Map<String, String> parsePlaceholderFields(String body) {
+    Map<String, String> fields = new java.util.LinkedHashMap<>();
+    Pattern fieldPattern = Pattern.compile("(\\w+)='([^']*)'");
+    Matcher m = fieldPattern.matcher(body);
+    while (m.find()) {
+      fields.put(m.group(1), m.group(2));
+    }
+    return fields;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -98,7 +99,6 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
 
   @BeforeAll
   void setUp() {
-    systemSettingsService.put("experimentalAnalyticsSqlEngineEnabled", false);
     systemSettingsService.clearCurrentSettings();
 
     OrganisationUnit organisationUnit = createOrganisationUnit('A');
@@ -184,11 +184,19 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
             + "nullif(cast((case when case when ax.\"ps\" = 'Program000B' then \"DataElmentB\" else null end >= 0 then 1 else 0 end) as double precision),0) end",
         getSql(
             "d2:condition( 'd2:hasValue(#{ProgrmStagA.DataElmentA})', 1+4, d2:zpvc(#{Program000B.DataElmentB}) )"));
-    assertEquals(
-        "case when (((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) is not null)) "
-            + "then 1::numeric + 4::numeric else nullif(cast((case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0) end",
+    String enrollmentSql =
         getSqlEnrollment(
-            "d2:condition( \"d2:hasValue(#{ProgrmStagA.DataElmentA})\", 1+4, d2:zpvc(#{Program000B.DataElmentB}) )"));
+            "d2:condition( \"d2:hasValue(#{ProgrmStagA.DataElmentA})\", 1+4, d2:zpvc(#{Program000B.DataElmentB}) )");
+    assertTrue(
+        enrollmentSql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
+                + piB.getUid()
+                + "')"));
+    assertTrue(
+        enrollmentSql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='Program000B', deUid='DataElmentB', offset='0', boundaryHash='noboundaries', piUid='"
+                + piB.getUid()
+                + "')"));
   }
 
   @Test
@@ -197,7 +205,9 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         normalizeSql(getSql("d2:count(#{ProgrmStagA.DataElmentA})")));
     assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "__D2FUNC__(func='d2:count', ps='ProgrmStagA', de='DataElmentA', argType='none', arg64='', hash='noboundaries', pi='"
+            + piB.getUid()
+            + "')__",
         normalizeSql(getSqlEnrollment("d2:count(#{ProgrmStagA.DataElmentA})")));
   }
 
@@ -210,13 +220,14 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         normalizeSql(
             getSql(
                 "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, ' >= #{Program000B.DataElmentB}')")));
-    assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\"::numeric >= coalesce("
-            + "(select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by occurreddate desc limit 1 )::numeric,0) "
-            + "and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+    String enrollmentSql =
         normalizeSql(
             getSqlEnrollment(
-                "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, \" >= #{Program000B.DataElmentB}\")")));
+                "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, \" >= #{Program000B.DataElmentB}\")"));
+    assertTrue(
+        enrollmentSql.startsWith(
+            "__D2FUNC__(func='d2:countIfCondition', ps='ProgrmStagA', de='DataElmentA'"));
+    assertTrue(enrollmentSql.contains("pi='" + piB.getUid() + "')__"));
   }
 
   @Test
@@ -224,9 +235,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\" = 10::numeric and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         normalizeSql(getSql("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)")));
-    assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and \"DataElmentA\" = 10::numeric and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
-        normalizeSql(getSqlEnrollment("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)")));
+    String enrollmentSql =
+        normalizeSql(getSqlEnrollment("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)"));
+    assertTrue(
+        enrollmentSql.startsWith(
+            "__D2FUNC__(func='d2:countIfValue', ps='ProgrmStagA', de='DataElmentA'"));
+    assertTrue(enrollmentSql.contains("pi='" + piB.getUid() + "')__"));
   }
 
   @Test
@@ -234,10 +248,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))",
         getSql("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertEquals(
-        "(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))",
-        getSqlEnrollment("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
+    assertTrue(
+        getSqlEnrollment("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -245,9 +261,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end is not null)",
         getSql("d2:hasValue(#{ProgrmStagA.DataElmentA})"));
-    assertEquals(
-        "((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) is not null)",
-        getSqlEnrollment("d2:hasValue(#{ProgrmStagA.DataElmentA})"));
+    assertTrue(
+        getSqlEnrollment("d2:hasValue(#{ProgrmStagA.DataElmentA})")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -267,11 +286,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "(extract(epoch from (cast(occurreddate as timestamp) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as timestamp))) / 60)",
         getSql("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertEquals(
-        "(extract(epoch from (cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as timestamp) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as timestamp))) / 60)",
-        getSqlEnrollment(
-            "d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
+    assertTrue(
+        getSqlEnrollment("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -292,12 +312,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         "((date_part('year',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date)))) * 12 "
             + "+ date_part('month',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))))",
         getSql("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
-    assertEquals(
-        "((date_part('year',age(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date), "
-            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date)))) "
-            + "* 12 + date_part('month',age(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date), "
-            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))))",
-        getSqlEnrollment("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
+    assertTrue(
+        getSqlEnrollment("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -309,9 +329,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "coalesce(case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end >= 0 then 1 else 0 end, 0)",
         getSql("d2:oizp(#{ProgrmStagA.DataElmentA})"));
-    assertEquals(
-        "coalesce(case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end, 0)",
-        getSqlEnrollment("d2:oizp(#{ProgrmStagA.DataElmentA})"));
+    assertTrue(
+        getSqlEnrollment("d2:oizp(#{ProgrmStagA.DataElmentA})")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -352,10 +375,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "((cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date)) / 7)",
         getSql("d2:weeksBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
-    assertEquals(
-        "((cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date)) / 7)",
-        getSqlEnrollment("d2:weeksBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
+    assertTrue(
+        getSqlEnrollment("d2:weeksBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -365,15 +390,11 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         getSql("d2:yearsBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
     var enrol =
         getSqlEnrollment("d2:yearsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)");
-    assertEquals(
-        "(date_part('year',age(cast((select occurreddate from analytics_event_Program000A "
-            + "where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < "
-            + "cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' "
-            + "order by occurreddate desc limit 1 ) as date), "
-            + "cast((select \"DataElmentD\" from analytics_event_Program000A "
-            + "where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentD\" is not null and occurreddate < "
-            + "cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))))",
-        enrol);
+    assertTrue(
+        enrol.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentD', offset='0', boundaryHash='noboundaries', piUid='"
+                + piB.getUid()
+                + "')"));
   }
 
   @Test
@@ -381,9 +402,12 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
     assertEquals(
         "greatest(0,coalesce(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end::numeric,0) + 5::numeric)",
         getSql("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"));
-    assertEquals(
-        "greatest(0,coalesce((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 )::numeric,0) + 5::numeric)",
-        getSqlEnrollment("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"));
+    assertTrue(
+        getSqlEnrollment("d2:zing(#{ProgrmStagA.DataElmentA} + 5)")
+            .contains(
+                "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
+                    + piB.getUid()
+                    + "')"));
   }
 
   @Test
@@ -392,10 +416,18 @@ class ProgramIndicatorServiceD2FunctionTest extends PostgresIntegrationTestBase 
         "nullif(cast((case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end >= 0 then 1 else 0 end "
             + "+ case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentB\" else null end >= 0 then 1 else 0 end) as double precision),0)",
         getSql("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagA.DataElmentB})"));
-    assertEquals(
-        "nullif(cast((case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end "
-            + "+ case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagB' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0)",
-        getSqlEnrollment("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagB.DataElmentB})"));
+    String enrollmentSql =
+        getSqlEnrollment("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagB.DataElmentB})");
+    assertTrue(
+        enrollmentSql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0', boundaryHash='noboundaries', piUid='"
+                + piB.getUid()
+                + "')"));
+    assertTrue(
+        enrollmentSql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagB', deUid='DataElmentB', offset='0', boundaryHash='noboundaries', piUid='"
+                + piB.getUid()
+                + "')"));
   }
 
   private String normalizeSql(String sql) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -149,7 +149,6 @@ class ProgramIndicatorServiceTest extends PostgresIntegrationTestBase {
   @BeforeEach
   void setUp() {
 
-    systemSettingsService.put("experimentalAnalyticsSqlEngineEnabled", false);
     systemSettingsService.clearCurrentSettings();
 
     OrganisationUnit organisationUnit = createOrganisationUnit('A');
@@ -617,19 +616,17 @@ class ProgramIndicatorServiceTest extends PostgresIntegrationTestBase {
   void testNestedSubqueryWithTableAlias() {
     Date dateFrom = getDate(2019, 1, 1);
     Date dateTo = getDate(2019, 12, 31);
-    // Generated subquery, since indicatorF is type Enrollment
-    String expected =
-        "coalesce((select \"DataElmentA\" from analytics_event_Program000B where analytics_event_Program000B.enrollment = axx1.enrollment and \"DataElmentA\" is not null and occurreddate < cast( '"
-            + "2020-01-11"
-            + "' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 )::numeric,0) - "
-            + "coalesce((select \"DataElmentC\" from analytics_event_Program000B where analytics_event_Program000B.enrollment = axx1.enrollment and \"DataElmentC\" is not null and occurreddate < cast( '"
-            + "2020-01-11"
-            + "' as date ) and ps = 'ProgrmStagB' order by occurreddate desc limit 1 )::numeric,0)";
     String expression = "#{ProgrmStagA.DataElmentA} - #{ProgrmStagB.DataElmentC}";
-    assertEquals(
-        expected,
+    String sql =
         programIndicatorService.getAnalyticsSql(
-            expression, NUMERIC, indicatorF, dateFrom, dateTo, "axx1"));
+            expression, NUMERIC, indicatorF, dateFrom, dateTo, "axx1");
+    assertTrue(
+        sql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagA', deUid='DataElmentA', offset='0'"));
+    assertTrue(
+        sql.contains(
+            "__PSDE_CTE_PLACEHOLDER__(psUid='ProgrmStagB', deUid='DataElmentC', offset='0'"));
+    assertTrue(sql.contains("piUid='" + indicatorF.getUid() + "'"));
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -79,7 +79,6 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   @BeforeEach
   void setUp() {
 
-    systemSettingsService.put("experimentalAnalyticsSqlEngineEnabled", false);
     systemSettingsService.clearCurrentSettings();
 
     OrganisationUnit organisationUnit = createOrganisationUnit('A');
@@ -135,7 +134,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testCreationDate() {
     assertEquals("created", getSql("V{creation_date}"));
     assertEquals(
-        "(select created from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and created is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vCreationDate', column='created', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{creation_date}"));
   }
 
@@ -150,7 +151,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testDueDate() {
     assertEquals("scheduleddate", getSql("V{due_date}"));
     assertEquals(
-        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and scheduleddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vDueDate', column='scheduleddate', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{due_date}"));
   }
 
@@ -176,7 +179,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testEventStatus() {
     assertEquals("eventstatus", getSql("V{event_status}"));
     assertEquals(
-        "(select eventstatus from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and eventstatus is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vEventStatus', column='eventstatus', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{event_status}"));
   }
 
@@ -207,7 +212,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testExecutionDate() {
     assertEquals("occurreddate", getSql("V{execution_date}"));
     assertEquals(
-        "(select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and eventstatus IN ('COMPLETED', 'ACTIVE') order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vEventDate', column='occurreddate', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{execution_date}"));
   }
 
@@ -215,7 +222,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testEventDate() {
     assertEquals("occurreddate", getSql("V{event_date}"));
     assertEquals(
-        "(select occurreddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and occurreddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and eventstatus IN ('COMPLETED', 'ACTIVE') order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vEventDate', column='occurreddate', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{event_date}"));
   }
 
@@ -223,7 +232,9 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
   void testScheduledDate() {
     assertEquals("scheduleddate", getSql("V{scheduled_date}"));
     assertEquals(
-        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.enrollment = ax.enrollment and scheduleddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and eventstatus = 'SCHEDULE' order by occurreddate desc limit 1 )",
+        "FUNC_CTE_VAR( type='vScheduledDate', column='scheduleddate', piUid='"
+            + piB.getUid()
+            + "', psUid='null', offset='0')",
         getSqlEnrollment("V{scheduled_date}"));
   }
 


### PR DESCRIPTION
## Summary

This PR removes the obsolete `experimentalAnalyticsSqlEngineEnabled` setting and completes the transition to the CTE-based analytics SQL engine as the default behaviour.

In practice, this means:

- removing the remaining flag plumbing from settings, services, and expression visitors
- deleting the last legacy enrollment SQL branches that were still selected via the old flag
- updating tests to assert the CTE/placeholder SQL output as the new default
- fixing several enrollment analytics regressions exposed by forcing the CTE path for all requests

## What Changed

Flag removal

- Removed `experimentalAnalyticsSqlEngineEnabled` from `SystemSettings`
- Removed `SystemSettingsService` usage that only existed to read this flag
- Removed `useExperimentalSqlEngine` from `CommonExpressionVisitor`

Expression / Program indicator SQL

- Made the former experimental CTE/placeholder path the default for enrollment analytics SQL generation
- Removed legacy branching in program indicator stage element, variable, and d2:count* SQL generation
- Preserved the existing event-analytics behaviour where direct event-table SQL is still intended

ref: [DHIS2-21272](https://dhis2.atlassian.net/browse/DHIS2-21272)


[DHIS2-21272]: https://dhis2.atlassian.net/browse/DHIS2-21272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ