### PR TITLE
perf: defer changelog inserts to enable JDBC batching during tracker import DHIS2-21239 [42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.FlushMode;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
@@ -84,8 +83,6 @@ public abstract class AbstractTrackerPersister<
     implements TrackerPersister<T, V> {
   protected final ReservedValueService reservedValueService;
 
-  protected final TrackedEntityChangeLogService trackedEntityChangeLogService;
-
   /**
    * Template method that can be used by classes extending this class to execute the persistence
    * flow of Tracker entities
@@ -102,6 +99,7 @@ public abstract class AbstractTrackerPersister<
     TrackerTypeReport typeReport = new TrackerTypeReport(getType());
 
     List<TrackerNotificationDataBundle> notificationDataBundles = new ArrayList<>();
+    ChangeLogAccumulator changeLogs = new ChangeLogAccumulator();
 
     //
     // Extract the entities to persist from the Bundle
@@ -114,6 +112,7 @@ public abstract class AbstractTrackerPersister<
       List<NotificationTrigger> triggers =
           determineNotificationTriggers(bundle.getPreheat(), trackerDto);
 
+      ChangeLogAccumulator.Mark mark = changeLogs.mark();
       try {
         V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
 
@@ -138,11 +137,17 @@ public abstract class AbstractTrackerPersister<
               trackerDto,
               convertedDto,
               originalEntity,
-              bundle.getUser());
+              bundle.getUser(),
+              changeLogs);
           typeReport.getStats().incCreated();
           typeReport.addEntity(objectReport);
           updateAttributes(
-              entityManager, bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser());
+              entityManager,
+              bundle.getPreheat(),
+              trackerDto,
+              convertedDto,
+              bundle.getUser(),
+              changeLogs);
           bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
         } else {
           if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -155,9 +160,15 @@ public abstract class AbstractTrackerPersister<
                 trackerDto,
                 convertedDto,
                 originalEntity,
-                bundle.getUser());
+                bundle.getUser(),
+                changeLogs);
             updateAttributes(
-                entityManager, bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser());
+                entityManager,
+                bundle.getPreheat(),
+                trackerDto,
+                convertedDto,
+                bundle.getUser(),
+                changeLogs);
             entityManager.merge(convertedDto);
             typeReport.getStats().incUpdated();
             typeReport.addEntity(objectReport);
@@ -175,9 +186,14 @@ public abstract class AbstractTrackerPersister<
         updatePreheat(bundle.getPreheat(), convertedDto);
 
         if (FlushMode.OBJECT == bundle.getFlushMode()) {
+          // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+          // (trackedentityid, eventid) exist before changelog rows reference them.
           entityManager.flush();
+          changeLogs.flushAll(entityManager);
         }
       } catch (Exception e) {
+        changeLogs.rollbackTo(mark);
+
         final String msg =
             "A Tracker Entity of type '"
                 + getType().getName()
@@ -198,6 +214,12 @@ public abstract class AbstractTrackerPersister<
       }
     }
 
+    if (FlushMode.AUTO == bundle.getFlushMode()) {
+      // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+      // (trackedentityid, eventid) exist before changelog rows reference them.
+      entityManager.flush();
+      changeLogs.flushAll(entityManager);
+    }
     typeReport.getNotificationDataBundles().addAll(notificationDataBundles);
 
     return typeReport;
@@ -233,7 +255,8 @@ public abstract class AbstractTrackerPersister<
       T trackerDto,
       V payloadEntity,
       V currentEntity,
-      UserDetails user);
+      UserDetails user,
+      ChangeLogAccumulator changeLogs);
 
   /** Execute the persistence of Attribute values linked to the entity being processed */
   protected abstract void updateAttributes(
@@ -241,7 +264,8 @@ public abstract class AbstractTrackerPersister<
       TrackerPreheat preheat,
       T trackerDto,
       V hibernateEntity,
-      UserDetails user);
+      UserDetails user,
+      ChangeLogAccumulator changeLogs);
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -321,7 +345,8 @@ public abstract class AbstractTrackerPersister<
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
@@ -348,7 +373,7 @@ public abstract class AbstractTrackerPersister<
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
           if (isDelete && !isNew) {
-            delete(entityManager, preheat, currentValue, trackedEntity, user);
+            delete(entityManager, preheat, currentValue, trackedEntity, user, changeLogs);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
                 entityManager,
@@ -358,7 +383,8 @@ public abstract class AbstractTrackerPersister<
                 currentValue,
                 isNew,
                 previousValue,
-                user);
+                user,
+                changeLogs);
           }
         });
   }
@@ -371,7 +397,8 @@ public abstract class AbstractTrackerPersister<
       TrackedEntityAttributeValue currentValue,
       boolean isNew,
       String previousValue,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     TrackedEntityAttributeValue attributeToPersist =
         Optional.ofNullable(currentValue)
             .orElseGet(
@@ -385,7 +412,14 @@ public abstract class AbstractTrackerPersister<
             .setLastUpdated(new Date());
 
     saveOrUpdate(
-        entityManager, preheat, isNew, trackedEntity, attributeToPersist, previousValue, user);
+        entityManager,
+        preheat,
+        isNew,
+        trackedEntity,
+        attributeToPersist,
+        previousValue,
+        user,
+        changeLogs);
 
     handleReservedValue(attributeToPersist);
   }
@@ -395,7 +429,8 @@ public abstract class AbstractTrackerPersister<
       TrackerPreheat preheat,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       TrackedEntity trackedEntity,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
       unassignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
@@ -406,7 +441,7 @@ public abstract class AbstractTrackerPersister<
             ? trackedEntityAttributeValue
             : entityManager.merge(trackedEntityAttributeValue));
 
-    trackedEntityChangeLogService.addTrackedEntityChangeLog(
+    changeLogs.addTrackedEntityChangeLog(
         trackedEntity,
         trackedEntityAttributeValue.getAttribute(),
         trackedEntityAttributeValue.getPlainValue(),
@@ -422,7 +457,8 @@ public abstract class AbstractTrackerPersister<
       TrackedEntity trackedEntity,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       String previousValue,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
       assignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
@@ -440,7 +476,7 @@ public abstract class AbstractTrackerPersister<
       changeLogType = UPDATE;
     }
 
-    trackedEntityChangeLogService.addTrackedEntityChangeLog(
+    changeLogs.addTrackedEntityChangeLog(
         trackedEntity,
         trackedEntityAttributeValue.getAttribute(),
         previousValue,
@@ -472,5 +508,20 @@ public abstract class AbstractTrackerPersister<
       reservedValueService.useReservedValue(
           attributeValue.getAttribute().getTextPattern(), attributeValue.getValue());
     }
+  }
+
+  protected static String formatDate(Date date) {
+    java.text.SimpleDateFormat formatter =
+        new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    return date != null ? formatter.format(date) : null;
+  }
+
+  protected static String formatGeometry(org.locationtech.jts.geom.Geometry geometry) {
+    if (geometry == null) {
+      return null;
+    }
+    return java.util.stream.Stream.of(geometry.getCoordinates())
+        .map(c -> String.format("(%f, %f)", c.x, c.y))
+        .collect(java.util.stream.Collectors.joining(", "));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -82,6 +84,7 @@ public abstract class AbstractTrackerPersister<
         T extends TrackerDto, V extends BaseIdentifiableObject>
     implements TrackerPersister<T, V> {
   protected final ReservedValueService reservedValueService;
+  protected final DhisConfigurationProvider config;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
@@ -99,7 +102,7 @@ public abstract class AbstractTrackerPersister<
     TrackerTypeReport typeReport = new TrackerTypeReport(getType());
 
     List<TrackerNotificationDataBundle> notificationDataBundles = new ArrayList<>();
-    ChangeLogAccumulator changeLogs = new ChangeLogAccumulator();
+    ChangeLogAccumulator changeLogs = new ChangeLogAccumulator(config.isEnabled(CHANGELOG_TRACKER));
 
     //
     // Extract the entities to persist from the Bundle

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -68,6 +68,8 @@ class ChangeLogAccumulator {
    */
   private static final int MAX_ROWS_PER_INSERT = 128;
 
+  private final boolean enabled;
+
   private static final String TE_CHANGELOG_TUPLE = "(?,?,?,?,?,?,?)";
   private static final String TE_CHANGELOG_VALUES =
       multiRowValues(TE_CHANGELOG_TUPLE, MAX_ROWS_PER_INSERT);
@@ -88,6 +90,10 @@ class ChangeLogAccumulator {
   private final List<TrackedEntityChangeLog> teChangeLogs = new ArrayList<>();
   private final List<EventChangeLog> eventChangeLogs = new ArrayList<>();
 
+  ChangeLogAccumulator(boolean enabled) {
+    this.enabled = enabled;
+  }
+
   void addTrackedEntityChangeLog(
       @Nonnull TrackedEntity trackedEntity,
       @Nonnull TrackedEntityAttribute attribute,
@@ -95,6 +101,7 @@ class ChangeLogAccumulator {
       @CheckForNull String currentValue,
       @Nonnull ChangeLogType type,
       @Nonnull String username) {
+    if (!enabled) return;
     teChangeLogs.add(
         new TrackedEntityChangeLog(
             trackedEntity, attribute, previousValue, currentValue, type, created, username));
@@ -107,6 +114,7 @@ class ChangeLogAccumulator {
       @CheckForNull String currentValue,
       @Nonnull ChangeLogType type,
       @Nonnull String username) {
+    if (!enabled) return;
     eventChangeLogs.add(
         new EventChangeLog(
             event, dataElement, null, previousValue, currentValue, type, created, username));
@@ -119,6 +127,7 @@ class ChangeLogAccumulator {
       @CheckForNull String currentValue,
       @Nonnull ChangeLogType type,
       @Nonnull String username) {
+    if (!enabled) return;
     eventChangeLogs.add(
         new EventChangeLog(
             event, null, eventField, previousValue, currentValue, type, created, username));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import jakarta.persistence.EntityManager;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.hibernate.Session;
+import org.hisp.dhis.changelog.ChangeLogType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.tracker.export.event.EventChangeLog;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLog;
+
+/**
+ * Collects changelog entries during the persist phase and inserts them via multi-row INSERT at the
+ * end. This avoids Hibernate's per-entity sequence round-trips and groups all changelog INSERTs
+ * separately from entity INSERTs/UPDATEs. Multi-row INSERT is processed by PostgreSQL as a single
+ * statement (one parse, one plan, one WAL entry batch) instead of individual per-row executes.
+ */
+class ChangeLogAccumulator {
+
+  /**
+   * Maximum rows per multi-row INSERT statement. pgjdbc found that performance does not improve
+   * much beyond 128 rows per multi-valued INSERT. The hard upper limit is {@link Short#MAX_VALUE}
+   * (32,767) bind parameters per statement, which gives ~4,000 rows with 8 columns. 128 rows is
+   * well within that.
+   *
+   * @see <a
+   *     href="https://github.com/pgjdbc/pgjdbc/blob/c44a2a99/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java#L1815-L1821">PgPreparedStatement.java#L1815-L1821</a>
+   */
+  private static final int MAX_ROWS_PER_INSERT = 128;
+
+  private static final String TE_CHANGELOG_TUPLE = "(?,?,?,?,?,?,?)";
+  private static final String TE_CHANGELOG_VALUES =
+      multiRowValues(TE_CHANGELOG_TUPLE, MAX_ROWS_PER_INSERT);
+  private static final String INSERT_TE_CHANGELOG =
+      "insert into trackedentitychangelog"
+          + " (trackedentityid, trackedentityattributeid, previousvalue, currentvalue,"
+          + " changelogtype, created, createdby) values ";
+
+  private static final String EVENT_CHANGELOG_TUPLE = "(?,?,?,?,?,?,?,?)";
+  private static final String EVENT_CHANGELOG_VALUES =
+      multiRowValues(EVENT_CHANGELOG_TUPLE, MAX_ROWS_PER_INSERT);
+  private static final String INSERT_EVENT_CHANGELOG =
+      "insert into eventchangelog"
+          + " (eventid, dataelementid, eventfield, previousvalue, currentvalue,"
+          + " changelogtype, created, createdby) values ";
+
+  private final Date created = new Date();
+  private final List<TrackedEntityChangeLog> teChangeLogs = new ArrayList<>();
+  private final List<EventChangeLog> eventChangeLogs = new ArrayList<>();
+
+  void addTrackedEntityChangeLog(
+      @Nonnull TrackedEntity trackedEntity,
+      @Nonnull TrackedEntityAttribute attribute,
+      @CheckForNull String previousValue,
+      @CheckForNull String currentValue,
+      @Nonnull ChangeLogType type,
+      @Nonnull String username) {
+    teChangeLogs.add(
+        new TrackedEntityChangeLog(
+            trackedEntity, attribute, previousValue, currentValue, type, created, username));
+  }
+
+  void addEventChangeLog(
+      @Nonnull Event event,
+      @Nonnull DataElement dataElement,
+      @CheckForNull String previousValue,
+      @CheckForNull String currentValue,
+      @Nonnull ChangeLogType type,
+      @Nonnull String username) {
+    eventChangeLogs.add(
+        new EventChangeLog(
+            event, dataElement, null, previousValue, currentValue, type, created, username));
+  }
+
+  void addEventFieldChangeLog(
+      @Nonnull Event event,
+      @Nonnull String eventField,
+      @CheckForNull String previousValue,
+      @CheckForNull String currentValue,
+      @Nonnull ChangeLogType type,
+      @Nonnull String username) {
+    eventChangeLogs.add(
+        new EventChangeLog(
+            event, null, eventField, previousValue, currentValue, type, created, username));
+  }
+
+  Mark mark() {
+    return new Mark(teChangeLogs.size(), eventChangeLogs.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(teChangeLogs, mark.teSize);
+    truncate(eventChangeLogs, mark.eventSize);
+  }
+
+  void flushAll(EntityManager entityManager) {
+    if (teChangeLogs.isEmpty() && eventChangeLogs.isEmpty()) {
+      return;
+    }
+
+    Session session = entityManager.unwrap(Session.class);
+    session.doWork(this::insertAll);
+    teChangeLogs.clear();
+    eventChangeLogs.clear();
+  }
+
+  private void insertAll(Connection connection) throws SQLException {
+    Timestamp timestamp = new Timestamp(created.getTime());
+    insertTeChangeLogs(connection, timestamp);
+    insertEventChangeLogs(connection, timestamp);
+  }
+
+  private void insertTeChangeLogs(Connection connection, Timestamp timestamp) throws SQLException {
+    for (int offset = 0; offset < teChangeLogs.size(); offset += MAX_ROWS_PER_INSERT) {
+      int end = Math.min(offset + MAX_ROWS_PER_INSERT, teChangeLogs.size());
+      int batchSize = end - offset;
+      String values =
+          batchSize == MAX_ROWS_PER_INSERT
+              ? TE_CHANGELOG_VALUES
+              : multiRowValues(TE_CHANGELOG_TUPLE, batchSize);
+      String sql = INSERT_TE_CHANGELOG + values;
+
+      try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        int idx = 1;
+        for (int i = offset; i < end; i++) {
+          TrackedEntityChangeLog cl = teChangeLogs.get(i);
+          ps.setLong(idx++, cl.getTrackedEntity().getId());
+          ps.setLong(idx++, cl.getTrackedEntityAttribute().getId());
+          ps.setString(idx++, cl.getPreviousValue());
+          ps.setString(idx++, cl.getCurrentValue());
+          ps.setString(idx++, cl.getChangeLogType().name());
+          ps.setTimestamp(idx++, timestamp);
+          ps.setString(idx++, cl.getCreatedByUsername());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void insertEventChangeLogs(Connection connection, Timestamp timestamp)
+      throws SQLException {
+    for (int offset = 0; offset < eventChangeLogs.size(); offset += MAX_ROWS_PER_INSERT) {
+      int end = Math.min(offset + MAX_ROWS_PER_INSERT, eventChangeLogs.size());
+      int batchSize = end - offset;
+      String values =
+          batchSize == MAX_ROWS_PER_INSERT
+              ? EVENT_CHANGELOG_VALUES
+              : multiRowValues(EVENT_CHANGELOG_TUPLE, batchSize);
+      String sql = INSERT_EVENT_CHANGELOG + values;
+
+      try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        int idx = 1;
+        for (int i = offset; i < end; i++) {
+          EventChangeLog cl = eventChangeLogs.get(i);
+          ps.setLong(idx++, cl.getEvent().getId());
+          setNullableLong(ps, idx++, cl.getDataElement());
+          ps.setString(idx++, cl.getEventField());
+          ps.setString(idx++, cl.getPreviousValue());
+          ps.setString(idx++, cl.getCurrentValue());
+          ps.setString(idx++, cl.getChangeLogType().name());
+          ps.setTimestamp(idx++, timestamp);
+          ps.setString(idx++, cl.getCreatedByUsername());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private static String multiRowValues(String tuple, int count) {
+    return (tuple + ",").repeat(count - 1) + tuple;
+  }
+
+  private static void setNullableLong(PreparedStatement ps, int index, Object obj)
+      throws SQLException {
+    if (obj instanceof org.hisp.dhis.common.IdentifiableObject io) {
+      ps.setLong(index, io.getId());
+    } else {
+      ps.setNull(index, Types.BIGINT);
+    }
+  }
+
+  private static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  record Mark(int teSize, int eventSize) {}
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -57,8 +58,9 @@ public class EnrollmentPersister
 
   public EnrollmentPersister(
       ReservedValueService reservedValueService,
+      DhisConfigurationProvider config,
       TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
-    super(reservedValueService);
+    super(reservedValueService, config);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
@@ -58,10 +57,8 @@ public class EnrollmentPersister
 
   public EnrollmentPersister(
       ReservedValueService reservedValueService,
-      TrackedEntityProgramOwnerService trackedEntityProgramOwnerService,
-      TrackedEntityChangeLogService trackedEntityChangeLogService) {
-    super(reservedValueService, trackedEntityChangeLogService);
-
+      TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
+    super(reservedValueService);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
   }
 
@@ -71,13 +68,15 @@ public class EnrollmentPersister
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     handleTrackedEntityAttributeValues(
         entityManager,
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
-        user);
+        user,
+        changeLogs);
   }
 
   @Override
@@ -166,8 +165,9 @@ public class EnrollmentPersister
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
       Enrollment payloadEntity,
       Enrollment currentEntity,
-      UserDetails user) {
-    // DO NOTHING - TE HAVE NO DATA VALUES
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
+    // DO NOTHING - ENROLLMENTS HAVE NO DATA VALUES
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -74,8 +75,9 @@ import org.springframework.stereotype.Component;
 public class EventPersister
     extends AbstractTrackerPersister<org.hisp.dhis.tracker.imports.domain.Event, Event> {
 
-  public EventPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public EventPersister(
+      ReservedValueService reservedValueService, DhisConfigurationProvider config) {
+    super(reservedValueService, config);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -40,6 +40,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -48,6 +49,7 @@ import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
@@ -56,8 +58,6 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.export.event.EventChangeLogService;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
@@ -73,14 +73,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class EventPersister
     extends AbstractTrackerPersister<org.hisp.dhis.tracker.imports.domain.Event, Event> {
-  private final EventChangeLogService eventChangeLogService;
 
-  public EventPersister(
-      ReservedValueService reservedValueService,
-      TrackedEntityChangeLogService trackedEntityChangeLogService,
-      EventChangeLogService eventChangeLogService) {
-    super(reservedValueService, trackedEntityChangeLogService);
-    this.eventChangeLogService = eventChangeLogService;
+  public EventPersister(ReservedValueService reservedValueService) {
+    super(reservedValueService);
   }
 
   @Override
@@ -160,7 +155,8 @@ public class EventPersister
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Event event,
       Event hibernateEntity,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 
@@ -171,9 +167,11 @@ public class EventPersister
       org.hisp.dhis.tracker.imports.domain.Event event,
       Event payloadEntity,
       Event currentEntity,
-      UserDetails user) {
-    handleDataValues(entityManager, preheat, event.getDataValues(), payloadEntity, user);
-    eventChangeLogService.addFieldChangeLog(currentEntity, payloadEntity, user.getUsername());
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
+    handleDataValues(
+        entityManager, preheat, event.getDataValues(), payloadEntity, user, changeLogs);
+    logFieldChanges(currentEntity, payloadEntity, user.getUsername(), changeLogs);
   }
 
   private void handleDataValues(
@@ -181,7 +179,9 @@ public class EventPersister
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
       Event event,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
+    String username = user.getUsername();
     Map<String, EventDataValue> dataValueDBMap =
         Optional.ofNullable(event)
             .map(
@@ -197,25 +197,66 @@ public class EventPersister
           EventDataValue dbDataValue = dataValueDBMap.get(dataElement.getUid());
 
           if (isNewDataValue(dbDataValue, dataValue)) {
-            eventChangeLogService.addEventChangeLog(
-                event, dataElement, null, dataValue.getValue(), CREATE, user.getUsername());
+            changeLogs.addEventChangeLog(
+                event, dataElement, null, dataValue.getValue(), CREATE, username);
             saveDataValue(dataValue, event, dataElement, user, entityManager, preheat);
           } else if (isUpdate(dbDataValue, dataValue)) {
-            eventChangeLogService.addEventChangeLog(
-                event,
-                dataElement,
-                dbDataValue.getValue(),
-                dataValue.getValue(),
-                UPDATE,
-                user.getUsername());
+            changeLogs.addEventChangeLog(
+                event, dataElement, dbDataValue.getValue(), dataValue.getValue(), UPDATE, username);
             updateDataValue(
                 dbDataValue, dataValue, event, dataElement, user, entityManager, preheat);
           } else if (isDeletion(dbDataValue, dataValue)) {
-            eventChangeLogService.addEventChangeLog(
-                event, dataElement, dbDataValue.getValue(), null, DELETE, user.getUsername());
+            changeLogs.addEventChangeLog(
+                event, dataElement, dbDataValue.getValue(), null, DELETE, username);
             deleteDataValue(dbDataValue, event, dataElement, entityManager, preheat);
           }
         });
+  }
+
+  private static void logFieldChanges(
+      Event currentEntity, Event payloadEntity, String username, ChangeLogAccumulator changeLogs) {
+    logFieldChange(
+        changeLogs,
+        payloadEntity,
+        "scheduledAt",
+        formatDate(currentEntity.getScheduledDate()),
+        formatDate(payloadEntity.getScheduledDate()),
+        username);
+    logFieldChange(
+        changeLogs,
+        payloadEntity,
+        "occurredAt",
+        formatDate(currentEntity.getOccurredDate()),
+        formatDate(payloadEntity.getOccurredDate()),
+        username);
+    logFieldChange(
+        changeLogs,
+        payloadEntity,
+        "geometry",
+        formatGeometry(currentEntity.getGeometry()),
+        formatGeometry(payloadEntity.getGeometry()),
+        username);
+  }
+
+  private static void logFieldChange(
+      ChangeLogAccumulator changeLogs,
+      Event event,
+      String field,
+      String currentValue,
+      String newValue,
+      String username) {
+    if (!Objects.equals(currentValue, newValue)) {
+      ChangeLogType changeLogType;
+      if (currentValue == null) {
+        changeLogType = CREATE;
+      } else if (newValue == null) {
+        changeLogType = DELETE;
+      } else {
+        changeLogType = UPDATE;
+      }
+      changeLogs.addEventFieldChangeLog(
+          event, field, currentValue, newValue, changeLogType, username);
+    }
   }
 
   private void saveDataValue(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
@@ -53,11 +52,8 @@ import org.springframework.stereotype.Component;
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.relationship.Relationship> {
 
-  public RelationshipPersister(
-      ReservedValueService reservedValueService,
-      TrackedEntityChangeLogService trackedEntityChangeLogService) {
-
-    super(reservedValueService, trackedEntityChangeLogService);
+  public RelationshipPersister(ReservedValueService reservedValueService) {
+    super(reservedValueService);
   }
 
   @Override
@@ -76,7 +72,8 @@ public class RelationshipPersister
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.relationship.Relationship hibernateEntity,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     // NOTHING TO DO
   }
 
@@ -115,8 +112,9 @@ public class RelationshipPersister
       Relationship trackerDto,
       org.hisp.dhis.relationship.Relationship payloadEntity,
       org.hisp.dhis.relationship.Relationship currentEntity,
-      UserDetails user) {
-    // DO NOTHING - TE HAVE NO DATA VALUES
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
+    // DO NOTHING - RELATIONSHIPS HAVE NO DATA VALUES
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -33,6 +33,7 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
@@ -52,8 +53,9 @@ import org.springframework.stereotype.Component;
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.relationship.Relationship> {
 
-  public RelationshipPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public RelationshipPersister(
+      ReservedValueService reservedValueService, DhisConfigurationProvider config) {
+    super(reservedValueService, config);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityChangeLogService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
@@ -54,10 +53,8 @@ public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
 
-  public TrackedEntityPersister(
-      ReservedValueService reservedValueService,
-      TrackedEntityChangeLogService trackedEntityChangeLogService) {
-    super(reservedValueService, trackedEntityChangeLogService);
+  public TrackedEntityPersister(ReservedValueService reservedValueService) {
+    super(reservedValueService);
   }
 
   @Override
@@ -66,9 +63,10 @@ public class TrackedEntityPersister
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     handleTrackedEntityAttributeValues(
-        entityManager, preheat, trackerDto.getAttributes(), te, user);
+        entityManager, preheat, trackerDto.getAttributes(), te, user, changeLogs);
   }
 
   @Override
@@ -109,7 +107,8 @@ public class TrackedEntityPersister
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity payloadEntity,
       TrackedEntity currentEntity,
-      UserDetails user) {
+      UserDetails user,
+      ChangeLogAccumulator changeLogs) {
     // DO NOTHING - TE HAVE NO DATA VALUES
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerType;
@@ -53,8 +54,9 @@ public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
 
-  public TrackedEntityPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public TrackedEntityPersister(
+      ReservedValueService reservedValueService, DhisConfigurationProvider config) {
+    super(reservedValueService, config);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
@@ -50,7 +50,7 @@ class ChangeLogAccumulatorTest {
 
   @BeforeEach
   void setUp() {
-    accumulator = new ChangeLogAccumulator();
+    accumulator = new ChangeLogAccumulator(true);
 
     trackedEntity = new TrackedEntity();
     attribute = new TrackedEntityAttribute();
@@ -101,6 +101,19 @@ class ChangeLogAccumulatorTest {
     ChangeLogAccumulator.Mark afterRollback = accumulator.mark();
     assertEquals(1, afterRollback.teSize());
     assertEquals(1, afterRollback.eventSize());
+  }
+
+  @Test
+  void addIsNoOpWhenDisabled() {
+    ChangeLogAccumulator disabled = new ChangeLogAccumulator(false);
+
+    disabled.addTrackedEntityChangeLog(trackedEntity, attribute, null, "value", CREATE, "admin");
+    disabled.addEventChangeLog(event, dataElement, null, "value", CREATE, "admin");
+    disabled.addEventFieldChangeLog(event, "occurredAt", null, "2024-01-01", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = disabled.mark();
+    assertEquals(0, mark.teSize());
+    assertEquals(0, mark.eventSize());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ChangeLogAccumulatorTest {
+
+  private ChangeLogAccumulator accumulator;
+
+  private TrackedEntity trackedEntity;
+  private TrackedEntityAttribute attribute;
+  private Event event;
+  private DataElement dataElement;
+
+  @BeforeEach
+  void setUp() {
+    accumulator = new ChangeLogAccumulator();
+
+    trackedEntity = new TrackedEntity();
+    attribute = new TrackedEntityAttribute();
+    event = new Event();
+    dataElement = new DataElement();
+  }
+
+  @Test
+  void addTrackedEntityChangeLog() {
+    accumulator.addTrackedEntityChangeLog(trackedEntity, attribute, null, "value", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+    assertEquals(1, mark.teSize());
+  }
+
+  @Test
+  void addEventChangeLog() {
+    accumulator.addEventChangeLog(event, dataElement, null, "value", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+    assertEquals(1, mark.eventSize());
+  }
+
+  @Test
+  void addEventFieldChangeLog() {
+    accumulator.addEventFieldChangeLog(event, "occurredAt", null, "2024-01-01", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+    assertEquals(1, mark.eventSize());
+  }
+
+  @Test
+  void rollbackToDiscardEntriesAfterMark() {
+    accumulator.addTrackedEntityChangeLog(trackedEntity, attribute, null, "v1", CREATE, "admin");
+    accumulator.addEventChangeLog(event, dataElement, null, "v1", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+
+    accumulator.addTrackedEntityChangeLog(trackedEntity, attribute, null, "v2", CREATE, "admin");
+    accumulator.addEventChangeLog(event, dataElement, null, "v2", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark afterAdd = accumulator.mark();
+    assertEquals(2, afterAdd.teSize());
+    assertEquals(2, afterAdd.eventSize());
+
+    accumulator.rollbackTo(mark);
+
+    ChangeLogAccumulator.Mark afterRollback = accumulator.mark();
+    assertEquals(1, afterRollback.teSize());
+    assertEquals(1, afterRollback.eventSize());
+  }
+
+  @Test
+  void rollbackToIsNoOpWhenNoEntriesAdded() {
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+
+    accumulator.rollbackTo(mark);
+
+    ChangeLogAccumulator.Mark afterRollback = accumulator.mark();
+    assertEquals(0, afterRollback.teSize());
+    assertEquals(0, afterRollback.eventSize());
+  }
+}


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/23510

On master, changelog is controlled per-entity via `Program.enableChangeLog` and `TrackedEntityType.enableChangeLog`. The master `ChangeLogAccumulator` checks these directly.

On 2.42, changelog is controlled by a global system config `CHANGELOG_TRACKER`. This backport adds the `CHANGELOG_TRACKER` config check to `ChangeLogAccumulator` via a `boolean enabled` constructor parameter, passed from `AbstractTrackerPersister` which reads the config at the start of the persist phase.
