### PR TITLE
chore: re-enable disabled oauth2 test

### DIFF
--- a/dhis-2/.gitignore
+++ b/dhis-2/.gitignore
@@ -63,3 +63,30 @@ http-client.private.env.json
 
 # Performance test env files
 run-simulation*.env
+
+
+
+# Local developer workspace (not for commit)
+/scripts/
+/http/
+/sql/
+/notes/
+/binaries/
+/doc/
+/nginx/
+/oauth2_cli_demo/
+/.agents/
+/.codex/
+/.agent/
+/artifacts/
+/___CURRENTPLAN___*
+/.sonarlint/
+/.jira-mcp
+/.github
+/jenkinsfiles
+/dhis-test-performance/ERRORS.md
+CLAUDE.md
+AGENTS.md
+.entire/
+# Performance test env files
+run-simulation*.env

--- a/dhis-2/.gitignore
+++ b/dhis-2/.gitignore
@@ -63,30 +63,3 @@ http-client.private.env.json
 
 # Performance test env files
 run-simulation*.env
-
-
-
-# Local developer workspace (not for commit)
-/scripts/
-/http/
-/sql/
-/notes/
-/binaries/
-/doc/
-/nginx/
-/oauth2_cli_demo/
-/.agents/
-/.codex/
-/.agent/
-/artifacts/
-/___CURRENTPLAN___*
-/.sonarlint/
-/.jira-mcp
-/.github
-/jenkinsfiles
-/dhis-test-performance/ERRORS.md
-CLAUDE.md
-AGENTS.md
-.entire/
-# Performance test env files
-run-simulation*.env

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -153,7 +153,7 @@ class OAuth2Test extends BaseE2ETest {
 
   @RepeatedTest(value = 10, name = "Get Access Token Test {currentRepetition}/{totalRepetitions}")
   void testGetAccessToken(TestInfo testInfo)
-      throws MalformedURLException, JsonProcessingException, InterruptedException {
+      throws MalformedURLException, JsonProcessingException {
     String testName = testInfo.getDisplayName();
     log.info("[{}] === START ===", testName);
 
@@ -207,7 +207,6 @@ class OAuth2Test extends BaseE2ETest {
     // detects it, not in a separate getCurrentUrl() call afterwards.
     String redirectUrl = wait.until(d -> {
       String url = d.getCurrentUrl();
-      log.debug("[{}] polling redirect, currentUrl={}", testName, url);
       return url.contains(REDIRECT_URI) ? url : null;
     });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
@@ -215,8 +214,7 @@ class OAuth2Test extends BaseE2ETest {
     String code = extractAuthorizationCode(redirectUrl, testName);
 
     log.info("[{}] authorization code extracted, length={}", testName, code.length());
-    assertTrue(
-        code.length() == 128,
+    assertEquals(128, code.length(),
         "code has wrong size: '" + code + "', code length: " + code.length()
             + ", full redirectUrl: " + redirectUrl);
 
@@ -226,7 +224,7 @@ class OAuth2Test extends BaseE2ETest {
     assertNotNull(accessToken);
     log.info("[{}] access token received, length={}", testName, accessToken.length());
 
-    String actualIssuerUri = null;
+    String actualIssuerUri;
     String expectedIssuerUri = "http://web:8080/";
 
     // Decode the access_token
@@ -268,7 +266,7 @@ class OAuth2Test extends BaseE2ETest {
    */
   @Test
   void testBearerTokenAuthWithMatchingUser(TestInfo testInfo)
-      throws MalformedURLException, JsonProcessingException, InterruptedException {
+      throws MalformedURLException, JsonProcessingException {
     String testName = testInfo.getDisplayName();
     log.info("[{}] === START ===", testName);
 
@@ -337,7 +335,6 @@ class OAuth2Test extends BaseE2ETest {
     // Capture redirect URL atomically (see comment in testGetAccessToken)
     String redirectUrl = wait.until(d -> {
       String url = d.getCurrentUrl();
-      log.debug("[{}] polling redirect, currentUrl={}", testName, url);
       return url.contains(REDIRECT_URI) ? url : null;
     });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -71,12 +71,12 @@ import org.springframework.http.ResponseEntity;
 @Slf4j
 class OAuth2Test extends BaseE2ETest {
 
-  private static final String REDIRECT_URI =
-      "http://localhost:9090/oauth2/code/dhis2-client";
+  private static final String REDIRECT_URI = "http://localhost:9090/oauth2/code/dhis2-client";
 
   private static final String AUTHORIZE_PARAMS =
       "/oauth2/authorize?response_type=code&client_id=dhis2-client"
-          + "&redirect_uri=" + REDIRECT_URI
+          + "&redirect_uri="
+          + REDIRECT_URI
           + "&scope=openid%20email";
 
   private WebDriver driver;
@@ -101,8 +101,11 @@ class OAuth2Test extends BaseE2ETest {
     // When testing with docker, use this: http://host.docker.internal:8080
     serverHostUrl = TestConfiguration.get().baseUrl().replace("/api", "");
 
-    log.info("[setup] seleniumUrl={}, serverApiUrl={}, serverHostUrl={}",
-        seleniumUrl, serverApiUrl, serverHostUrl);
+    log.info(
+        "[setup] seleniumUrl={}, serverApiUrl={}, serverHostUrl={}",
+        seleniumUrl,
+        serverApiUrl,
+        serverHostUrl);
 
     orgUnitUID = createOrgUnit();
     log.info("[setup] created orgUnit uid={}", orgUnitUID);
@@ -152,8 +155,7 @@ class OAuth2Test extends BaseE2ETest {
   }
 
   @RepeatedTest(value = 10, name = "Get Access Token Test {currentRepetition}/{totalRepetitions}")
-  void testGetAccessToken(TestInfo testInfo)
-      throws MalformedURLException, JsonProcessingException {
+  void testGetAccessToken(TestInfo testInfo) throws MalformedURLException, JsonProcessingException {
     String testName = testInfo.getDisplayName();
     log.info("[{}] === START ===", testName);
 
@@ -191,9 +193,7 @@ class OAuth2Test extends BaseE2ETest {
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".form-check")));
     String consentPageUrl = driver.getCurrentUrl();
     log.info("[{}] consent page loaded, url={}", testName, consentPageUrl);
-    assertEquals(
-        serverHostUrl + AUTHORIZE_PARAMS,
-        consentPageUrl);
+    assertEquals(serverHostUrl + AUTHORIZE_PARAMS, consentPageUrl);
 
     // Give consent
     ConsentPage consentPage = new ConsentPage(driver);
@@ -205,18 +205,26 @@ class OAuth2Test extends BaseE2ETest {
     // The redirect goes to localhost:9090 which doesn't exist, so Chrome will quickly
     // navigate to an error page — we must capture the URL in the same poll cycle that
     // detects it, not in a separate getCurrentUrl() call afterwards.
-    String redirectUrl = wait.until(d -> {
-      String url = d.getCurrentUrl();
-      return url.contains(REDIRECT_URI) ? url : null;
-    });
+    String redirectUrl =
+        wait.until(
+            d -> {
+              String url = d.getCurrentUrl();
+              return url.contains(REDIRECT_URI) ? url : null;
+            });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
 
     String code = extractAuthorizationCode(redirectUrl, testName);
 
     log.info("[{}] authorization code extracted, length={}", testName, code.length());
-    assertEquals(128, code.length(),
-        "code has wrong size: '" + code + "', code length: " + code.length()
-            + ", full redirectUrl: " + redirectUrl);
+    assertEquals(
+        128,
+        code.length(),
+        "code has wrong size: '"
+            + code
+            + "', code length: "
+            + code.length()
+            + ", full redirectUrl: "
+            + redirectUrl);
 
     // Call the token endpoint with the authorization code and get access token
     log.info("[{}] exchanging code for access token", testName);
@@ -276,7 +284,8 @@ class OAuth2Test extends BaseE2ETest {
 
     // Create user with openId set to email so JWT bearer auth can find the user.
     // The JWT auth resolver maps the "email" claim to User.openId via getUserByOpenId().
-    log.info("[{}] creating user with openId mapping, username={}, email={}", testName, username, email);
+    log.info(
+        "[{}] creating user with openId mapping, username={}, email={}", testName, username, email);
     Map<String, Object> userMap =
         Map.of(
             "username",
@@ -297,8 +306,11 @@ class OAuth2Test extends BaseE2ETest {
             List.of(Map.of("id", orgUnitUID)));
 
     ResponseEntity<String> createResp = postWithAdminBasicAuth("/users", userMap);
-    log.info("[{}] user creation response: status={}, body={}",
-        testName, createResp.getStatusCode(), createResp.getBody());
+    log.info(
+        "[{}] user creation response: status={}, body={}",
+        testName,
+        createResp.getStatusCode(),
+        createResp.getBody());
     JsonNode createJson = objectMapper.readTree(createResp.getBody());
     String uid = createJson.get("response").get("uid").asText();
     assertNotNull(uid);
@@ -333,10 +345,12 @@ class OAuth2Test extends BaseE2ETest {
     log.info("[{}] consent submitted, waiting for redirect", testName);
 
     // Capture redirect URL atomically (see comment in testGetAccessToken)
-    String redirectUrl = wait.until(d -> {
-      String url = d.getCurrentUrl();
-      return url.contains(REDIRECT_URI) ? url : null;
-    });
+    String redirectUrl =
+        wait.until(
+            d -> {
+              String url = d.getCurrentUrl();
+              return url.contains(REDIRECT_URI) ? url : null;
+            });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
 
     String code = extractAuthorizationCode(redirectUrl, testName);
@@ -354,8 +368,11 @@ class OAuth2Test extends BaseE2ETest {
     // After the fix this should return 200 with the authenticated user's details.
     log.info("[{}] calling /me with bearer JWT", testName);
     ResponseEntity<String> response = getWithBearerJwt(serverApiUrl + "/me", accessToken);
-    log.info("[{}] /me response: status={}, body={}",
-        testName, response.getStatusCode(), response.getBody());
+    log.info(
+        "[{}] /me response: status={}, body={}",
+        testName,
+        response.getStatusCode(),
+        response.getBody());
     assertEquals(
         HttpStatus.OK,
         response.getStatusCode(),
@@ -374,8 +391,7 @@ class OAuth2Test extends BaseE2ETest {
     log.info("[getAccessToken] token endpoint response body: {}", body);
     JsonNode jsonNode = objectMapper.readTree(body);
     JsonNode accessToken = jsonNode.get("access_token");
-    assertNotNull(accessToken,
-        "No 'access_token' field in token response: " + body);
+    assertNotNull(accessToken, "No 'access_token' field in token response: " + body);
     return accessToken.asText();
   }
 
@@ -396,19 +412,19 @@ class OAuth2Test extends BaseE2ETest {
   }
 
   /**
-   * Extracts the authorization code from a redirect URL like
-   * {@code http://localhost:9090/oauth2/code/dhis2-client?code=XXXXX}.
+   * Extracts the authorization code from a redirect URL like {@code
+   * http://localhost:9090/oauth2/code/dhis2-client?code=XXXXX}.
    *
-   * <p>Parses the query string properly instead of using brittle indexOf, and logs
-   * diagnostics for CI debugging.
+   * <p>Parses the query string properly instead of using brittle indexOf, and logs diagnostics for
+   * CI debugging.
    */
   private static String extractAuthorizationCode(String redirectUrl, String testName) {
     assertNotNull(redirectUrl, "redirectUrl is null");
     assertFalse(redirectUrl.isBlank(), "redirectUrl is blank");
 
     int queryStart = redirectUrl.indexOf('?');
-    assertTrue(queryStart > 0,
-        "[" + testName + "] redirect URL has no query string: " + redirectUrl);
+    assertTrue(
+        queryStart > 0, "[" + testName + "] redirect URL has no query string: " + redirectUrl);
 
     String query = redirectUrl.substring(queryStart + 1);
     log.info("[{}] redirect query string: {}", testName, query);
@@ -422,9 +438,9 @@ class OAuth2Test extends BaseE2ETest {
       }
     }
 
-    assertNotNull(code,
-        "[" + testName + "] no 'code' parameter in redirect URL: " + redirectUrl);
-    assertFalse(code.isBlank(),
+    assertNotNull(code, "[" + testName + "] no 'code' parameter in redirect URL: " + redirectUrl);
+    assertFalse(
+        code.isBlank(),
         "[" + testName + "] 'code' parameter is blank in redirect URL: " + redirectUrl);
 
     return code;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -205,11 +205,13 @@ class OAuth2Test extends BaseE2ETest {
     // The redirect goes to localhost:9090 which doesn't exist, so Chrome will quickly
     // navigate to an error page — we must capture the URL in the same poll cycle that
     // detects it, not in a separate getCurrentUrl() call afterwards.
+    // IMPORTANT: use startsWith, not contains — the authorize URL itself contains
+    // the REDIRECT_URI as a query parameter value, so contains() would match it too.
     String redirectUrl =
         wait.until(
             d -> {
               String url = d.getCurrentUrl();
-              return url.contains(REDIRECT_URI) ? url : null;
+              return url.startsWith(REDIRECT_URI) ? url : null;
             });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
 
@@ -349,7 +351,7 @@ class OAuth2Test extends BaseE2ETest {
         wait.until(
             d -> {
               String url = d.getCurrentUrl();
-              return url.contains(REDIRECT_URI) ? url : null;
+              return url.startsWith(REDIRECT_URI) ? url : null;
             });
     log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -67,7 +67,6 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
 @Tag("oauth2tests")
-@Disabled("Started failing on master. testGetAccessToken times out, needs investigation")
 @Slf4j
 class OAuth2Test extends BaseE2ETest {
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.uitest.ConsentPage;
 import org.hisp.dhis.uitest.LoginPage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -51,10 +51,12 @@ import org.hisp.dhis.test.e2e.helpers.config.TestConfiguration;
 import org.hisp.dhis.uitest.ConsentPage;
 import org.hisp.dhis.uitest.LoginPage;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -69,7 +71,15 @@ import org.springframework.http.ResponseEntity;
 @Slf4j
 class OAuth2Test extends BaseE2ETest {
 
-  private static WebDriver driver;
+  private static final String REDIRECT_URI =
+      "http://localhost:9090/oauth2/code/dhis2-client";
+
+  private static final String AUTHORIZE_PARAMS =
+      "/oauth2/authorize?response_type=code&client_id=dhis2-client"
+          + "&redirect_uri=" + REDIRECT_URI
+          + "&scope=openid%20email";
+
+  private WebDriver driver;
 
   // Selenium URL if running locally
   private static String seleniumUrl = "http://localhost:4444";
@@ -91,8 +101,14 @@ class OAuth2Test extends BaseE2ETest {
     // When testing with docker, use this: http://host.docker.internal:8080
     serverHostUrl = TestConfiguration.get().baseUrl().replace("/api", "");
 
+    log.info("[setup] seleniumUrl={}, serverApiUrl={}, serverHostUrl={}",
+        seleniumUrl, serverApiUrl, serverHostUrl);
+
     orgUnitUID = createOrgUnit();
+    log.info("[setup] created orgUnit uid={}", orgUnitUID);
+
     setupOAuth2Client();
+    log.info("[setup] OAuth2 client created");
   }
 
   static void setupOAuth2Client() throws JsonProcessingException {
@@ -102,7 +118,7 @@ class OAuth2Test extends BaseE2ETest {
             "clientSecret", "$2a$12$FtWBAB.hWkR3SSul7.HWROr8/aEuUEjywnB86wrYz0HtHh4iam6/G",
             "clientAuthenticationMethods", "client_secret_post",
             "authorizationGrantTypes", "refresh_token,authorization_code",
-            "redirectUris", "http://localhost:9090/oauth2/code/dhis2-client",
+            "redirectUris", REDIRECT_URI,
             "postLogoutRedirectUris", "http://127.0.0.1:8080/",
             "scopes", "email_verified,openid,profile,email");
 
@@ -118,124 +134,130 @@ class OAuth2Test extends BaseE2ETest {
     assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
   }
 
+  @AfterEach
+  void cleanupDriver() {
+    if (driver != null) {
+      try {
+        driver.quit();
+      } catch (Exception e) {
+        log.warn("[cleanupDriver] failed to quit WebDriver", e);
+      }
+      driver = null;
+    }
+  }
+
   @AfterAll
   static void tearDown() {
-    if (driver != null) driver.quit();
     invalidateAllSession();
   }
 
   @RepeatedTest(value = 10, name = "Get Access Token Test {currentRepetition}/{totalRepetitions}")
-  void testGetAccessToken()
+  void testGetAccessToken(TestInfo testInfo)
       throws MalformedURLException, JsonProcessingException, InterruptedException {
+    String testName = testInfo.getDisplayName();
+    log.info("[{}] === START ===", testName);
+
     String username = CodeGenerator.generateCode(8);
     String password = "Test123###...";
+    log.info("[{}] creating superuser username={}", testName, username);
     createSuperuser(username, password, orgUnitUID);
+    log.info("[{}] superuser created", testName);
 
-    ChromeOptions chromeOptions = new ChromeOptions();
-    chromeOptions.addArguments("--remote-allow-origins=*");
-    chromeOptions.addArguments("--no-sandbox");
-    chromeOptions.addArguments("--disable-dev-shm-usage");
-    chromeOptions.addArguments("--disable-gpu");
-    chromeOptions.setPageLoadTimeout(Duration.ofSeconds(60));
-
-    driver = new RemoteWebDriver(new URL(seleniumUrl), chromeOptions);
+    driver = createDriver();
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));
 
     // Call the authorize endpoint
-    driver.get(
-        serverHostUrl
-            + "/oauth2/authorize?response_type=code&client_id=dhis2-client&redirect_uri=http://localhost:9090/oauth2/code/dhis2-client&scope=openid%20email");
+    String authorizeUrl = serverHostUrl + AUTHORIZE_PARAMS;
+    log.info("[{}] navigating to authorize URL: {}", testName, authorizeUrl);
+    driver.get(authorizeUrl);
+
     wait.until(ExpectedConditions.urlContains(serverHostUrl + "/login/"));
     String currentUrl = driver.getCurrentUrl();
+    log.info("[{}] redirected to login page: {}", testName, currentUrl);
     assertEquals(serverHostUrl + "/login/", currentUrl);
 
     // Wait for the login page to load
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("input#username")));
+    log.info("[{}] login page loaded, entering credentials", testName);
 
     // Login
     LoginPage mainPage = new LoginPage(driver);
     mainPage.inputUsername.sendKeys(username);
     mainPage.inputPassword.sendKeys(password);
     mainPage.inputSubmit.click();
+    log.info("[{}] login submitted, waiting for consent page", testName);
 
     // Wait for the consent page to load
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".form-check")));
     String consentPageUrl = driver.getCurrentUrl();
+    log.info("[{}] consent page loaded, url={}", testName, consentPageUrl);
     assertEquals(
-        serverHostUrl
-            + "/oauth2/authorize?response_type=code&client_id=dhis2-client&redirect_uri=http://localhost:9090/oauth2/code/dhis2-client&scope=openid%20email",
+        serverHostUrl + AUTHORIZE_PARAMS,
         consentPageUrl);
 
     // Give consent
     ConsentPage consentPage = new ConsentPage(driver);
     consentPage.emailCheckbox.click();
     consentPage.submitButton.click();
+    log.info("[{}] consent submitted, waiting for redirect to {}", testName, REDIRECT_URI);
 
-    // Wait for the redirect to happen
-    wait.until(ExpectedConditions.urlContains("http://localhost:9090/oauth2/code/dhis2-client"));
-    int codeStartIndex = driver.getCurrentUrl().indexOf("code=") + 5;
+    // Wait for redirect and capture the URL atomically inside the wait callback.
+    // The redirect goes to localhost:9090 which doesn't exist, so Chrome will quickly
+    // navigate to an error page — we must capture the URL in the same poll cycle that
+    // detects it, not in a separate getCurrentUrl() call afterwards.
+    String redirectUrl = wait.until(d -> {
+      String url = d.getCurrentUrl();
+      log.debug("[{}] polling redirect, currentUrl={}", testName, url);
+      return url.contains(REDIRECT_URI) ? url : null;
+    });
+    log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
 
-    // Workaround for weird behavior in some cases, where the getCurrentUrl() returns an empty
-    // string.
-    if (codeStartIndex < 6) {
-      log.error("Failed to fetch current url, sleep and retry: " + driver.getCurrentUrl());
-      Thread.sleep(1000);
-      int tries = 0;
-      while (codeStartIndex < 6 && tries < 5) {
-        codeStartIndex = driver.getCurrentUrl().indexOf("code=") + 5;
-        tries++;
-        Thread.sleep(333);
-      }
-    }
-    assertTrue(codeStartIndex > 5, "codeStartIndex is not valid codeStartIndex: " + codeStartIndex);
+    String code = extractAuthorizationCode(redirectUrl, testName);
 
-    String code = driver.getCurrentUrl().substring(codeStartIndex);
-    assertNotNull(code);
-    assertNotNull(code, "code is null");
-    assertFalse(code.isBlank(), "code is empty");
-    log.info("Authorization code: " + code);
-
+    log.info("[{}] authorization code extracted, length={}", testName, code.length());
     assertTrue(
-        code.length() == 128, "code has wrong size: '" + code + "', code length: " + code.length());
+        code.length() == 128,
+        "code has wrong size: '" + code + "', code length: " + code.length()
+            + ", full redirectUrl: " + redirectUrl);
 
     // Call the token endpoint with the authorization code and get access token
+    log.info("[{}] exchanging code for access token", testName);
     String accessToken = getAccessToken(code);
+    assertNotNull(accessToken);
+    log.info("[{}] access token received, length={}", testName, accessToken.length());
 
     String actualIssuerUri = null;
     String expectedIssuerUri = "http://web:8080/";
 
-    // 6. Decode the access_token
+    // Decode the access_token
     try {
       SignedJWT signedJWT = SignedJWT.parse(accessToken);
       JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-      // 3. Extract the actual issuer URI from the token's "iss" claim
       actualIssuerUri = claimsSet.getIssuer();
+      log.info("[{}] JWT issuer: {}", testName, actualIssuerUri);
     } catch (ParseException e) {
-      log.info("Parsing failed", e);
+      log.error("[{}] JWT parsing failed, accessToken={}", testName, accessToken, e);
       throw new RuntimeException(e);
     }
-    // 5. Assert that the actual issuer URI matches the configured SERVER_BASE_URL
     assertEquals(
         expectedIssuerUri,
         actualIssuerUri,
         "The JWT issuer URI should match the configured SERVER_BASE_URL.");
 
-    assertNotNull(accessToken);
-    log.info("Access token: " + accessToken);
-
     // Call the /me endpoint with the access token
+    log.info("[{}] calling /me with bearer JWT", testName);
     ResponseEntity<String> withBearerJwt = getWithBearerJwt(serverApiUrl + "/me", accessToken);
     HttpStatusCode statusCode = withBearerJwt.getStatusCode();
-    assertEquals(HttpStatus.UNAUTHORIZED, statusCode);
     String body = withBearerJwt.getBody();
-    assertNotNull(body);
+    log.info("[{}] /me response: status={}, body={}", testName, statusCode, body);
 
-    log.info("Body: " + body);
+    assertEquals(HttpStatus.UNAUTHORIZED, statusCode);
+    assertNotNull(body);
     assertTrue(
         body.contains(
             "Found no matching DHIS2 user for the mapping claim: 'email' with the value:"));
 
-    driver.quit();
+    log.info("[{}] === PASS ===", testName);
   }
 
   /**
@@ -245,14 +267,18 @@ class OAuth2Test extends BaseE2ETest {
    * instead, which has authorities eagerly loaded.
    */
   @Test
-  void testBearerTokenAuthWithMatchingUser()
+  void testBearerTokenAuthWithMatchingUser(TestInfo testInfo)
       throws MalformedURLException, JsonProcessingException, InterruptedException {
+    String testName = testInfo.getDisplayName();
+    log.info("[{}] === START ===", testName);
+
     String username = CodeGenerator.generateCode(8);
     String password = "Test123###...";
     String email = username + "@email.com";
 
     // Create user with openId set to email so JWT bearer auth can find the user.
     // The JWT auth resolver maps the "email" claim to User.openId via getUserByOpenId().
+    log.info("[{}] creating user with openId mapping, username={}, email={}", testName, username, email);
     Map<String, Object> userMap =
         Map.of(
             "username",
@@ -273,65 +299,66 @@ class OAuth2Test extends BaseE2ETest {
             List.of(Map.of("id", orgUnitUID)));
 
     ResponseEntity<String> createResp = postWithAdminBasicAuth("/users", userMap);
+    log.info("[{}] user creation response: status={}, body={}",
+        testName, createResp.getStatusCode(), createResp.getBody());
     JsonNode createJson = objectMapper.readTree(createResp.getBody());
     String uid = createJson.get("response").get("uid").asText();
     assertNotNull(uid);
+    log.info("[{}] user created, uid={}", testName, uid);
 
-    ChromeOptions chromeOptions = new ChromeOptions();
-    chromeOptions.addArguments("--remote-allow-origins=*");
-    chromeOptions.addArguments("--no-sandbox");
-    chromeOptions.addArguments("--disable-dev-shm-usage");
-    chromeOptions.addArguments("--disable-gpu");
-    chromeOptions.setPageLoadTimeout(Duration.ofSeconds(60));
-
-    driver = new RemoteWebDriver(new URL(seleniumUrl), chromeOptions);
+    driver = createDriver();
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));
 
     // Start OAuth2 authorization code flow
-    driver.get(
-        serverHostUrl
-            + "/oauth2/authorize?response_type=code&client_id=dhis2-client&redirect_uri=http://localhost:9090/oauth2/code/dhis2-client&scope=openid%20email");
+    String authorizeUrl = serverHostUrl + AUTHORIZE_PARAMS;
+    log.info("[{}] navigating to authorize URL: {}", testName, authorizeUrl);
+    driver.get(authorizeUrl);
+
     wait.until(ExpectedConditions.urlContains(serverHostUrl + "/login/"));
+    log.info("[{}] redirected to login page: {}", testName, driver.getCurrentUrl());
 
     // Login
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("input#username")));
+    log.info("[{}] login page loaded, entering credentials", testName);
     LoginPage mainPage = new LoginPage(driver);
     mainPage.inputUsername.sendKeys(username);
     mainPage.inputPassword.sendKeys(password);
     mainPage.inputSubmit.click();
+    log.info("[{}] login submitted, waiting for consent page", testName);
 
     // Give consent
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".form-check")));
+    log.info("[{}] consent page loaded, url={}", testName, driver.getCurrentUrl());
     ConsentPage consentPage = new ConsentPage(driver);
     consentPage.emailCheckbox.click();
     consentPage.submitButton.click();
+    log.info("[{}] consent submitted, waiting for redirect", testName);
 
-    // Extract authorization code from redirect
-    wait.until(ExpectedConditions.urlContains("http://localhost:9090/oauth2/code/dhis2-client"));
-    int codeStartIndex = driver.getCurrentUrl().indexOf("code=") + 5;
-    if (codeStartIndex < 6) {
-      log.error("Failed to fetch current url, sleep and retry: " + driver.getCurrentUrl());
-      Thread.sleep(1000);
-      int tries = 0;
-      while (codeStartIndex < 6 && tries < 5) {
-        codeStartIndex = driver.getCurrentUrl().indexOf("code=") + 5;
-        tries++;
-        Thread.sleep(333);
-      }
-    }
-    assertTrue(codeStartIndex > 5, "codeStartIndex is not valid: " + codeStartIndex);
-    String code = driver.getCurrentUrl().substring(codeStartIndex);
+    // Capture redirect URL atomically (see comment in testGetAccessToken)
+    String redirectUrl = wait.until(d -> {
+      String url = d.getCurrentUrl();
+      log.debug("[{}] polling redirect, currentUrl={}", testName, url);
+      return url.contains(REDIRECT_URI) ? url : null;
+    });
+    log.info("[{}] captured redirect URL: {}", testName, redirectUrl);
+
+    String code = extractAuthorizationCode(redirectUrl, testName);
     assertFalse(code.isBlank(), "code is empty");
+    log.info("[{}] authorization code extracted, length={}", testName, code.length());
 
     // Exchange code for access token
+    log.info("[{}] exchanging code for access token", testName);
     String accessToken = getAccessToken(code);
     assertNotNull(accessToken);
-    log.info("Access token for matching user test: " + accessToken);
+    log.info("[{}] access token received, length={}", testName, accessToken.length());
 
     // Call /me with the JWT bearer token.
     // Before the fix this returned 500 (LazyInitializationException on User.userRoles).
     // After the fix this should return 200 with the authenticated user's details.
+    log.info("[{}] calling /me with bearer JWT", testName);
     ResponseEntity<String> response = getWithBearerJwt(serverApiUrl + "/me", accessToken);
+    log.info("[{}] /me response: status={}, body={}",
+        testName, response.getStatusCode(), response.getBody());
     assertEquals(
         HttpStatus.OK,
         response.getStatusCode(),
@@ -341,15 +368,68 @@ class OAuth2Test extends BaseE2ETest {
     JsonNode meJson = objectMapper.readTree(response.getBody());
     assertEquals(username, meJson.get("username").asText());
 
-    driver.quit();
+    log.info("[{}] === PASS ===", testName);
   }
 
   public String getAccessToken(String code) throws JsonProcessingException {
     String body = callTokenEndpoint(code);
-    assertNotNull(body);
+    assertNotNull(body, "Token endpoint returned null body");
+    log.info("[getAccessToken] token endpoint response body: {}", body);
     JsonNode jsonNode = objectMapper.readTree(body);
     JsonNode accessToken = jsonNode.get("access_token");
-    assertNotNull(accessToken);
+    assertNotNull(accessToken,
+        "No 'access_token' field in token response: " + body);
     return accessToken.asText();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private WebDriver createDriver() throws MalformedURLException {
+    ChromeOptions chromeOptions = new ChromeOptions();
+    chromeOptions.addArguments("--remote-allow-origins=*");
+    chromeOptions.addArguments("--no-sandbox");
+    chromeOptions.addArguments("--disable-dev-shm-usage");
+    chromeOptions.addArguments("--disable-gpu");
+    chromeOptions.setPageLoadTimeout(Duration.ofSeconds(60));
+    WebDriver wd = new RemoteWebDriver(new URL(seleniumUrl), chromeOptions);
+    log.info("[createDriver] new WebDriver session created");
+    return wd;
+  }
+
+  /**
+   * Extracts the authorization code from a redirect URL like
+   * {@code http://localhost:9090/oauth2/code/dhis2-client?code=XXXXX}.
+   *
+   * <p>Parses the query string properly instead of using brittle indexOf, and logs
+   * diagnostics for CI debugging.
+   */
+  private static String extractAuthorizationCode(String redirectUrl, String testName) {
+    assertNotNull(redirectUrl, "redirectUrl is null");
+    assertFalse(redirectUrl.isBlank(), "redirectUrl is blank");
+
+    int queryStart = redirectUrl.indexOf('?');
+    assertTrue(queryStart > 0,
+        "[" + testName + "] redirect URL has no query string: " + redirectUrl);
+
+    String query = redirectUrl.substring(queryStart + 1);
+    log.info("[{}] redirect query string: {}", testName, query);
+
+    // Parse query params — code might not be the only parameter
+    String code = null;
+    for (String param : query.split("&")) {
+      if (param.startsWith("code=")) {
+        code = param.substring(5);
+        break;
+      }
+    }
+
+    assertNotNull(code,
+        "[" + testName + "] no 'code' parameter in redirect URL: " + redirectUrl);
+    assertFalse(code.isBlank(),
+        "[" + testName + "] 'code' parameter is blank in redirect URL: " + redirectUrl);
+
+    return code;
   }
 }


### PR DESCRIPTION
## Summary
Re-enables disabled flaky test. The test did not need any changes to pass again, but some safeguards against potential race conditions during fetching of the result was added.
Using WebDriverWait.until() to get the result, instead of a polling for loop with sleep() that retries.