### PR TITLE
fix: disable cache busting rewrite of immutable resources

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingService.java
@@ -146,7 +146,11 @@ public class HtmlCacheBustingService {
 
   private void rewriteAttribute(Element el, String attr, String param) {
     String url = el.attr(attr).trim();
-    if (url.isEmpty() || isExternal(url) || url.contains("?v=") || url.contains("&v=")) {
+    if (url.isEmpty()
+        || isExternal(url)
+        || url.contains("?v=")
+        || url.contains("&v=")
+        || hasContentHash(url)) {
       return;
     }
     // Split off fragment (#...) — query params must come before the fragment
@@ -158,6 +162,16 @@ public class HtmlCacheBustingService {
     }
     String separator = url.contains("?") ? "&" : "?";
     el.attr(attr, url + separator + param + fragment);
+  }
+
+  /**
+   * Returns {@code true} if the URL contains a content hash from a bundler, making {@code ?v=}
+   * cache-busting redundant. Critically, for ES modules adding {@code ?v=} to the HTML {@code
+   * <script>} tag but not to inter-chunk {@code import()} statements inside the JS causes the
+   * browser to treat them as different modules and fetch+execute the bundle twice.
+   */
+  private static boolean hasContentHash(String url) {
+    return StaticCacheControlService.looksLikeHashedFilename(url);
   }
 
   private boolean isExternal(String url) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
@@ -34,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import lombok.RequiredArgsConstructor;
@@ -215,19 +214,11 @@ public class StaticCacheControlService {
   /**
    * Detects hashed filenames produced by common bundlers. Webpack uses dot-separated lowercase hex
    * ({@code main.abc12345.js}). Vite/Rollup uses dash-separated base64url ({@code
-   * main-Dhu2pmiS.js}, {@code main-D-tfNpnx.js}). The Vite pattern requires at least one uppercase
-   * letter to distinguish hashes from normal dash-separated filenames like {@code
-   * main-component.js}.
+   * main-Dhu2pmiS.js}, {@code main-zwggxcug.js}).
    */
   static boolean looksLikeHashedFilename(String uri) {
     if (WEBPACK_HASH.matcher(uri).find()) return true;
-
-    Matcher m = VITE_HASH.matcher(uri);
-    if (m.find()) {
-      String candidate = m.group(1);
-      return candidate.chars().anyMatch(Character::isUpperCase);
-    }
-    return false;
+    return VITE_HASH.matcher(uri).find();
   }
 
   private boolean isHtmlPath(String uri) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
@@ -219,7 +219,7 @@ public class StaticCacheControlService {
    * letter to distinguish hashes from normal dash-separated filenames like {@code
    * main-component.js}.
    */
-  private static boolean looksLikeHashedFilename(String uri) {
+  static boolean looksLikeHashedFilename(String uri) {
     if (WEBPACK_HASH.matcher(uri).find()) return true;
 
     Matcher m = VITE_HASH.matcher(uri);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
@@ -336,6 +336,64 @@ class HtmlCacheBustingServiceTest {
   }
 
   @Test
+  @DisplayName("Skips assets with content hashes in filenames (Vite-style)")
+  void skipsContentHashedViteAssets() throws IOException {
+    String html =
+        "<html><head>"
+            + "<script type=\"module\" crossorigin src=\"./assets/main-DBGta5R0.js\"></script>"
+            + "<link rel=\"stylesheet\" crossorigin href=\"./assets/main-Dmx4sX17.css\">"
+            + "</head><body>"
+            + "<img src=\"./assets/logo-BxK9a3Qp.png\">"
+            + "</body></html>";
+    App app = appWithCacheBustKey("abc123");
+
+    String result = rewrite(html, app, "/apps/my-app/index.html");
+
+    assertThat(result, containsString("src=\"./assets/main-DBGta5R0.js\""));
+    assertThat(result, not(containsString("main-DBGta5R0.js?v=")));
+    assertThat(result, containsString("href=\"./assets/main-Dmx4sX17.css\""));
+    assertThat(result, not(containsString("main-Dmx4sX17.css?v=")));
+    assertThat(result, containsString("src=\"./assets/logo-BxK9a3Qp.png\""));
+    assertThat(result, not(containsString("logo-BxK9a3Qp.png?v=")));
+  }
+
+  @Test
+  @DisplayName("Skips assets with content hashes in filenames (Webpack-style)")
+  void skipsContentHashedWebpackAssets() throws IOException {
+    String html =
+        "<html><head>"
+            + "<script src=\"static/js/main.abc123ef.js\"></script>"
+            + "<link href=\"static/css/main.9f3b1c2d.css\" rel=\"stylesheet\">"
+            + "</head></html>";
+    App app = appWithCacheBustKey("abc123");
+
+    String result = rewrite(html, app, "/apps/my-app/index.html");
+
+    assertThat(result, not(containsString("?v=")));
+  }
+
+  @Test
+  @DisplayName("Still rewrites non-hashed assets")
+  void rewritesNonHashedAssets() throws IOException {
+    String html =
+        "<html><head>"
+            + "<script src=\"app.js\"></script>"
+            + "<link href=\"style.css\" rel=\"stylesheet\">"
+            + "</head><body>"
+            + "<img src=\"favicon.ico\">"
+            + "<img src=\"favicon-48x48.png\">"
+            + "</body></html>";
+    App app = appWithCacheBustKey("abc123");
+
+    String result = rewrite(html, app, "/apps/my-app/index.html");
+
+    assertThat(result, containsString("src=\"app.js?v=abc123\""));
+    assertThat(result, containsString("href=\"style.css?v=abc123\""));
+    assertThat(result, containsString("src=\"favicon.ico?v=abc123\""));
+    assertThat(result, containsString("src=\"favicon-48x48.png?v=abc123\""));
+  }
+
+  @Test
   @DisplayName("invalidateAll clears the cache")
   void invalidateAllClearsCache() {
     service.invalidateAll();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
@@ -358,6 +358,24 @@ class HtmlCacheBustingServiceTest {
   }
 
   @Test
+  @DisplayName("Skips assets with all-lowercase Vite hash in filenames (deployed pattern)")
+  void skipsContentHashedViteAssetsAllLowercase() throws IOException {
+    String html =
+        "<html><head>"
+            + "<script type=\"module\" crossorigin src=\"./assets/main-zwggxcug.js\"></script>"
+            + "<link rel=\"stylesheet\" crossorigin href=\"./assets/main-Dmx4sX17.css\">"
+            + "</head></html>";
+    App app = appWithCacheBustKey("abc123");
+
+    String result = rewrite(html, app, "/apps/login/index.html");
+
+    assertThat(result, containsString("src=\"./assets/main-zwggxcug.js\""));
+    assertThat(result, not(containsString("main-zwggxcug.js?v=")));
+    assertThat(result, containsString("href=\"./assets/main-Dmx4sX17.css\""));
+    assertThat(result, not(containsString("main-Dmx4sX17.css?v=")));
+  }
+
+  @Test
   @DisplayName("Skips assets with content hashes in filenames (Webpack-style)")
   void skipsContentHashedWebpackAssets() throws IOException {
     String html =

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
@@ -181,12 +181,14 @@ class StaticCacheControlServiceTest {
   }
 
   @Test
-  @DisplayName("Normal dash-separated filename (all lowercase) is NOT treated as hashed")
-  void dashSeparated_allLowercase_notHashed() {
+  @DisplayName("All-lowercase Vite hash gets immutable treatment")
+  void viteHash_allLowercase_getsImmutable() {
     MockHttpServletResponse response = new MockHttpServletResponse();
-    service.setHeaders(response, "/apps/dashboard/main-component.js", null, null);
+    service.setHeaders(response, "/apps/login/assets/main-zwggxcug.js", null, null);
 
-    assertThat(response.getHeader("Cache-Control"), containsString("max-age=3600"));
+    String cc = response.getHeader("Cache-Control");
+    assertThat(cc, containsString("max-age=31536000"));
+    assertThat(cc, containsString("immutable"));
   }
 
   @Test


### PR DESCRIPTION
### Problem
Immutable URLs linked in .html pages, will be rewritten and appended a cache busting parameter. This will result in resources loaded through the global-shell to be loaded twice, one with the parameter and one without.
### Fix 
Don't rewrite URLs that already are considered "immutable", these are URLs that get a hash appended to the filename.