### PR TITLE
chore: Recalibrate user performance tests

### DIFF
--- a/dhis-2/dhis-test-performance/scripts/analyze-user-perf-results.py
+++ b/dhis-2/dhis-test-performance/scripts/analyze-user-perf-results.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Analyze Gatling simulation.csv results across multiple runs to derive calibrated
+assertion thresholds for UsersPerformanceTest.java.
+
+Usage:
+    python3 analyze-user-perf-results.py [--dir ./gatling-downloads] [--slack 1.5]
+
+    --dir    Root directory containing per-run subdirectories (default: ./gatling-downloads)
+    --slack  Multiplier applied to observed p95/max to produce suggested thresholds (default: 1.5)
+
+The script walks all subdirectories, finds simulation.csv files, parses request rows,
+and prints:
+  1. Per-run summary table
+  2. Aggregate stats across all runs
+  3. Suggested assertion thresholds (observed + slack headroom)
+"""
+
+import argparse
+import csv
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def percentile(sorted_vals, p):
+    if not sorted_vals:
+        return 0
+    idx = int(len(sorted_vals) * p / 100)
+    idx = min(idx, len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def load_csv(path: Path) -> dict[str, list[int]]:
+    """Parse a simulation.csv and return {request_name: [response_time_ms, ...]} for OK requests."""
+    times: dict[str, list[int]] = defaultdict(list)
+    try:
+        with path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("record_type") != "request":
+                    continue
+                if row.get("status") != "OK":
+                    continue
+                name = row.get("request_name", "").strip()
+                rt = row.get("response_time_ms", "").strip()
+                if name and rt:
+                    try:
+                        times[name].append(int(rt))
+                    except ValueError:
+                        pass
+    except Exception as e:
+        print(f"  Warning: could not parse {path}: {e}", file=sys.stderr)
+    return times
+
+
+def stats(vals: list[int]) -> dict:
+    if not vals:
+        return {"n": 0, "min": 0, "p50": 0, "p75": 0, "p95": 0, "p99": 0, "max": 0}
+    s = sorted(vals)
+    return {
+        "n": len(s),
+        "min": s[0],
+        "p50": percentile(s, 50),
+        "p75": percentile(s, 75),
+        "p95": percentile(s, 95),
+        "p99": percentile(s, 99),
+        "max": s[-1],
+    }
+
+
+def find_csvs(root: Path) -> list[tuple[str, Path]]:
+    """Find all simulation.csv files, skipping warmup runs, returning (run_label, path) pairs sorted by label."""
+    found = []
+    for csv_path in sorted(root.rglob("simulation.csv")):
+        # Skip warmup runs — they reflect cold JVM state, not steady-state performance
+        if "warmup" in csv_path.parts[-2].lower():
+            continue
+        # Label: the top-level subdir under root (date_runid)
+        parts = csv_path.relative_to(root).parts
+        label = parts[0] if parts else str(csv_path.parent.name)
+        found.append((label, csv_path))
+    return found
+
+
+def print_run_table(label: str, run_data: dict[str, list[int]]):
+    print(f"\n### Run: {label}")
+    header = f"{'Scenario':<38} {'n':>4} {'min':>5} {'p50':>5} {'p75':>5} {'p95':>5} {'p99':>5} {'max':>5}"
+    print(header)
+    print("-" * len(header))
+    for name in sorted(run_data):
+        s = stats(run_data[name])
+        print(
+            f"{name:<38} {s['n']:>4} {s['min']:>5} {s['p50']:>5} {s['p75']:>5} "
+            f"{s['p95']:>5} {s['p99']:>5} {s['max']:>5}"
+        )
+
+
+def suggest_threshold(observed: int, slack: float) -> int:
+    """Round up to the nearest 50ms after applying slack."""
+    raw = observed * slack
+    return int((raw + 49) // 50 * 50)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dir", default="./gatling-downloads", help="Root directory of downloaded results")
+    parser.add_argument("--slack", type=float, default=1.5, help="Slack multiplier for suggested thresholds (default: 1.5)")
+    args = parser.parse_args()
+
+    root = Path(args.dir)
+    if not root.exists():
+        print(f"Error: directory not found: {root}", file=sys.stderr)
+        sys.exit(1)
+
+    csvs = find_csvs(root)
+    if not csvs:
+        print(f"No simulation.csv files found under {root}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Found {len(csvs)} simulation.csv file(s) under {root}")
+    print(f"Slack multiplier: {args.slack}x\n")
+
+    # Per-run tables
+    all_times: dict[str, list[int]] = defaultdict(list)
+    for label, csv_path in csvs:
+        run_data = load_csv(csv_path)
+        print_run_table(label, run_data)
+        for name, times in run_data.items():
+            all_times[name].extend(times)
+
+    # Aggregate table
+    print("\n\n" + "=" * 70)
+    print("## AGGREGATE STATISTICS (all runs combined)")
+    print("=" * 70)
+    header = f"{'Scenario':<38} {'n':>5} {'min':>5} {'p50':>5} {'p75':>5} {'p95':>5} {'p99':>5} {'max':>5}"
+    print(header)
+    print("-" * len(header))
+
+    agg_stats = {}
+    for name in sorted(all_times):
+        s = stats(all_times[name])
+        agg_stats[name] = s
+        print(
+            f"{name:<38} {s['n']:>5} {s['min']:>5} {s['p50']:>5} {s['p75']:>5} "
+            f"{s['p95']:>5} {s['p99']:>5} {s['max']:>5}"
+        )
+
+    # Suggested thresholds
+    print("\n\n" + "=" * 70)
+    print(f"## SUGGESTED ASSERTION THRESHOLDS (slack: {args.slack}x observed p95/max)")
+    print("## Copy these into UsersPerformanceTest.java assertions block")
+    print("=" * 70)
+
+    # Map scenario names to Java constants
+    java_const = {
+        "POST User - create":          ("POST_REQUEST",         "post"),
+        "GET User - by uid":           ("GET_REQUEST",          "get"),
+        "PUT User - full update":      ("PUT_REQUEST",          "put"),
+        "PATCH User - partial update": ("PATCH_REQUEST",        "patch"),
+        "PATCH User - replace userGroups": ("PATCH_GROUPS_REQUEST", "patchGroups"),
+        "POST User - replicate":       ("REPLICA_REQUEST",      "replica"),
+        "DELETE User - delete":        ("DELETE_REQUEST",       "delete"),
+    }
+
+    for name in sorted(agg_stats):
+        s = agg_stats[name]
+        p95_thresh = suggest_threshold(s["p95"], args.slack)
+        max_thresh = suggest_threshold(s["max"], args.slack)
+        const, _ = java_const.get(name, (f'"{name}"', "?"))
+        print(f"\n// {name}  [observed p95={s['p95']}ms, max={s['max']}ms across {s['n']} requests]")
+        print(f"details({const}).responseTime().percentile(95).lt({p95_thresh}),")
+        print(f"details({const}).responseTime().max().lt({max_thresh}),")
+        print(f"details({const}).successfulRequests().percent().is(100D),")
+
+
+if __name__ == "__main__":
+    main()

--- a/dhis-2/dhis-test-performance/scripts/compare-gatling-run.sh
+++ b/dhis-2/dhis-test-performance/scripts/compare-gatling-run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Downloads artifacts from a GitHub Actions performance comparison run and
+# prints a GitHub markdown comparison table.
+#
+# Usage:
+#   ./compare-gatling-run.sh <run-id>
+#
+# Requires: [gh]    (https://cli.github.com)
+#           [gstat] (https://github.com/dhis2/gatling-statistics)
+#           [glog]  (https://github.com/dhis2/gatling/releases)
+#
+# Example:
+#   ./compare-gatling-run.sh 24079806891
+
+set -euo pipefail
+
+REPO="dhis2/dhis2-core"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <run-id>"
+  exit 1
+fi
+
+RUN_ID="$1"
+
+command -v gh    &>/dev/null || { echo "Error: gh not found"    >&2; exit 1; }
+command -v gstat &>/dev/null || { echo "Error: gstat not found. Install with: uv tool install git+https://github.com/dhis2/gatling-statistics" >&2; exit 1; }
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Downloading artifacts for run ${RUN_ID}..." >&2
+gh run download "$RUN_ID" --repo "$REPO" --dir "$WORK_DIR" 2>&1 >&2
+
+# Find the non-warmup baseline and candidate result directories
+BASELINE_DIR=$(find "$WORK_DIR" -maxdepth 2 -type d -name '*-baseline' | sort | tail -n1)
+CANDIDATE_DIR=$(find "$WORK_DIR" -maxdepth 2 -type d -name '*-candidate' | sort | tail -n1)
+
+if [[ -z "$BASELINE_DIR" ]]; then
+  echo "Error: could not find a baseline result directory in the downloaded artifacts" >&2
+  exit 1
+fi
+if [[ -z "$CANDIDATE_DIR" ]]; then
+  echo "Error: could not find a candidate result directory in the downloaded artifacts" >&2
+  exit 1
+fi
+
+echo "Baseline:  $BASELINE_DIR" >&2
+echo "Candidate: $CANDIDATE_DIR" >&2
+
+BTMP=$(mktemp)
+FTMP=$(mktemp)
+trap 'rm -rf "$WORK_DIR"; rm -f "$BTMP" "$FTMP"' EXIT
+
+# gstat CSV columns:
+#   directory,simulation,run_timestamp,request_name,count,min,50th,75th,95th,99th,max
+#   1         2          3              4            5     6   7    8    9    10   11
+gstat "$BASELINE_DIR"  | tail -n +2 > "$BTMP"
+gstat "$CANDIDATE_DIR" | tail -n +2 > "$FTMP"
+
+echo
+echo "> Baseline:  \`$(basename "$BASELINE_DIR")\`"
+echo "> Candidate: \`$(basename "$CANDIDATE_DIR")\`"
+
+print_table() {
+  local col="$1"
+  local heading="$2"
+
+  echo
+  echo "### ${heading} (ms)"
+  echo
+  echo "| Scenario | Baseline | Candidate | Diff | Change |"
+  echo "|:---|---:|---:|---:|:---|"
+
+  awk -F',' -v col="$col" '
+    NR == FNR {
+      if ($4 != "") baseline[$4] = $col + 0
+      next
+    }
+    $4 != "" {
+      name = $4
+      bval = baseline[name] + 0
+      fval = $col + 0
+      diff = fval - bval
+      if (bval > 0) {
+        pct = (diff / bval) * 100
+        pct_str = sprintf("%+.1f%%", pct)
+        if      (diff < 0) change = ":arrow_down: " pct_str
+        else if (diff > 0) change = ":arrow_up: "   pct_str
+        else               change = pct_str
+      } else {
+        change = "N/A"
+      }
+      printf "| %s | %d | %d | %+d | %s |\n", name, bval, fval, diff, change
+    }
+  ' "$BTMP" "$FTMP"
+}
+
+print_table 7 "Median Response Time (p50)"
+print_table 9 "95th Percentile Response Time (p95)"
+
+echo
+echo "_:arrow_down: = faster (improvement), :arrow_up: = slower (regression)_"
+echo

--- a/dhis-2/dhis-test-performance/scripts/download-user-perf-results.sh
+++ b/dhis-2/dhis-test-performance/scripts/download-user-perf-results.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Downloads gatling-report-users-load artifacts from the last N scheduled performance test runs.
+#
+# Usage:
+#   ./download-user-perf-results.sh [--runs N] [--out-dir DIR]
+#
+# Defaults: 10 runs, output to ./gatling-downloads/
+#
+# Requires: gh CLI (authenticated), jq or python3
+
+set -euo pipefail
+
+RUNS=10
+OUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gatling-downloads"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs) RUNS="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR"
+
+echo "Fetching last $RUNS runs from dhis2/dhis2-core performance-tests-scheduled.yml ..."
+
+RUN_IDS=$(gh run list \
+  --repo dhis2/dhis2-core \
+  --workflow performance-tests-scheduled.yml \
+  --limit "$RUNS" \
+  --json databaseId,createdAt \
+  | python3 -c "
+import json, sys
+runs = json.load(sys.stdin)
+for r in runs:
+    print(r['databaseId'], r['createdAt'])
+")
+
+echo "Run IDs (newest first):"
+echo "$RUN_IDS"
+echo
+
+while IFS=' ' read -r run_id created_at; do
+  date_tag="${created_at:0:10}"
+  artifact_name="gatling-report-users-load-${run_id}-attempt-1"
+  dest="$OUT_DIR/${date_tag}_${run_id}"
+
+  if [[ -d "$dest" ]]; then
+    echo "[$date_tag] $run_id — already downloaded, skipping."
+    continue
+  fi
+
+  echo -n "[$date_tag] $run_id — downloading... "
+
+  # Check artifact exists before trying to download
+  count=$(gh api "repos/dhis2/dhis2-core/actions/runs/${run_id}/artifacts" \
+    | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+matches = [a for a in d.get('artifacts', []) if a['name'] == '${artifact_name}']
+print(len(matches))
+")
+
+  if [[ "$count" == "0" ]]; then
+    echo "artifact not found (skipping)."
+    continue
+  fi
+
+  mkdir -p "$dest"
+  if gh run download \
+      --repo dhis2/dhis2-core \
+      "$run_id" \
+      --name "$artifact_name" \
+      --dir "$dest" 2>/dev/null; then
+    echo "done."
+  else
+    rmdir "$dest" 2>/dev/null || true
+    echo "download failed (skipping)."
+  fi
+done <<< "$RUN_IDS"
+
+echo
+echo "Downloads complete. Results in: $OUT_DIR"
+echo "Run analyze-user-perf-results.py to compute metrics."

--- a/dhis-2/dhis-test-performance/scripts/run-compare.sh
+++ b/dhis-2/dhis-test-performance/scripts/run-compare.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Trigger a performance comparison run on GitHub Actions.
+# Edit the variables below, then run: bash scripts/run-compare.sh
+
+PERF_TESTS_GIT_REF="master"
+
+BASELINE_IMAGE="dhis2/core-dev:latest"   # master
+CANDIDATE_IMAGE="dhis2/core-dev:latest"   # perf-oumode-selected-master
+
+SIMULATION_CLASS="org.hisp.dhis.test.tracker.TrackerTest"
+WARMUP=1
+MVN_ARGS="-Dprofile=smoke"
+
+DB_TYPE="sierra-leone"
+DB_VERSION="dev"
+
+# ---------------------------------------------------------------------------
+
+BASELINE_ENV="DHIS2_IMAGE=${BASELINE_IMAGE}
+SIMULATION_CLASS=${SIMULATION_CLASS}
+DB_TYPE=${DB_TYPE}
+DB_VERSION=${DB_VERSION}
+WARMUP=${WARMUP}
+MVN_ARGS=\"${MVN_ARGS}\""
+
+CANDIDATE_ENV="DHIS2_IMAGE=${CANDIDATE_IMAGE}
+SIMULATION_CLASS=${SIMULATION_CLASS}
+DB_TYPE=${DB_TYPE}
+DB_VERSION=${DB_VERSION}
+WARMUP=${WARMUP}
+MVN_ARGS=\"${MVN_ARGS}\""
+
+gh workflow run performance-tests-compare.yml \
+  --repo dhis2/dhis2-core \
+  --field perf_tests_git_ref="${PERF_TESTS_GIT_REF}" \
+  --field baseline_env="${BASELINE_ENV}" \
+  --field candidate_env="${CANDIDATE_ENV}"

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -510,28 +510,38 @@ public class UsersPerformanceTest extends Simulation {
                 replicaPopulation,
                 deletePopulation);
 
+    // Thresholds derived from 10 consecutive nightly runs (2026-04-02 – 2026-04-11),
+    // 10 iterations per scenario per run (100 samples each).  Values are 1.5× the
+    // observed p95/max to give headroom without masking real regressions.
     sim.protocols(httpProtocol)
         .assertions(
-            details(POST_REQUEST).responseTime().percentile(95).lt(450),
-            details(POST_REQUEST).responseTime().max().lt(600),
+            // POST create: observed p95=804ms, max=982ms
+            details(POST_REQUEST).responseTime().percentile(95).lt(1250),
+            details(POST_REQUEST).responseTime().max().lt(1500),
             details(POST_REQUEST).successfulRequests().percent().is(100D),
+            // GET by uid: observed p95=231ms, max=675ms (one 1095ms infra spike excluded)
             details(GET_REQUEST).responseTime().percentile(95).lt(350),
-            details(GET_REQUEST).responseTime().max().lt(500),
+            details(GET_REQUEST).responseTime().max().lt(1050),
             details(GET_REQUEST).successfulRequests().percent().is(100D),
-            details(PUT_REQUEST).responseTime().percentile(95).lt(600),
-            details(PUT_REQUEST).responseTime().max().lt(800),
+            // PUT full update: observed p95=999ms, max=1396ms
+            details(PUT_REQUEST).responseTime().percentile(95).lt(1500),
+            details(PUT_REQUEST).responseTime().max().lt(2100),
             details(PUT_REQUEST).successfulRequests().percent().is(100D),
-            details(PATCH_REQUEST).responseTime().percentile(95).lt(550),
-            details(PATCH_REQUEST).responseTime().max().lt(750),
+            // PATCH partial: observed p95=560ms, max=627ms
+            details(PATCH_REQUEST).responseTime().percentile(95).lt(850),
+            details(PATCH_REQUEST).responseTime().max().lt(950),
             details(PATCH_REQUEST).successfulRequests().percent().is(100D),
-            details(PATCH_GROUPS_REQUEST).responseTime().percentile(95).lt(700),
-            details(PATCH_GROUPS_REQUEST).responseTime().max().lt(900),
+            // PATCH userGroups: observed p95=563ms, max=601ms
+            details(PATCH_GROUPS_REQUEST).responseTime().percentile(95).lt(850),
+            details(PATCH_GROUPS_REQUEST).responseTime().max().lt(950),
             details(PATCH_GROUPS_REQUEST).successfulRequests().percent().is(100D),
-            details(REPLICA_REQUEST).responseTime().percentile(95).lt(700),
-            details(REPLICA_REQUEST).responseTime().max().lt(1000),
+            // REPLICA: observed p95=685ms, max=797ms
+            details(REPLICA_REQUEST).responseTime().percentile(95).lt(1050),
+            details(REPLICA_REQUEST).responseTime().max().lt(1200),
             details(REPLICA_REQUEST).successfulRequests().percent().is(100D),
-            details(DELETE_REQUEST).responseTime().percentile(95).lt(1800),
-            details(DELETE_REQUEST).responseTime().max().lt(2500),
+            // DELETE: observed p95=944ms, max=1296ms
+            details(DELETE_REQUEST).responseTime().percentile(95).lt(1450),
+            details(DELETE_REQUEST).responseTime().max().lt(1950),
             details(DELETE_REQUEST).successfulRequests().percent().is(100D));
   }
 }


### PR DESCRIPTION
The UsersPerformanceTest assertion thresholds were initially estimates. This PR replaces them with data-driven values derived from 10 consecutive nightly CI runs  (2026-04-02 – 2026-04-11), giving 100 samples per scenario. Warmup runs were ignored.
                                                                                                                                                                       
Thresholds are set at 1.5× the observed p95/max to provide headroom without masking real regressions.               
                                                                                
  |              Scenario               | p95: before → after | max: before → after |                                                                         
  |-------------------------------------|----------------------|---------------------|
  | POST /api/users                     |       450 → 1250 ms |       600 → 1500 ms |
  | GET /api/users/{uid}                |        350 → 350 ms |       500 → 1050 ms |                                                                                  
  | PUT /api/users/{uid}                |       600 → 1500 ms |       800 → 2100 ms |                                                                                                                                                      
  | PATCH /api/users/{uid}              |        550 → 850 ms |        750 → 950 ms |                                                                                
  | PATCH /api/users/{uid} (userGroups) |        700 → 850 ms |        900 → 950 ms |                                                                    
  | POST /api/users/{uid}/replica       |       700 → 1050 ms |      1000 → 1200 ms |                                                                             
  | DELETE /api/users/{uid}             |      1800 → 1450 ms |      2500 → 1950 ms |                                                                           
   
Notable: DELETE was over-generous and is now tighter (observed p95 ~944ms). The GET max was inflated by a single infra spike (1095ms on one day); that outlier was excluded and the threshold set from the next-highest observed max (675ms).
                                                                                                                                                                       
  Also adds two utility scripts:                                                                                                                                       
  - download-user-perf-results.sh — fetches the last N gatling-report-users-load artifacts from GitHub Actions
  - analyze-user-perf-results.py — parses simulation.csv files, prints per-run and aggregate stats, and generates ready-to-paste assertion thresholds 