### PR TITLE
fix: ProgramMessage.deliveryChannels share references when saving DS

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/dataset/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/dataset/DefaultDataSetNotificationService.java
@@ -373,16 +373,12 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
       recipients = resolveExternalRecipients(template, registration);
     }
 
-    ProgramMessage programMessage =
-        ProgramMessage.builder()
-            .subject(message.getSubject())
-            .text(message.getMessage())
-            .recipients(recipients)
-            .build();
-
-    programMessage.setDeliveryChannels(template.getDeliveryChannels());
-
-    return programMessage;
+    return ProgramMessage.builder()
+        .subject(message.getSubject())
+        .text(message.getMessage())
+        .recipients(recipients)
+        .deliveryChannels(new HashSet<>(template.getDeliveryChannels()))
+        .build();
   }
 
   private DhisMessage createDhisMessage(

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/dataset/DataSetNotificationServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/dataset/DataSetNotificationServiceTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.program.notification.dataset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
@@ -429,5 +430,29 @@ class DataSetNotificationServiceTest extends TrackerTestBase {
     assertTrue(
         !capturedUsers.contains(userDisabled),
         "The disabled user should NOT be in the recipient list.");
+  }
+
+  @Test
+  void testCreateProgramMessage_eachMessageGetsItsOwnDeliveryChannelsCopy() {
+    // Returning the same template twice causes createProgramMessage to be called twice
+    // with the same template instance — reproducing the shared-collection bug
+    when(dsntService.getCompleteNotifications(any(DataSet.class)))
+        .thenReturn(List.of(smsTemplateA, smsTemplateA));
+    when(renderer.render(any(), any())).thenReturn(notificationMessage);
+    when(externalMessageService.sendMessages(anyList())).thenReturn(successStatus);
+    I18nFormat format = Mockito.mock(I18nFormat.class);
+    when(i18nManager.getI18nFormat()).thenReturn(format);
+    when(format.formatPeriod(any())).thenReturn("2000-1-1");
+
+    subject.sendCompleteDataSetNotifications(registrationA);
+
+    verify(externalMessageService).sendMessages(programMessageCaptor.capture());
+    List<ProgramMessage> messages = programMessageCaptor.getValue();
+    assertEquals(2, messages.size());
+    assertNotSame(
+        messages.get(0).getDeliveryChannels(),
+        messages.get(1).getDeliveryChannels(),
+        "Each ProgramMessage must own an independent copy of deliveryChannels, "
+            + "not a shared reference to the template's collection");
   }
 }


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/23469