### PR TITLE
perf: defer changelog inserts to enable JDBC batching during tracker import DHIS2-21239 [41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -148,6 +148,10 @@
       <artifactId>dhis-support-hibernate</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jasypt</groupId>
+      <artifactId>jasypt</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -48,13 +49,12 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLog;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.FlushMode;
@@ -68,6 +68,7 @@ import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
 
 /**
  * @author Luciano Fiandesio
@@ -79,8 +80,9 @@ public abstract class AbstractTrackerPersister<
     implements TrackerPersister<T, V> {
   protected final ReservedValueService reservedValueService;
 
-  protected final TrackedEntityAttributeValueChangeLogService
-      trackedEntityAttributeValueChangeLogService;
+  protected final DhisConfigurationProvider config;
+
+  protected final PBEStringEncryptor encryptor;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
@@ -98,6 +100,8 @@ public abstract class AbstractTrackerPersister<
     TrackerTypeReport typeReport = new TrackerTypeReport(getType());
 
     List<TrackerSideEffectDataBundle> sideEffectDataBundles = new ArrayList<>();
+    ChangeLogAccumulator changeLogs =
+        new ChangeLogAccumulator(config.isEnabled(CHANGELOG_TRACKER), encryptor);
 
     //
     // Extract the entities to persist from the Bundle
@@ -115,6 +119,7 @@ public abstract class AbstractTrackerPersister<
               ? List.of()
               : determineSideEffectTriggers(bundle.getPreheat(), trackerDto);
 
+      ChangeLogAccumulator.Mark mark = changeLogs.mark();
       try {
         //
         // Convert the TrackerDto into an Hibernate-managed entity
@@ -131,7 +136,7 @@ public abstract class AbstractTrackerPersister<
         //
         persistOwnership(bundle.getPreheat(), convertedDto);
 
-        updateDataValues(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+        updateDataValues(entityManager, bundle.getPreheat(), trackerDto, convertedDto, changeLogs);
 
         //
         // Save or update the entity
@@ -140,11 +145,13 @@ public abstract class AbstractTrackerPersister<
           entityManager.persist(convertedDto);
           typeReport.getStats().incCreated();
           typeReport.addEntity(objectReport);
-          updateAttributes(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+          updateAttributes(
+              entityManager, bundle.getPreheat(), trackerDto, convertedDto, changeLogs);
           bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
         } else {
           if (isUpdatable()) {
-            updateAttributes(entityManager, bundle.getPreheat(), trackerDto, convertedDto);
+            updateAttributes(
+                entityManager, bundle.getPreheat(), trackerDto, convertedDto, changeLogs);
             entityManager.merge(convertedDto);
             typeReport.getStats().incUpdated();
             typeReport.addEntity(objectReport);
@@ -168,9 +175,14 @@ public abstract class AbstractTrackerPersister<
         updatePreheat(bundle.getPreheat(), convertedDto);
 
         if (FlushMode.OBJECT == bundle.getFlushMode()) {
+          // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+          // (trackedentityid, eventid) exist before changelog rows reference them.
           entityManager.flush();
+          changeLogs.flushAll(entityManager);
         }
       } catch (Exception e) {
+        changeLogs.rollbackTo(mark);
+
         final String msg =
             "A Tracker Entity of type '"
                 + getType().getName()
@@ -189,6 +201,13 @@ public abstract class AbstractTrackerPersister<
           typeReport.getStats().incIgnored();
         }
       }
+    }
+
+    if (FlushMode.AUTO == bundle.getFlushMode()) {
+      // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+      // (trackedentityid, eventid) exist before changelog rows reference them.
+      entityManager.flush();
+      changeLogs.flushAll(entityManager);
     }
 
     return new PersistResult(typeReport, sideEffectDataBundles);
@@ -220,11 +239,19 @@ public abstract class AbstractTrackerPersister<
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(
-      EntityManager entityManager, TrackerPreheat preheat, T trackerDto, V hibernateEntity);
+      EntityManager entityManager,
+      TrackerPreheat preheat,
+      T trackerDto,
+      V hibernateEntity,
+      ChangeLogAccumulator changeLogs);
 
   /** Execute the persistence of Attribute values linked to the entity being processed */
   protected abstract void updateAttributes(
-      EntityManager entityManager, TrackerPreheat preheat, T trackerDto, V hibernateEntity);
+      EntityManager entityManager,
+      TrackerPreheat preheat,
+      T trackerDto,
+      V hibernateEntity,
+      ChangeLogAccumulator changeLogs);
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -342,7 +369,8 @@ public abstract class AbstractTrackerPersister<
       EntityManager entityManager,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
-      TrackedEntity trackedEntity) {
+      TrackedEntity trackedEntity,
+      ChangeLogAccumulator changeLogs) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
@@ -370,10 +398,10 @@ public abstract class AbstractTrackerPersister<
           String previousValue = isNew ? null : currentValue.getPlainValue();
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
           if (isDelete && !isNew) {
-            delete(entityManager, preheat, currentValue, trackedEntity);
+            delete(entityManager, preheat, currentValue, trackedEntity, changeLogs);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
-                entityManager, preheat, trackedEntity, attribute, currentValue, isNew);
+                entityManager, preheat, trackedEntity, attribute, currentValue, isNew, changeLogs);
           }
         });
   }
@@ -382,7 +410,8 @@ public abstract class AbstractTrackerPersister<
       EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
-      TrackedEntity trackedEntity) {
+      TrackedEntity trackedEntity,
+      ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
       unassignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
@@ -393,8 +422,14 @@ public abstract class AbstractTrackerPersister<
             ? trackedEntityAttributeValue
             : entityManager.merge(trackedEntityAttributeValue));
 
-    logTrackedEntityAttributeValueHistory(
-        preheat.getUsername(), trackedEntityAttributeValue, trackedEntity, ChangeLogType.DELETE);
+    if (trackedEntity.getTrackedEntityType().isAllowAuditLog()) {
+      changeLogs.addTrackedEntityAttributeValueAudit(
+          trackedEntity,
+          trackedEntityAttributeValue.getAttribute(),
+          trackedEntityAttributeValue.getValue(),
+          ChangeLogType.DELETE,
+          preheat.getUsername());
+    }
   }
 
   private void saveOrUpdateAttributeValue(
@@ -403,7 +438,8 @@ public abstract class AbstractTrackerPersister<
       TrackedEntity trackedEntity,
       Attribute attribute,
       TrackedEntityAttributeValue currentValue,
-      boolean isNew) {
+      boolean isNew,
+      ChangeLogAccumulator changeLogs) {
     TrackedEntityAttributeValue attributeToPersist =
         Optional.ofNullable(currentValue)
             .orElseGet(
@@ -416,7 +452,7 @@ public abstract class AbstractTrackerPersister<
             .setValue(attribute.getValue())
             .setLastUpdated(new Date());
 
-    saveOrUpdate(entityManager, preheat, isNew, trackedEntity, attributeToPersist);
+    saveOrUpdate(entityManager, preheat, isNew, trackedEntity, attributeToPersist, changeLogs);
 
     handleReservedValue(attributeToPersist);
   }
@@ -426,13 +462,14 @@ public abstract class AbstractTrackerPersister<
       TrackerPreheat preheat,
       boolean isNew,
       TrackedEntity trackedEntity,
-      TrackedEntityAttributeValue trackedEntityAttributeValue) {
+      TrackedEntityAttributeValue trackedEntityAttributeValue,
+      ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
       assignFileResource(
           entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
-    ChangeLogType changeLogType = null;
+    ChangeLogType changeLogType;
 
     if (isNew) {
       entityManager.persist(trackedEntityAttributeValue);
@@ -445,8 +482,14 @@ public abstract class AbstractTrackerPersister<
       changeLogType = ChangeLogType.UPDATE;
     }
 
-    logTrackedEntityAttributeValueHistory(
-        preheat.getUsername(), trackedEntityAttributeValue, trackedEntity, changeLogType);
+    if (trackedEntity.getTrackedEntityType().isAllowAuditLog()) {
+      changeLogs.addTrackedEntityAttributeValueAudit(
+          trackedEntity,
+          trackedEntityAttributeValue.getAttribute(),
+          trackedEntityAttributeValue.getValue(),
+          changeLogType,
+          preheat.getUsername());
+    }
   }
 
   private static boolean isFileResource(TrackedEntityAttributeValue trackedEntityAttributeValue) {
@@ -471,24 +514,6 @@ public abstract class AbstractTrackerPersister<
         && attributeValue.getAttribute().getTextPattern() != null) {
       reservedValueService.useReservedValue(
           attributeValue.getAttribute().getTextPattern(), attributeValue.getValue());
-    }
-  }
-
-  private void logTrackedEntityAttributeValueHistory(
-      String userName,
-      TrackedEntityAttributeValue attributeValue,
-      TrackedEntity trackedEntity,
-      ChangeLogType changeLogType) {
-    boolean allowAuditLog = trackedEntity.getTrackedEntityType().isAllowAuditLog();
-
-    // create log entry only for updated, created and deleted attributes
-    if (allowAuditLog && changeLogType != null) {
-      TrackedEntityAttributeValueChangeLog valueAudit =
-          new TrackedEntityAttributeValueChangeLog(
-              attributeValue, attributeValue.getValue(), userName, changeLogType);
-      valueAudit.setTrackedEntity(trackedEntity);
-      trackedEntityAttributeValueChangeLogService.addTrackedEntityAttributeValueChangLog(
-          valueAudit);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -68,23 +68,25 @@ class ChangeLogAccumulator {
   private final boolean enabled;
 
   // trackedentityattributevalueaudit columns:
-  // trackedentityid, trackedentityattributeid, value, encryptedvalue, created, modifiedby,
-  // audittype
-  private static final String TE_AUDIT_TUPLE = "(?,?,?,?,?,?,?)";
+  // trackedentityattributevalueauditid, trackedentityid, trackedentityattributeid, value,
+  // encryptedvalue, created, modifiedby, audittype
+  private static final String TE_AUDIT_TUPLE = "(nextval('hibernate_sequence'),?,?,?,?,?,?,?)";
   private static final String TE_AUDIT_VALUES = multiRowValues(TE_AUDIT_TUPLE, MAX_ROWS_PER_INSERT);
   private static final String INSERT_TE_AUDIT =
       "insert into trackedentityattributevalueaudit"
-          + " (trackedentityid, trackedentityattributeid, value, encryptedvalue,"
-          + " created, modifiedby, audittype) values ";
+          + " (trackedentityattributevalueauditid, trackedentityid, trackedentityattributeid,"
+          + " value, encryptedvalue, created, modifiedby, audittype) values ";
 
   // trackedentitydatavalueaudit columns:
-  // eventid, dataelementid, value, providedelsewhere, created, modifiedby, audittype
-  private static final String EVENT_AUDIT_TUPLE = "(?,?,?,?,?,?,?)";
+  // trackedentitydatavalueauditid, eventid, dataelementid, value, providedelsewhere, created,
+  // modifiedby, audittype
+  private static final String EVENT_AUDIT_TUPLE =
+      "(nextval('trackedentitydatavalueaudit_sequence'),?,?,?,?,?,?,?)";
   private static final String EVENT_AUDIT_VALUES =
       multiRowValues(EVENT_AUDIT_TUPLE, MAX_ROWS_PER_INSERT);
   private static final String INSERT_EVENT_AUDIT =
       "insert into trackedentitydatavalueaudit"
-          + " (eventid, dataelementid, value, providedelsewhere,"
+          + " (trackedentitydatavalueauditid, eventid, dataelementid, value, providedelsewhere,"
           + " created, modifiedby, audittype) values ";
 
   private final PBEStringEncryptor encryptor;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import org.hibernate.Session;
+import org.hisp.dhis.changelog.ChangeLogType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+
+/**
+ * Collects changelog entries during the persist phase and inserts them via multi-row INSERT at the
+ * end. This avoids Hibernate's per-entity sequence round-trips and groups all changelog INSERTs
+ * separately from entity INSERTs/UPDATEs. Multi-row INSERT is processed by PostgreSQL as a single
+ * statement (one parse, one plan, one WAL entry batch) instead of individual per-row executes.
+ */
+class ChangeLogAccumulator {
+
+  /**
+   * Maximum rows per multi-row INSERT statement. pgjdbc found that performance does not improve
+   * much beyond 128 rows per multi-valued INSERT. The hard upper limit is {@link Short#MAX_VALUE}
+   * (32,767) bind parameters per statement, which gives ~4,000 rows with 8 columns. 128 rows is
+   * well within that.
+   *
+   * @see <a
+   *     href="https://github.com/pgjdbc/pgjdbc/blob/c44a2a99/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java#L1815-L1821">PgPreparedStatement.java#L1815-L1821</a>
+   */
+  private static final int MAX_ROWS_PER_INSERT = 128;
+
+  private final boolean enabled;
+
+  // trackedentityattributevalueaudit columns:
+  // trackedentityid, trackedentityattributeid, value, encryptedvalue, created, modifiedby,
+  // audittype
+  private static final String TE_AUDIT_TUPLE = "(?,?,?,?,?,?,?)";
+  private static final String TE_AUDIT_VALUES = multiRowValues(TE_AUDIT_TUPLE, MAX_ROWS_PER_INSERT);
+  private static final String INSERT_TE_AUDIT =
+      "insert into trackedentityattributevalueaudit"
+          + " (trackedentityid, trackedentityattributeid, value, encryptedvalue,"
+          + " created, modifiedby, audittype) values ";
+
+  // trackedentitydatavalueaudit columns:
+  // eventid, dataelementid, value, providedelsewhere, created, modifiedby, audittype
+  private static final String EVENT_AUDIT_TUPLE = "(?,?,?,?,?,?,?)";
+  private static final String EVENT_AUDIT_VALUES =
+      multiRowValues(EVENT_AUDIT_TUPLE, MAX_ROWS_PER_INSERT);
+  private static final String INSERT_EVENT_AUDIT =
+      "insert into trackedentitydatavalueaudit"
+          + " (eventid, dataelementid, value, providedelsewhere,"
+          + " created, modifiedby, audittype) values ";
+
+  private final PBEStringEncryptor encryptor;
+  private final Date created = new Date();
+  private final List<TeAttributeAudit> teAudits = new ArrayList<>();
+  private final List<EventDataValueAudit> eventAudits = new ArrayList<>();
+
+  ChangeLogAccumulator(boolean enabled, PBEStringEncryptor encryptor) {
+    this.enabled = enabled;
+    this.encryptor = encryptor;
+  }
+
+  void addTrackedEntityAttributeValueAudit(
+      @Nonnull TrackedEntity trackedEntity,
+      @Nonnull TrackedEntityAttribute attribute,
+      @CheckForNull String value,
+      @Nonnull ChangeLogType type,
+      @Nonnull String username) {
+    if (!enabled) return;
+    teAudits.add(new TeAttributeAudit(trackedEntity, attribute, value, type, username));
+  }
+
+  void addEventDataValueAudit(
+      @Nonnull Event event,
+      @Nonnull DataElement dataElement,
+      @CheckForNull String value,
+      boolean providedElsewhere,
+      @Nonnull ChangeLogType type,
+      @Nonnull String username) {
+    if (!enabled) return;
+    eventAudits.add(
+        new EventDataValueAudit(event, dataElement, value, providedElsewhere, type, username));
+  }
+
+  Mark mark() {
+    return new Mark(teAudits.size(), eventAudits.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(teAudits, mark.teSize);
+    truncate(eventAudits, mark.eventSize);
+  }
+
+  void flushAll(EntityManager entityManager) {
+    if (teAudits.isEmpty() && eventAudits.isEmpty()) {
+      return;
+    }
+
+    Session session = entityManager.unwrap(Session.class);
+    session.doWork(this::insertAll);
+    teAudits.clear();
+    eventAudits.clear();
+  }
+
+  private void insertAll(Connection connection) throws SQLException {
+    Timestamp timestamp = new Timestamp(created.getTime());
+    insertTeAudits(connection, timestamp);
+    insertEventAudits(connection, timestamp);
+  }
+
+  private void insertTeAudits(Connection connection, Timestamp timestamp) throws SQLException {
+    for (int offset = 0; offset < teAudits.size(); offset += MAX_ROWS_PER_INSERT) {
+      int end = Math.min(offset + MAX_ROWS_PER_INSERT, teAudits.size());
+      int batchSize = end - offset;
+      String values =
+          batchSize == MAX_ROWS_PER_INSERT
+              ? TE_AUDIT_VALUES
+              : multiRowValues(TE_AUDIT_TUPLE, batchSize);
+      String sql = INSERT_TE_AUDIT + values;
+
+      try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        int idx = 1;
+        for (int i = offset; i < end; i++) {
+          TeAttributeAudit a = teAudits.get(i);
+          ps.setLong(idx++, a.trackedEntity.getId());
+          ps.setLong(idx++, a.attribute.getId());
+          if (a.attribute.getConfidential()) {
+            ps.setNull(idx++, Types.VARCHAR); // value (plain) = null
+            if (a.value != null) {
+              ps.setString(idx++, encryptor.encrypt(a.value)); // encryptedvalue
+            } else {
+              ps.setNull(idx++, Types.VARCHAR);
+            }
+          } else {
+            ps.setString(idx++, a.value); // value (plain)
+            ps.setNull(idx++, Types.VARCHAR); // encryptedvalue = null
+          }
+          ps.setTimestamp(idx++, timestamp);
+          ps.setString(idx++, a.username);
+          ps.setString(idx++, a.type.name());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void insertEventAudits(Connection connection, Timestamp timestamp) throws SQLException {
+    for (int offset = 0; offset < eventAudits.size(); offset += MAX_ROWS_PER_INSERT) {
+      int end = Math.min(offset + MAX_ROWS_PER_INSERT, eventAudits.size());
+      int batchSize = end - offset;
+      String values =
+          batchSize == MAX_ROWS_PER_INSERT
+              ? EVENT_AUDIT_VALUES
+              : multiRowValues(EVENT_AUDIT_TUPLE, batchSize);
+      String sql = INSERT_EVENT_AUDIT + values;
+
+      try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        int idx = 1;
+        for (int i = offset; i < end; i++) {
+          EventDataValueAudit a = eventAudits.get(i);
+          ps.setLong(idx++, a.event.getId());
+          ps.setLong(idx++, a.dataElement.getId());
+          ps.setString(idx++, a.value);
+          ps.setBoolean(idx++, a.providedElsewhere);
+          ps.setTimestamp(idx++, timestamp);
+          ps.setString(idx++, a.username);
+          ps.setString(idx++, a.type.name());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private static String multiRowValues(String tuple, int count) {
+    return (tuple + ",").repeat(count - 1) + tuple;
+  }
+
+  private static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  record Mark(int teSize, int eventSize) {}
+
+  private record TeAttributeAudit(
+      TrackedEntity trackedEntity,
+      TrackedEntityAttribute attribute,
+      String value,
+      ChangeLogType type,
+      String username) {}
+
+  private record EventDataValueAudit(
+      Event event,
+      DataElement dataElement,
+      String value,
+      boolean providedElsewhere,
+      ChangeLogType type,
+      String username) {}
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -163,7 +163,7 @@ class ChangeLogAccumulator {
           TeAttributeAudit a = teAudits.get(i);
           ps.setLong(idx++, a.trackedEntity.getId());
           ps.setLong(idx++, a.attribute.getId());
-          if (a.attribute.getConfidential()) {
+          if (a.attribute.isConfidentialBool()) {
             ps.setNull(idx++, Types.VARCHAR); // value (plain) = null
             if (a.value != null) {
               ps.setString(idx++, encryptor.encrypt(a.value)); // encryptedvalue

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -35,11 +35,11 @@ import java.util.Objects;
 import java.util.Set;
 import javax.persistence.EntityManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerService;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
@@ -47,6 +47,8 @@ import org.hisp.dhis.tracker.imports.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.imports.job.SideEffectTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -62,11 +64,12 @@ public class EnrollmentPersister
 
   public EnrollmentPersister(
       ReservedValueService reservedValueService,
+      DhisConfigurationProvider config,
+      @Qualifier("aes128StringEncryptor") PBEStringEncryptor encryptor,
       TrackerConverterService<org.hisp.dhis.tracker.imports.domain.Enrollment, Enrollment>
           enrollmentConverter,
-      TrackedEntityProgramOwnerService trackedEntityProgramOwnerService,
-      TrackedEntityAttributeValueChangeLogService trackedEntityAttributeValueChangeLogService) {
-    super(reservedValueService, trackedEntityAttributeValueChangeLogService);
+      TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
+    super(reservedValueService, config, encryptor);
 
     this.enrollmentConverter = enrollmentConverter;
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
@@ -77,12 +80,14 @@ public class EnrollmentPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-      Enrollment enrollmentToPersist) {
+      Enrollment enrollmentToPersist,
+      ChangeLogAccumulator changeLogs) {
     handleTrackedEntityAttributeValues(
         entityManager,
         preheat,
         enrollment.getAttributes(),
-        preheat.getTrackedEntity(enrollmentToPersist.getTrackedEntity().getUid()));
+        preheat.getTrackedEntity(enrollmentToPersist.getTrackedEntity().getUid()),
+        changeLogs);
   }
 
   @Override
@@ -90,7 +95,8 @@ public class EnrollmentPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-      Enrollment enrollmentToPersist) {
+      Enrollment enrollmentToPersist,
+      ChangeLogAccumulator changeLogs) {
     // DO NOTHING - TE HAVE NO DATA VALUES
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -51,12 +51,10 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
-import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
-import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
@@ -65,6 +63,8 @@ import org.hisp.dhis.tracker.imports.job.SideEffectTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.util.DateUtils;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -76,16 +76,13 @@ public class EventPersister
   private final TrackerConverterService<org.hisp.dhis.tracker.imports.domain.Event, Event>
       eventConverter;
 
-  private final TrackedEntityDataValueChangeLogService trackedEntityDataValueAuditService;
-
   public EventPersister(
       ReservedValueService reservedValueService,
-      TrackerConverterService<org.hisp.dhis.tracker.imports.domain.Event, Event> eventConverter,
-      TrackedEntityAttributeValueChangeLogService trackedEntityAttributeValueChangeLogService,
-      TrackedEntityDataValueChangeLogService trackedEntityDataValueChangeLogService) {
-    super(reservedValueService, trackedEntityAttributeValueChangeLogService);
+      DhisConfigurationProvider config,
+      @Qualifier("aes128StringEncryptor") PBEStringEncryptor encryptor,
+      TrackerConverterService<org.hisp.dhis.tracker.imports.domain.Event, Event> eventConverter) {
+    super(reservedValueService, config, encryptor);
     this.eventConverter = eventConverter;
-    this.trackedEntityDataValueAuditService = trackedEntityDataValueChangeLogService;
   }
 
   @Override
@@ -168,7 +165,8 @@ public class EventPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Event event,
-      Event hibernateEntity) {
+      Event hibernateEntity,
+      ChangeLogAccumulator changeLogs) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 
@@ -177,15 +175,17 @@ public class EventPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Event event,
-      Event hibernateEntity) {
-    handleDataValues(entityManager, preheat, event.getDataValues(), hibernateEntity);
+      Event hibernateEntity,
+      ChangeLogAccumulator changeLogs) {
+    handleDataValues(entityManager, preheat, event.getDataValues(), hibernateEntity, changeLogs);
   }
 
   private void handleDataValues(
       EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
-      Event event) {
+      Event event,
+      ChangeLogAccumulator changeLogs) {
     Map<String, EventDataValue> dataValueDBMap =
         Optional.ofNullable(preheat.getEvent(event.getUid()))
             .map(
@@ -232,31 +232,20 @@ public class EventPersister
             event.getEventDataValues().add(eventDataValue);
           }
 
-          logTrackedEntityDataValueHistory(
-              preheat.getUsername(), dataElement, event, new Date(), valuesHolder);
+          if (valuesHolder.getChangeLogType() != null) {
+            changeLogs.addEventDataValueAudit(
+                event,
+                dataElement,
+                valuesHolder.getValue(),
+                valuesHolder.isProvidedElseWhere(),
+                valuesHolder.getChangeLogType(),
+                preheat.getUsername());
+          }
         });
   }
 
   private Date getFromOrNewDate(DataValue dv, Function<DataValue, Instant> dateGetter) {
     return Optional.of(dv).map(dateGetter).map(DateUtils::fromInstant).orElseGet(Date::new);
-  }
-
-  private void logTrackedEntityDataValueHistory(
-      String userName, DataElement de, Event event, Date created, ValuesHolder valuesHolder) {
-    ChangeLogType changeLogType = valuesHolder.getChangeLogType();
-
-    if (changeLogType != null) {
-      TrackedEntityDataValueChangeLog valueAudit = new TrackedEntityDataValueChangeLog();
-      valueAudit.setEvent(event);
-      valueAudit.setValue(valuesHolder.getValue());
-      valueAudit.setAuditType(changeLogType);
-      valueAudit.setDataElement(de);
-      valueAudit.setModifiedBy(userName);
-      valueAudit.setProvidedElsewhere(valuesHolder.isProvidedElseWhere());
-      valueAudit.setCreated(created);
-
-      trackedEntityDataValueAuditService.addTrackedEntityDataValueChangeLog(valueAudit);
-    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Set;
 import javax.persistence.EntityManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
@@ -40,6 +40,8 @@ import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.job.SideEffectTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,11 +55,12 @@ public class RelationshipPersister
 
   public RelationshipPersister(
       ReservedValueService reservedValueService,
+      DhisConfigurationProvider config,
+      @Qualifier("aes128StringEncryptor") PBEStringEncryptor encryptor,
       TrackerConverterService<Relationship, org.hisp.dhis.relationship.Relationship>
-          relationshipConverter,
-      TrackedEntityAttributeValueChangeLogService trackedEntityAttributeValueChangeLogService) {
+          relationshipConverter) {
 
-    super(reservedValueService, trackedEntityAttributeValueChangeLogService);
+    super(reservedValueService, config, encryptor);
     this.relationshipConverter = relationshipConverter;
   }
 
@@ -80,7 +83,8 @@ public class RelationshipPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
-      org.hisp.dhis.relationship.Relationship hibernateEntity) {
+      org.hisp.dhis.relationship.Relationship hibernateEntity,
+      ChangeLogAccumulator changeLogs) {
     // NOTHING TO DO
   }
 
@@ -89,7 +93,8 @@ public class RelationshipPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
-      org.hisp.dhis.relationship.Relationship hibernateEntity) {
+      org.hisp.dhis.relationship.Relationship hibernateEntity,
+      ChangeLogAccumulator changeLogs) {
     // NOTHING TO DO
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -33,15 +33,17 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.imports.job.SideEffectTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -58,10 +60,11 @@ public class TrackedEntityPersister
 
   public TrackedEntityPersister(
       ReservedValueService reservedValueService,
+      DhisConfigurationProvider config,
+      @Qualifier("aes128StringEncryptor") PBEStringEncryptor encryptor,
       TrackerConverterService<org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity>
-          teConverter,
-      TrackedEntityAttributeValueChangeLogService trackedEntityAttributeValueChangeLogService) {
-    super(reservedValueService, trackedEntityAttributeValueChangeLogService);
+          teConverter) {
+    super(reservedValueService, config, encryptor);
     this.teConverter = teConverter;
   }
 
@@ -70,8 +73,10 @@ public class TrackedEntityPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity te) {
-    handleTrackedEntityAttributeValues(entityManager, preheat, trackerDto.getAttributes(), te);
+      TrackedEntity te,
+      ChangeLogAccumulator changeLogs) {
+    handleTrackedEntityAttributeValues(
+        entityManager, preheat, trackerDto.getAttributes(), te, changeLogs);
   }
 
   @Override
@@ -79,7 +84,8 @@ public class TrackedEntityPersister
       EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity te) {
+      TrackedEntity te,
+      ChangeLogAccumulator changeLogs) {
     // DO NOTHING - TE HAVE NO DATA VALUES
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ChangeLogAccumulatorTest {
+
+  private ChangeLogAccumulator accumulator;
+
+  private TrackedEntity trackedEntity;
+  private TrackedEntityAttribute attribute;
+  private Event event;
+  private DataElement dataElement;
+
+  @BeforeEach
+  void setUp() {
+    accumulator = new ChangeLogAccumulator(true, null);
+
+    trackedEntity = new TrackedEntity();
+    attribute = new TrackedEntityAttribute();
+    event = new Event();
+    dataElement = new DataElement();
+  }
+
+  @Test
+  void addTrackedEntityAttributeValueAudit() {
+    accumulator.addTrackedEntityAttributeValueAudit(
+        trackedEntity, attribute, "value", CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+    assertEquals(1, mark.teSize());
+  }
+
+  @Test
+  void addEventDataValueAudit() {
+    accumulator.addEventDataValueAudit(event, dataElement, "value", false, CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+    assertEquals(1, mark.eventSize());
+  }
+
+  @Test
+  void addIsNoOpWhenDisabled() {
+    ChangeLogAccumulator disabled = new ChangeLogAccumulator(false, null);
+
+    disabled.addTrackedEntityAttributeValueAudit(
+        trackedEntity, attribute, "value", CREATE, "admin");
+    disabled.addEventDataValueAudit(event, dataElement, "value", false, CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = disabled.mark();
+    assertEquals(0, mark.teSize());
+    assertEquals(0, mark.eventSize());
+  }
+
+  @Test
+  void rollbackToDiscardEntriesAfterMark() {
+    accumulator.addTrackedEntityAttributeValueAudit(
+        trackedEntity, attribute, "v1", CREATE, "admin");
+    accumulator.addEventDataValueAudit(event, dataElement, "v1", false, CREATE, "admin");
+
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+
+    accumulator.addTrackedEntityAttributeValueAudit(
+        trackedEntity, attribute, "v2", CREATE, "admin");
+    accumulator.addEventDataValueAudit(event, dataElement, "v2", false, CREATE, "admin");
+
+    ChangeLogAccumulator.Mark afterAdd = accumulator.mark();
+    assertEquals(2, afterAdd.teSize());
+    assertEquals(2, afterAdd.eventSize());
+
+    accumulator.rollbackTo(mark);
+
+    ChangeLogAccumulator.Mark afterRollback = accumulator.mark();
+    assertEquals(1, afterRollback.teSize());
+    assertEquals(1, afterRollback.eventSize());
+  }
+
+  @Test
+  void rollbackToIsNoOpWhenNoEntriesAdded() {
+    ChangeLogAccumulator.Mark mark = accumulator.mark();
+
+    accumulator.rollbackTo(mark);
+
+    ChangeLogAccumulator.Mark afterRollback = accumulator.mark();
+    assertEquals(0, afterRollback.teSize());
+    assertEquals(0, afterRollback.eventSize());
+  }
+}


### PR DESCRIPTION
Adapted from https://github.com/dhis2/dhis2-core/pull/23510 (master) and https://github.com/dhis2/dhis2-core/pull/23551 (2.42).

This is not a cherry-pick. The 2.41 changelog tables and domain model differ significantly from 2.42/master, so the `ChangeLogAccumulator` was rewritten for the 2.41 schema.

### Differences from 2.42/master

* **Table names**: 2.41 uses `trackedentityattributevalueaudit` and `trackedentitydatavalueaudit`. 2.42 uses `trackedentitychangelog` and `eventchangelog`
* **Column schema**: 2.41 columns are `value`, `encryptedvalue`, `audittype`, `modifiedby`, `providedelsewhere`. 2.42 columns are `previousvalue`, `currentvalue`, `changelogtype`, `createdby`, `eventfield`
* **Sequence-generated PKs**: 2.41 audit tables require explicit ID generation via `nextval('hibernate_sequence')` and `nextval('trackedentitydatavalueaudit_sequence')`. 2.42 tables use `DEFAULT` on the PK column so the INSERT can omit the ID
* **Encrypted attributes**: 2.41 has a separate `encryptedvalue` column for confidential tracked entity attributes. Before this change, Hibernate handled encryption transparently via its `Aes128EncryptedString` custom type on `session.save()`. Now the `ChangeLogAccumulator` does the same encryption explicitly: for confidential attributes, it encrypts the value with `PBEStringEncryptor` and binds it to the `encryptedvalue` column while setting `value` to null. For non-confidential attributes, it binds the plaintext to `value` and sets `encryptedvalue` to null. 2.42 removed this column entirely in the migration to `trackedentitychangelog`
* **`allowAuditLog` check**: 2.41 checks `TrackedEntityType.isAllowAuditLog()` before writing TE attribute audits. This check is preserved in the accumulator callers
* **`CHANGELOG_TRACKER` config**: Same as the 2.42 backport, the accumulator respects the global `changelog.tracker` config via a `boolean enabled` constructor parameter
* **No event field changelogs**: 2.41 does not have the `eventfield` column, so there is no `addEventFieldChangeLog` method
