### PR TITLE
perf: Reduce allocations for program rules evaluation [DHIS2-21178] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -30,23 +30,25 @@
 package org.hisp.dhis.tracker.imports.programrule;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.rules.models.RuleAttributeValue;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
@@ -72,30 +74,50 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   private final EventService eventService;
 
+  private final ConstantService constantService;
+
+  private final org.hisp.dhis.programrule.ProgramRuleService programRuleMetadataService;
+
   private final RuleActionEnrollmentMapper ruleActionEnrollmentMapper;
 
   private final RuleActionEventMapper ruleActionEventMapper;
 
   /**
-   * This is calculating the rule effects for all the enrollments and events present in the payload.
-   * First, this method is iterating over the enrollments present in the payload and related events
-   * (also the ones not present in the payload) and it is calculating rule effects for those. The,
-   * this method is iterating over events present in the payload and related enrollment (also if it
-   * is not present in the payload) and it is calculating rule effects for those. {@link
-   * #calculateTrackerEventRuleEffects(TrackerBundle, TrackerPreheat)} method makes sure that rule
-   * effects are calculated only once for every event. This ensures that there will be no duplicate
-   * effects. Finally, this method is iterating over all program events present in the payload, and
-   * it is calculating rule effects for those.
+   * Calculates rule effects for all enrollments, tracker events, and single events in the payload.
+   *
+   * <p>All programs referenced by the bundle are collected in a single pass and their rules fetched
+   * at once. The constant map is allocated only when at least one program has applicable rules.
+   * Enrollments and tracker events whose enrollment is not in the payload are grouped by program so
+   * that {@link ProgramRuleEngine#evaluateEnrollmentsAndTrackerEvents} is called at most once per
+   * distinct program. Single events are evaluated separately per program.
    */
   @Override
   @Transactional(readOnly = true)
   public void calculateRuleEffects(TrackerBundle bundle, TrackerPreheat preheat) {
+    // Collect all programs referenced by the bundle in one pass, then fetch rules for all of them
+    // at once. This avoids per-program DB queries inside the sub-methods and lets us skip the
+    // constant map allocation entirely when no program has applicable rules.
+    Set<Program> allPrograms =
+        Stream.concat(
+                bundle.getEnrollments().stream().map(e -> preheat.getProgram(e.getProgram())),
+                bundle.getEvents().stream().map(e -> preheat.getProgram(e.getProgram())))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    Map<Program, List<ProgramRule>> rulesByProgram = getRulesForPrograms(allPrograms);
+    if (rulesByProgram.isEmpty()) {
+      return;
+    }
+
+    Map<String, String> constantMap =
+        constantService.getConstantMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, v -> Double.toString(v.getValue().getValue())));
+
     RuleEngineEffects ruleEffects =
         RuleEngineEffects.merge(
-            RuleEngineEffects.merge(
-                calculateEnrollmentRuleEffects(bundle, preheat),
-                calculateTrackerEventRuleEffects(bundle, preheat)),
-            calculateProgramEventRuleEffects(bundle, preheat));
+            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, rulesByProgram),
+            calculateProgramEventRuleEffects(bundle, preheat, constantMap, rulesByProgram));
 
     bundle.setEnrollmentNotifications(ruleEffects.getEnrollmentNotifications());
     bundle.setEventNotifications(ruleEffects.getEventNotifications());
@@ -107,73 +129,142 @@ class DefaultProgramRuleService implements ProgramRuleService {
   }
 
   private RuleEngineEffects calculateEnrollmentRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> byProgram =
+      TrackerBundle bundle,
+      TrackerPreheat preheat,
+      Map<String, String> constantMap,
+      Map<Program, List<ProgramRule>> rulesByProgram) {
+    Set<UID> payloadEnrollmentUids =
         bundle.getEnrollments().stream()
-            .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
+            .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid)
+            .collect(Collectors.toSet());
+    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>>
+        payloadEnrollmentsByProgram =
+            bundle.getEnrollments().stream()
+                .filter(e -> rulesByProgram.containsKey(preheat.getProgram(e.getProgram())))
+                .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
+    Map<Program, List<Enrollment>> savedEnrollmentsByProgram =
+        bundle.getEvents().stream()
+            .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
+            .filter(event -> !payloadEnrollmentUids.contains(event.getEnrollment()))
+            .map(event -> preheat.getEnrollment(event.getEnrollment()))
+            .filter(Objects::nonNull)
+            .distinct()
+            .filter(e -> rulesByProgram.containsKey(e.getProgram()))
+            .collect(Collectors.groupingBy(Enrollment::getProgram));
 
-    return byProgram.entrySet().stream()
+    if (payloadEnrollmentsByProgram.isEmpty() && savedEnrollmentsByProgram.isEmpty()) {
+      return RuleEngineEffects.empty();
+    }
+
+    Set<UID> enrollmentUids =
+        Stream.concat(
+                payloadEnrollmentsByProgram.values().stream()
+                    .flatMap(List::stream)
+                    .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid),
+                savedEnrollmentsByProgram.values().stream().flatMap(List::stream).map(UID::of))
+            .collect(Collectors.toSet());
+    Map<UID, List<RuleEvent>> savedEventsByEnrollment =
+        fetchSavedRuleEventsByEnrollment(enrollmentUids, bundle);
+    Map<UID, List<org.hisp.dhis.tracker.imports.domain.Event>> payloadEventsByEnrollment =
+        bundle.getEvents().stream()
+            .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
+            .collect(Collectors.groupingBy(e -> e.getEnrollment()));
+
+    return rulesByProgram.entrySet().stream()
+        .filter(
+            entry ->
+                payloadEnrollmentsByProgram.containsKey(entry.getKey())
+                    || savedEnrollmentsByProgram.containsKey(entry.getKey()))
         .map(
             entry -> {
-              Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents = new HashMap<>();
-              for (org.hisp.dhis.tracker.imports.domain.Enrollment e : entry.getValue()) {
-                List<RuleAttributeValue> attributes =
-                    getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat);
-                RuleEnrollment enrollment =
-                    RuleEngineMapper.mapPayloadEnrollment(preheat, e, attributes);
-                enrollmentsWithEvents.put(
-                    enrollment, getEventsFromEnrollment(e.getUid(), bundle, preheat));
-              }
+              Program program = entry.getKey();
+              Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents =
+                  buildEnrollmentsWithEvents(
+                      program,
+                      payloadEnrollmentsByProgram,
+                      savedEnrollmentsByProgram,
+                      savedEventsByEnrollment,
+                      payloadEventsByEnrollment,
+                      bundle,
+                      preheat);
               return programRuleEngine.evaluateEnrollmentsAndTrackerEvents(
-                  enrollmentsWithEvents, entry.getKey(), bundle.getUser());
+                  enrollmentsWithEvents, program, bundle.getUser(), constantMap, entry.getValue());
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());
   }
 
-  private RuleEngineEffects calculateTrackerEventRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Set<Enrollment> enrollments =
-        bundle.getEvents().stream()
-            .filter(event -> bundle.findEnrollmentByUid(event.getEnrollment()).isEmpty())
-            .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
-            .map(event -> preheat.getEnrollment(event.getEnrollment()))
-            .collect(Collectors.toSet());
+  // Fetches rules for each program and returns only programs that have applicable rules.
+  private Map<Program, List<ProgramRule>> getRulesForPrograms(Set<Program> programs) {
+    Map<Program, List<ProgramRule>> rulesByProgram = new HashMap<>();
+    for (Program program : programs) {
+      List<ProgramRule> rules =
+          programRuleMetadataService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
+      if (!rules.isEmpty()) {
+        rulesByProgram.put(program, rules);
+      }
+    }
+    return rulesByProgram;
+  }
 
-    Map<Program, List<Enrollment>> byProgram =
-        enrollments.stream().collect(Collectors.groupingBy(Enrollment::getProgram));
+  // Builds the map of rule enrollments to rule events for a single program,
+  // combining payload and saved enrollments with their respective events.
+  private Map<RuleEnrollment, List<RuleEvent>> buildEnrollmentsWithEvents(
+      Program program,
+      Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> payloadByProgram,
+      Map<Program, List<Enrollment>> savedByProgram,
+      Map<UID, List<RuleEvent>> savedEventsByEnrollment,
+      Map<UID, List<org.hisp.dhis.tracker.imports.domain.Event>> payloadEventsByEnrollment,
+      TrackerBundle bundle,
+      TrackerPreheat preheat) {
+    Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents = new HashMap<>();
 
-    return byProgram.entrySet().stream()
-        .map(
-            entry -> {
-              Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents = new HashMap<>();
-              for (Enrollment e : entry.getValue()) {
-                List<RuleAttributeValue> attributes =
-                    getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat);
-                RuleEnrollment enrollment = RuleEngineMapper.mapSavedEnrollment(e, attributes);
-                enrollmentsWithEvents.put(
-                    enrollment, getEventsFromEnrollment(UID.of(e), bundle, preheat));
-              }
-              return programRuleEngine.evaluateEnrollmentsAndTrackerEvents(
-                  enrollmentsWithEvents, entry.getKey(), bundle.getUser());
-            })
-        .reduce(RuleEngineEffects::merge)
-        .orElse(RuleEngineEffects.empty());
+    for (org.hisp.dhis.tracker.imports.domain.Enrollment e :
+        payloadByProgram.getOrDefault(program, List.of())) {
+      List<RuleAttributeValue> attributes =
+          getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat);
+      enrollmentsWithEvents.put(
+          RuleEngineMapper.mapPayloadEnrollment(preheat, e, attributes),
+          buildRuleEvents(
+              savedEventsByEnrollment.getOrDefault(e.getUid(), List.of()),
+              payloadEventsByEnrollment.getOrDefault(e.getUid(), List.of()),
+              preheat));
+    }
+
+    for (Enrollment e : savedByProgram.getOrDefault(program, List.of())) {
+      List<RuleAttributeValue> attributes =
+          getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat);
+      enrollmentsWithEvents.put(
+          RuleEngineMapper.mapSavedEnrollment(e, attributes),
+          buildRuleEvents(
+              savedEventsByEnrollment.getOrDefault(UID.of(e), List.of()),
+              payloadEventsByEnrollment.getOrDefault(UID.of(e), List.of()),
+              preheat));
+    }
+
+    return enrollmentsWithEvents;
   }
 
   private RuleEngineEffects calculateProgramEventRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Event>> programEvents =
-        bundle.getEvents().stream()
-            .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
-            .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())));
-
-    return programEvents.entrySet().stream()
-        .map(
+      TrackerBundle bundle,
+      TrackerPreheat preheat,
+      Map<String, String> constantMap,
+      Map<Program, List<ProgramRule>> rulesByProgram) {
+    return bundle.getEvents().stream()
+        .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
+        .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())))
+        .entrySet()
+        .stream()
+        .flatMap(
             entry -> {
+              List<ProgramRule> rules = rulesByProgram.get(entry.getKey());
+              if (rules == null) {
+                return Stream.empty();
+              }
               List<RuleEvent> events = RuleEngineMapper.mapPayloadEvents(preheat, entry.getValue());
-              return programRuleEngine.evaluateProgramEvents(
-                  events, entry.getKey(), bundle.getUser());
+              return Stream.of(
+                  programRuleEngine.evaluateSingleEvents(
+                      events, entry.getKey(), bundle.getUser(), constantMap, rules));
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());
@@ -200,55 +291,66 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .orElse(Collections.emptyList());
 
     TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
-    List<RuleAttributeValue> payloadAttributes =
-        Stream.concat(payloadTrackedEntityAttributes.stream(), payloadProgramAttributes.stream())
-            .toList();
-
     if (trackedEntity == null) {
-      return payloadAttributes;
+      return Stream.concat(
+              payloadTrackedEntityAttributes.stream(), payloadProgramAttributes.stream())
+          .toList();
     }
 
-    List<String> payloadAttributeValuesIds =
-        payloadAttributes.stream().map(RuleAttributeValue::getTrackedEntityAttribute).toList();
+    // Build the payload UID set directly from the two component lists to avoid materialising
+    // payloadAttributes into an intermediate List that is only streamed again below.
+    Set<String> payloadAttributeUids = new HashSet<>();
+    for (RuleAttributeValue a : payloadTrackedEntityAttributes)
+      payloadAttributeUids.add(a.getTrackedEntityAttribute());
+    for (RuleAttributeValue a : payloadProgramAttributes)
+      payloadAttributeUids.add(a.getTrackedEntityAttribute());
 
     Stream<RuleAttributeValue> dbAttributesNotPresentInPayload =
         trackedEntity.getTrackedEntityAttributeValues().stream()
-            .filter(av -> !payloadAttributeValuesIds.contains(av.getAttribute().getUid()))
+            .filter(av -> !payloadAttributeUids.contains(av.getAttribute().getUid()))
             .map(av -> new RuleAttributeValue(av.getAttribute().getUid(), av.getValue()));
-    return Stream.concat(payloadAttributes.stream(), dbAttributesNotPresentInPayload).toList();
+    return Stream.concat(
+            Stream.concat(
+                payloadTrackedEntityAttributes.stream(), payloadProgramAttributes.stream()),
+            dbAttributesNotPresentInPayload)
+        .toList();
   }
 
-  // Get all the events linked to enrollment from the payload and the DB,
-  // using the one from payload if they are present in both places
-  @Nonnull
-  private List<RuleEvent> getEventsFromEnrollment(
-      UID enrollmentUid, TrackerBundle bundle, TrackerPreheat preheat) {
-    Stream<Event> events;
+  // Fetch all saved events for the given enrollments in a single DB query and group by enrollment.
+  // Payload events (already in the bundle) are excluded since they will be added in
+  // buildRuleEvents.
+  private Map<UID, List<RuleEvent>> fetchSavedRuleEventsByEnrollment(
+      Set<UID> enrollmentUids, TrackerBundle bundle) {
+    if (enrollmentUids.isEmpty()) {
+      return Map.of();
+    }
     try {
-      events =
-          eventService
-              .findEvents(
-                  EventOperationParams.builder()
-                      .fields(EventFields.all())
-                      .orgUnitMode(ACCESSIBLE)
-                      .enrollments(Set.of(enrollmentUid))
-                      .build())
-              .stream()
-              .filter(e -> bundle.findEventByUid(UID.of(e)).isEmpty());
+      return eventService
+          .findEvents(
+              EventOperationParams.builder()
+                  .fields(EventFields.all())
+                  .orgUnitMode(ACCESSIBLE)
+                  .enrollments(enrollmentUids)
+                  .build())
+          .stream()
+          .filter(e -> bundle.findEventByUid(UID.of(e)).isEmpty())
+          .collect(
+              Collectors.groupingBy(
+                  e -> UID.of(e.getEnrollment()),
+                  Collectors.collectingAndThen(
+                      Collectors.toList(), RuleEngineMapper::mapSavedEvents)));
     } catch (BadRequestException | ForbiddenException e) {
       throw new RuntimeException(e);
     }
+  }
 
-    List<RuleEvent> ruleEvents =
-        RuleEngineMapper.mapPayloadEvents(
-            preheat,
-            bundle.getEvents().stream()
-                .filter(e -> e.getEnrollment().equals(enrollmentUid))
-                .toList());
-
-    return Stream.concat(
-            RuleEngineMapper.mapSavedEvents(events.toList()).stream(), ruleEvents.stream())
-        .toList();
+  // Combine pre-fetched saved events with payload events for a single enrollment.
+  private List<RuleEvent> buildRuleEvents(
+      List<RuleEvent> savedRuleEvents,
+      List<org.hisp.dhis.tracker.imports.domain.Event> payloadEvents,
+      TrackerPreheat preheat) {
+    List<RuleEvent> payloadRuleEvents = RuleEngineMapper.mapPayloadEvents(preheat, payloadEvents);
+    return Stream.concat(savedRuleEvents.stream(), payloadRuleEvents.stream()).toList();
   }
 
   private List<Attribute> filterNullAttributes(List<Attribute> attributes) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.programrule;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -107,19 +108,24 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   private RuleEngineEffects calculateEnrollmentRuleEffects(
       TrackerBundle bundle, TrackerPreheat preheat) {
-    return bundle.getEnrollments().stream()
-        .map(
-            e -> {
-              List<RuleAttributeValue> attributes =
-                  getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat);
-              RuleEnrollment enrollment =
-                  RuleEngineMapper.mapPayloadEnrollment(preheat, e, attributes);
+    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> byProgram =
+        bundle.getEnrollments().stream()
+            .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
 
-              return programRuleEngine.evaluateEnrollmentAndTrackerEvents(
-                  enrollment,
-                  getEventsFromEnrollment(e.getUid(), bundle, preheat),
-                  preheat.getProgram(e.getProgram()),
-                  bundle.getUser());
+    return byProgram.entrySet().stream()
+        .map(
+            entry -> {
+              Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents = new HashMap<>();
+              for (org.hisp.dhis.tracker.imports.domain.Enrollment e : entry.getValue()) {
+                List<RuleAttributeValue> attributes =
+                    getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat);
+                RuleEnrollment enrollment =
+                    RuleEngineMapper.mapPayloadEnrollment(preheat, e, attributes);
+                enrollmentsWithEvents.put(
+                    enrollment, getEventsFromEnrollment(e.getUid(), bundle, preheat));
+              }
+              return programRuleEngine.evaluateEnrollmentsAndTrackerEvents(
+                  enrollmentsWithEvents, entry.getKey(), bundle.getUser());
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());
@@ -134,17 +140,22 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(event -> preheat.getEnrollment(event.getEnrollment()))
             .collect(Collectors.toSet());
 
-    return enrollments.stream()
+    Map<Program, List<Enrollment>> byProgram =
+        enrollments.stream().collect(Collectors.groupingBy(Enrollment::getProgram));
+
+    return byProgram.entrySet().stream()
         .map(
-            e -> {
-              List<RuleAttributeValue> attributes =
-                  getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat);
-              RuleEnrollment enrollment = RuleEngineMapper.mapSavedEnrollment(e, attributes);
-              return programRuleEngine.evaluateEnrollmentAndTrackerEvents(
-                  enrollment,
-                  getEventsFromEnrollment(UID.of(e), bundle, preheat),
-                  e.getProgram(),
-                  bundle.getUser());
+            entry -> {
+              Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents = new HashMap<>();
+              for (Enrollment e : entry.getValue()) {
+                List<RuleAttributeValue> attributes =
+                    getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat);
+                RuleEnrollment enrollment = RuleEngineMapper.mapSavedEnrollment(e, attributes);
+                enrollmentsWithEvents.put(
+                    enrollment, getEventsFromEnrollment(UID.of(e), bundle, preheat));
+              }
+              return programRuleEngine.evaluateEnrollmentsAndTrackerEvents(
+                  enrollmentsWithEvents, entry.getKey(), bundle.getUser());
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());
@@ -161,7 +172,6 @@ class DefaultProgramRuleService implements ProgramRuleService {
         .map(
             entry -> {
               List<RuleEvent> events = RuleEngineMapper.mapPayloadEvents(preheat, entry.getValue());
-
               return programRuleEngine.evaluateProgramEvents(
                   events, entry.getKey(), bundle.getUser());
             })

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -49,6 +49,9 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleVariable;
+import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
 import org.hisp.dhis.rules.models.RuleAttributeValue;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
@@ -58,6 +61,7 @@ import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.tracker.imports.programrule.engine.RuleEngineEffects;
@@ -78,6 +82,8 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   private final org.hisp.dhis.programrule.ProgramRuleService programRuleMetadataService;
 
+  private final ProgramRuleVariableService programRuleVariableService;
+
   private final RuleActionEnrollmentMapper ruleActionEnrollmentMapper;
 
   private final RuleActionEventMapper ruleActionEventMapper;
@@ -94,18 +100,12 @@ class DefaultProgramRuleService implements ProgramRuleService {
   @Override
   @Transactional(readOnly = true)
   public void calculateRuleEffects(TrackerBundle bundle, TrackerPreheat preheat) {
-    // Collect all programs referenced by the bundle in one pass, then fetch rules for all of them
-    // at once. This avoids per-program DB queries inside the sub-methods and lets us skip the
-    // constant map allocation entirely when no program has applicable rules.
-    Set<Program> allPrograms =
-        Stream.concat(
-                bundle.getEnrollments().stream().map(e -> preheat.getProgram(e.getProgram())),
-                bundle.getEvents().stream().map(e -> preheat.getProgram(e.getProgram())))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+    // Deduplicate UIDs before hitting preheat: many enrollments/events typically share the same
+    // program, so look up each distinct program UID and enrollment UID at most once.
+    Set<Program> allPrograms = getAllProgramsFromPayload(bundle, preheat);
 
-    Map<Program, List<ProgramRule>> rulesByProgram = getRulesForPrograms(allPrograms);
-    if (rulesByProgram.isEmpty()) {
+    Map<Program, ProgramRuleContext> contextByProgram = getRulesForPrograms(allPrograms);
+    if (contextByProgram.isEmpty()) {
       return;
     }
 
@@ -116,8 +116,8 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
     RuleEngineEffects ruleEffects =
         RuleEngineEffects.merge(
-            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, rulesByProgram),
-            calculateProgramEventRuleEffects(bundle, preheat, constantMap, rulesByProgram));
+            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, contextByProgram),
+            calculateSingleEventRuleEffects(bundle, preheat, constantMap, contextByProgram));
 
     bundle.setEnrollmentNotifications(ruleEffects.getEnrollmentNotifications());
     bundle.setEventNotifications(ruleEffects.getEventNotifications());
@@ -128,11 +128,27 @@ class DefaultProgramRuleService implements ProgramRuleService {
         ruleActionEventMapper.mapRuleEffects(ruleEffects.getEventValidationEffects(), bundle));
   }
 
+  private static Set<Program> getAllProgramsFromPayload(
+      TrackerBundle bundle, TrackerPreheat preheat) {
+    // Deduplicate program identifiers before hitting preheat: many enrollments/events typically
+    // share the same program, so look up each distinct program identifier at most once.
+    Set<MetadataIdentifier> programIdentifiers = new HashSet<>();
+    bundle.getEnrollments().forEach(e -> programIdentifiers.add(e.getProgram()));
+    bundle.getEvents().forEach(e -> programIdentifiers.add(e.getProgram()));
+
+    Set<Program> allPrograms = new HashSet<>(programIdentifiers.size());
+    for (MetadataIdentifier identifier : programIdentifiers) {
+      Program p = preheat.getProgram(identifier);
+      if (p != null) allPrograms.add(p);
+    }
+    return allPrograms;
+  }
+
   private RuleEngineEffects calculateEnrollmentRuleEffects(
       TrackerBundle bundle,
       TrackerPreheat preheat,
       Map<String, String> constantMap,
-      Map<Program, List<ProgramRule>> rulesByProgram) {
+      Map<Program, ProgramRuleContext> contextByProgram) {
     Set<UID> payloadEnrollmentUids =
         bundle.getEnrollments().stream()
             .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid)
@@ -140,7 +156,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
     Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>>
         payloadEnrollmentsByProgram =
             bundle.getEnrollments().stream()
-                .filter(e -> rulesByProgram.containsKey(preheat.getProgram(e.getProgram())))
+                .filter(e -> contextByProgram.containsKey(preheat.getProgram(e.getProgram())))
                 .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
     Map<Program, List<Enrollment>> savedEnrollmentsByProgram =
         bundle.getEvents().stream()
@@ -149,7 +165,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(event -> preheat.getEnrollment(event.getEnrollment()))
             .filter(Objects::nonNull)
             .distinct()
-            .filter(e -> rulesByProgram.containsKey(e.getProgram()))
+            .filter(e -> contextByProgram.containsKey(e.getProgram()))
             .collect(Collectors.groupingBy(Enrollment::getProgram));
 
     if (payloadEnrollmentsByProgram.isEmpty() && savedEnrollmentsByProgram.isEmpty()) {
@@ -170,7 +186,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
             .collect(Collectors.groupingBy(e -> e.getEnrollment()));
 
-    return rulesByProgram.entrySet().stream()
+    return contextByProgram.entrySet().stream()
         .filter(
             entry ->
                 payloadEnrollmentsByProgram.containsKey(entry.getKey())
@@ -178,9 +194,11 @@ class DefaultProgramRuleService implements ProgramRuleService {
         .map(
             entry -> {
               Program program = entry.getKey();
+              ProgramRuleContext ctx = entry.getValue();
               Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents =
                   buildEnrollmentsWithEvents(
                       program,
+                      ctx.needsTeAttributes(),
                       payloadEnrollmentsByProgram,
                       savedEnrollmentsByProgram,
                       savedEventsByEnrollment,
@@ -188,29 +206,47 @@ class DefaultProgramRuleService implements ProgramRuleService {
                       bundle,
                       preheat);
               return programRuleEngine.evaluateEnrollmentsAndTrackerEvents(
-                  enrollmentsWithEvents, program, bundle.getUser(), constantMap, entry.getValue());
+                  enrollmentsWithEvents,
+                  bundle.getUser(),
+                  constantMap,
+                  ctx.rules(),
+                  ctx.variables());
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());
   }
 
-  // Fetches rules for each program and returns only programs that have applicable rules.
-  private Map<Program, List<ProgramRule>> getRulesForPrograms(Set<Program> programs) {
-    Map<Program, List<ProgramRule>> rulesByProgram = new HashMap<>();
+  /**
+   * Rules and variables for a single program, co-fetched once per program so that the engine does
+   * not need to re-query variables during context construction.
+   */
+  private record ProgramRuleContext(
+      List<ProgramRule> rules, List<ProgramRuleVariable> variables, boolean needsTeAttributes) {}
+
+  // Fetches rules and variables for each program; skips programs with no applicable rules.
+  private Map<Program, ProgramRuleContext> getRulesForPrograms(Set<Program> programs) {
+    Map<Program, ProgramRuleContext> contextByProgram = new HashMap<>();
     for (Program program : programs) {
       List<ProgramRule> rules =
           programRuleMetadataService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
       if (!rules.isEmpty()) {
-        rulesByProgram.put(program, rules);
+        List<ProgramRuleVariable> variables =
+            programRuleVariableService.getProgramRuleVariable(program);
+        boolean needsTeAttributes =
+            variables.stream()
+                .anyMatch(v -> v.getSourceType() == ProgramRuleVariableSourceType.TEI_ATTRIBUTE);
+        contextByProgram.put(program, new ProgramRuleContext(rules, variables, needsTeAttributes));
       }
     }
-    return rulesByProgram;
+    return contextByProgram;
   }
 
   // Builds the map of rule enrollments to rule events for a single program,
   // combining payload and saved enrollments with their respective events.
+  // Attribute loading is skipped when the program has no TEI_ATTRIBUTE variables.
   private Map<RuleEnrollment, List<RuleEvent>> buildEnrollmentsWithEvents(
       Program program,
+      boolean needsTeAttributes,
       Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> payloadByProgram,
       Map<Program, List<Enrollment>> savedByProgram,
       Map<UID, List<RuleEvent>> savedEventsByEnrollment,
@@ -222,7 +258,9 @@ class DefaultProgramRuleService implements ProgramRuleService {
     for (org.hisp.dhis.tracker.imports.domain.Enrollment e :
         payloadByProgram.getOrDefault(program, List.of())) {
       List<RuleAttributeValue> attributes =
-          getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat);
+          needsTeAttributes
+              ? getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat)
+              : List.of();
       enrollmentsWithEvents.put(
           RuleEngineMapper.mapPayloadEnrollment(preheat, e, attributes),
           buildRuleEvents(
@@ -233,7 +271,9 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
     for (Enrollment e : savedByProgram.getOrDefault(program, List.of())) {
       List<RuleAttributeValue> attributes =
-          getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat);
+          needsTeAttributes
+              ? getAttributes(UID.of(e), UID.of(e.getTrackedEntity()), bundle, preheat)
+              : List.of();
       enrollmentsWithEvents.put(
           RuleEngineMapper.mapSavedEnrollment(e, attributes),
           buildRuleEvents(
@@ -245,11 +285,11 @@ class DefaultProgramRuleService implements ProgramRuleService {
     return enrollmentsWithEvents;
   }
 
-  private RuleEngineEffects calculateProgramEventRuleEffects(
+  private RuleEngineEffects calculateSingleEventRuleEffects(
       TrackerBundle bundle,
       TrackerPreheat preheat,
       Map<String, String> constantMap,
-      Map<Program, List<ProgramRule>> rulesByProgram) {
+      Map<Program, ProgramRuleContext> contextByProgram) {
     return bundle.getEvents().stream()
         .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
         .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())))
@@ -257,14 +297,14 @@ class DefaultProgramRuleService implements ProgramRuleService {
         .stream()
         .flatMap(
             entry -> {
-              List<ProgramRule> rules = rulesByProgram.get(entry.getKey());
-              if (rules == null) {
+              ProgramRuleContext ctx = contextByProgram.get(entry.getKey());
+              if (ctx == null) {
                 return Stream.empty();
               }
               List<RuleEvent> events = RuleEngineMapper.mapPayloadEvents(preheat, entry.getValue());
               return Stream.of(
                   programRuleEngine.evaluateSingleEvents(
-                      events, entry.getKey(), bundle.getUser(), constantMap, rules));
+                      events, bundle.getUser(), constantMap, ctx.rules(), ctx.variables()));
             })
         .reduce(RuleEngineEffects::merge)
         .orElse(RuleEngineEffects.empty());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
@@ -61,25 +61,40 @@ class RuleActionEventMapper {
 
   public Map<Event, List<RuleActionExecutor<Event>>> mapRuleEffects(
       Map<UID, List<ValidationEffect>> eventValidationEffects, TrackerBundle bundle) {
-    return eventValidationEffects.keySet().stream()
-        .filter(e -> bundle.findEventByUid(e).isPresent())
-        .collect(
-            Collectors.toMap(
-                e -> bundle.findEventByUid(e).get(),
-                e ->
-                    mapRuleEffects(
-                        bundle.findEventByUid(e).get(), eventValidationEffects.get(e), bundle)));
+    // Use entrySet() so findEventByUid is called once per entry instead of three times,
+    // avoiding two redundant Optional allocations per event.
+    return eventValidationEffects.entrySet().stream()
+        .flatMap(
+            entry ->
+                bundle
+                    .findEventByUid(entry.getKey())
+                    .map(event -> Map.entry(event, mapRuleEffects(event, entry.getValue(), bundle)))
+                    .stream())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private List<RuleActionExecutor<Event>> mapRuleEffects(
       Event event, List<ValidationEffect> ruleValidationEffects, TrackerBundle bundle) {
     ProgramStage programStage = bundle.getPreheat().getProgramStage(event.getProgramStage());
 
+    // needsToValidateDataValues depends only on event+programStage, not on individual effects;
+    // hoist the check to avoid evaluating it once per effect and short-circuit early.
+    if (!needsToValidateDataValues(event, programStage)) {
+      return List.of();
+    }
+
+    // Pre-build the set of data element UIDs for this program stage so that
+    // isDataElementPartOfProgramStage does not stream over the collection per effect.
+    Set<String> stageDataElementUids =
+        programStage.getDataElements().stream()
+            .map(IdentifiableObject::getUid)
+            .collect(Collectors.toSet());
+
     return ruleValidationEffects.stream()
-        .filter(executor -> needsToValidateDataValues(event, programStage))
         .map(effect -> buildEventRuleActionExecutor(effect, event.getDataValues()))
         .filter(
-            executor -> isDataElementPartOfProgramStage(executor.getDataElementUid(), programStage))
+            executor ->
+                isDataElementPartOfProgramStage(executor.getDataElementUid(), stageDataElementUids))
         .toList();
   }
 
@@ -104,13 +119,8 @@ class RuleActionEventMapper {
     };
   }
 
-  private boolean isDataElementPartOfProgramStage(UID dataElementUid, ProgramStage programStage) {
-    if (dataElementUid == null) {
-      return true;
-    }
-
-    return programStage.getDataElements().stream()
-        .map(IdentifiableObject::getUid)
-        .anyMatch(de -> de.equals(dataElementUid.getValue()));
+  private boolean isDataElementPartOfProgramStage(
+      UID dataElementUid, Set<String> stageDataElementUids) {
+    return dataElementUid == null || stageDataElementUids.contains(dataElementUid.getValue());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
@@ -118,14 +118,14 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   @Override
   public RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
       @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
-      @Nonnull Program program,
       @Nonnull UserDetails user,
       @Nonnull Map<String, String> constantMap,
-      @Nonnull List<ProgramRule> rules) {
+      @Nonnull List<ProgramRule> rules,
+      @Nonnull List<ProgramRuleVariable> variables) {
     if (enrollmentsWithEvents.isEmpty()) {
       return RuleEngineEffects.of(Collections.emptyList());
     }
-    RuleEngineContext context = getRuleEngineContext(program, rules, user, constantMap);
+    RuleEngineContext context = getRuleEngineContext(rules, variables, user, constantMap);
     List<RuleEffects> allEffects = new ArrayList<>();
     for (Map.Entry<RuleEnrollment, List<RuleEvent>> entry : enrollmentsWithEvents.entrySet()) {
       try {
@@ -140,11 +140,11 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   @Override
   public RuleEngineEffects evaluateSingleEvents(
       @Nonnull List<RuleEvent> events,
-      @Nonnull Program program,
       @Nonnull UserDetails user,
       @Nonnull Map<String, String> constantMap,
-      @Nonnull List<ProgramRule> rules) {
-    RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user, constantMap);
+      @Nonnull List<ProgramRule> rules,
+      @Nonnull List<ProgramRuleVariable> variables) {
+    RuleEngineContext ruleEngineContext = getRuleEngineContext(rules, variables, user, constantMap);
     try {
       return RuleEngineEffects.of(ruleEngine.evaluateAll(null, events, ruleEngineContext));
     } catch (Exception e) {
@@ -154,13 +154,10 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   }
 
   private RuleEngineContext getRuleEngineContext(
-      @Nonnull Program program,
       @Nonnull List<ProgramRule> programRules,
+      @Nonnull List<ProgramRuleVariable> programRuleVariables,
       @Nonnull UserDetails user,
       @Nonnull Map<String, String> constantMap) {
-    List<ProgramRuleVariable> programRuleVariables =
-        programRuleVariableService.getProgramRuleVariable(program);
-
     RuleSupplementaryData supplementaryData =
         supplementaryDataProvider.getSupplementaryData(programRules, user);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
@@ -29,13 +29,10 @@
  */
 package org.hisp.dhis.tracker.imports.programrule.engine;
 
-import static org.hisp.dhis.programrule.ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.UID;
@@ -44,7 +41,6 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.programrule.ProgramRule;
-import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.rules.api.RuleEngine;
@@ -69,8 +65,6 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
 
   private final ConstantService constantService;
 
-  private final ProgramRuleService programRuleService;
-
   private final SupplementaryDataProvider supplementaryDataProvider;
 
   private final ProgramService programService;
@@ -81,13 +75,11 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
       ProgramRuleEntityMapperService programRuleEntityMapperService,
       ProgramRuleVariableService programRuleVariableService,
       ConstantService constantService,
-      ProgramRuleService programRuleService,
       SupplementaryDataProvider supplementaryDataProvider,
       ProgramService programService) {
     this.programRuleEntityMapperService = programRuleEntityMapperService;
     this.programRuleVariableService = programRuleVariableService;
     this.constantService = constantService;
-    this.programRuleService = programRuleService;
     this.supplementaryDataProvider = supplementaryDataProvider;
     this.programService = programService;
     this.ruleEngine = RuleEngine.getInstance();
@@ -127,16 +119,13 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   public RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
       @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
       @Nonnull Program program,
-      @Nonnull UserDetails user) {
+      @Nonnull UserDetails user,
+      @Nonnull Map<String, String> constantMap,
+      @Nonnull List<ProgramRule> rules) {
     if (enrollmentsWithEvents.isEmpty()) {
       return RuleEngineEffects.of(Collections.emptyList());
     }
-    List<ProgramRule> rules =
-        programRuleService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
-    if (rules.isEmpty()) {
-      return RuleEngineEffects.of(Collections.emptyList());
-    }
-    RuleEngineContext context = getRuleEngineContext(program, rules, user);
+    RuleEngineContext context = getRuleEngineContext(program, rules, user, constantMap);
     List<RuleEffects> allEffects = new ArrayList<>();
     for (Map.Entry<RuleEnrollment, List<RuleEvent>> entry : enrollmentsWithEvents.entrySet()) {
       try {
@@ -149,16 +138,13 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   }
 
   @Override
-  public RuleEngineEffects evaluateProgramEvents(
-      @Nonnull List<RuleEvent> events, @Nonnull Program program, @Nonnull UserDetails user) {
-    List<ProgramRule> rules =
-        programRuleService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
-
-    if (rules.isEmpty()) {
-      return RuleEngineEffects.of(Collections.emptyList());
-    }
-
-    RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user);
+  public RuleEngineEffects evaluateSingleEvents(
+      @Nonnull List<RuleEvent> events,
+      @Nonnull Program program,
+      @Nonnull UserDetails user,
+      @Nonnull Map<String, String> constantMap,
+      @Nonnull List<ProgramRule> rules) {
+    RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user, constantMap);
     try {
       return RuleEngineEffects.of(ruleEngine.evaluateAll(null, events, ruleEngineContext));
     } catch (Exception e) {
@@ -170,14 +156,10 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   private RuleEngineContext getRuleEngineContext(
       @Nonnull Program program,
       @Nonnull List<ProgramRule> programRules,
-      @Nonnull UserDetails user) {
+      @Nonnull UserDetails user,
+      @Nonnull Map<String, String> constantMap) {
     List<ProgramRuleVariable> programRuleVariables =
         programRuleVariableService.getProgramRuleVariable(program);
-
-    Map<String, String> constantMap =
-        constantService.getConstantMap().entrySet().stream()
-            .collect(
-                Collectors.toMap(Map.Entry::getKey, v -> Double.toString(v.getValue().getValue())));
 
     RuleSupplementaryData supplementaryData =
         supplementaryDataProvider.getSupplementaryData(programRules, user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEngine.java
@@ -31,15 +31,14 @@ package org.hisp.dhis.tracker.imports.programrule.engine;
 
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.Program;
@@ -125,25 +124,33 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
   }
 
   @Override
-  public RuleEngineEffects evaluateEnrollmentAndTrackerEvents(
-      @Nonnull RuleEnrollment enrollment,
-      @Nonnull List<RuleEvent> events,
+  public RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
+      @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
       @Nonnull Program program,
       @Nonnull UserDetails user) {
-    return evaluateEnrollmentAndEvents(enrollment, events, program, user);
+    if (enrollmentsWithEvents.isEmpty()) {
+      return RuleEngineEffects.of(Collections.emptyList());
+    }
+    List<ProgramRule> rules =
+        programRuleService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
+    if (rules.isEmpty()) {
+      return RuleEngineEffects.of(Collections.emptyList());
+    }
+    RuleEngineContext context = getRuleEngineContext(program, rules, user);
+    List<RuleEffects> allEffects = new ArrayList<>();
+    for (Map.Entry<RuleEnrollment, List<RuleEvent>> entry : enrollmentsWithEvents.entrySet()) {
+      try {
+        allEffects.addAll(ruleEngine.evaluateAll(entry.getKey(), entry.getValue(), context));
+      } catch (Exception e) {
+        log.error("Call to rule-engine failed", e);
+      }
+    }
+    return RuleEngineEffects.of(allEffects);
   }
 
   @Override
   public RuleEngineEffects evaluateProgramEvents(
       @Nonnull List<RuleEvent> events, @Nonnull Program program, @Nonnull UserDetails user) {
-    return evaluateEnrollmentAndEvents(null, events, program, user);
-  }
-
-  private RuleEngineEffects evaluateEnrollmentAndEvents(
-      @CheckForNull RuleEnrollment enrollment,
-      @Nonnull List<RuleEvent> events,
-      @Nonnull Program program,
-      @Nonnull UserDetails user) {
     List<ProgramRule> rules =
         programRuleService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
 
@@ -151,23 +158,12 @@ public class DefaultProgramRuleEngine implements ProgramRuleEngine {
       return RuleEngineEffects.of(Collections.emptyList());
     }
 
-    List<RuleEffects> ruleEffects =
-        evaluateProgramRulesForMultipleTrackerObjects(enrollment, program, events, rules, user);
-    return RuleEngineEffects.of(ruleEffects);
-  }
-
-  private List<RuleEffects> evaluateProgramRulesForMultipleTrackerObjects(
-      @CheckForNull RuleEnrollment ruleEnrollment,
-      @Nonnull Program program,
-      @Nonnull List<RuleEvent> ruleEvents,
-      @Nonnull List<ProgramRule> rules,
-      @Nonnull UserDetails user) {
+    RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user);
     try {
-      RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user);
-      return ruleEngine.evaluateAll(ruleEnrollment, ruleEvents, ruleEngineContext);
+      return RuleEngineEffects.of(ruleEngine.evaluateAll(null, events, ruleEngineContext));
     } catch (Exception e) {
-      log.error(DebugUtils.getStackTrace(e));
-      return Collections.emptyList();
+      log.error("Call to rule-engine failed", e);
+      return RuleEngineEffects.of(List.of());
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
 import org.hisp.dhis.rules.models.RuleValidationResult;
@@ -45,27 +46,27 @@ public interface ProgramRuleEngine {
   /**
    * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
    * the rule engine context once. Rules are evaluated under the authorization of given {@link
-   * UserDetails}. {@code rules} and {@code constantMap} are pre-fetched by the caller so they are
-   * not re-queried inside the engine.
+   * UserDetails}. {@code rules}, {@code variables}, and {@code constantMap} are pre-fetched by the
+   * caller so they are not re-queried inside the engine.
    */
   RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
       @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
-      @Nonnull Program program,
       @Nonnull UserDetails user,
       @Nonnull Map<String, String> constantMap,
-      @Nonnull List<ProgramRule> rules);
+      @Nonnull List<ProgramRule> rules,
+      @Nonnull List<ProgramRuleVariable> variables);
 
   /**
    * Evaluate program rules as the given {@link UserDetails} for {@link Program} for program events.
-   * {@code rules} and {@code constantMap} are pre-fetched by the caller so they are not re-queried
-   * inside the engine.
+   * {@code rules}, {@code variables}, and {@code constantMap} are pre-fetched by the caller so they
+   * are not re-queried inside the engine.
    */
   RuleEngineEffects evaluateSingleEvents(
       @Nonnull List<RuleEvent> events,
-      @Nonnull Program program,
       @Nonnull UserDetails user,
       @Nonnull Map<String, String> constantMap,
-      @Nonnull List<ProgramRule> rules);
+      @Nonnull List<ProgramRule> rules,
+      @Nonnull List<ProgramRuleVariable> variables);
 
   /**
    * To getDescription rule condition in order to fetch its description

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
 import org.hisp.dhis.rules.models.RuleValidationResult;
@@ -44,19 +45,27 @@ public interface ProgramRuleEngine {
   /**
    * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
    * the rule engine context once. Rules are evaluated under the authorization of given {@link
-   * UserDetails}.
+   * UserDetails}. {@code rules} and {@code constantMap} are pre-fetched by the caller so they are
+   * not re-queried inside the engine.
    */
   RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
       @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
       @Nonnull Program program,
-      @Nonnull UserDetails user);
+      @Nonnull UserDetails user,
+      @Nonnull Map<String, String> constantMap,
+      @Nonnull List<ProgramRule> rules);
 
   /**
    * Evaluate program rules as the given {@link UserDetails} for {@link Program} for program events.
-   * Rules are evaluated under the authorization of given {@link UserDetails}.
+   * {@code rules} and {@code constantMap} are pre-fetched by the caller so they are not re-queried
+   * inside the engine.
    */
-  RuleEngineEffects evaluateProgramEvents(
-      @Nonnull List<RuleEvent> events, @Nonnull Program program, UserDetails user);
+  RuleEngineEffects evaluateSingleEvents(
+      @Nonnull List<RuleEvent> events,
+      @Nonnull Program program,
+      @Nonnull UserDetails user,
+      @Nonnull Map<String, String> constantMap,
+      @Nonnull List<ProgramRule> rules);
 
   /**
    * To getDescription rule condition in order to fetch its description

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEngine.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.imports.programrule.engine;
 
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -41,12 +42,12 @@ import org.hisp.dhis.user.UserDetails;
 
 public interface ProgramRuleEngine {
   /**
-   * Evaluate program rules for {@link Program} for enrollment and tracker events. Rules are
-   * evaluated under the authorization of given {@link UserDetails}.
+   * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
+   * the rule engine context once. Rules are evaluated under the authorization of given {@link
+   * UserDetails}.
    */
-  RuleEngineEffects evaluateEnrollmentAndTrackerEvents(
-      @Nonnull RuleEnrollment enrollment,
-      @Nonnull List<RuleEvent> events,
+  RuleEngineEffects evaluateEnrollmentsAndTrackerEvents(
+      @Nonnull Map<RuleEnrollment, List<RuleEvent>> enrollmentsWithEvents,
       @Nonnull Program program,
       @Nonnull UserDetails user);
 


### PR DESCRIPTION
Backport of DHIS2-21178 PRs from master:

1. #23346 - perf: Reduce allocations for program rules evaluation
2. #23381 - perf: Create context only for programs with rules
3. #23388 - perf: Bump to more performative rule-engine version
4. #23457 - perf: Only calculate attributes when TEI_ATTRIBUTE variable is present