### PR TITLE
perf: Reduce allocations for program rules evaluation [DHIS2-21178] (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.programrule.engine;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,15 @@ import org.hisp.dhis.user.UserDetails;
 @RequiredArgsConstructor
 public class ProgramRuleEngine {
   private static final String ERROR = "Program cannot be null";
+
+  /**
+   * Holds an enrollment together with its related events and tracked entity attribute values, used
+   * as input for batch rule evaluation.
+   */
+  public record EnrollmentWithEvents(
+      Enrollment enrollment,
+      Set<Event> events,
+      List<TrackedEntityAttributeValue> attributeValues) {}
 
   private final ProgramRuleEntityMapperService programRuleEntityMapperService;
 
@@ -122,6 +132,36 @@ public class ProgramRuleEngine {
         getRuleEvents(events, null),
         rules,
         user);
+  }
+
+  /**
+   * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
+   * the rule engine context once. Rules are evaluated under the authorization of given {@link
+   * UserDetails}.
+   */
+  public List<RuleEffects> evaluateEnrollmentsAndTrackerEvents(
+      List<EnrollmentWithEvents> enrollmentsWithEvents, Program program, UserDetails user) {
+    if (enrollmentsWithEvents.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<ProgramRule> rules = implementableRuleService.getProgramRules(program);
+    if (rules.isEmpty()) {
+      return Collections.emptyList();
+    }
+    RuleEngineContext context = getRuleEngineContext(program, rules, user);
+    List<RuleEffects> allEffects = new ArrayList<>();
+    for (EnrollmentWithEvents ewc : enrollmentsWithEvents) {
+      try {
+        allEffects.addAll(
+            ruleEngine.evaluateAll(
+                getRuleEnrollment(ewc.enrollment(), ewc.attributeValues()),
+                getRuleEvents(ewc.events(), null),
+                context));
+      } catch (Exception e) {
+        log.error(DebugUtils.getStackTrace(e));
+      }
+    }
+    return allEffects;
   }
 
   public List<RuleEffects> evaluateProgramEvents(

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -194,6 +194,36 @@ public class ProgramRuleEngine {
     return allEffects;
   }
 
+  /**
+   * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
+   * the rule engine context once. {@code rules}, {@code variables}, and {@code constantMap} are
+   * pre-fetched by the caller so they are not re-queried inside the engine.
+   */
+  public List<RuleEffects> evaluateEnrollmentsAndTrackerEvents(
+      List<EnrollmentWithEvents> enrollmentsWithEvents,
+      UserDetails user,
+      Map<String, String> constantMap,
+      List<ProgramRule> rules,
+      List<ProgramRuleVariable> variables) {
+    if (enrollmentsWithEvents.isEmpty() || rules.isEmpty()) {
+      return Collections.emptyList();
+    }
+    RuleEngineContext context = getRuleEngineContext(rules, variables, user, constantMap);
+    List<RuleEffects> allEffects = new ArrayList<>();
+    for (EnrollmentWithEvents ewc : enrollmentsWithEvents) {
+      try {
+        allEffects.addAll(
+            ruleEngine.evaluateAll(
+                getRuleEnrollment(ewc.enrollment(), ewc.attributeValues()),
+                getRuleEvents(ewc.events(), null),
+                context));
+      } catch (Exception e) {
+        log.error(DebugUtils.getStackTrace(e));
+      }
+    }
+    return allEffects;
+  }
+
   public List<RuleEffects> evaluateProgramEvents(
       Set<Event> events, Program program, UserDetails user) {
     List<ProgramRule> rules = implementableRuleService.getProgramRules(program);
@@ -213,6 +243,28 @@ public class ProgramRuleEngine {
       List<ProgramRule> rules) {
     try {
       RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user, constantMap);
+      return ruleEngine.evaluateAll(null, getRuleEvents(events, null), ruleEngineContext);
+    } catch (Exception e) {
+      log.error(DebugUtils.getStackTrace(e));
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Evaluate program rules for program events (without-registration). {@code rules}, {@code
+   * variables}, and {@code constantMap} are pre-fetched by the caller so they are not re-queried
+   * inside the engine.
+   */
+  public List<RuleEffects> evaluateProgramEvents(
+      Set<Event> events,
+      Program program,
+      UserDetails user,
+      Map<String, String> constantMap,
+      List<ProgramRule> rules,
+      List<ProgramRuleVariable> variables) {
+    try {
+      RuleEngineContext ruleEngineContext =
+          getRuleEngineContext(rules, variables, user, constantMap);
       return ruleEngine.evaluateAll(null, getRuleEvents(events, null), ruleEngineContext);
     } catch (Exception e) {
       log.error(DebugUtils.getStackTrace(e));
@@ -329,6 +381,21 @@ public class ProgramRuleEngine {
     List<ProgramRuleVariable> programRuleVariables =
         programRuleVariableService.getProgramRuleVariable(program);
 
+    RuleSupplementaryData supplementaryData =
+        supplementaryDataProvider.getSupplementaryData(programRules, user);
+
+    return new RuleEngineContext(
+        programRuleEntityMapperService.toMappedProgramRules(programRules),
+        programRuleEntityMapperService.toMappedProgramRuleVariables(programRuleVariables),
+        supplementaryData,
+        constantMap);
+  }
+
+  private RuleEngineContext getRuleEngineContext(
+      List<ProgramRule> programRules,
+      List<ProgramRuleVariable> programRuleVariables,
+      UserDetails user,
+      Map<String, String> constantMap) {
     RuleSupplementaryData supplementaryData =
         supplementaryDataProvider.getSupplementaryData(programRules, user);
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -164,11 +164,60 @@ public class ProgramRuleEngine {
     return allEffects;
   }
 
+  /**
+   * Evaluate program rules for multiple enrollments belonging to the same {@link Program}, building
+   * the rule engine context once. {@code rules} and {@code constantMap} are pre-fetched by the
+   * caller so they are not re-queried inside the engine.
+   */
+  public List<RuleEffects> evaluateEnrollmentsAndTrackerEvents(
+      List<EnrollmentWithEvents> enrollmentsWithEvents,
+      Program program,
+      UserDetails user,
+      Map<String, String> constantMap,
+      List<ProgramRule> rules) {
+    if (enrollmentsWithEvents.isEmpty() || rules.isEmpty()) {
+      return Collections.emptyList();
+    }
+    RuleEngineContext context = getRuleEngineContext(program, rules, user, constantMap);
+    List<RuleEffects> allEffects = new ArrayList<>();
+    for (EnrollmentWithEvents ewc : enrollmentsWithEvents) {
+      try {
+        allEffects.addAll(
+            ruleEngine.evaluateAll(
+                getRuleEnrollment(ewc.enrollment(), ewc.attributeValues()),
+                getRuleEvents(ewc.events(), null),
+                context));
+      } catch (Exception e) {
+        log.error(DebugUtils.getStackTrace(e));
+      }
+    }
+    return allEffects;
+  }
+
   public List<RuleEffects> evaluateProgramEvents(
       Set<Event> events, Program program, UserDetails user) {
     List<ProgramRule> rules = implementableRuleService.getProgramRules(program);
     return evaluateProgramRulesForMultipleTrackerObjects(
         null, program, getRuleEvents(events, null), rules, user);
+  }
+
+  /**
+   * Evaluate program rules for program events (without-registration). {@code rules} and {@code
+   * constantMap} are pre-fetched by the caller so they are not re-queried inside the engine.
+   */
+  public List<RuleEffects> evaluateProgramEvents(
+      Set<Event> events,
+      Program program,
+      UserDetails user,
+      Map<String, String> constantMap,
+      List<ProgramRule> rules) {
+    try {
+      RuleEngineContext ruleEngineContext = getRuleEngineContext(program, rules, user, constantMap);
+      return ruleEngine.evaluateAll(null, getRuleEvents(events, null), ruleEngineContext);
+    } catch (Exception e) {
+      log.error(DebugUtils.getStackTrace(e));
+      return Collections.emptyList();
+    }
   }
 
   private List<RuleEffect> evaluateProgramRules(
@@ -261,6 +310,24 @@ public class ProgramRuleEngine {
         constantService.getConstantMap().entrySet().stream()
             .collect(
                 Collectors.toMap(Map.Entry::getKey, v -> Double.toString(v.getValue().getValue())));
+
+    RuleSupplementaryData supplementaryData =
+        supplementaryDataProvider.getSupplementaryData(programRules, user);
+
+    return new RuleEngineContext(
+        programRuleEntityMapperService.toMappedProgramRules(programRules),
+        programRuleEntityMapperService.toMappedProgramRuleVariables(programRuleVariables),
+        supplementaryData,
+        constantMap);
+  }
+
+  private RuleEngineContext getRuleEngineContext(
+      Program program,
+      List<ProgramRule> programRules,
+      UserDetails user,
+      Map<String, String> constantMap) {
+    List<ProgramRuleVariable> programRuleVariables =
+        programRuleVariableService.getProgramRuleVariable(program);
 
     RuleSupplementaryData supplementaryData =
         supplementaryDataProvider.getSupplementaryData(programRules, user);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -28,9 +28,11 @@
 package org.hisp.dhis.tracker.imports.programrule;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.programrule.ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,11 +42,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
+import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -83,30 +87,50 @@ class DefaultProgramRuleService implements ProgramRuleService {
   private final TrackerConverterService<Attribute, TrackedEntityAttributeValue>
       attributeValueTrackerConverterService;
 
+  private final ConstantService constantService;
+
+  private final org.hisp.dhis.programrule.ProgramRuleService programRuleMetadataService;
+
   private final RuleActionEnrollmentMapper ruleActionEnrollmentMapper;
 
   private final RuleActionEventMapper ruleActionEventMapper;
 
   /**
-   * This is calculating the rule effects for all the enrollments and events present in the payload.
-   * First, this method is iterating over the enrollments present in the payload and related events
-   * (also the ones not present in the payload) and it is calculating rule effects for those. The,
-   * this method is iterating over events present in the payload and related enrollment (also if it
-   * is not present in the payload) and it is calculating rule effects for those. {@link
-   * #calculateTrackerEventRuleEffects(TrackerBundle, TrackerPreheat)} method makes sure that rule
-   * effects are calculated only once for every event. This ensures that there will be no duplicate
-   * effects. Finally, this method is iterating over all program events present in the payload, and
-   * it is calculating rule effects for those.
+   * Calculates rule effects for all enrollments, tracker events, and single events in the payload.
+   *
+   * <p>All programs referenced by the bundle are collected in a single pass and their rules fetched
+   * at once. The constant map is allocated only when at least one program has applicable rules.
+   * Enrollments and tracker events whose enrollment is not in the payload are grouped by program so
+   * that {@link ProgramRuleEngine#evaluateEnrollmentsAndTrackerEvents} is called at most once per
+   * distinct program. Single events are evaluated separately per program.
    */
   @Override
   @Transactional(readOnly = true)
   public void calculateRuleEffects(TrackerBundle bundle, TrackerPreheat preheat) {
+    // Collect all programs referenced by the bundle in one pass, then fetch rules for all of them
+    // at once. This avoids per-program DB queries inside the sub-methods and lets us skip the
+    // constant map allocation entirely when no program has applicable rules.
+    Set<Program> allPrograms =
+        Stream.concat(
+                bundle.getEnrollments().stream().map(e -> preheat.getProgram(e.getProgram())),
+                bundle.getEvents().stream().map(e -> preheat.getProgram(e.getProgram())))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    Map<Program, List<ProgramRule>> rulesByProgram = getRulesForPrograms(allPrograms);
+    if (rulesByProgram.isEmpty()) {
+      return;
+    }
+
+    Map<String, String> constantMap =
+        constantService.getConstantMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, v -> Double.toString(v.getValue().getValue())));
+
     List<RuleEffects> ruleEffects =
         ListUtils.union(
-            calculateEnrollmentRuleEffects(bundle, preheat),
-            ListUtils.union(
-                calculateProgramEventRuleEffects(bundle, preheat),
-                calculateTrackerEventRuleEffects(bundle, preheat)));
+            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, rulesByProgram),
+            calculateProgramEventRuleEffects(bundle, preheat, constantMap, rulesByProgram));
 
     // This is needed for bundle side effects process
     bundle.setRuleEffects(ruleEffects);
@@ -117,88 +141,185 @@ class DefaultProgramRuleService implements ProgramRuleService {
     bundle.setEventRuleActionExecutors(ruleActionEventMapper.mapRuleEffects(ruleEffects, bundle));
   }
 
-  private List<RuleEffects> calculateEnrollmentRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> byProgram =
-        bundle.getEnrollments().stream()
-            .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
+  // Fetches rules for each program and returns only programs that have applicable rules.
+  private Map<Program, List<ProgramRule>> getRulesForPrograms(Set<Program> programs) {
+    Map<Program, List<ProgramRule>> rulesByProgram = new HashMap<>();
+    for (Program program : programs) {
+      List<ProgramRule> rules =
+          programRuleMetadataService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
+      if (!rules.isEmpty()) {
+        rulesByProgram.put(program, rules);
+      }
+    }
+    return rulesByProgram;
+  }
 
-    return byProgram.entrySet().stream()
+  private List<RuleEffects> calculateEnrollmentRuleEffects(
+      TrackerBundle bundle,
+      TrackerPreheat preheat,
+      Map<String, String> constantMap,
+      Map<Program, List<ProgramRule>> rulesByProgram) {
+    Set<String> payloadEnrollmentUids =
+        bundle.getEnrollments().stream()
+            .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid)
+            .collect(Collectors.toSet());
+
+    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>>
+        payloadEnrollmentsByProgram =
+            bundle.getEnrollments().stream()
+                .filter(e -> rulesByProgram.containsKey(preheat.getProgram(e.getProgram())))
+                .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
+
+    Map<Program, List<Enrollment>> savedEnrollmentsByProgram =
+        bundle.getEvents().stream()
+            .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
+            .filter(event -> !payloadEnrollmentUids.contains(event.getEnrollment()))
+            .map(event -> preheat.getEnrollment(event.getEnrollment()))
+            .filter(Objects::nonNull)
+            .distinct()
+            .filter(e -> rulesByProgram.containsKey(e.getProgram()))
+            .collect(Collectors.groupingBy(Enrollment::getProgram));
+
+    if (payloadEnrollmentsByProgram.isEmpty() && savedEnrollmentsByProgram.isEmpty()) {
+      return List.of();
+    }
+
+    Set<String> enrollmentUids =
+        Stream.concat(
+                payloadEnrollmentsByProgram.values().stream()
+                    .flatMap(List::stream)
+                    .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid),
+                savedEnrollmentsByProgram.values().stream()
+                    .flatMap(List::stream)
+                    .map(Enrollment::getUid))
+            .collect(Collectors.toSet());
+
+    Map<String, Set<Event>> savedEventsByEnrollment =
+        fetchSavedEventsForEnrollments(enrollmentUids, bundle);
+
+    return rulesByProgram.entrySet().stream()
+        .filter(
+            entry ->
+                payloadEnrollmentsByProgram.containsKey(entry.getKey())
+                    || savedEnrollmentsByProgram.containsKey(entry.getKey()))
         .flatMap(
             entry -> {
+              Program program = entry.getKey();
               List<ProgramRuleEngine.EnrollmentWithEvents> enrollmentsWithEvents =
-                  entry.getValue().stream()
-                      .map(
-                          e -> {
-                            Enrollment enrollment =
-                                enrollmentTrackerConverterService.fromForRuleEngine(preheat, e);
-                            return new ProgramRuleEngine.EnrollmentWithEvents(
-                                enrollment,
-                                getEventsFromEnrollment(enrollment.getUid(), bundle, preheat),
-                                getAttributes(
-                                    e.getEnrollment(), e.getTrackedEntity(), bundle, preheat));
-                          })
-                      .toList();
+                  buildEnrollmentsWithEvents(
+                      program,
+                      payloadEnrollmentsByProgram,
+                      savedEnrollmentsByProgram,
+                      savedEventsByEnrollment,
+                      bundle,
+                      preheat);
               return programRuleEngine
                   .evaluateEnrollmentsAndTrackerEvents(
-                      enrollmentsWithEvents, entry.getKey(), UserDetails.fromUser(bundle.getUser()))
+                      enrollmentsWithEvents,
+                      program,
+                      UserDetails.fromUser(bundle.getUser()),
+                      constantMap,
+                      entry.getValue())
                   .stream();
             })
         .toList();
   }
 
-  private List<RuleEffects> calculateTrackerEventRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Set<Enrollment> enrollments =
-        bundle.getEvents().stream()
-            .filter(event -> bundle.findEnrollmentByUid(event.getEnrollment()).isEmpty())
-            .filter(event -> preheat.getProgram(event.getProgram()).isRegistration())
-            .map(event -> preheat.getEnrollment(event.getEnrollment()))
-            .collect(Collectors.toSet());
+  // Builds the list of EnrollmentWithEvents for a single program,
+  // combining payload and saved enrollments with their respective events.
+  private List<ProgramRuleEngine.EnrollmentWithEvents> buildEnrollmentsWithEvents(
+      Program program,
+      Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> payloadByProgram,
+      Map<Program, List<Enrollment>> savedByProgram,
+      Map<String, Set<Event>> savedEventsByEnrollment,
+      TrackerBundle bundle,
+      TrackerPreheat preheat) {
+    List<ProgramRuleEngine.EnrollmentWithEvents> result = new ArrayList<>();
 
-    Map<Program, List<Enrollment>> byProgram =
-        enrollments.stream().collect(Collectors.groupingBy(Enrollment::getProgram));
+    for (org.hisp.dhis.tracker.imports.domain.Enrollment e :
+        payloadByProgram.getOrDefault(program, List.of())) {
+      Enrollment enrollment = enrollmentTrackerConverterService.fromForRuleEngine(preheat, e);
+      Set<Event> allEvents =
+          new HashSet<>(savedEventsByEnrollment.getOrDefault(e.getUid(), Set.of()));
+      bundle.getEvents().stream()
+          .filter(ev -> ev.getEnrollment().equals(e.getUid()))
+          .filter(ev -> preheat.getProgram(ev.getProgram()).isRegistration())
+          .map(ev -> eventTrackerConverterService.fromForRuleEngine(preheat, ev))
+          .forEach(allEvents::add);
+      result.add(
+          new ProgramRuleEngine.EnrollmentWithEvents(
+              enrollment,
+              allEvents,
+              getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat)));
+    }
 
-    return byProgram.entrySet().stream()
-        .flatMap(
-            entry -> {
-              List<ProgramRuleEngine.EnrollmentWithEvents> enrollmentsWithEvents =
-                  entry.getValue().stream()
-                      .map(
-                          e ->
-                              new ProgramRuleEngine.EnrollmentWithEvents(
-                                  e,
-                                  getEventsFromEnrollment(e.getUid(), bundle, preheat),
-                                  getAttributes(
-                                      e.getUid(), e.getTrackedEntity().getUid(), bundle, preheat)))
-                      .toList();
-              return programRuleEngine
-                  .evaluateEnrollmentsAndTrackerEvents(
-                      enrollmentsWithEvents, entry.getKey(), UserDetails.fromUser(bundle.getUser()))
-                  .stream();
-            })
-        .toList();
+    for (Enrollment e : savedByProgram.getOrDefault(program, List.of())) {
+      Set<Event> allEvents =
+          new HashSet<>(savedEventsByEnrollment.getOrDefault(e.getUid(), Set.of()));
+      bundle.getEvents().stream()
+          .filter(ev -> ev.getEnrollment().equals(e.getUid()))
+          .filter(ev -> preheat.getProgram(ev.getProgram()).isRegistration())
+          .map(ev -> eventTrackerConverterService.fromForRuleEngine(preheat, ev))
+          .forEach(allEvents::add);
+      result.add(
+          new ProgramRuleEngine.EnrollmentWithEvents(
+              e,
+              allEvents,
+              getAttributes(e.getUid(), e.getTrackedEntity().getUid(), bundle, preheat)));
+    }
+
+    return result;
   }
 
   private List<RuleEffects> calculateProgramEventRuleEffects(
-      TrackerBundle bundle, TrackerPreheat preheat) {
-    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Event>> programEvents =
-        bundle.getEvents().stream()
-            .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
-            .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())));
-
-    return programEvents.entrySet().stream()
+      TrackerBundle bundle,
+      TrackerPreheat preheat,
+      Map<String, String> constantMap,
+      Map<Program, List<ProgramRule>> rulesByProgram) {
+    return bundle.getEvents().stream()
+        .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
+        .filter(event -> rulesByProgram.containsKey(preheat.getProgram(event.getProgram())))
+        .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())))
+        .entrySet()
+        .stream()
         .flatMap(
             entry -> {
               List<Event> events =
                   eventTrackerConverterService.fromForRuleEngine(preheat, entry.getValue());
-
               return programRuleEngine
                   .evaluateProgramEvents(
-                      new HashSet<>(events), entry.getKey(), UserDetails.fromUser(bundle.getUser()))
+                      new HashSet<>(events),
+                      entry.getKey(),
+                      UserDetails.fromUser(bundle.getUser()),
+                      constantMap,
+                      rulesByProgram.get(entry.getKey()))
                   .stream();
             })
         .toList();
+  }
+
+  // Fetch all saved events for the given enrollments in a single DB query and group by enrollment.
+  // Payload events (already in the bundle) are excluded since they will be added in
+  // buildEnrollmentsWithEvents.
+  private Map<String, Set<Event>> fetchSavedEventsForEnrollments(
+      Set<String> enrollmentUids, TrackerBundle bundle) {
+    if (enrollmentUids.isEmpty()) {
+      return Map.of();
+    }
+    try {
+      return eventService
+          .getEvents(
+              EventOperationParams.builder()
+                  .eventParams(EventParams.TRUE)
+                  .orgUnitMode(ACCESSIBLE)
+                  .enrollments(enrollmentUids)
+                  .build())
+          .stream()
+          .filter(e -> bundle.findEventByUid(e.getUid()).isEmpty())
+          .collect(Collectors.groupingBy(e -> e.getEnrollment().getUid(), Collectors.toSet()));
+    } catch (BadRequestException | ForbiddenException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   // Get all the attributes linked to enrollment from the payload and the DB,
@@ -236,35 +357,6 @@ class DefaultProgramRuleService implements ProgramRuleService {
     }
 
     return attributeValues;
-  }
-
-  // Get all the events linked to enrollment from the payload and the DB,
-  // using the one from payload
-  // if they are present in both places
-  private Set<Event> getEventsFromEnrollment(
-      String enrollmentUid, TrackerBundle bundle, TrackerPreheat preheat) {
-    Stream<Event> events;
-    try {
-      events =
-          eventService
-              .getEvents(
-                  EventOperationParams.builder()
-                      .eventParams(EventParams.TRUE)
-                      .orgUnitMode(ACCESSIBLE)
-                      .enrollments(Set.of(enrollmentUid))
-                      .build())
-              .stream()
-              .filter(e -> bundle.findEventByUid(e.getUid()).isEmpty());
-    } catch (BadRequestException | ForbiddenException e) {
-      throw new RuntimeException(e);
-    }
-
-    Stream<Event> bundleEvents =
-        bundle.getEvents().stream()
-            .filter(e -> e.getEnrollment().equals(enrollmentUid))
-            .map(event -> eventTrackerConverterService.fromForRuleEngine(preheat, event));
-
-    return Stream.concat(events, bundleEvents).collect(Collectors.toSet());
   }
 
   private List<Attribute> filterNullAttributes(List<Attribute> attributes) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.imports.programrule;
 
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
 
 import java.util.ArrayList;
@@ -49,17 +48,20 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleVariable;
+import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
 import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
-import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.converter.RuleEngineConverterService;
 import org.hisp.dhis.tracker.imports.converter.TrackerConverterService;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -91,6 +93,8 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   private final org.hisp.dhis.programrule.ProgramRuleService programRuleMetadataService;
 
+  private final ProgramRuleVariableService programRuleVariableService;
+
   private final RuleActionEnrollmentMapper ruleActionEnrollmentMapper;
 
   private final RuleActionEventMapper ruleActionEventMapper;
@@ -107,18 +111,12 @@ class DefaultProgramRuleService implements ProgramRuleService {
   @Override
   @Transactional(readOnly = true)
   public void calculateRuleEffects(TrackerBundle bundle, TrackerPreheat preheat) {
-    // Collect all programs referenced by the bundle in one pass, then fetch rules for all of them
-    // at once. This avoids per-program DB queries inside the sub-methods and lets us skip the
-    // constant map allocation entirely when no program has applicable rules.
-    Set<Program> allPrograms =
-        Stream.concat(
-                bundle.getEnrollments().stream().map(e -> preheat.getProgram(e.getProgram())),
-                bundle.getEvents().stream().map(e -> preheat.getProgram(e.getProgram())))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+    // Deduplicate UIDs before hitting preheat: many enrollments/events typically share the same
+    // program, so look up each distinct program identifier at most once.
+    Set<Program> allPrograms = getAllProgramsFromPayload(bundle, preheat);
 
-    Map<Program, List<ProgramRule>> rulesByProgram = getRulesForPrograms(allPrograms);
-    if (rulesByProgram.isEmpty()) {
+    Map<Program, ProgramRuleContext> contextByProgram = getRulesForPrograms(allPrograms);
+    if (contextByProgram.isEmpty()) {
       return;
     }
 
@@ -129,8 +127,8 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
     List<RuleEffects> ruleEffects =
         ListUtils.union(
-            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, rulesByProgram),
-            calculateProgramEventRuleEffects(bundle, preheat, constantMap, rulesByProgram));
+            calculateEnrollmentRuleEffects(bundle, preheat, constantMap, contextByProgram),
+            calculateSingleEventRuleEffects(bundle, preheat, constantMap, contextByProgram));
 
     // This is needed for bundle side effects process
     bundle.setRuleEffects(ruleEffects);
@@ -141,24 +139,52 @@ class DefaultProgramRuleService implements ProgramRuleService {
     bundle.setEventRuleActionExecutors(ruleActionEventMapper.mapRuleEffects(ruleEffects, bundle));
   }
 
-  // Fetches rules for each program and returns only programs that have applicable rules.
-  private Map<Program, List<ProgramRule>> getRulesForPrograms(Set<Program> programs) {
-    Map<Program, List<ProgramRule>> rulesByProgram = new HashMap<>();
+  private static Set<Program> getAllProgramsFromPayload(
+      TrackerBundle bundle, TrackerPreheat preheat) {
+    // Deduplicate program identifiers before hitting preheat: many enrollments/events typically
+    // share the same program, so look up each distinct program identifier at most once.
+    Set<MetadataIdentifier> programIdentifiers = new HashSet<>();
+    bundle.getEnrollments().forEach(e -> programIdentifiers.add(e.getProgram()));
+    bundle.getEvents().forEach(e -> programIdentifiers.add(e.getProgram()));
+
+    Set<Program> allPrograms = new HashSet<>(programIdentifiers.size());
+    for (MetadataIdentifier identifier : programIdentifiers) {
+      Program p = preheat.getProgram(identifier);
+      if (p != null) allPrograms.add(p);
+    }
+    return allPrograms;
+  }
+
+  /**
+   * Rules and variables for a single program, co-fetched once per program so that the engine does
+   * not need to re-query variables during context construction.
+   */
+  private record ProgramRuleContext(
+      List<ProgramRule> rules, List<ProgramRuleVariable> variables, boolean needsTeAttributes) {}
+
+  // Fetches rules and variables for each program; skips programs with no applicable rules.
+  private Map<Program, ProgramRuleContext> getRulesForPrograms(Set<Program> programs) {
+    Map<Program, ProgramRuleContext> contextByProgram = new HashMap<>();
     for (Program program : programs) {
       List<ProgramRule> rules =
           programRuleMetadataService.getProgramRulesByActionTypes(program, SERVER_SUPPORTED_TYPES);
       if (!rules.isEmpty()) {
-        rulesByProgram.put(program, rules);
+        List<ProgramRuleVariable> variables =
+            programRuleVariableService.getProgramRuleVariable(program);
+        boolean needsTeAttributes =
+            variables.stream()
+                .anyMatch(v -> v.getSourceType() == ProgramRuleVariableSourceType.TEI_ATTRIBUTE);
+        contextByProgram.put(program, new ProgramRuleContext(rules, variables, needsTeAttributes));
       }
     }
-    return rulesByProgram;
+    return contextByProgram;
   }
 
   private List<RuleEffects> calculateEnrollmentRuleEffects(
       TrackerBundle bundle,
       TrackerPreheat preheat,
       Map<String, String> constantMap,
-      Map<Program, List<ProgramRule>> rulesByProgram) {
+      Map<Program, ProgramRuleContext> contextByProgram) {
     Set<String> payloadEnrollmentUids =
         bundle.getEnrollments().stream()
             .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getUid)
@@ -167,7 +193,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
     Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>>
         payloadEnrollmentsByProgram =
             bundle.getEnrollments().stream()
-                .filter(e -> rulesByProgram.containsKey(preheat.getProgram(e.getProgram())))
+                .filter(e -> contextByProgram.containsKey(preheat.getProgram(e.getProgram())))
                 .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
 
     Map<Program, List<Enrollment>> savedEnrollmentsByProgram =
@@ -177,7 +203,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(event -> preheat.getEnrollment(event.getEnrollment()))
             .filter(Objects::nonNull)
             .distinct()
-            .filter(e -> rulesByProgram.containsKey(e.getProgram()))
+            .filter(e -> contextByProgram.containsKey(e.getProgram()))
             .collect(Collectors.groupingBy(Enrollment::getProgram));
 
     if (payloadEnrollmentsByProgram.isEmpty() && savedEnrollmentsByProgram.isEmpty()) {
@@ -197,7 +223,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
     Map<String, Set<Event>> savedEventsByEnrollment =
         fetchSavedEventsForEnrollments(enrollmentUids, bundle);
 
-    return rulesByProgram.entrySet().stream()
+    return contextByProgram.entrySet().stream()
         .filter(
             entry ->
                 payloadEnrollmentsByProgram.containsKey(entry.getKey())
@@ -205,9 +231,11 @@ class DefaultProgramRuleService implements ProgramRuleService {
         .flatMap(
             entry -> {
               Program program = entry.getKey();
+              ProgramRuleContext ctx = entry.getValue();
               List<ProgramRuleEngine.EnrollmentWithEvents> enrollmentsWithEvents =
                   buildEnrollmentsWithEvents(
                       program,
+                      ctx.needsTeAttributes(),
                       payloadEnrollmentsByProgram,
                       savedEnrollmentsByProgram,
                       savedEventsByEnrollment,
@@ -216,10 +244,10 @@ class DefaultProgramRuleService implements ProgramRuleService {
               return programRuleEngine
                   .evaluateEnrollmentsAndTrackerEvents(
                       enrollmentsWithEvents,
-                      program,
                       UserDetails.fromUser(bundle.getUser()),
                       constantMap,
-                      entry.getValue())
+                      ctx.rules(),
+                      ctx.variables())
                   .stream();
             })
         .toList();
@@ -227,8 +255,10 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   // Builds the list of EnrollmentWithEvents for a single program,
   // combining payload and saved enrollments with their respective events.
+  // Attribute loading is skipped when the program has no TEI_ATTRIBUTE variables.
   private List<ProgramRuleEngine.EnrollmentWithEvents> buildEnrollmentsWithEvents(
       Program program,
+      boolean needsTeAttributes,
       Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> payloadByProgram,
       Map<Program, List<Enrollment>> savedByProgram,
       Map<String, Set<Event>> savedEventsByEnrollment,
@@ -246,11 +276,11 @@ class DefaultProgramRuleService implements ProgramRuleService {
           .filter(ev -> preheat.getProgram(ev.getProgram()).isRegistration())
           .map(ev -> eventTrackerConverterService.fromForRuleEngine(preheat, ev))
           .forEach(allEvents::add);
-      result.add(
-          new ProgramRuleEngine.EnrollmentWithEvents(
-              enrollment,
-              allEvents,
-              getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat)));
+      List<TrackedEntityAttributeValue> attributes =
+          needsTeAttributes
+              ? getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat)
+              : Collections.emptyList();
+      result.add(new ProgramRuleEngine.EnrollmentWithEvents(enrollment, allEvents, attributes));
     }
 
     for (Enrollment e : savedByProgram.getOrDefault(program, List.of())) {
@@ -261,29 +291,30 @@ class DefaultProgramRuleService implements ProgramRuleService {
           .filter(ev -> preheat.getProgram(ev.getProgram()).isRegistration())
           .map(ev -> eventTrackerConverterService.fromForRuleEngine(preheat, ev))
           .forEach(allEvents::add);
-      result.add(
-          new ProgramRuleEngine.EnrollmentWithEvents(
-              e,
-              allEvents,
-              getAttributes(e.getUid(), e.getTrackedEntity().getUid(), bundle, preheat)));
+      List<TrackedEntityAttributeValue> attributes =
+          needsTeAttributes
+              ? getAttributes(e.getUid(), e.getTrackedEntity().getUid(), bundle, preheat)
+              : Collections.emptyList();
+      result.add(new ProgramRuleEngine.EnrollmentWithEvents(e, allEvents, attributes));
     }
 
     return result;
   }
 
-  private List<RuleEffects> calculateProgramEventRuleEffects(
+  private List<RuleEffects> calculateSingleEventRuleEffects(
       TrackerBundle bundle,
       TrackerPreheat preheat,
       Map<String, String> constantMap,
-      Map<Program, List<ProgramRule>> rulesByProgram) {
+      Map<Program, ProgramRuleContext> contextByProgram) {
     return bundle.getEvents().stream()
         .filter(event -> preheat.getProgram(event.getProgram()).isWithoutRegistration())
-        .filter(event -> rulesByProgram.containsKey(preheat.getProgram(event.getProgram())))
+        .filter(event -> contextByProgram.containsKey(preheat.getProgram(event.getProgram())))
         .collect(Collectors.groupingBy(event -> preheat.getProgram(event.getProgram())))
         .entrySet()
         .stream()
         .flatMap(
             entry -> {
+              ProgramRuleContext ctx = contextByProgram.get(entry.getKey());
               List<Event> events =
                   eventTrackerConverterService.fromForRuleEngine(preheat, entry.getValue());
               return programRuleEngine
@@ -292,7 +323,8 @@ class DefaultProgramRuleService implements ProgramRuleService {
                       entry.getKey(),
                       UserDetails.fromUser(bundle.getUser()),
                       constantMap,
-                      rulesByProgram.get(entry.getKey()))
+                      ctx.rules(),
+                      ctx.variables())
                   .stream();
             })
         .toList();
@@ -308,12 +340,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
     }
     try {
       return eventService
-          .getEvents(
-              EventOperationParams.builder()
-                  .eventParams(EventParams.TRUE)
-                  .orgUnitMode(ACCESSIBLE)
-                  .enrollments(enrollmentUids)
-                  .build())
+          .getEvents(EventOperationParams.builder().enrollments(enrollmentUids).build())
           .stream()
           .filter(e -> bundle.findEventByUid(e.getUid()).isEmpty())
           .collect(Collectors.groupingBy(e -> e.getEnrollment().getUid(), Collectors.toSet()));
@@ -323,8 +350,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
   }
 
   // Get all the attributes linked to enrollment from the payload and the DB,
-  // using the one from payload
-  // if they are present in both places
+  // using the one from payload if they are present in both places
   private List<TrackedEntityAttributeValue> getAttributes(
       String enrollmentUid, String teUid, TrackerBundle bundle, TrackerPreheat preheat) {
     List<TrackedEntityAttributeValue> attributeValues =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -119,18 +119,29 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
   private List<RuleEffects> calculateEnrollmentRuleEffects(
       TrackerBundle bundle, TrackerPreheat preheat) {
-    return bundle.getEnrollments().stream()
-        .flatMap(
-            e -> {
-              Enrollment enrollment =
-                  enrollmentTrackerConverterService.fromForRuleEngine(preheat, e);
+    Map<Program, List<org.hisp.dhis.tracker.imports.domain.Enrollment>> byProgram =
+        bundle.getEnrollments().stream()
+            .collect(Collectors.groupingBy(e -> preheat.getProgram(e.getProgram())));
 
+    return byProgram.entrySet().stream()
+        .flatMap(
+            entry -> {
+              List<ProgramRuleEngine.EnrollmentWithEvents> enrollmentsWithEvents =
+                  entry.getValue().stream()
+                      .map(
+                          e -> {
+                            Enrollment enrollment =
+                                enrollmentTrackerConverterService.fromForRuleEngine(preheat, e);
+                            return new ProgramRuleEngine.EnrollmentWithEvents(
+                                enrollment,
+                                getEventsFromEnrollment(enrollment.getUid(), bundle, preheat),
+                                getAttributes(
+                                    e.getEnrollment(), e.getTrackedEntity(), bundle, preheat));
+                          })
+                      .toList();
               return programRuleEngine
-                  .evaluateEnrollmentAndTrackerEvents(
-                      enrollment,
-                      getEventsFromEnrollment(enrollment.getUid(), bundle, preheat),
-                      getAttributes(e.getEnrollment(), e.getTrackedEntity(), bundle, preheat),
-                      UserDetails.fromUser(bundle.getUser()))
+                  .evaluateEnrollmentsAndTrackerEvents(
+                      enrollmentsWithEvents, entry.getKey(), UserDetails.fromUser(bundle.getUser()))
                   .stream();
             })
         .toList();
@@ -145,20 +156,27 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(event -> preheat.getEnrollment(event.getEnrollment()))
             .collect(Collectors.toSet());
 
-    return enrollments.stream()
+    Map<Program, List<Enrollment>> byProgram =
+        enrollments.stream().collect(Collectors.groupingBy(Enrollment::getProgram));
+
+    return byProgram.entrySet().stream()
         .flatMap(
-            enrollment ->
-                programRuleEngine
-                    .evaluateEnrollmentAndTrackerEvents(
-                        enrollment,
-                        getEventsFromEnrollment(enrollment.getUid(), bundle, preheat),
-                        getAttributes(
-                            enrollment.getUid(),
-                            enrollment.getTrackedEntity().getUid(),
-                            bundle,
-                            preheat),
-                        UserDetails.fromUser(bundle.getUser()))
-                    .stream())
+            entry -> {
+              List<ProgramRuleEngine.EnrollmentWithEvents> enrollmentsWithEvents =
+                  entry.getValue().stream()
+                      .map(
+                          e ->
+                              new ProgramRuleEngine.EnrollmentWithEvents(
+                                  e,
+                                  getEventsFromEnrollment(e.getUid(), bundle, preheat),
+                                  getAttributes(
+                                      e.getUid(), e.getTrackedEntity().getUid(), bundle, preheat)))
+                      .toList();
+              return programRuleEngine
+                  .evaluateEnrollmentsAndTrackerEvents(
+                      enrollmentsWithEvents, entry.getKey(), UserDetails.fromUser(bundle.getUser()))
+                  .stream();
+            })
         .toList();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
@@ -65,18 +65,31 @@ class RuleActionEventMapper {
       List<RuleEffects> ruleEffects, TrackerBundle bundle) {
     return ruleEffects.stream()
         .filter(RuleEffects::isEvent)
-        .filter(e -> bundle.findEventByUid(e.getTrackerObjectUid()).isPresent())
-        .collect(
-            Collectors.toMap(
-                e -> bundle.findEventByUid(e.getTrackerObjectUid()).get(),
-                e ->
-                    mapRuleEffects(
-                        bundle.findEventByUid(e.getTrackerObjectUid()).get(), e, bundle)));
+        .flatMap(
+            e ->
+                bundle
+                    .findEventByUid(e.getTrackerObjectUid())
+                    .map(event -> Map.entry(event, mapRuleEffects(event, e, bundle)))
+                    .stream())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private List<RuleActionExecutor<Event>> mapRuleEffects(
       Event event, RuleEffects ruleEffects, TrackerBundle bundle) {
     ProgramStage programStage = bundle.getPreheat().getProgramStage(event.getProgramStage());
+
+    // needsToValidateDataValues depends only on event+programStage, not on individual effects;
+    // hoist the check to avoid evaluating it once per effect and short-circuit early.
+    if (!needsToValidateDataValues(event, programStage)) {
+      return List.of();
+    }
+
+    // Pre-build the set of data element UIDs for this program stage so that
+    // isDataElementPartOfProgramStage does not stream over the collection per effect.
+    Set<String> stageDataElementUids =
+        programStage.getDataElements().stream()
+            .map(IdentifiableObject::getUid)
+            .collect(Collectors.toSet());
 
     return ruleEffects.getRuleEffects().stream()
         .map(
@@ -88,8 +101,8 @@ class RuleActionEventMapper {
                     event.getDataValues()))
         .filter(Objects::nonNull)
         .filter(
-            executor -> isDataElementPartOfProgramStage(executor.getDataElementUid(), programStage))
-        .filter(executor -> needsToValidateDataValues(event, programStage))
+            executor ->
+                isDataElementPartOfProgramStage(executor.getDataElementUid(), stageDataElementUids))
         .toList();
   }
 
@@ -125,13 +138,7 @@ class RuleActionEventMapper {
   }
 
   private boolean isDataElementPartOfProgramStage(
-      String dataElementUid, ProgramStage programStage) {
-    if (StringUtils.isEmpty(dataElementUid)) {
-      return true;
-    }
-
-    return programStage.getDataElements().stream()
-        .map(IdentifiableObject::getUid)
-        .anyMatch(de -> de.equals(dataElementUid));
+      String dataElementUid, Set<String> stageDataElementUids) {
+    return StringUtils.isEmpty(dataElementUid) || stageDataElementUids.contains(dataElementUid);
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -78,7 +78,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.7.1</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.7.2</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.6</dhis-hisp-quick.version>


### PR DESCRIPTION
In the process of backporting I found and fix an issue: https://dhis2.atlassian.net/browse/DHIS2-21280
The default value `ACTIVE` for `status` field in enrollment was assigned only when running rule-engine. I moved the default value assignment to the web layer.
The issue was not present in any of the newer versions.

Backport of DHIS2-21178 PRs from master:

1. #23346 - perf: Reduce allocations for program rules evaluation
2. #23381 - perf: Create context only for programs with rules
3. #23388 - perf: Bump to more performative rule-engine version
4. #23457 - perf: Only calculate attributes when TEI_ATTRIBUTE variable is present