### PR TITLE
chore: Re-enable e2e metadata import test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
@@ -49,8 +49,10 @@ import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
+@Order(1)
 class CategoryComboMergeTest extends ApiTest {
 
   private RestApiActions categoryComboApiActions;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
@@ -49,10 +49,8 @@ import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
-@Order(1)
 class CategoryComboMergeTest extends ApiTest {
 
   private RestApiActions categoryComboApiActions;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
@@ -69,8 +69,8 @@ import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.hisp.dhis.test.e2e.utils.DataGenerator;
 import org.hisp.dhis.test.e2e.utils.SharingUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -78,13 +78,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
+@Order(2)
 class MetadataImportTest extends ApiTest {
   private MetadataActions metadataActions;
   private RestApiActions dataElementActions;
   private SystemActions systemActions;
 
   @BeforeAll
-  public void before() {
+  void before() {
     metadataActions = new MetadataActions();
     systemActions = new SystemActions();
     dataElementActions = new RestApiActions("dataElements");
@@ -185,13 +186,16 @@ class MetadataImportTest extends ApiTest {
         .body("shortName", equalTo("ANC 1st visit_m update"));
   }
 
-  @Disabled("Started failing intermittently in GitHub, April 2026")
   @ParameterizedTest(name = "withImportStrategy[{0}]")
   @CsvSource({"CREATE, ignored, 409", "CREATE_AND_UPDATE, updated, 200"})
   void shouldUpdateExistingMetadata(
       String importStrategy, String expected, int expectedStatusCode) {
     // arrange
     JsonObject exported = metadataActions.get().getBody();
+
+    // CategoryComboMergeTest leaves duplicate COCs (intentionally) meaning they cannot be imported
+    // All duplicate COCs cannot be removed from the DB as DataValues can only be soft-deleted
+    exported.remove("categoryOptionCombos");
 
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     queryParamsBuilder.addAll(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
@@ -70,7 +70,6 @@ import org.hisp.dhis.test.e2e.utils.DataGenerator;
 import org.hisp.dhis.test.e2e.utils.SharingUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -78,7 +77,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-@Order(2)
 class MetadataImportTest extends ApiTest {
   private MetadataActions metadataActions;
   private RestApiActions dataElementActions;


### PR DESCRIPTION
- This test started failing intermittently on GitHub only (likely due to new tests being added and test order changing)
- The test was failing because it was trying to import an incorrect number of `COC`s for a `CC` (12 instead of 4)
- `CategoryComboMergeTest` leaves duplicate `COC`s after a successful merge (intentional)
  - One of these has a reference to a `DataValue`
  - `DataValue`s cannot be hard deleted
  - This means a `COC` referencing a `DataValue` cannot be deleted
- removing `COC`s from the metadata import (this PR change) allows keeping the existing test which still provides value
  - the test exports all metadata in the system (can be a lot leftover from other tests) and then imports it, proving metadata updates are working for many types