### PR TITLE
perf: skip notification tasks for programs without matching templates DHIS2-21177 [42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -29,12 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IndirectTransactional;
@@ -45,12 +40,10 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preprocess.TrackerPreprocessService;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationResult;
 import org.hisp.dhis.tracker.imports.validation.ValidationService;
@@ -164,28 +157,13 @@ public class DefaultTrackerImportService implements TrackerImportService {
   }
 
   protected PersistenceReport commitBundle(TrackerBundle trackerBundle) {
-    PersistenceReport persistenceReport = trackerBundleService.commit(trackerBundle);
+    TrackerBundleService.CommitResult result = trackerBundleService.commit(trackerBundle);
 
     if (!trackerBundle.isSkipSideEffects()) {
-      List<TrackerNotificationDataBundle> notificationDataBundles =
-          Stream.of(TrackerType.ENROLLMENT, TrackerType.EVENT)
-              .map(trackerType -> safelyGetNotificationDataBundles(persistenceReport, trackerType))
-              .flatMap(Collection::stream)
-              .toList();
-
-      trackerBundleService.sendNotifications(notificationDataBundles);
+      trackerBundleService.sendNotifications(result.notificationBundles());
     }
 
-    return persistenceReport;
-  }
-
-  private List<TrackerNotificationDataBundle> safelyGetNotificationDataBundles(
-      PersistenceReport persistenceReport, TrackerType trackerType) {
-    return Optional.ofNullable(persistenceReport)
-        .map(PersistenceReport::getTypeReportMap)
-        .map(reportMap -> reportMap.get(trackerType))
-        .map(TrackerTypeReport::getNotificationDataBundles)
-        .orElse(Collections.emptyList());
+    return result.report();
   }
 
   protected PersistenceReport deleteBundle(TrackerBundle trackerBundle)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.bundle.persister.CommitService;
 import org.hisp.dhis.tracker.imports.bundle.persister.PersistenceException;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerObjectDeletionService;
+import org.hisp.dhis.tracker.imports.bundle.persister.TrackerPersister;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
@@ -113,23 +114,28 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
   @Nonnull
   @Override
   @Transactional
-  public PersistenceReport commit(@Nonnull TrackerBundle bundle) {
+  public CommitResult commit(@Nonnull TrackerBundle bundle) {
     if (TrackerBundleMode.VALIDATE == bundle.getImportMode()) {
-      return PersistenceReport.emptyReport();
+      return new CommitResult(PersistenceReport.emptyReport(), List.of());
     }
 
-    Map<TrackerType, TrackerTypeReport> reportMap =
-        Map.of(
-            TrackerType.TRACKED_ENTITY,
+    List<TrackerPersister.PersistResult> results =
+        List.of(
             commitService.getTrackerPersister().persist(entityManager, bundle),
-            TrackerType.ENROLLMENT,
             commitService.getEnrollmentPersister().persist(entityManager, bundle),
-            TrackerType.EVENT,
             commitService.getEventPersister().persist(entityManager, bundle),
-            TrackerType.RELATIONSHIP,
             commitService.getRelationshipPersister().persist(entityManager, bundle));
 
-    return new PersistenceReport(reportMap);
+    Map<TrackerType, TrackerTypeReport> reportMap =
+        results.stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    r -> r.report().getTrackerType(), TrackerPersister.PersistResult::report));
+
+    List<TrackerNotificationDataBundle> notificationBundles =
+        results.stream().flatMap(r -> r.notificationBundles().stream()).toList();
+
+    return new CommitResult(new PersistenceReport(reportMap), notificationBundles);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
@@ -43,6 +43,9 @@ import org.hisp.dhis.user.UserDetails;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface TrackerBundleService {
+  record CommitResult(
+      PersistenceReport report, List<TrackerNotificationDataBundle> notificationBundles) {}
+
   /**
    * Creates and prepares tracker bundle.
    *
@@ -69,7 +72,7 @@ public interface TrackerBundleService {
    * @param bundle TrackerBundle to commit.
    */
   @Nonnull
-  PersistenceReport commit(@Nonnull TrackerBundle bundle);
+  CommitResult commit(@Nonnull TrackerBundle bundle);
 
   /**
    * Carry out notifications for TrackerImporter.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -51,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -95,7 +96,7 @@ public abstract class AbstractTrackerPersister<
    * @return a {@link TrackerTypeReport}
    */
   @Override
-  public TrackerTypeReport persist(EntityManager entityManager, TrackerBundle bundle) {
+  public PersistResult persist(EntityManager entityManager, TrackerBundle bundle) {
     //
     // Init the report that will hold the results of the persist operation
     //
@@ -112,8 +113,13 @@ public abstract class AbstractTrackerPersister<
     for (T trackerDto : dtos) {
 
       Entity objectReport = new Entity(getType(), trackerDto.getUid());
+      // Determine triggers before convert() because convert() mutates the preheat entity
+      // (e.g. sets status on the preheat enrollment), which would make the before/after
+      // comparison in determineNotificationTriggers() see the new status on both sides.
       List<NotificationTrigger> triggers =
-          determineNotificationTriggers(bundle.getPreheat(), trackerDto);
+          bundle.isSkipSideEffects()
+              ? List.of()
+              : determineNotificationTriggers(bundle.getPreheat(), trackerDto);
 
       ChangeLogAccumulator.Mark mark = changeLogs.mark();
       try {
@@ -180,7 +186,11 @@ public abstract class AbstractTrackerPersister<
         }
 
         if (!bundle.isSkipSideEffects()) {
-          notificationDataBundles.add(handleNotifications(bundle, convertedDto, triggers));
+          TrackerNotificationDataBundle notificationBundle =
+              handleNotifications(bundle, convertedDto, triggers);
+          if (notificationBundle != null) {
+            notificationDataBundles.add(notificationBundle);
+          }
         }
 
         //
@@ -223,9 +233,7 @@ public abstract class AbstractTrackerPersister<
       entityManager.flush();
       changeLogs.flushAll(entityManager);
     }
-    typeReport.getNotificationDataBundles().addAll(notificationDataBundles);
-
-    return typeReport;
+    return new PersistResult(typeReport, notificationDataBundles);
   }
 
   // // // // // // // //
@@ -289,6 +297,33 @@ public abstract class AbstractTrackerPersister<
 
   /** Get the Tracker Type for which the current Persister is responsible for. */
   protected abstract TrackerType getType();
+
+  protected static boolean hasMatchingNotificationTemplates(
+      IdentifiableObject programOrStage, List<NotificationTrigger> triggers) {
+    Set<org.hisp.dhis.program.notification.NotificationTrigger> templateTriggers =
+        triggers.stream()
+            .map(NotificationTrigger::toTemplateTrigger)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    if (templateTriggers.isEmpty()) {
+      return false;
+    }
+
+    Set<org.hisp.dhis.program.notification.ProgramNotificationTemplate> templates;
+    if (programOrStage instanceof org.hisp.dhis.program.Program p) {
+      templates = p.getNotificationTemplates();
+    } else if (programOrStage instanceof org.hisp.dhis.program.ProgramStage ps) {
+      templates = ps.getNotificationTemplates();
+    } else {
+      return false;
+    }
+
+    if (templates == null || templates.isEmpty()) {
+      return false;
+    }
+
+    return templates.stream().anyMatch(t -> templateTriggers.contains(t.getNotificationTrigger()));
+  }
 
   protected boolean isNew(TrackerBundle bundle, TrackerDto trackerDto) {
     return bundle.getStrategy(trackerDto) == TrackerImportStrategy.CREATE;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -93,16 +94,22 @@ public class EnrollmentPersister
   @Override
   protected TrackerNotificationDataBundle handleNotifications(
       TrackerBundle bundle, Enrollment enrollment, List<NotificationTrigger> triggers) {
+    boolean hasTemplates = hasMatchingNotificationTemplates(enrollment.getProgram(), triggers);
+    List<Notification> ruleEngineNotifications =
+        bundle.getEnrollmentNotifications().getOrDefault(UID.of(enrollment), List.of());
+    if (!hasTemplates && ruleEngineNotifications.isEmpty()) {
+      return null;
+    }
 
     return TrackerNotificationDataBundle.builder()
         .klass(Enrollment.class)
-        .enrollmentNotifications(bundle.getEnrollmentNotifications().get(UID.of(enrollment)))
+        .enrollmentNotifications(ruleEngineNotifications)
         .object(enrollment.getUid())
         .importStrategy(bundle.getImportStrategy())
         .accessedBy(bundle.getUser().getUsername())
         .enrollment(enrollment)
         .program(enrollment.getProgram())
-        .triggers(triggers)
+        .triggers(hasTemplates ? triggers : List.of())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.job.NotificationTrigger;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -88,16 +89,22 @@ public class EventPersister
   @Override
   protected TrackerNotificationDataBundle handleNotifications(
       TrackerBundle bundle, Event event, List<NotificationTrigger> triggers) {
+    boolean hasTemplates = hasMatchingNotificationTemplates(event.getProgramStage(), triggers);
+    List<Notification> ruleEngineNotifications =
+        bundle.getEventNotifications().getOrDefault(UID.of(event), List.of());
+    if (!hasTemplates && ruleEngineNotifications.isEmpty()) {
+      return null;
+    }
 
     return TrackerNotificationDataBundle.builder()
         .klass(Event.class)
-        .eventNotifications(bundle.getEventNotifications().get(UID.of(event)))
+        .eventNotifications(ruleEngineNotifications)
         .object(event.getUid())
         .importStrategy(bundle.getImportStrategy())
         .accessedBy(bundle.getUser().getUsername())
         .event(event)
         .program(event.getProgramStage().getProgram())
-        .triggers(triggers)
+        .triggers(hasTemplates ? triggers : List.of())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -90,7 +90,7 @@ public class RelationshipPersister
       TrackerBundle bundle,
       org.hisp.dhis.relationship.Relationship entity,
       List<NotificationTrigger> triggers) {
-    return TrackerNotificationDataBundle.builder().build();
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -90,7 +90,7 @@ public class TrackedEntityPersister
   @Override
   protected TrackerNotificationDataBundle handleNotifications(
       TrackerBundle bundle, TrackedEntity entity, List<NotificationTrigger> triggers) {
-    return TrackerNotificationDataBundle.builder().build();
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
@@ -30,8 +30,10 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 
 /**
@@ -41,13 +43,16 @@ import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
  */
 public interface TrackerPersister<T extends TrackerDto, V> {
 
+  record PersistResult(
+      TrackerTypeReport report, List<TrackerNotificationDataBundle> notificationBundles) {}
+
   /**
    * Persist one of the collections in the provided Tracker Bundle. Each class implementing this
    * method should be responsible to persist one collection of the TrackerBundle (e.g. Enrollments)
    *
    * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
-   * @return a {@link TrackerTypeReport}
+   * @return a {@link PersistResult} containing the type report and notification bundles
    */
-  TrackerTypeReport persist(EntityManager entityManager, TrackerBundle bundle);
+  PersistResult persist(EntityManager entityManager, TrackerBundle bundle);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/job/NotificationTrigger.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/job/NotificationTrigger.java
@@ -36,5 +36,18 @@ public enum NotificationTrigger {
   ENROLLMENT,
   ENROLLMENT_COMPLETION,
   EVENT_COMPLETION,
-  NONE
+  NONE;
+
+  /**
+   * Returns the corresponding {@link org.hisp.dhis.program.notification.NotificationTrigger} used
+   * on {@link org.hisp.dhis.program.notification.ProgramNotificationTemplate}.
+   */
+  public org.hisp.dhis.program.notification.NotificationTrigger toTemplateTrigger() {
+    return switch (this) {
+      case ENROLLMENT -> org.hisp.dhis.program.notification.NotificationTrigger.ENROLLMENT;
+      case ENROLLMENT_COMPLETION, EVENT_COMPLETION ->
+          org.hisp.dhis.program.notification.NotificationTrigger.COMPLETION;
+      case NONE -> null;
+    };
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramNotificationTemplateMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramNotificationTemplateMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,53 +29,21 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
-import java.util.Set;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(
-    uses = {
-      DebugMapper.class,
-      OrganisationUnitMapper.class,
-      CategoryComboMapper.class,
-      TrackedEntityTypeMapper.class,
-      ProgramStageMapper.class,
-      ProgramTrackedEntityAttributeMapper.class,
-      ProgramNotificationTemplateMapper.class,
-      AttributeValuesMapper.class,
-      SharingMapper.class
-    })
-public interface ProgramMapper extends PreheatMapper<Program> {
-  ProgramMapper INSTANCE = Mappers.getMapper(ProgramMapper.class);
+@Mapper
+public interface ProgramNotificationTemplateMapper
+    extends PreheatMapper<ProgramNotificationTemplate> {
+  ProgramNotificationTemplateMapper INSTANCE =
+      Mappers.getMapper(ProgramNotificationTemplateMapper.class);
 
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "id")
   @Mapping(target = "uid")
-  @Mapping(target = "code")
-  @Mapping(target = "name")
-  @Mapping(target = "attributeValues")
-  @Mapping(target = "trackedEntityType")
-  @Mapping(target = "programType")
-  @Mapping(target = "programAttributes")
-  @Mapping(target = "programStages")
-  @Mapping(target = "onlyEnrollOnce")
-  @Mapping(target = "featureType")
-  @Mapping(target = "categoryCombo")
-  @Mapping(target = "selectEnrollmentDatesInFuture")
-  @Mapping(target = "selectIncidentDatesInFuture")
-  @Mapping(target = "displayIncidentDate")
-  @Mapping(target = "ignoreOverdueEvents")
-  @Mapping(target = "expiryDays")
-  @Mapping(target = "expiryPeriodType")
-  @Mapping(target = "completeEventsExpiryDays")
-  @Mapping(target = "sharing")
-  @Mapping(target = "accessLevel")
-  @Mapping(target = "notificationTemplates")
-  Program map(Program program);
-
-  Set<ProgramStage> mapProgramStages(Set<ProgramStage> programStages);
+  @Mapping(target = "notificationTrigger")
+  ProgramNotificationTemplate map(ProgramNotificationTemplate template);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
@@ -44,6 +44,7 @@ import org.mapstruct.factory.Mappers;
       AttributeValuesMapper.class,
       SharingMapper.class,
       ProgramStageDataElementMapper.class,
+      ProgramNotificationTemplateMapper.class,
     })
 public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   ProgramStageMapper INSTANCE = Mappers.getMapper(ProgramStageMapper.class);
@@ -63,6 +64,7 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   @Mapping(target = "validationStrategy")
   @Mapping(target = "featureType")
   @Mapping(target = "sharing")
+  @Mapping(target = "notificationTemplates")
   ProgramStage map(ProgramStage programStage);
 
   @Named("program")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
@@ -30,13 +30,11 @@
 package org.hisp.dhis.tracker.imports.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -46,9 +44,6 @@ public class TrackerTypeReport {
   @JsonProperty private final TrackerType trackerType;
 
   @JsonProperty private Stats stats = new Stats();
-
-  @JsonIgnore
-  private List<TrackerNotificationDataBundle> notificationDataBundles = new ArrayList<>();
 
   private List<Entity> entityReport = new ArrayList<>();
 
@@ -60,12 +55,9 @@ public class TrackerTypeReport {
   public TrackerTypeReport(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("stats") Stats stats,
-      @JsonProperty("sideEffectDataBundles")
-          List<TrackerNotificationDataBundle> notificationDataBundles,
       @JsonProperty("objectReports") List<Entity> entityReport) {
     this.trackerType = trackerType;
     this.stats = stats;
-    this.notificationDataBundles = notificationDataBundles;
     this.entityReport = entityReport;
   }
 
@@ -93,9 +85,5 @@ public class TrackerTypeReport {
 
   private List<Error> getErrorReports() {
     return entityReport.stream().flatMap(e -> e.getErrorReports().stream()).toList();
-  }
-
-  public List<TrackerNotificationDataBundle> getNotificationDataBundles() {
-    return notificationDataBundles;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -127,7 +127,8 @@ class TrackerImporterServiceTest {
     when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
         .thenReturn(ParamsConverter.convert(parameters, objects, user));
     when(trackerBundleService.commit(any(TrackerBundle.class)))
-        .thenReturn(PersistenceReport.emptyReport());
+        .thenReturn(
+            new TrackerBundleService.CommitResult(PersistenceReport.emptyReport(), List.of()));
 
     subject.importTracker(parameters, trackerObjects, JobProgress.noop());
 
@@ -140,7 +141,8 @@ class TrackerImporterServiceTest {
     when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
         .thenReturn(ParamsConverter.convert(params, trackerObjects, user));
     when(trackerBundleService.commit(any(TrackerBundle.class)))
-        .thenReturn(PersistenceReport.emptyReport());
+        .thenReturn(
+            new TrackerBundleService.CommitResult(PersistenceReport.emptyReport(), List.of()));
 
     subject.importTracker(params, trackerObjects, JobProgress.noop());
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/ImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/ImportReportTest.java
@@ -90,6 +90,6 @@ class ImportReportTest {
     teStats.setCreated(created);
     teStats.setUpdated(updated);
     teStats.setDeleted(deleted);
-    return new TrackerTypeReport(type, teStats, new ArrayList<>(), new ArrayList<>());
+    return new TrackerTypeReport(type, teStats, new ArrayList<>());
   }
 }


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/23347 (master).

This is the first of 9 master PRs under DHIS2-21177. It provides the biggest performance win: skipping notification task submission for programs/stages without matching templates. On master this reduced notification allocations from 28.2 GB to 251 MB (-99%) during a 4u/300s import test.

### What changed

* `NotificationTrigger` gets `toTemplateTrigger()` to map import triggers to template triggers
* New `ProgramNotificationTemplateMapper` added to preheat so templates are available during persist
* `ProgramMapper` and `ProgramStageMapper` now include `notificationTemplates` in the preheat mapping
* `AbstractTrackerPersister.persist()` returns `PersistResult(report, notificationBundles)` instead of stuffing notification bundles into `TrackerTypeReport`
* `handleNotifications()` in `EnrollmentPersister` and `EventPersister` checks `hasMatchingNotificationTemplates()` and returns null when no templates match and no rule engine notifications exist
* `DefaultTrackerBundleService.commit()` returns `CommitResult(report, notificationBundles)` instead of `PersistenceReport`
* `DefaultTrackerImportService.commitBundle()` simplified, `safelyGetNotificationDataBundles()` removed
* `TrackerTypeReport` no longer carries notification bundles

### Differences from 2.43/master

* 2.42 has `EVENT_COMPLETION` in `NotificationTrigger`, master split this into `TRACKER_EVENT_COMPLETION` and `SINGLE_EVENT_COMPLETION`
* 2.42 tracker code lives in `dhis-services/dhis-service-tracker`, master moved it to `dhis-tracker`
* 2.42 uses `UID.of(entity)` for notification map lookups, master uses `entity.getUID()`
* 2.42 has `bundle.getEventNotifications()`, master splits into `getTrackerEventNotifications()` and `getSingleEventNotifications()`
