### PR TITLE
perf: skip notification tasks for programs without matching templates DHIS2-21177 [41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -27,12 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IndirectTransactional;
@@ -41,12 +36,10 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
-import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preprocess.TrackerPreprocessService;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.Status;
-import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.tracker.imports.validation.ValidationResult;
 import org.hisp.dhis.tracker.imports.validation.ValidationService;
@@ -150,28 +143,13 @@ public class DefaultTrackerImportService implements TrackerImportService {
   }
 
   protected PersistenceReport commitBundle(TrackerBundle trackerBundle) {
-    PersistenceReport persistenceReport = trackerBundleService.commit(trackerBundle);
+    TrackerBundleService.CommitResult result = trackerBundleService.commit(trackerBundle);
 
     if (!trackerBundle.isSkipSideEffects()) {
-      List<TrackerSideEffectDataBundle> sideEffectDataBundles =
-          Stream.of(TrackerType.ENROLLMENT, TrackerType.EVENT)
-              .map(trackerType -> safelyGetSideEffectsDataBundles(persistenceReport, trackerType))
-              .flatMap(Collection::stream)
-              .toList();
-
-      trackerBundleService.handleTrackerSideEffects(sideEffectDataBundles);
+      trackerBundleService.handleTrackerSideEffects(result.sideEffectBundles());
     }
 
-    return persistenceReport;
-  }
-
-  private List<TrackerSideEffectDataBundle> safelyGetSideEffectsDataBundles(
-      PersistenceReport persistenceReport, TrackerType trackerType) {
-    return Optional.ofNullable(persistenceReport)
-        .map(PersistenceReport::getTypeReportMap)
-        .map(reportMap -> reportMap.get(trackerType))
-        .map(TrackerTypeReport::getSideEffectDataBundles)
-        .orElse(Collections.emptyList());
+    return result.report();
   }
 
   protected PersistenceReport deleteBundle(TrackerBundle trackerBundle) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.bundle.persister.CommitService;
 import org.hisp.dhis.tracker.imports.bundle.persister.PersistenceException;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerObjectDeletionService;
+import org.hisp.dhis.tracker.imports.bundle.persister.TrackerPersister;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
@@ -111,23 +112,28 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
 
   @Override
   @Transactional
-  public PersistenceReport commit(TrackerBundle bundle) {
+  public CommitResult commit(TrackerBundle bundle) {
     if (TrackerBundleMode.VALIDATE == bundle.getImportMode()) {
-      return PersistenceReport.emptyReport();
+      return new CommitResult(PersistenceReport.emptyReport(), List.of());
     }
 
-    Map<TrackerType, TrackerTypeReport> reportMap =
-        Map.of(
-            TrackerType.TRACKED_ENTITY,
+    List<TrackerPersister.PersistResult> results =
+        List.of(
             commitService.getTrackerPersister().persist(entityManager, bundle),
-            TrackerType.ENROLLMENT,
             commitService.getEnrollmentPersister().persist(entityManager, bundle),
-            TrackerType.EVENT,
             commitService.getEventPersister().persist(entityManager, bundle),
-            TrackerType.RELATIONSHIP,
             commitService.getRelationshipPersister().persist(entityManager, bundle));
 
-    return new PersistenceReport(reportMap);
+    Map<TrackerType, TrackerTypeReport> reportMap =
+        results.stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    r -> r.report().getTrackerType(), TrackerPersister.PersistResult::report));
+
+    List<TrackerSideEffectDataBundle> sideEffectBundles =
+        results.stream().flatMap(r -> r.sideEffectBundles().stream()).toList();
+
+    return new CommitResult(new PersistenceReport(reportMap), sideEffectBundles);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundleService.java
@@ -38,6 +38,9 @@ import org.hisp.dhis.user.User;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface TrackerBundleService {
+  record CommitResult(
+      PersistenceReport report, List<TrackerSideEffectDataBundle> sideEffectBundles) {}
+
   /**
    * Creates and prepares tracker bundle.
    *
@@ -58,7 +61,7 @@ public interface TrackerBundleService {
    *
    * @param bundle TrackerBundle to commit.
    */
-  PersistenceReport commit(TrackerBundle bundle);
+  CommitResult commit(TrackerBundle bundle);
 
   /**
    * Carry out side effect for TrackerImporter i.e audits, notifications and program rule actions.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
@@ -90,7 +91,7 @@ public abstract class AbstractTrackerPersister<
    * @return a {@link TrackerTypeReport}
    */
   @Override
-  public TrackerTypeReport persist(EntityManager entityManager, TrackerBundle bundle) {
+  public PersistResult persist(EntityManager entityManager, TrackerBundle bundle) {
     //
     // Init the report that will hold the results of the persist operation
     //
@@ -106,9 +107,13 @@ public abstract class AbstractTrackerPersister<
     for (T trackerDto : dtos) {
 
       Entity objectReport = new Entity(getType(), trackerDto.getUid());
-
+      // Determine triggers before convert() because convert() mutates the preheat entity
+      // (e.g. sets status on the preheat enrollment), which would make the before/after
+      // comparison in determineSideEffectTriggers() see the new status on both sides.
       List<SideEffectTrigger> triggers =
-          determineSideEffectTriggers(bundle.getPreheat(), trackerDto);
+          bundle.isSkipSideEffects()
+              ? List.of()
+              : determineSideEffectTriggers(bundle.getPreheat(), trackerDto);
 
       try {
         //
@@ -150,7 +155,11 @@ public abstract class AbstractTrackerPersister<
         }
 
         if (!bundle.isSkipSideEffects()) {
-          sideEffectDataBundles.add(handleSideEffects(bundle, convertedDto, triggers));
+          TrackerSideEffectDataBundle sideEffectBundle =
+              handleSideEffects(bundle, convertedDto, triggers);
+          if (sideEffectBundle != null) {
+            sideEffectDataBundles.add(sideEffectBundle);
+          }
         }
 
         //
@@ -182,9 +191,7 @@ public abstract class AbstractTrackerPersister<
       }
     }
 
-    typeReport.getSideEffectDataBundles().addAll(sideEffectDataBundles);
-
-    return typeReport;
+    return new PersistResult(typeReport, sideEffectDataBundles);
   }
 
   // // // // // // // //
@@ -228,6 +235,33 @@ public abstract class AbstractTrackerPersister<
    */
   protected boolean isUpdatable() {
     return true;
+  }
+
+  protected static boolean hasMatchingNotificationTemplates(
+      IdentifiableObject programOrStage, List<SideEffectTrigger> triggers) {
+    Set<org.hisp.dhis.program.notification.NotificationTrigger> templateTriggers =
+        triggers.stream()
+            .map(SideEffectTrigger::toTemplateTrigger)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    if (templateTriggers.isEmpty()) {
+      return false;
+    }
+
+    Set<org.hisp.dhis.program.notification.ProgramNotificationTemplate> templates;
+    if (programOrStage instanceof org.hisp.dhis.program.Program p) {
+      templates = p.getNotificationTemplates();
+    } else if (programOrStage instanceof org.hisp.dhis.program.ProgramStage ps) {
+      templates = ps.getNotificationTemplates();
+    } else {
+      return false;
+    }
+
+    if (templates == null || templates.isEmpty()) {
+      return false;
+    }
+
+    return templates.stream().anyMatch(t -> templateTriggers.contains(t.getNotificationTrigger()));
   }
 
   /** Determines if the given trackerDto belongs to an existing entity */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -123,6 +123,11 @@ public class EnrollmentPersister
   @Override
   protected TrackerSideEffectDataBundle handleSideEffects(
       TrackerBundle bundle, Enrollment enrollment, List<SideEffectTrigger> triggers) {
+    boolean hasTemplates = hasMatchingNotificationTemplates(enrollment.getProgram(), triggers);
+    boolean hasRuleEffects = !bundle.getEnrollmentRuleEffects().isEmpty();
+    if (!hasTemplates && !hasRuleEffects) {
+      return null;
+    }
 
     return TrackerSideEffectDataBundle.builder()
         .klass(Enrollment.class)
@@ -133,7 +138,7 @@ public class EnrollmentPersister
         .accessedBy(bundle.getUsername())
         .enrollment(enrollment)
         .program(enrollment.getProgram())
-        .triggers(triggers)
+        .triggers(hasTemplates ? triggers : List.of())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EventPersister.java
@@ -112,6 +112,12 @@ public class EventPersister
   @Override
   protected TrackerSideEffectDataBundle handleSideEffects(
       TrackerBundle bundle, Event event, List<SideEffectTrigger> triggers) {
+    boolean hasTemplates = hasMatchingNotificationTemplates(event.getProgramStage(), triggers);
+    boolean hasRuleEffects = !bundle.getEventRuleEffects().isEmpty();
+    if (!hasTemplates && !hasRuleEffects) {
+      return null;
+    }
+
     return TrackerSideEffectDataBundle.builder()
         .klass(Event.class)
         .enrollmentRuleEffects(new HashMap<>())
@@ -121,7 +127,7 @@ public class EventPersister
         .accessedBy(bundle.getUsername())
         .event(event)
         .program(event.getProgramStage().getProgram())
-        .triggers(triggers)
+        .triggers(hasTemplates ? triggers : List.of())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -126,7 +126,7 @@ public class RelationshipPersister
       TrackerBundle bundle,
       org.hisp.dhis.relationship.Relationship entity,
       List<SideEffectTrigger> triggers) {
-    return TrackerSideEffectDataBundle.builder().build();
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -113,7 +113,7 @@ public class TrackedEntityPersister
   @Override
   protected TrackerSideEffectDataBundle handleSideEffects(
       TrackerBundle bundle, TrackedEntity entity, List<SideEffectTrigger> triggers) {
-    return TrackerSideEffectDataBundle.builder().build();
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import java.util.List;
 import javax.persistence.EntityManager;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 
 /**
@@ -39,13 +41,16 @@ import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
  */
 public interface TrackerPersister<T extends TrackerDto, V> {
 
+  record PersistResult(
+      TrackerTypeReport report, List<TrackerSideEffectDataBundle> sideEffectBundles) {}
+
   /**
    * Persist one of the collections in the provided Tracker Bundle. Each class implementing this
    * method should be responsible to persist one collection of the TrackerBundle (e.g. Enrollments)
    *
    * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
-   * @return a {@link TrackerTypeReport}
+   * @return a {@link PersistResult} containing the type report and side effect bundles
    */
-  TrackerTypeReport persist(EntityManager entityManager, TrackerBundle bundle);
+  PersistResult persist(EntityManager entityManager, TrackerBundle bundle);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/job/SideEffectTrigger.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/job/SideEffectTrigger.java
@@ -34,5 +34,18 @@ public enum SideEffectTrigger {
   ENROLLMENT,
   ENROLLMENT_COMPLETION,
   EVENT_COMPLETION,
-  NONE
+  NONE;
+
+  /**
+   * Returns the corresponding {@link org.hisp.dhis.program.notification.NotificationTrigger} used
+   * on {@link org.hisp.dhis.program.notification.ProgramNotificationTemplate}.
+   */
+  public org.hisp.dhis.program.notification.NotificationTrigger toTemplateTrigger() {
+    return switch (this) {
+      case ENROLLMENT -> org.hisp.dhis.program.notification.NotificationTrigger.ENROLLMENT;
+      case ENROLLMENT_COMPLETION, EVENT_COMPLETION ->
+          org.hisp.dhis.program.notification.NotificationTrigger.COMPLETION;
+      case NONE -> null;
+    };
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramNotificationTemplateMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramNotificationTemplateMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2025, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,53 +27,21 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
-import java.util.Set;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(
-    uses = {
-      DebugMapper.class,
-      OrganisationUnitMapper.class,
-      CategoryComboMapper.class,
-      TrackedEntityTypeMapper.class,
-      ProgramStageMapper.class,
-      ProgramTrackedEntityAttributeMapper.class,
-      ProgramNotificationTemplateMapper.class,
-      AttributeValueMapper.class,
-      SharingMapper.class
-    })
-public interface ProgramMapper extends PreheatMapper<Program> {
-  ProgramMapper INSTANCE = Mappers.getMapper(ProgramMapper.class);
+@Mapper
+public interface ProgramNotificationTemplateMapper
+    extends PreheatMapper<ProgramNotificationTemplate> {
+  ProgramNotificationTemplateMapper INSTANCE =
+      Mappers.getMapper(ProgramNotificationTemplateMapper.class);
 
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "id")
   @Mapping(target = "uid")
-  @Mapping(target = "code")
-  @Mapping(target = "name")
-  @Mapping(target = "attributeValues")
-  @Mapping(target = "trackedEntityType")
-  @Mapping(target = "programType")
-  @Mapping(target = "programAttributes")
-  @Mapping(target = "programStages")
-  @Mapping(target = "onlyEnrollOnce")
-  @Mapping(target = "featureType")
-  @Mapping(target = "categoryCombo")
-  @Mapping(target = "selectEnrollmentDatesInFuture")
-  @Mapping(target = "selectIncidentDatesInFuture")
-  @Mapping(target = "displayIncidentDate")
-  @Mapping(target = "ignoreOverdueEvents")
-  @Mapping(target = "expiryDays")
-  @Mapping(target = "expiryPeriodType")
-  @Mapping(target = "completeEventsExpiryDays")
-  @Mapping(target = "sharing")
-  @Mapping(target = "accessLevel")
-  @Mapping(target = "notificationTemplates")
-  Program map(Program program);
-
-  Set<ProgramStage> mapProgramStages(Set<ProgramStage> programStages);
+  @Mapping(target = "notificationTrigger")
+  ProgramNotificationTemplate map(ProgramNotificationTemplate template);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
@@ -40,7 +40,8 @@ import org.mapstruct.factory.Mappers;
       DebugMapper.class,
       TrackedEntityTypeMapper.class,
       AttributeValueMapper.class,
-      SharingMapper.class
+      SharingMapper.class,
+      ProgramNotificationTemplateMapper.class,
     })
 public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   ProgramStageMapper INSTANCE = Mappers.getMapper(ProgramStageMapper.class);
@@ -60,6 +61,7 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   @Mapping(target = "validationStrategy")
   @Mapping(target = "featureType")
   @Mapping(target = "sharing")
+  @Mapping(target = "notificationTemplates")
   ProgramStage map(ProgramStage programStage);
 
   @Named("program")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
@@ -28,13 +28,11 @@
 package org.hisp.dhis.tracker.imports.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -44,8 +42,6 @@ public class TrackerTypeReport {
   @JsonProperty private final TrackerType trackerType;
 
   @JsonProperty private Stats stats = new Stats();
-
-  @JsonIgnore private List<TrackerSideEffectDataBundle> sideEffectDataBundles = new ArrayList<>();
 
   private List<Entity> entityReport = new ArrayList<>();
 
@@ -57,12 +53,9 @@ public class TrackerTypeReport {
   public TrackerTypeReport(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("stats") Stats stats,
-      @JsonProperty("sideEffectDataBundles")
-          List<TrackerSideEffectDataBundle> sideEffectDataBundles,
       @JsonProperty("objectReports") List<Entity> entityReport) {
     this.trackerType = trackerType;
     this.stats = stats;
-    this.sideEffectDataBundles = sideEffectDataBundles;
     this.entityReport = entityReport;
   }
 
@@ -90,9 +83,5 @@ public class TrackerTypeReport {
 
   private List<Error> getErrorReports() {
     return entityReport.stream().flatMap(e -> e.getErrorReports().stream()).toList();
-  }
-
-  public List<TrackerSideEffectDataBundle> getSideEffectDataBundles() {
-    return sideEffectDataBundles;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -102,10 +102,11 @@ class TrackerImporterServiceTest {
             .trackedEntities(new ArrayList<>())
             .build();
 
-    PersistenceReport persistenceReport = PersistenceReport.emptyReport();
     when(trackerUserService.getUser(anyString())).thenReturn(getUser());
 
-    when(trackerBundleService.commit(any(TrackerBundle.class))).thenReturn(persistenceReport);
+    when(trackerBundleService.commit(any(TrackerBundle.class)))
+        .thenReturn(
+            new TrackerBundleService.CommitResult(PersistenceReport.emptyReport(), List.of()));
 
     when(validationService.validate(any(TrackerBundle.class))).thenReturn(validationResult);
     when(validationService.validateRuleEngine(any(TrackerBundle.class)))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/ImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/ImportReportTest.java
@@ -89,6 +89,6 @@ class ImportReportTest {
     teStats.setCreated(created);
     teStats.setUpdated(updated);
     teStats.setDeleted(deleted);
-    return new TrackerTypeReport(type, teStats, new ArrayList<>(), new ArrayList<>());
+    return new TrackerTypeReport(type, teStats, new ArrayList<>());
   }
 }


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/23347 (master), adapted from https://github.com/dhis2/dhis2-core/pull/23583 (2.42 backport).

Same change as the 2.42 backport, adapted for 2.41's naming conventions.

### Differences from 2.42

* 2.41 uses `SideEffectTrigger` / `TrackerSideEffectDataBundle` / `handleSideEffects` / `determineSideEffectTriggers` instead of 2.42's `NotificationTrigger` / `TrackerNotificationDataBundle` / `handleNotifications` / `determineNotificationTriggers`
* 2.41 passes rule engine effects as maps (`enrollmentRuleEffects`, `eventRuleEffects`) not per-entity notification lists. The "has rule effects" check uses `!bundle.getEnrollmentRuleEffects().isEmpty()` / `!bundle.getEventRuleEffects().isEmpty()`
* 2.41 uses `TrackerConverterService` in persisters, 2.42 uses `TrackerObjectsMapper`
* 2.41 uses `javax.persistence` (Java EE), 2.42 uses `jakarta.persistence`
