### PR TITLE
perf: replace linear scans with indexed lookups in tracker import DHIS2-21287

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -37,9 +37,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
@@ -113,6 +114,12 @@ public class TrackerBundle {
   /** Relationships to import. */
   @Builder.Default private List<Relationship> relationships = new ArrayList<>();
 
+  @JsonIgnore private transient Map<UID, TrackedEntity> trackedEntityByUid;
+  @JsonIgnore private transient Map<UID, Enrollment> enrollmentByUid;
+  @JsonIgnore private transient Map<UID, TrackerEvent> trackerEventByUid;
+  @JsonIgnore private transient Map<UID, SingleEvent> singleEventByUid;
+  @JsonIgnore private transient Map<UID, Relationship> relationshipByUid;
+
   /** Notifications for enrollments. */
   @Builder.Default private Map<UID, List<Notification>> enrollmentNotifications = new HashMap<>();
 
@@ -151,32 +158,95 @@ public class TrackerBundle {
 
   @Builder.Default @JsonIgnore private Set<UID> updatedTrackedEntities = new HashSet<>();
 
+  public void setTrackedEntities(List<TrackedEntity> trackedEntities) {
+    this.trackedEntities = trackedEntities;
+    this.trackedEntityByUid = null;
+  }
+
+  public void setEnrollments(List<Enrollment> enrollments) {
+    this.enrollments = enrollments;
+    this.enrollmentByUid = null;
+  }
+
+  public void setTrackerEvents(List<TrackerEvent> trackerEvents) {
+    this.trackerEvents = trackerEvents;
+    this.trackerEventByUid = null;
+  }
+
+  public void setSingleEvents(List<SingleEvent> singleEvents) {
+    this.singleEvents = singleEvents;
+    this.singleEventByUid = null;
+  }
+
+  public void setRelationships(List<Relationship> relationships) {
+    this.relationships = relationships;
+    this.relationshipByUid = null;
+  }
+
   public Optional<TrackedEntity> findTrackedEntityByUid(@Nonnull UID uid) {
-    return findById(this.trackedEntities, uid);
+    return Optional.ofNullable(getTrackedEntityByUid().get(uid));
   }
 
   public Optional<Enrollment> findEnrollmentByUid(@Nonnull UID uid) {
-    return findById(this.enrollments, uid);
+    return Optional.ofNullable(getEnrollmentByUid().get(uid));
   }
 
   public Optional<TrackerEvent> findTrackerEventByUid(@Nonnull UID uid) {
-    return findById(this.getTrackerEvents(), uid);
+    return Optional.ofNullable(getTrackerEventByUid().get(uid));
   }
 
   public Optional<SingleEvent> findSingleEventByUid(@Nonnull UID uid) {
-    return findById(this.getSingleEvents(), uid);
+    return Optional.ofNullable(getSingleEventByUid().get(uid));
   }
 
   public Optional<Event> findEventByUid(@Nonnull UID uid) {
-    return findById(this.getEvents(), uid);
+    TrackerEvent te = getTrackerEventByUid().get(uid);
+    if (te != null) return Optional.of(te);
+    return Optional.ofNullable(getSingleEventByUid().get(uid));
   }
 
   public Optional<Relationship> findRelationshipByUid(@Nonnull UID uid) {
-    return findById(this.relationships, uid);
+    return Optional.ofNullable(getRelationshipByUid().get(uid));
   }
 
-  private static <T extends TrackerDto> Optional<T> findById(List<T> entities, UID uid) {
-    return entities.stream().filter(e -> Objects.equals(e.getUID(), uid)).findFirst();
+  private Map<UID, TrackedEntity> getTrackedEntityByUid() {
+    if (trackedEntityByUid == null) {
+      trackedEntityByUid = indexByUid(trackedEntities);
+    }
+    return trackedEntityByUid;
+  }
+
+  private Map<UID, Enrollment> getEnrollmentByUid() {
+    if (enrollmentByUid == null) {
+      enrollmentByUid = indexByUid(enrollments);
+    }
+    return enrollmentByUid;
+  }
+
+  private Map<UID, TrackerEvent> getTrackerEventByUid() {
+    if (trackerEventByUid == null) {
+      trackerEventByUid = indexByUid(trackerEvents);
+    }
+    return trackerEventByUid;
+  }
+
+  private Map<UID, SingleEvent> getSingleEventByUid() {
+    if (singleEventByUid == null) {
+      singleEventByUid = indexByUid(singleEvents);
+    }
+    return singleEventByUid;
+  }
+
+  private Map<UID, Relationship> getRelationshipByUid() {
+    if (relationshipByUid == null) {
+      relationshipByUid = indexByUid(relationships);
+    }
+    return relationshipByUid;
+  }
+
+  private static <T extends TrackerDto> Map<UID, T> indexByUid(List<T> entities) {
+    return entities.stream()
+        .collect(Collectors.toMap(TrackerDto::getUID, Function.identity(), (a, b) -> a));
   }
 
   public Set<UID> getUpdatedTrackedEntities() {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -29,8 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -81,13 +79,13 @@ public class TrackerBundle {
   @Builder.Default private TrackerImportStrategy importStrategy = TrackerImportStrategy.CREATE;
 
   /** Should text pattern validation be skipped or not, default is not. */
-  @JsonProperty private boolean skipTextPatternValidation;
+  private boolean skipTextPatternValidation;
 
   /** Should side effects be skipped or not, default is not. */
-  @JsonProperty private boolean skipSideEffects;
+  private boolean skipSideEffects;
 
   /** Should rule engine call be skipped or not, default is to skip. */
-  @JsonProperty private boolean skipRuleEngine;
+  private boolean skipRuleEngine;
 
   /** Should import be treated as an atomic import (all or nothing). */
   @Builder.Default private AtomicMode atomicMode = AtomicMode.ALL;
@@ -114,11 +112,12 @@ public class TrackerBundle {
   /** Relationships to import. */
   @Builder.Default private List<Relationship> relationships = new ArrayList<>();
 
-  @JsonIgnore private Map<UID, TrackedEntity> trackedEntityByUid;
-  @JsonIgnore private Map<UID, Enrollment> enrollmentByUid;
-  @JsonIgnore private Map<UID, TrackerEvent> trackerEventByUid;
-  @JsonIgnore private Map<UID, SingleEvent> singleEventByUid;
-  @JsonIgnore private Map<UID, Relationship> relationshipByUid;
+  // Lazily-built UID indexes for O(1) lookups. Invalidated when entity lists change.
+  private Map<UID, TrackedEntity> trackedEntityByUid;
+  private Map<UID, Enrollment> enrollmentByUid;
+  private Map<UID, TrackerEvent> trackerEventByUid;
+  private Map<UID, SingleEvent> singleEventByUid;
+  private Map<UID, Relationship> relationshipByUid;
 
   /** Notifications for enrollments. */
   @Builder.Default private Map<UID, List<Notification>> enrollmentNotifications = new HashMap<>();
@@ -156,7 +155,7 @@ public class TrackerBundle {
     return resolvedStrategyMap;
   }
 
-  @Builder.Default @JsonIgnore private Set<UID> updatedTrackedEntities = new HashSet<>();
+  @Builder.Default private Set<UID> updatedTrackedEntities = new HashSet<>();
 
   public void setTrackedEntities(List<TrackedEntity> trackedEntities) {
     this.trackedEntities = trackedEntities;
@@ -200,9 +199,11 @@ public class TrackerBundle {
   }
 
   public Optional<Event> findEventByUid(@Nonnull UID uid) {
-    TrackerEvent te = getTrackerEventByUid().get(uid);
-    if (te != null) return Optional.of(te);
-    return Optional.ofNullable(getSingleEventByUid().get(uid));
+    Event event = getTrackerEventByUid().get(uid);
+    if (event == null) {
+      event = getSingleEventByUid().get(uid);
+    }
+    return Optional.ofNullable(event);
   }
 
   public Optional<Relationship> findRelationshipByUid(@Nonnull UID uid) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -114,11 +114,11 @@ public class TrackerBundle {
   /** Relationships to import. */
   @Builder.Default private List<Relationship> relationships = new ArrayList<>();
 
-  @JsonIgnore private transient Map<UID, TrackedEntity> trackedEntityByUid;
-  @JsonIgnore private transient Map<UID, Enrollment> enrollmentByUid;
-  @JsonIgnore private transient Map<UID, TrackerEvent> trackerEventByUid;
-  @JsonIgnore private transient Map<UID, SingleEvent> singleEventByUid;
-  @JsonIgnore private transient Map<UID, Relationship> relationshipByUid;
+  @JsonIgnore private Map<UID, TrackedEntity> trackedEntityByUid;
+  @JsonIgnore private Map<UID, Enrollment> enrollmentByUid;
+  @JsonIgnore private Map<UID, TrackerEvent> trackerEventByUid;
+  @JsonIgnore private Map<UID, SingleEvent> singleEventByUid;
+  @JsonIgnore private Map<UID, Relationship> relationshipByUid;
 
   /** Notifications for enrollments. */
   @Builder.Default private Map<UID, List<Notification>> enrollmentNotifications = new HashMap<>();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -61,10 +61,12 @@ import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -642,6 +644,33 @@ public class TrackerPreheat {
       case EVENT -> getTrackerEvent(uid) != null || getSingleEvent(uid) != null;
       case RELATIONSHIP -> getRelationship(uid) != null;
     };
+  }
+
+  private final Map<String, Set<MetadataIdentifier>> mandatoryProgramAttributeCache =
+      new HashMap<>();
+
+  private final Map<String, Set<MetadataIdentifier>> mandatoryTetAttributeCache = new HashMap<>();
+
+  public Set<MetadataIdentifier> getMandatoryProgramAttributes(Program program) {
+    return mandatoryProgramAttributeCache.computeIfAbsent(
+        program.getUid(),
+        uid ->
+            program.getProgramAttributes().stream()
+                .filter(ProgramTrackedEntityAttribute::isMandatory)
+                .map(pa -> idSchemes.toMetadataIdentifier(pa.getAttribute()))
+                .collect(Collectors.toUnmodifiableSet()));
+  }
+
+  public Set<MetadataIdentifier> getMandatoryTrackedEntityTypeAttributes(
+      TrackedEntityType trackedEntityType) {
+    return mandatoryTetAttributeCache.computeIfAbsent(
+        trackedEntityType.getUid(),
+        uid ->
+            trackedEntityType.getTrackedEntityTypeAttributes().stream()
+                .filter(a -> Boolean.TRUE.equals(a.isMandatory()))
+                .map(TrackedEntityTypeAttribute::getTrackedEntityAttribute)
+                .map(idSchemes::toMetadataIdentifier)
+                .collect(Collectors.toUnmodifiableSet()));
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
@@ -646,24 +645,23 @@ public class TrackerPreheat {
     };
   }
 
-  private final Map<String, Set<MetadataIdentifier>> mandatoryProgramAttributeCache =
-      new HashMap<>();
+  private final Map<String, Set<MetadataIdentifier>> mandatoryProgramAttributes = new HashMap<>();
 
-  private final Map<String, Set<MetadataIdentifier>> mandatoryTetAttributeCache = new HashMap<>();
+  private final Map<String, Set<MetadataIdentifier>> mandatoryTetAttributes = new HashMap<>();
 
   public Set<MetadataIdentifier> getMandatoryProgramAttributes(Program program) {
-    return mandatoryProgramAttributeCache.computeIfAbsent(
+    return mandatoryProgramAttributes.computeIfAbsent(
         program.getUid(),
         uid ->
             program.getProgramAttributes().stream()
-                .filter(ProgramTrackedEntityAttribute::isMandatory)
+                .filter(pa -> Boolean.TRUE.equals(pa.isMandatory()))
                 .map(pa -> idSchemes.toMetadataIdentifier(pa.getAttribute()))
                 .collect(Collectors.toUnmodifiableSet()));
   }
 
   public Set<MetadataIdentifier> getMandatoryTrackedEntityTypeAttributes(
       TrackedEntityType trackedEntityType) {
-    return mandatoryTetAttributeCache.computeIfAbsent(
+    return mandatoryTetAttributes.computeIfAbsent(
         trackedEntityType.getUid(),
         uid ->
             trackedEntityType.getTrackedEntityTypeAttributes().stream()

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
@@ -145,6 +145,11 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
     return mergeAttributes(teUniqueAttributes, enrollmentUniqueAttributes);
   }
 
+  /**
+   * Finds the tracked entity referenced by an enrollment. Checks the payload first, then falls back
+   * to building a minimal TE from preheat (DB). If the TE is not found in either, a stub with just
+   * the UID is returned; validation will report the error later.
+   */
   private org.hisp.dhis.tracker.imports.domain.TrackedEntity getEntityForEnrollment(
       Map<UID, org.hisp.dhis.tracker.imports.domain.TrackedEntity> teByUid,
       TrackerPreheat preheat,
@@ -154,10 +159,11 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
       return payloadTe;
     }
 
-    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
     org.hisp.dhis.tracker.imports.domain.TrackedEntity te =
         new org.hisp.dhis.tracker.imports.domain.TrackedEntity();
     te.setTrackedEntity(teUid);
+
+    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
     if (trackedEntity != null) {
       te.setOrgUnit(
           preheat.getIdSchemes().toMetadataIdentifier(trackedEntity.getOrganisationUnit()));

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributesSupplier.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -108,6 +107,14 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
           TrackerObjects trackerObjects,
           TrackerPreheat preheat,
           List<TrackedEntityAttribute> uniqueTrackedEntityAttributes) {
+    Map<UID, org.hisp.dhis.tracker.imports.domain.TrackedEntity> teByUid =
+        trackerObjects.getTrackedEntities().stream()
+            .collect(
+                toMap(
+                    org.hisp.dhis.tracker.imports.domain.TrackedEntity::getUID,
+                    Function.identity(),
+                    (a, b) -> a));
+
     Map<org.hisp.dhis.tracker.imports.domain.TrackedEntity, Set<Attribute>> teUniqueAttributes =
         trackerObjects.getTrackedEntities().stream()
             .collect(
@@ -120,8 +127,7 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
         enrollmentUniqueAttributes =
             trackerObjects.getEnrollments().stream()
                 .collect(
-                    groupingBy(
-                        e -> getEntityForEnrollment(trackerObjects, preheat, e.getTrackedEntity())))
+                    groupingBy(e -> getEntityForEnrollment(teByUid, preheat, e.getTrackedEntity())))
                 .entrySet()
                 .stream()
                 .collect(
@@ -140,32 +146,23 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier {
   }
 
   private org.hisp.dhis.tracker.imports.domain.TrackedEntity getEntityForEnrollment(
-      TrackerObjects trackerObjects, TrackerPreheat preheat, UID teUid) {
-    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
+      Map<UID, org.hisp.dhis.tracker.imports.domain.TrackedEntity> teByUid,
+      TrackerPreheat preheat,
+      UID teUid) {
+    org.hisp.dhis.tracker.imports.domain.TrackedEntity payloadTe = teByUid.get(teUid);
+    if (payloadTe != null) {
+      return payloadTe;
+    }
 
-    // Get te from Preheat
-    Optional<org.hisp.dhis.tracker.imports.domain.TrackedEntity> optionalTe =
-        trackerObjects.getTrackedEntities().stream()
-            .filter(te -> Objects.equals(te.getUID(), teUid))
-            .findAny();
-    if (optionalTe.isPresent()) {
-      return optionalTe.get();
-    } else if (trackedEntity != null) // Otherwise build it from Payload
-    {
-      org.hisp.dhis.tracker.imports.domain.TrackedEntity te =
-          new org.hisp.dhis.tracker.imports.domain.TrackedEntity();
-      te.setTrackedEntity(teUid);
+    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
+    org.hisp.dhis.tracker.imports.domain.TrackedEntity te =
+        new org.hisp.dhis.tracker.imports.domain.TrackedEntity();
+    te.setTrackedEntity(teUid);
+    if (trackedEntity != null) {
       te.setOrgUnit(
           preheat.getIdSchemes().toMetadataIdentifier(trackedEntity.getOrganisationUnit()));
-      return te;
-    } else // TE is not present. but we do not fail here.
-    // A validation error will be thrown in validation phase
-    {
-      org.hisp.dhis.tracker.imports.domain.TrackedEntity te =
-          new org.hisp.dhis.tracker.imports.domain.TrackedEntity();
-      te.setTrackedEntity(teUid);
-      return te;
     }
+    return te;
   }
 
   private Map<org.hisp.dhis.tracker.imports.domain.TrackedEntity, Set<Attribute>> mergeAttributes(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
@@ -41,7 +41,6 @@ import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.common.UID;
@@ -82,10 +81,14 @@ class AttributeValidator
     OrganisationUnit orgUnit =
         preheat.getOrganisationUnit(getOrgUnitUidFromTei(bundle, enrollment.getTrackedEntity()));
 
+    Set<MetadataIdentifier> mandatoryProgramAttributes =
+        preheat.getMandatoryProgramAttributes(program);
+
     Map<MetadataIdentifier, String> attributeValueMap = Maps.newHashMap();
 
     for (Attribute attribute : enrollment.getAttributes()) {
-      validateRequiredProperties(reporter, preheat, enrollment, attribute, program);
+      validateRequiredProperties(
+          reporter, preheat, enrollment, attribute, mandatoryProgramAttributes);
 
       TrackedEntityAttribute teAttribute =
           bundle.getPreheat().getTrackedEntityAttribute(attribute.getAttribute());
@@ -112,18 +115,13 @@ class AttributeValidator
       TrackerPreheat preheat,
       Enrollment enrollment,
       Attribute attribute,
-      Program program) {
+      Set<MetadataIdentifier> mandatoryProgramAttributes) {
     if (attribute.getAttribute().isBlank()) {
       reporter.addError(enrollment, E1075, attribute);
       return;
     }
 
-    Optional<ProgramTrackedEntityAttribute> optionalTrackedAttr =
-        program.getProgramAttributes().stream()
-            .filter(pa -> attribute.getAttribute().isEqualTo(pa.getAttribute()) && pa.isMandatory())
-            .findFirst();
-
-    if (optionalTrackedAttr.isPresent()) {
+    if (mandatoryProgramAttributes.contains(attribute.getAttribute())) {
       reporter.addErrorIfNull(
           attribute.getValue(),
           enrollment,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
@@ -36,14 +36,11 @@ import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateOptionSet;
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateValueType;
 
-import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
@@ -90,22 +87,18 @@ class AttributeValidator
     Set<MetadataIdentifier> trackedEntityAttributes =
         getTrackedEntityAttributes(bundle, trackedEntity.getUID());
 
-    TrackerIdSchemeParams idSchemes = bundle.getPreheat().getIdSchemes();
-    trackedEntityType.getTrackedEntityTypeAttributes().stream()
-        .filter(
-            trackedEntityTypeAttribute ->
-                Boolean.TRUE.equals(trackedEntityTypeAttribute.isMandatory()))
-        .map(TrackedEntityTypeAttribute::getTrackedEntityAttribute)
-        .map(idSchemes::toMetadataIdentifier)
-        .filter(mandatoryAttribute -> !trackedEntityAttributes.contains(mandatoryAttribute))
-        .forEach(
-            attribute ->
-                reporter.addError(
-                    trackedEntity,
-                    E1090,
-                    attribute,
-                    trackedEntityType.getUid(),
-                    trackedEntity.getTrackedEntity()));
+    Set<MetadataIdentifier> mandatoryAttributes =
+        bundle.getPreheat().getMandatoryTrackedEntityTypeAttributes(trackedEntityType);
+    for (MetadataIdentifier attribute : mandatoryAttributes) {
+      if (!trackedEntityAttributes.contains(attribute)) {
+        reporter.addError(
+            trackedEntity,
+            E1090,
+            attribute,
+            trackedEntityType.getUid(),
+            trackedEntity.getTrackedEntity());
+      }
+    }
   }
 
   protected void validateAttributes(
@@ -116,6 +109,8 @@ class AttributeValidator
       OrganisationUnit orgUnit,
       TrackedEntityType trackedEntityType) {
     TrackerPreheat preheat = bundle.getPreheat();
+    Set<MetadataIdentifier> mandatoryTetAttributes =
+        preheat.getMandatoryTrackedEntityTypeAttributes(trackedEntityType);
 
     for (Attribute attribute : trackedEntity.getAttributes()) {
       TrackedEntityAttribute tea = preheat.getTrackedEntityAttribute(attribute.getAttribute());
@@ -126,28 +121,13 @@ class AttributeValidator
       }
 
       if (attribute.getValue() == null) {
-        Optional<TrackedEntityTypeAttribute> optionalTea =
-            Optional.of(trackedEntityType)
-                .map(tet -> tet.getTrackedEntityTypeAttributes().stream())
-                .flatMap(
-                    tetAtts ->
-                        tetAtts
-                            .filter(
-                                teaAtt ->
-                                    attribute
-                                            .getAttribute()
-                                            .isEqualTo(teaAtt.getTrackedEntityAttribute())
-                                        && teaAtt.isMandatory() != null
-                                        && teaAtt.isMandatory())
-                            .findFirst());
-
-        if (optionalTea.isPresent())
+        if (mandatoryTetAttributes.contains(attribute.getAttribute())) {
           reporter.addError(
               trackedEntity,
               E1076,
               TrackedEntityAttribute.class.getSimpleName(),
               attribute.getAttribute());
-
+        }
         continue;
       }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
@@ -109,7 +109,7 @@ class AttributeValidator
       OrganisationUnit orgUnit,
       TrackedEntityType trackedEntityType) {
     TrackerPreheat preheat = bundle.getPreheat();
-    Set<MetadataIdentifier> mandatoryTetAttributes =
+    Set<MetadataIdentifier> mandatoryAttributes =
         preheat.getMandatoryTrackedEntityTypeAttributes(trackedEntityType);
 
     for (Attribute attribute : trackedEntity.getAttributes()) {
@@ -121,7 +121,7 @@ class AttributeValidator
       }
 
       if (attribute.getValue() == null) {
-        if (mandatoryTetAttributes.contains(attribute.getAttribute())) {
+        if (mandatoryAttributes.contains(attribute.getAttribute())) {
           reporter.addError(
               trackedEntity,
               E1076,

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
@@ -135,7 +135,7 @@ class AttributeValidatorTest {
             invocation -> {
               Program p = invocation.getArgument(0);
               return p.getProgramAttributes().stream()
-                  .filter(ProgramTrackedEntityAttribute::isMandatory)
+                  .filter(pa -> Boolean.TRUE.equals(pa.isMandatory()))
                   .map(pa -> idSchemes.toMetadataIdentifier(pa.getAttribute()))
                   .collect(Collectors.toUnmodifiableSet());
             });

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
@@ -126,8 +127,18 @@ class AttributeValidatorTest {
         new TrackedEntityAttribute("percentage", "percent", ValueType.PERCENTAGE, false, false);
     trackedEntityAttributeP.setUid(TRACKED_ATTRIBUTE_P);
 
-    when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
+    TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+    when(preheat.getIdSchemes()).thenReturn(idSchemes);
     when(preheat.getProgram((MetadataIdentifier) any())).thenReturn(program);
+    when(preheat.getMandatoryProgramAttributes(any()))
+        .thenAnswer(
+            invocation -> {
+              Program p = invocation.getArgument(0);
+              return p.getProgramAttributes().stream()
+                  .filter(ProgramTrackedEntityAttribute::isMandatory)
+                  .map(pa -> idSchemes.toMetadataIdentifier(pa.getAttribute()))
+                  .collect(Collectors.toUnmodifiableSet());
+            });
     when(enrollment.getProgram()).thenReturn(MetadataIdentifier.ofUid("program"));
     when(preheat.getTrackedEntityAttribute(MetadataIdentifier.ofUid(TRACKED_ATTRIBUTE)))
         .thenReturn(trackedEntityAttribute);
@@ -147,7 +158,6 @@ class AttributeValidatorTest {
 
     bundle = TrackerBundle.builder().preheat(preheat).build();
 
-    TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
     reporter = new Reporter(idSchemes);
   }
 

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
@@ -99,6 +100,16 @@ class AttributeValidatorTest {
     bundle = TrackerBundle.builder().preheat(preheat).build();
     idSchemes = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(idSchemes);
+    when(preheat.getMandatoryTrackedEntityTypeAttributes(any()))
+        .thenAnswer(
+            invocation -> {
+              TrackedEntityType tet = invocation.getArgument(0);
+              return tet.getTrackedEntityTypeAttributes().stream()
+                  .filter(a -> Boolean.TRUE.equals(a.isMandatory()))
+                  .map(TrackedEntityTypeAttribute::getTrackedEntityAttribute)
+                  .map(idSchemes::toMetadataIdentifier)
+                  .collect(Collectors.toUnmodifiableSet());
+            });
     reporter = new Reporter(idSchemes);
     when(dhisConfigurationProvider.getEncryptionStatus()).thenReturn(EncryptionStatus.OK);
   }


### PR DESCRIPTION
Replace O(n) linear stream scans with O(1) indexed lookups in tracker import validation and preheat. Profiling shows validation at 6.7% CPU. The main costs:

* `TrackerBundle.findById`: linear scan of the entity list on every call, invoked 6+ times per enrollment from different validators. With 500 TEs per request that is ~3,000 linear scans.
* `UniqueAttributesSupplier.getEntityForEnrollment`: linear scan of the TE list per enrollment during preheat.
* `AttributeValidator.validateRequiredProperties`: streams through program attributes per attribute per enrollment to check if mandatory.

### Changes

**TrackerBundle**: add lazily-built `Map<UID, T>` indexes for each entity type. `findXxxByUid` does a map lookup instead of a stream scan. Maps are invalidated when entity lists change (after validation, after rule engine).

**UniqueAttributesSupplier**: build a `Map<UID, TrackedEntity>` once from the payload and use it in `getEntityForEnrollment` instead of scanning the list per enrollment.

**TrackerPreheat**: cache mandatory attribute sets per program and per tracked entity type. `getMandatoryProgramAttributes` and `getMandatoryTrackedEntityTypeAttributes` compute the set once on first access and reuse it for all entities of the same program/type.

**Cleanup**: remove unused `@JsonProperty`/`@JsonIgnore` annotations from `TrackerBundle`.

## Performance

CPU profile: 1 user, 5 min, `skipRuleEngine=true&skipSideEffects=true`, 500 TEs/request.

Baseline [run 24357292097](https://github.com/dhis2/dhis2-core/actions/runs/24357292097). PR [cpu run 24394901884](https://github.com/dhis2/dhis2-core/actions/runs/24394901884), [alloc run 24398234369](https://github.com/dhis2/dhis2-core/actions/runs/24398234369).

| Subsystem | Baseline (17,652 samples) | PR (15,848 samples) |
|---|---|---|
| Hibernate flush/persist | ~9,000 (51%) | 8,695 (54.8%) |
| DB I/O (__write) | ~2,475 (14%) | 2,528 (15.9%) |
| **Validation** | **~1,177 (6.7%)** | **534 (3.3%)** |
| Preheat | ~1,131 (6.4%) | 1,061 (6.6%) |
| **TrackerBundle.findById** | **466 (2.6%)** | **5 (0.0%)** |
| **validateRequiredProperties** | **164 (0.9%)** | **21 (0.1%)** |

Validation halved (6.7% -> 3.3%). `findById` eliminated. No regressions. Throughput improved ~5% (220 -> 231 imports in 5 min) though these are single-user profile runs with profiler overhead, not load tests.
