### PR TITLE
fix: deliveryChannels is not persisted

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHook.java
@@ -117,7 +117,7 @@ public class ProgramNotificationTemplateObjectBundleHook
     ValueType valueType = toValueType == null ? null : toValueType.apply(template);
 
     Set<DeliveryChannel> deliveryChannels =
-        valueType == null ? null : CHANNEL_MAPPER.get(valueType);
+        valueType == null ? template.getDeliveryChannels() : CHANNEL_MAPPER.get(valueType);
     template.setDeliveryChannels(deliveryChannels == null ? new HashSet<>() : deliveryChannels);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -1312,6 +1312,27 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
             .contains("IndUid000x1"));
   }
 
+  @Test
+  void testSaveNotificationTemplateWithDeliveryChannels() {
+    POST("/metadata", Path.of("program/program_notification_template.json")).content(HttpStatus.OK);
+    JsonObject template =
+        GET("/programNotificationTemplates/uivYkvFEOss")
+            .content(HttpStatus.OK)
+            .as(JsonObject.class);
+    assertNotNull(template);
+    assertEquals(1, template.getArray("deliveryChannels").size());
+
+    // Update the template with an additional delivery channel
+    POST("/metadata", Path.of("program/program_notification_template_update.json"))
+        .content(HttpStatus.OK);
+    template =
+        GET("/programNotificationTemplates/uivYkvFEOss")
+            .content(HttpStatus.OK)
+            .as(JsonObject.class);
+    assertNotNull(template);
+    assertEquals(2, template.getArray("deliveryChannels").size());
+  }
+
   private void setupDataElementsWithCatCombos(CategoryCombo... categoryCombos) {
     DataElement deA = createDataElement('A', categoryCombos[0]);
     DataElement deB = createDataElement('B', categoryCombos[1]);

--- a/dhis-2/dhis-test-web-api/src/test/resources/program/program_notification_template.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/program/program_notification_template.json
@@ -1,0 +1,22 @@
+{
+  "programNotificationTemplates": [
+    {
+      "notificationTrigger": "SCHEDULED_DAYS_DUE_DATE",
+      "lastUpdated": "2026-04-14T04:24:42.392",
+      "relativeScheduledDays": -3,
+      "subjectTemplate": "Immunization visit reminder",
+      "id": "uivYkvFEOss",
+      "notifyUsersInHierarchyOnly": false,
+      "created": "2016-10-11T10:32:58.490",
+      "sendRepeatable": false,
+      "notificationRecipient": "TRACKED_ENTITY_INSTANCE",
+      "notifyParentOrganisationUnitOnly": false,
+      "name": "Immunization visit reminder",
+      "messageTemplate": "Dear A{w75KJ2mc4zz}. This to remind you that you have an upcoming visit in V{days_until_due_date} days for your second immunization visit at V{program_stage_name} health facility. Please ensure to bring your immunization card with you.",
+      "translations": [],
+      "deliveryChannels": [
+        "SMS"
+      ]
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/program/program_notification_template_update.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/program/program_notification_template_update.json
@@ -1,0 +1,23 @@
+{
+  "programNotificationTemplates": [
+    {
+      "notificationTrigger": "SCHEDULED_DAYS_DUE_DATE",
+      "lastUpdated": "2026-04-14T04:24:42.392",
+      "relativeScheduledDays": -3,
+      "subjectTemplate": "Immunization visit reminder",
+      "id": "uivYkvFEOss",
+      "notifyUsersInHierarchyOnly": false,
+      "created": "2016-10-11T10:32:58.490",
+      "sendRepeatable": false,
+      "notificationRecipient": "TRACKED_ENTITY_INSTANCE",
+      "notifyParentOrganisationUnitOnly": false,
+      "name": "Immunization visit reminder",
+      "messageTemplate": "Dear A{w75KJ2mc4zz}. This to remind you that you have an upcoming visit in V{days_until_due_date} days for your second immunization visit at V{program_stage_name} health facility. Please ensure to bring your immunization card with you.",
+      "translations": [],
+      "deliveryChannels": [
+        "SMS",
+        "EMAIL"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15969
### Issue
- `ProgramNotificationTemplate.deliveryChannels` is not persisted when user send POST request to `api/metadata`

### Fix
- There is a logic to calculate the delivery channels base on value type in `ProgramNotificationTemplateObjectBundleHook` however it doesn't fallback to the input data if the calculations return `null`.

### Test
- Added controller test.