### PR TITLE
fix: Operate on copy of collection to avoid ConcurrentModificationException [DHIS2-18323]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/categorycombo/CategoryComboMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/category/categorycombo/CategoryComboMergeHandler.java
@@ -78,7 +78,7 @@ public class CategoryComboMergeHandler {
    */
   public void handleCategories(List<CategoryCombo> sources, CategoryCombo target) {
     for (CategoryCombo source : sources) {
-      for (Category category : source.getCategories()) {
+      for (Category category : List.copyOf(source.getCategories())) {
         category.removeCategoryCombo(source);
       }
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/category/categorycombo/CategoryComboMergeHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/category/categorycombo/CategoryComboMergeHandlerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.merge.category.categorycombo;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.common.CodeGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CategoryComboMergeHandler} methods that operate purely on in-memory domain
+ * objects, requiring no store or service dependencies.
+ */
+class CategoryComboMergeHandlerTest {
+
+  private CategoryComboMergeHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new CategoryComboMergeHandler(null, null, null, null, null, null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // handleCategories
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("handleCategories does not throw ConcurrentModificationException")
+  void handleCategories_doesNotThrowConcurrentModificationException() {
+    // given a source with 3 categories - with only 2, the iterator cursor reaches the end of the
+    // shrunk list and exits early without throwing; 3+ categories reliably trigger the CME because
+    // after the first removal the list still has elements remaining when next() is called again
+    Category cat1 = createCategory("cat1");
+    Category cat2 = createCategory("cat2");
+    Category cat3 = createCategory("cat3");
+    CategoryCombo source = createCategoryCombo("source", cat1, cat2, cat3);
+    CategoryCombo target = createCategoryCombo("target", cat1, cat2, cat3);
+
+    // then
+    assertDoesNotThrow(() -> handler.handleCategories(List.of(source), target));
+  }
+
+  @Test
+  @DisplayName("handleCategories removes source CategoryCombo from each Category")
+  void handleCategories_removesSourceFromCategories() {
+    // given
+    Category cat1 = createCategory("cat1");
+    Category cat2 = createCategory("cat2");
+    CategoryCombo source = createCategoryCombo("source", cat1, cat2);
+    CategoryCombo target = createCategoryCombo("target", cat1, cat2);
+
+    // when
+    handler.handleCategories(List.of(source), target);
+
+    // then source is no longer referenced by either category
+    assertFalse(cat1.getCategoryCombos().contains(source));
+    assertFalse(cat2.getCategoryCombos().contains(source));
+  }
+
+  @Test
+  @DisplayName("handleCategories with multiple sources removes all sources from each Category")
+  void handleCategories_multipleSources_removesAllSourcesFromCategories() {
+    // given two sources sharing the same categories
+    Category cat1 = createCategory("cat1");
+    Category cat2 = createCategory("cat2");
+    CategoryCombo source1 = createCategoryCombo("source1", cat1, cat2);
+    CategoryCombo source2 = createCategoryCombo("source2", cat1, cat2);
+    CategoryCombo target = createCategoryCombo("target", cat1, cat2);
+
+    // when
+    assertDoesNotThrow(() -> handler.handleCategories(List.of(source1, source2), target));
+
+    // then both sources are removed from both categories
+    assertFalse(cat1.getCategoryCombos().contains(source1));
+    assertFalse(cat1.getCategoryCombos().contains(source2));
+    assertFalse(cat2.getCategoryCombos().contains(source1));
+    assertFalse(cat2.getCategoryCombos().contains(source2));
+  }
+
+  @Test
+  @DisplayName("handleCategories leaves target CategoryCombo references on Categories intact")
+  void handleCategories_doesNotRemoveTargetFromCategories() {
+    // given
+    Category cat1 = createCategory("cat1");
+    Category cat2 = createCategory("cat2");
+    CategoryCombo source = createCategoryCombo("source", cat1, cat2);
+    CategoryCombo target = createCategoryCombo("target", cat1, cat2);
+
+    // when
+    handler.handleCategories(List.of(source), target);
+
+    // then target is still referenced by both categories
+    assertTrue(cat1.getCategoryCombos().contains(target));
+    assertTrue(cat2.getCategoryCombos().contains(target));
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private Category createCategory(String name) {
+    Category category = new Category();
+    category.setUid(CodeGenerator.generateUid());
+    category.setName(name);
+    return category;
+  }
+
+  private CategoryCombo createCategoryCombo(String name, Category... categories) {
+    CategoryCombo combo = new CategoryCombo();
+    combo.setUid(CodeGenerator.generateUid());
+    combo.setName(name);
+    for (Category category : categories) {
+      combo.addCategory(category);
+    }
+    return combo;
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/CategoryComboMergeTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonArray;
@@ -55,6 +56,7 @@ class CategoryComboMergeTest extends ApiTest {
 
   private RestApiActions categoryComboApiActions;
   private RestApiActions categoryOptionComboApiActions;
+  private RestApiActions categoriesApiActions;
   private RestApiActions dataElementApiActions;
   private RestApiActions programsApiActions;
   private RestApiActions dataApprovalWorkflowsApiActions;
@@ -74,6 +76,7 @@ class CategoryComboMergeTest extends ApiTest {
     loginActions = new LoginActions();
     categoryComboApiActions = new RestApiActions("categoryCombos");
     categoryOptionComboApiActions = new RestApiActions("categoryOptionCombos");
+    categoriesApiActions = new RestApiActions("categories");
     dataElementApiActions = new RestApiActions("dataElements");
     programsApiActions = new RestApiActions("programs");
     dataApprovalWorkflowsApiActions = new RestApiActions("dataApprovalWorkflows");
@@ -133,9 +136,9 @@ class CategoryComboMergeTest extends ApiTest {
                 .formatted(srcCoc))
         .validateStatus(201);
 
-    assertEquals(4, srcCc1Cocs.size(), "Source CC1 should have 4 COCs");
-    assertEquals(4, srcCc2Cocs.size(), "Source CC2 should have 4 COCs");
-    assertEquals(4, targetCcCocs.size(), "Target CC should have 4 COCs");
+    assertEquals(8, srcCc1Cocs.size(), "Source CC1 should have 8 COCs");
+    assertEquals(8, srcCc2Cocs.size(), "Source CC2 should have 8 COCs");
+    assertEquals(8, targetCcCocs.size(), "Target CC should have 8 COCs");
 
     // login as merge user
     loginActions.loginAsUser("userWithCcMergeAuth", "Test1234!");
@@ -240,6 +243,11 @@ class CategoryComboMergeTest extends ApiTest {
     assertProgIndHasCc("prgIndUID01", targetUid);
     assertProgIndHasCc("prgIndUID02", targetUid);
     assertProgIndHasCc("prgIndUID03", targetUid);
+
+    // source combos are no longer referenced by any of their categories
+    assertCategoryDoesNotReferenceCombo("UIDCategx01", sourceUid1, sourceUid2);
+    assertCategoryDoesNotReferenceCombo("UIDCategx02", sourceUid1, sourceUid2);
+    assertCategoryDoesNotReferenceCombo("UIDCategx03", sourceUid1, sourceUid2);
   }
 
   private void assertProgIndHasCc(String prgIndUid, String ccUid) {
@@ -263,9 +271,9 @@ class CategoryComboMergeTest extends ApiTest {
   }
 
   private void assertPreMergeState() {
-    assertComboHasCategories(sourceUid1, "UIDCategx01", "UIDCategx02");
-    assertComboHasCategories(sourceUid2, "UIDCategx01", "UIDCategx02");
-    assertComboHasCategories(targetUid, "UIDCategx01", "UIDCategx02");
+    assertComboHasCategories(sourceUid1, "UIDCategx01", "UIDCategx02", "UIDCategx03");
+    assertComboHasCategories(sourceUid2, "UIDCategx01", "UIDCategx02", "UIDCategx03");
+    assertComboHasCategories(targetUid, "UIDCategx01", "UIDCategx02", "UIDCategx03");
 
     // data elements
     assertDataElementHasCombo("DeUID0000x1", sourceUid1);
@@ -318,7 +326,7 @@ class CategoryComboMergeTest extends ApiTest {
                 getDataApprovalWorkflows(sourceUid1, sourceUid2, targetUid),
                 getProgramIndicators(sourceUid1, sourceUid2, targetUid));
 
-    metadataActions.importMetadata(metadata).validate().body("response.stats.created", equalTo(25));
+    metadataActions.importMetadata(metadata).validate().body("response.stats.created", equalTo(28));
 
     generateCocs();
   }
@@ -338,13 +346,20 @@ class CategoryComboMergeTest extends ApiTest {
     }
   }
 
-  private void assertComboHasCategories(String catComboUid, String catUid1, String catUid2) {
+  private void assertCategoryDoesNotReferenceCombo(String categoryUid, String... comboUids) {
+    categoriesApiActions
+        .get(categoryUid + "?fields=categoryCombos[id]")
+        .validateStatus(200)
+        .validate()
+        .body("categoryCombos.id", not(hasItems(comboUids)));
+  }
+
+  private void assertComboHasCategories(String catComboUid, String... catUids) {
     categoryComboApiActions
         .get(catComboUid)
         .validateStatus(200)
         .validate()
-        .body(
-            "categories.id", containsInAnyOrder(List.of(catUid1, catUid2).toArray(String[]::new)));
+        .body("categories.id", containsInAnyOrder(catUids));
   }
 
   private void assertDataSetHasCombo(String dsUid, String comboUid) {
@@ -396,6 +411,16 @@ class CategoryComboMergeTest extends ApiTest {
                 "id": "UIDCatOpx2B",
                 "name": "cat optionx 2B",
                 "shortName": "cat optionx 2B"
+            },
+            {
+                "id": "UIDCatOpx3A",
+                "name": "cat optionx 3A",
+                "shortName": "cat optionx 3A"
+            },
+            {
+                "id": "UIDCatOpx3B",
+                "name": "cat optionx 3B",
+                "shortName": "cat optionx 3B"
             }
         ]
         """;
@@ -431,6 +456,20 @@ class CategoryComboMergeTest extends ApiTest {
                         "id": "UIDCatOpx2B"
                     }
                 ]
+            },
+            {
+                "id": "UIDCategx03",
+                "name": "category x3",
+                "shortName": "category x3",
+                "dataDimensionType": "DISAGGREGATION",
+                "categoryOptions": [
+                    {
+                        "id": "UIDCatOpx3A"
+                    },
+                    {
+                        "id": "UIDCatOpx3B"
+                    }
+                ]
             }
         ]
         """;
@@ -449,6 +488,9 @@ class CategoryComboMergeTest extends ApiTest {
                     },
                     {
                         "id": "UIDCategx02"
+                    },
+                    {
+                        "id": "UIDCategx03"
                     }
                 ]
             },
@@ -462,6 +504,9 @@ class CategoryComboMergeTest extends ApiTest {
                     },
                     {
                         "id": "UIDCategx02"
+                    },
+                    {
+                        "id": "UIDCategx03"
                     }
                 ]
             },
@@ -475,6 +520,9 @@ class CategoryComboMergeTest extends ApiTest {
                     },
                     {
                         "id": "UIDCategx02"
+                    },
+                    {
+                        "id": "UIDCategx03"
                     }
                 ]
             }


### PR DESCRIPTION
# Issue
500 server error response when performing a `CategoryCombo` merge with specific state
- only seen when `CategoryCombo` does not have 2 `Categories`! e.g. 1, 3, 4 etc.

# Cause
`ConcurrentModificationException` is thrown when operating on the `CategoryCombo`'s `Categories` (removing).
A Java collection's iterator with 2 elements has a blind spot and doesn't throw the exception.
  - CME is only thrown when next() is called — if the list size and cursor align so next() is never called
   again, the misuse goes silently undetected
  - With exactly 2 elements, after removing the first, cursor(1) == size(1) → hasNext() returns false →
  next() never fires → no CME, no detection
  - With 1 or 3+ elements, hasNext() returns true → next() fires → CME thrown

Manual testing and automated tests always used 2 `Categories` which is how this was never caught.

# Fix
Operating on a copy of the collection avoids this issue, while still maintaining the correct end state

# Testing
Manually tested with 1, 2, 3 categories.
Automated:
- New unit tests added that cover the found bug
- E2E test updated to operate using 3 categories (also covering the bug)