### PR TITLE
chore: update capture-app version to 105.13.6

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -3,7 +3,7 @@
   "https://github.com/d2-ci/approval-app#v100.1.5",
   "https://github.com/d2-ci/app-management-app#v100.5.0",
   "https://github.com/d2-ci/cache-cleaner-app#v100.2.2",
-  "https://github.com/d2-ci/capture-app#v105.13.3",
+  "https://github.com/d2-ci/capture-app#v105.13.6",
   "https://github.com/d2-ci/dashboard-app#v101.6.0",
   "https://github.com/d2-ci/data-administration-app#v100.2.0",
   "https://github.com/d2-ci/data-visualizer-app#v101.5.2",


### PR DESCRIPTION
Bumping capture-app version to include DHIS2-21224 fix in the 2.43.0 bundle