### PR TITLE
fix: update aggregate-data-entry to 102.0.1 for custom translations

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -1,5 +1,5 @@
 [
-  "https://github.com/d2-ci/aggregate-data-entry-app#v102.0.0",
+  "https://github.com/d2-ci/aggregate-data-entry-app#v102.0.1",
   "https://github.com/d2-ci/approval-app#v100.1.5",
   "https://github.com/d2-ci/app-management-app#v100.5.0",
   "https://github.com/d2-ci/cache-cleaner-app#v100.2.2",


### PR DESCRIPTION
**Approved by RCB**

Part of https://dhis2.atlassian.net/browse/DHIS2-21102 -- this was [merged before the hard freeze](https://github.com/dhis2/aggregate-data-entry-app/pull/535), but the automated release process didn't work, so a new bundle and version wasn't published before cutting 43.0

Only the App Platform upgrade for custom translations is included: [v102.0.1](https://github.com/dhis2/aggregate-data-entry-app/releases/tag/v102.0.1)