### PR TITLE
perf: recalibrate TrackerTest p95 thresholds DHIS2-20671

### DIFF
--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -551,7 +551,7 @@ public class TrackerTest extends Simulation {
     Request searchEventsNotAssigned =
         new Request(
             getEventsUrl + "&assignedUserMode=NONE",
-            new EnumMap<>(Map.of(Profile.SMOKE, 108, Profile.LOAD, 160)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 108, Profile.LOAD, 173)),
             "Search not assigned",
             "Get ANC events");
     Request getFirstEvent =
@@ -769,7 +769,7 @@ public class TrackerTest extends Simulation {
     Request getFirstEventFromEnrollment =
         new Request(
             eventUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 58, Profile.LOAD, 101)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 58, Profile.LOAD, 141)),
             "Get first event from enrollment",
             "Get Child Programme TEs",
             "Go to single enrollment",

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -533,31 +533,31 @@ public class TrackerTest extends Simulation {
     Request goToFirstPage =
         new Request(
             getEventsUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 88, Profile.LOAD, 126)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 107, Profile.LOAD, 131)),
             "Go to first page",
             "Get ANC events");
     Request goToSecondPage =
         new Request(
             getEventsUrl + "&page=2",
-            new EnumMap<>(Map.of(Profile.SMOKE, 89, Profile.LOAD, 164)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 107, Profile.LOAD, 153)),
             "Go to second page",
             "Get ANC events");
     Request searchEventsByDateRange =
         new Request(
             getEventsUrl + "&occurredAfter=2020-01-01&occurredBefore=2025-12-31",
-            new EnumMap<>(Map.of(Profile.SMOKE, 29, Profile.LOAD, 542)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 41, Profile.LOAD, 509)),
             "Search by date range",
             "Get ANC events");
     Request searchEventsNotAssigned =
         new Request(
             getEventsUrl + "&assignedUserMode=NONE",
-            new EnumMap<>(Map.of(Profile.SMOKE, 84, Profile.LOAD, 167)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 108, Profile.LOAD, 160)),
             "Search not assigned",
             "Get ANC events");
     Request getFirstEvent =
         new Request(
             singleEventUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 27, Profile.LOAD, 116)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 55, Profile.LOAD, 118)),
             "Get first event",
             "Get ANC events",
             "Get one event");
@@ -700,62 +700,62 @@ public class TrackerTest extends Simulation {
     Request notFoundTeByNameWithLikeOperator =
         new Request(
             notFoundTEByName,
-            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 105)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 111)),
             "Not found TE by name with like operator",
             "Get Child Programme TEs");
     Request notFoundTeByNameWithEqOperator =
         new Request(
             notFoundTEByExactName,
-            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 27)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 42)),
             "Not found TE by name with eq operator",
             "Get Child Programme TEs");
     Request searchTeByNameWithLikeOperator =
         new Request(
             searchTEByName,
-            new EnumMap<>(Map.of(Profile.SMOKE, 36, Profile.LOAD, 173)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 50, Profile.LOAD, 174)),
             "Search TE by name with like operator",
             "Get Child Programme TEs");
     Request searchTeByNameWithEqOperator =
         new Request(
             searchTEByExactName,
-            new EnumMap<>(Map.of(Profile.SMOKE, 32, Profile.LOAD, 112)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 44, Profile.LOAD, 117)),
             "Search TE by name with eq operator",
             "Get Child Programme TEs");
     Request searchBirthEventsByStage =
         new Request(
             searchBirthEvents,
-            new EnumMap<>(Map.of(Profile.SMOKE, 40, Profile.LOAD, 975)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 53, Profile.LOAD, 943)),
             "Search Birth events",
             "Get Child Programme TEs");
     Request getTrackedEntitiesForEvents =
         new Request(
             getTEsFromEvents,
-            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 25)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 28)),
             "Get TEs from events",
             "Get Child Programme TEs");
     Request getFirstPageOfTEs =
         new Request(
             getTEsUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 38, Profile.LOAD, 155)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 50, Profile.LOAD, 162)),
             "Get first page of TEs",
             "Get Child Programme TEs");
     Request getTEsWithEnrollmentStatus =
         new Request(
             getTEsWithEnrollmentStatusUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 52, Profile.LOAD, 184)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 71, Profile.LOAD, 177)),
             "Get TEs with enrollment status",
             "Get Child Programme TEs");
     Request getFirstTrackedEntity =
         new Request(
             singleTrackedEntityUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 34, Profile.LOAD, 118)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 47, Profile.LOAD, 121)),
             "Get first tracked entity",
             "Get Child Programme TEs",
             "Go to single enrollment");
     Request getFirstEnrollment =
         new Request(
             singleEnrollmentUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 25, Profile.LOAD, 38)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 37, Profile.LOAD, 56)),
             "Get first enrollment",
             "Get Child Programme TEs",
             "Go to single enrollment");
@@ -769,7 +769,7 @@ public class TrackerTest extends Simulation {
     Request getFirstEventFromEnrollment =
         new Request(
             eventUrl,
-            new EnumMap<>(Map.of(Profile.SMOKE, 42, Profile.LOAD, 111)),
+            new EnumMap<>(Map.of(Profile.SMOKE, 58, Profile.LOAD, 101)),
             "Get first event from enrollment",
             "Get Child Programme TEs",
             "Go to single enrollment",
@@ -1006,11 +1006,11 @@ public class TrackerTest extends Simulation {
   }
 
   private static final EnumMap<Profile, Integer> MNCH_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 416, Profile.LOAD, 9776));
+      new EnumMap<>(Map.of(Profile.SMOKE, 303, Profile.LOAD, 3526));
   private static final EnumMap<Profile, Integer> CHILD_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 227, Profile.LOAD, 4215));
+      new EnumMap<>(Map.of(Profile.SMOKE, 168, Profile.LOAD, 1769));
   private static final EnumMap<Profile, Integer> ANC_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 149, Profile.LOAD, 6772));
+      new EnumMap<>(Map.of(Profile.SMOKE, 119, Profile.LOAD, 2652));
 
   private Stream<Assertion> getImportAssertions(Profile profile) {
     return Stream.of(


### PR DESCRIPTION
Recalibrates all TrackerTest p95 thresholds using an improved formula and data from 8 scheduled pipeline runs (Apr 9-16).

## Problem

The scheduled tracker-smoke test failed 2 out of 8 days (Apr 13, Apr 16) since [#23516](https://github.com/dhis2/dhis2-core/pull/23516) was merged on Apr 8. Both failures were caused by a single request:

| Request | Threshold | Apr 13 | Apr 16 |
|---|---:|---:|---:|
| Get first event | 27ms | 33ms | 36ms |

The other 6 runs had "Get first event" at 17-21ms, so these are CI runner variability spikes, not regressions. The old formula `ceil(max * 1.2)` with a 25ms floor did not leave enough headroom for fast requests.

Additionally, import p95s have dropped significantly due to recent import improvements but thresholds were still calibrated from before those changes (e.g., MNCH import load: max observed 3191ms vs old threshold 9776ms).

## New formula

**Before:** `ceil(max(p95) * 1.2)`, 25ms floor

**After:** `ceil(max(p95) * 1.1) + 15`, 25ms floor

The old formula applied a flat 20% multiplier. The fixed `+15` in the new formula dominates for fast requests (where CI jitter matters most) and becomes negligible for slow ones, giving tighter thresholds where it counts:

| Request | max p95 | Old (1.2x) | New (1.1x+15) | Headroom |
|---|---:|---:|---:|---:|
| Get first event | 36ms | 44ms (+22%) | 55ms (+53%) | more room for jitter |
| Go to first page | 83ms | 100ms (+20%) | 107ms (+29%) | more room for jitter |
| Search by date range (load) | 449ms | 539ms (+20%) | 509ms (+13%) | tighter |
| MNCH import (load) | 3191ms | 3830ms (+20%) | 3526ms (+11%) | tighter |

This is simpler than stddev-based approaches (which need more samples and per-request statistics) while solving the core problem: fast requests get more headroom to absorb CI jitter, slow requests get tighter thresholds to catch regressions sooner.

## Import threshold tightening

Import p95s are now far below the old thresholds due to recent improvements. The new formula tightens them to reflect current performance:

| Request | Old threshold | New threshold | Max observed (8 runs) |
|---|---:|---:|---:|
| MNCH import (smoke) | 416ms | 303ms | 261ms |
| Child Programme import (smoke) | 227ms | 168ms | 139ms |
| ANC import (smoke) | 149ms | 119ms | 94ms |
| MNCH import (load) | 9776ms | 3526ms | 3191ms |
| Child Programme import (load) | 4215ms | 1769ms | 1594ms |
| ANC import (load) | 6772ms | 2652ms | 2397ms |

## Performance

Validation runs using `dhis2/core-dev@sha256:d0b0233c221dcf4e518c4a09e0894f1748d8291c7741b81270317d3d190a03f6` (same image as the scheduled runs above).

### Smoke runs (5/5 passed)

| Run | Result |
|-----|--------|
| [Run 1](https://github.com/dhis2/dhis2-core/actions/runs/24501975149) | success |
| [Run 2](https://github.com/dhis2/dhis2-core/actions/runs/24501978209) | success |
| [Run 3](https://github.com/dhis2/dhis2-core/actions/runs/24501981017) | success |
| [Run 4](https://github.com/dhis2/dhis2-core/actions/runs/24501983807) | success |
| [Run 5](https://github.com/dhis2/dhis2-core/actions/runs/24501986599) | success |

### Load runs (4/5 passed, 1 failed)

| Run | Result | Notes |
|-----|--------|-------|
| [Run 1](https://github.com/dhis2/dhis2-core/actions/runs/24501976661) | success | |
| [Run 2](https://github.com/dhis2/dhis2-core/actions/runs/24501979382) | failure | "Get first event from enrollment" 114ms > 101ms threshold |
| [Run 3](https://github.com/dhis2/dhis2-core/actions/runs/24501982371) | success | |
| [Run 4](https://github.com/dhis2/dhis2-core/actions/runs/24501985151) | success | |
| [Run 5](https://github.com/dhis2/dhis2-core/actions/runs/24501988038) | success | |

Load run 2 revealed "Get first event from enrollment" spiking to 114ms, exceeding both the new threshold (101ms) and the old threshold (111ms). The initial 8 scheduled runs had a max of 78ms for this request, so the spike was not captured in the calibration data. Updated thresholds to include validation run data:

| Request | Initial threshold | Updated threshold | Max observed |
|---|---:|---:|---:|
| Get first event from enrollment (load) | 101ms | 141ms | 114ms |
| Search not assigned (load) | 160ms | 173ms | 143ms |

## Data

P95 values extracted via `gatling-report` from 8 scheduled pipeline runs (Apr 9-16), all using the same `core-dev` image built from master at the time. Kept here as reference since workflow artifacts expire.

### Tracker smoke (8 runs, 2 failures)

| Request | Threshold | 04-09 | 04-10 | 04-11 | 04-12 | 04-13 FAIL | 04-14 | 04-15 | 04-16 FAIL |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Go to first page | 88 | 83 | 72 | 15 | 69 | 79 | 72 | 67 | 15 |
| Go to second page | 89 | 83 | 69 | 17 | 70 | 74 | 70 | 67 | 17 |
| Search by date range | 29 | 23 | 22 | 15 | 21 | 22 | 22 | 22 | 15 |
| Search not assigned | 84 | 84 | 68 | 15 | 70 | 68 | 69 | 68 | 16 |
| **Get first event** | **27** | 17 | 21 | 20 | 18 | **33** | 19 | 20 | **36** |
| Get first event from enrollment | 42 | 27 | 39 | 31 | 28 | 31 | 29 | 29 | 27 |
| Get first page of TEs | 38 | 23 | 27 | 31 | 31 | 30 | 27 | 24 | 26 |
| Get TEs with enrollment status | 52 | 50 | 40 | 46 | 35 | 43 | 39 | 42 | 45 |
| Get first tracked entity | 34 | 21 | 22 | 27 | 29 | 28 | 23 | 20 | 23 |
| Search Birth events | 40 | 32 | 31 | 34 | 12 | 26 | 26 | 33 | 26 |
| Search TE by name with like operator | 36 | 24 | 24 | 29 | 31 | 31 | 25 | 24 | 24 |
| MNCH import | 416 | 237 | 261 | 181 | 189 | 199 | 176 | 175 | 183 |
| Child Programme import | 227 | 139 | 122 | 111 | 121 | 99 | 105 | 94 | 129 |
| ANC import | 149 | 87 | 94 | 67 | 75 | 77 | 71 | 68 | 71 |

### Tracker load (8 runs, 0 failures)

| Request | Threshold | 04-09 | 04-10 | 04-11 | 04-12 | 04-13 | 04-14 | 04-15 | 04-16 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Go to first page | 126 | 95 | 96 | 16 | 96 | 95 | 105 | 96 | 96 |
| Go to second page | 164 | 113 | 111 | 52 | 125 | 95 | 115 | 114 | 101 |
| Search by date range | 542 | 425 | 422 | 440 | 449 | 430 | 434 | 165 | 43 |
| Search not assigned | 167 | 109 | 109 | 106 | 105 | 102 | 131 | 112 | 106 |
| Get first event | 116 | 69 | 67 | 67 | 72 | 69 | 76 | 74 | 93 |
| Get first event from enrollment | 111 | 78 | 73 | 73 | 74 | 70 | 69 | 75 | 67 |
| Get first page of TEs | 155 | 111 | 122 | 128 | 119 | 133 | 125 | 124 | 130 |
| Get TEs with enrollment status | 184 | 139 | 146 | 147 | 145 | 134 | 146 | 144 | 124 |
| Search Birth events | 975 | 114 | 843 | 138 | 127 | 129 | 118 | 136 | 808 |
| MNCH import | 9776 | 3191 | 3185 | 1698 | 1823 | 1173 | 1780 | 2244 | 2075 |
| Child Programme import | 4215 | 1543 | 1318 | 581 | 670 | 542 | 660 | 1594 | 788 |
| ANC import | 6772 | 871 | 923 | 781 | 869 | 447 | 2397 | 881 | 708 |
