### PR TITLE
feat: add warn on missing server.base.url

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -68,6 +68,7 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
     }
 
     checkSecurityConfiguration();
+    checkServerBaseUrl();
 
     Configuration config = configurationService.getConfiguration();
 
@@ -88,6 +89,16 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
       log.warn("Encryption not configured: " + status.getKey());
     } else {
       log.info("Encryption is available");
+    }
+  }
+
+  private void checkServerBaseUrl() {
+    if (dhisConfigurationProvider.getServerBaseUrl() == null) {
+      log.warn(
+          "The 'server.base.url' property in dhis.conf is missing. "
+              + "It must be an absolute HTTP or HTTPS URL with a valid hostname and no trailing slash, "
+              + "for example https://dhis2.example.org/dhis. "
+              + "If absent, password recovery throws an error and is completely unavailable.");
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -104,7 +104,7 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
       return;
     }
 
-    String[] schemes = new String[]{"http","https"};
+    String[] schemes = new String[] {"http", "https"};
     UrlValidator urlValidator = new UrlValidator(schemes);
     if (!urlValidator.isValid(baseUrl)) {
       log.warn("'server.base.url' is not a valid URL: '{}'." + BASE_URL_HINT, baseUrl);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -104,7 +104,8 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
       return;
     }
 
-    UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
+    String[] schemes = new String[]{"http","https"};
+    UrlValidator urlValidator = new UrlValidator(schemes);
     if (!urlValidator.isValid(baseUrl)) {
       log.warn("'server.base.url' is not a valid URL: '{}'." + BASE_URL_HINT, baseUrl);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -97,7 +97,7 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
       log.warn(
           "The 'server.base.url' property in dhis.conf is missing. "
               + "It must be an absolute HTTP or HTTPS URL with a valid hostname and no trailing slash, "
-              + "for example https://dhis2.example.org/dhis. "
+              + "for example: 'https://dhis2.example.org/dhis'. "
               + "If absent, password recovery throws an error and is completely unavailable.");
     }
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.user.CurrentUserUtil.injectUserInSecurityContext;
 
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.encryption.EncryptionStatus;
@@ -92,13 +93,24 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
     }
   }
 
+  private static final String BASE_URL_HINT =
+      " Expected an absolute URL without a trailing slash,"
+          + " for example: 'https://dhis2.example.org/dhis'.";
+
   private void checkServerBaseUrl() {
-    if (dhisConfigurationProvider.getServerBaseUrl() == null) {
+    String baseUrl = dhisConfigurationProvider.getServerBaseUrl();
+    if (baseUrl == null) {
+      log.warn("'server.base.url' is not set in dhis.conf." + BASE_URL_HINT);
+      return;
+    }
+
+    UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
+    if (!urlValidator.isValid(baseUrl)) {
+      log.warn("'server.base.url' is not a valid URL: '{}'." + BASE_URL_HINT, baseUrl);
+
+    } else if (baseUrl.endsWith("/")) {
       log.warn(
-          "The 'server.base.url' property in dhis.conf is missing. "
-              + "It must be an absolute HTTP or HTTPS URL with a valid hostname and no trailing slash, "
-              + "for example: 'https://dhis2.example.org/dhis'. "
-              + "If absent, password recovery throws an error and is completely unavailable.");
+          "'server.base.url' must not end with a trailing slash: '{}'." + BASE_URL_HINT, baseUrl);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -95,7 +95,11 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
 
   private static final String BASE_URL_HINT =
       " Expected an absolute URL without a trailing slash,"
-          + " for example: 'https://dhis2.example.org/dhis'.";
+          + " for example: 'https://dhis2.example.org/dhis'."
+          + " This value is important: features including password recovery, OIDC/OAuth2"
+          + " redirects, notification emails, and interpretation sharing will not work"
+          + " correctly without it. See the 'Server base URL' section in the dhis.conf"
+          + " reference documentation.";
 
   private void checkServerBaseUrl() {
     String baseUrl = dhisConfigurationProvider.getServerBaseUrl();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
@@ -29,15 +29,20 @@
  */
 package org.hisp.dhis.startup;
 
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.stream.Stream;
 import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -45,7 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Unit tests for {@link ConfigurationPopulator}.
  *
  * <p>The startup routine only logs warnings for misconfigured properties. These tests verify that
- * each validation path completes without error.
+ * each validation path completes without error and does not modify the existing configuration.
  */
 @ExtendWith(MockitoExtension.class)
 class ConfigurationPopulatorTest {
@@ -66,34 +71,23 @@ class ConfigurationPopulatorTest {
     when(configurationService.getConfiguration()).thenReturn(config);
   }
 
-  @Test
-  void testValidBaseUrl() {
-    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("https://dhis2.example.org");
-    populator.executeInTransaction();
+  static Stream<Arguments> baseUrlScenarios() {
+    return Stream.of(
+        Arguments.of("valid URL", "https://dhis2.example.org"),
+        Arguments.of("valid URL with path", "https://dhis2.example.org/dhis"),
+        Arguments.of("missing URL", null),
+        Arguments.of("invalid URL", "not-a-url"),
+        Arguments.of("URL with trailing slash", "https://dhis2.example.org/dhis/"));
   }
 
-  @Test
-  void testValidBaseUrlWithPath() {
-    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("https://dhis2.example.org/dhis");
-    populator.executeInTransaction();
-  }
+  @ParameterizedTest(name = "{0}: {1}")
+  @MethodSource("baseUrlScenarios")
+  void testBaseUrlValidation(String scenario, String baseUrl) {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn(baseUrl);
 
-  @Test
-  void testMissingBaseUrl() {
-    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn(null);
     populator.executeInTransaction();
-  }
 
-  @Test
-  void testInvalidBaseUrl() {
-    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("not-a-url");
-    populator.executeInTransaction();
-  }
-
-  @Test
-  void testBaseUrlWithTrailingSlash() {
-    when(dhisConfigurationProvider.getServerBaseUrl())
-        .thenReturn("https://dhis2.example.org/dhis/");
-    populator.executeInTransaction();
+    verify(dhisConfigurationProvider).getServerBaseUrl();
+    verify(configurationService, never()).setConfiguration(org.mockito.ArgumentMatchers.any());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.startup;
+
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.configuration.Configuration;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.encryption.EncryptionStatus;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link ConfigurationPopulator}.
+ *
+ * <p>The startup routine only logs warnings for misconfigured properties. These tests verify that
+ * each validation path completes without error.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfigurationPopulatorTest {
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private DhisConfigurationProvider dhisConfigurationProvider;
+
+  private ConfigurationPopulator populator;
+
+  @BeforeEach
+  void setUp() {
+    populator = new ConfigurationPopulator(configurationService, dhisConfigurationProvider);
+
+    // Stubs required by executeInTransaction() regardless of the test scenario
+    when(dhisConfigurationProvider.getEncryptionStatus()).thenReturn(EncryptionStatus.OK);
+    Configuration config = new Configuration();
+    config.setSystemId("existing-id");
+    when(configurationService.getConfiguration()).thenReturn(config);
+  }
+
+  @Test
+  void testValidBaseUrl() {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("https://dhis2.example.org");
+    populator.executeInTransaction();
+  }
+
+  @Test
+  void testValidBaseUrlWithPath() {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("https://dhis2.example.org/dhis");
+    populator.executeInTransaction();
+  }
+
+  @Test
+  void testMissingBaseUrl() {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn(null);
+    populator.executeInTransaction();
+  }
+
+  @Test
+  void testInvalidBaseUrl() {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn("not-a-url");
+    populator.executeInTransaction();
+  }
+
+  @Test
+  void testBaseUrlWithTrailingSlash() {
+    when(dhisConfigurationProvider.getServerBaseUrl())
+        .thenReturn("https://dhis2.example.org/dhis/");
+    populator.executeInTransaction();
+  }
+}


### PR DESCRIPTION
# Summary
Adds startup validation for the server.base.url property in dhis.conf. Warns at WARN level when the value is:

 - missing or empty
 - not a valid URL
 - has a trailing slash

The check is added to the existing ConfigurationPopulator startup routine, alongside the encryption status check. Uses UrlValidator (commons-validator, already a dependency) for URL validation.

Docs: https://github.com/dhis2/dhis2-docs/pull/1738 — expands `server.base.url` documentation with why it matters (password recovery, OIDC/OAuth2, notification emails, interpretation sharing), valid-value rules, and a note about this startup validation.

Based on @david-mackessy analysis in https://github.com/dhis2/dhis2-core/pull/20227  (feat: Analyse server.base.url usage [DHIS2-19183])


Jira: https://dhis2.atlassian.net/browse/DHIS2-21283
AI assisted


[DHIS2-19183]: https://dhis2.atlassian.net/browse/DHIS2-19183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ