### PR TITLE
refactor(analytics): pull up `getColumnWithCte` and simplify with CteColumn record [DHIS2-21331]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1921,9 +1921,128 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     return organisationUnitResolver.buildStageOuCteContext(item, params);
   }
 
-  /** Returns the column name associated with the CTE */
-  protected abstract String getColumnWithCte(
-      QueryItem item, CteContext cteContext, EventQueryParams params);
+  /**
+   * Builds the SELECT-clause fragment for a CTE-backed {@link QueryItem}.
+   *
+   * <p>Each CTE-backed item contributes one required column and up to four optional helper columns,
+   * joined with commas and newlines. The general shape of the output is:
+   *
+   * <pre>
+   *   &lt;cteAlias&gt;.value as "alias"
+   *   [, &lt;cteAlias&gt;.ev_ouname as "stageUid.ouname"]              // stage.ou dimensions only
+   *   [, &lt;cteAlias&gt;.ev_oucode as "stageUid.oucode"]              // stage.ou dimensions only
+   *   [, coalesce(&lt;cteAlias&gt;.rn = N, false) as "alias.exists"]   // row-context CTEs only
+   *   [, &lt;cteAlias&gt;.eventstatus as "alias.status"]               // row-context CTEs only
+   * </pre>
+   *
+   * <p>The {@code value} column's alias is resolved via {@link #getAlias(QueryItem)}, falling back
+   * to {@code programStageUid.itemId} when no explicit alias is set. The CTE alias itself is
+   * offset-aware (see {@link #computeRowNumberOffset(int)}): a negative program-stage offset is
+   * translated into a positive row-number position, so the same CTE can serve several occurrences
+   * of a repeatable stage.
+   *
+   * <p><b>Stage-OU dimensions.</b> When {@link #isStageOuDimension(QueryItem)} is true and the
+   * query declares headers, the {@code ouname} and {@code oucode} helper columns are emitted only
+   * when the corresponding headers ({@code stageUid.ouname}, {@code stageUid.oucode}) are
+   * requested. Missing headers mean the caller does not want that data, so emitting the columns
+   * unconditionally would produce unused SELECT output.
+   *
+   * <p><b>Row context.</b> When the backing {@link CteDefinition} is a row-context CTE (see {@link
+   * CteDefinition#isRowContext()}), two metadata columns are appended:
+   *
+   * <ul>
+   *   <li>{@code alias.exists} — {@code true} iff the CTE row number matches the requested offset
+   *       (i.e. the event actually existed at that offset), otherwise {@code false}. Implemented
+   *       with {@code coalesce(rn = N, false)} so a missing join row yields {@code false} rather
+   *       than {@code null}.
+   *   <li>{@code alias.status} — the raw {@code eventstatus} from the CTE, letting callers
+   *       distinguish scheduled vs. completed events when populating row-context metadata.
+   * </ul>
+   *
+   * @param item the {@link QueryItem} whose CTE-backed column(s) should be emitted; must have a
+   *     program stage.
+   * @param cteContext the current {@link CteContext} — must contain a {@link CteDefinition}
+   *     registered for the item's CTE key (see {@link CteUtils#computeKey(QueryItem)}).
+   * @param params the current {@link EventQueryParams}, used to look up requested headers for the
+   *     optional stage-OU expansion.
+   * @return the comma+newline-joined SELECT-clause fragment for this item; never {@code null}.
+   * @throws IllegalQueryException with {@link ErrorCode#E7148} if no {@link CteDefinition} exists
+   *     for the item's CTE key in the supplied context.
+   */
+  protected String getColumnWithCte(
+      QueryItem item, CteContext cteContext, EventQueryParams params) {
+    CteDefinition cteDef = cteContext.getDefinitionByItemUid(CteUtils.computeKey(item));
+    if (cteDef == null) {
+      throw new IllegalQueryException(ErrorCode.E7148, item.getItemId());
+    }
+    int offset = computeRowNumberOffset(item.getProgramStageOffset());
+    String cteAlias = cteDef.getAlias(offset);
+    // For a non-repeatable stage the alias falls back to "<programStage>.<itemId>".
+    String valueAlias =
+        getAlias(item).orElse("%s.%s".formatted(item.getProgramStage().getUid(), item.getItemId()));
+
+    List<CteColumn> columns = new ArrayList<>();
+    columns.add(valueColumn(cteAlias, valueAlias));
+    columns.addAll(stageOuHelperColumns(cteAlias, item, params));
+    columns.addAll(rowContextColumns(cteDef, cteAlias, offset, valueAlias));
+    return columns.stream().map(CteColumn::sql).collect(joining(",\n"));
+  }
+
+  private CteColumn valueColumn(String cteAlias, String valueAlias) {
+    return new CteColumn(cteAlias + ".value", quote(valueAlias));
+  }
+
+  /**
+   * Emits the optional {@code stageUid.ouname} and {@code stageUid.oucode} helper columns for
+   * stage-level organisation-unit dimensions. Each helper is included only when the caller
+   * explicitly requested it via its matching header — requesting the OU dimension without the
+   * {@code .ouname}/{@code .oucode} headers means the caller only wants the OU id, so emitting the
+   * helpers anyway would just bloat the SELECT output.
+   */
+  private List<CteColumn> stageOuHelperColumns(
+      String cteAlias, QueryItem item, EventQueryParams params) {
+    if (!isStageOuDimension(item) || !params.hasHeaders()) {
+      return List.of();
+    }
+    String stageUid = item.getProgramStage().getUid();
+    List<CteColumn> helpers = new ArrayList<>();
+    if (params.getHeaders().contains(stageUid + ".ouname")) {
+      helpers.add(
+          new CteColumn(cteAlias + "." + STAGE_OU_NAME_COLUMN, quote(stageUid + ".ouname")));
+    }
+    if (params.getHeaders().contains(stageUid + ".oucode")) {
+      helpers.add(
+          new CteColumn(cteAlias + "." + STAGE_OU_CODE_COLUMN, quote(stageUid + ".oucode")));
+    }
+    return helpers;
+  }
+
+  /**
+   * Emits the two repeatable-stage row-context metadata columns: {@code .exists} (whether an event
+   * actually occurred at the requested offset) and {@code .status} (its event status). The {@code
+   * coalesce(rn = N, false)} form ensures a missing CTE join row yields {@code false} rather than
+   * {@code null}, so callers can treat {@code .exists} as a plain boolean.
+   */
+  private List<CteColumn> rowContextColumns(
+      CteDefinition cteDef, String cteAlias, int offset, String valueAlias) {
+    if (!cteDef.isRowContext()) {
+      return List.of();
+    }
+    String existsExpr = "coalesce(%s.rn = %s, false)".formatted(cteAlias, offset + 1);
+    return List.of(
+        new CteColumn(existsExpr, quote(valueAlias + ".exists")),
+        new CteColumn(cteAlias + ".eventstatus", quote(valueAlias + ".status")));
+  }
+
+  /**
+   * A single SELECT-list column emitted by {@link #getColumnWithCte}: a raw SQL expression plus a
+   * pre-quoted alias. Rendered as {@code <expr> as <quotedAlias>}.
+   */
+  private record CteColumn(String expr, String quotedAlias) {
+    String sql() {
+      return expr + " as " + quotedAlias;
+    }
+  }
 
   protected abstract CteContext getCteDefinitions(EventQueryParams params);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -34,15 +34,12 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
-import static org.hisp.dhis.analytics.common.CteUtils.computeKey;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParam.StaticDimension.PROGRAM_STATUS;
 import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.isAggregateEnrollment;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getHeaderColumns;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getOrgUnitLevelColumns;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getPeriodColumns;
 import static org.hisp.dhis.analytics.event.data.OrgUnitTableJoiner.joinOrgUnitTables;
-import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_CODE_COLUMN;
-import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_NAME_COLUMN;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
 import static org.hisp.dhis.analytics.util.EventQueryParamsUtils.getProgramIndicators;
 import static org.hisp.dhis.analytics.util.EventQueryParamsUtils.withoutProgramStageItems;
@@ -104,7 +101,6 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.FallbackCoordinateFieldType;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueStatus;
@@ -114,7 +110,6 @@ import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.program.AnalyticsType;
@@ -669,59 +664,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     return ColumnAndAlias.EMPTY;
-  }
-
-  @Override
-  protected String getColumnWithCte(
-      QueryItem item, CteContext cteContext, EventQueryParams params) {
-    Set<String> columns = new LinkedHashSet<>();
-
-    // Get the CTE definition for the item
-    CteDefinition cteDef = cteContext.getDefinitionByItemUid(computeKey(item));
-    if (cteDef == null) {
-      throw new IllegalQueryException(ErrorCode.E7148, item.getItemId());
-    }
-    int programStageOffset = computeRowNumberOffset(item.getProgramStageOffset());
-    // calculate the alias for the column
-    // if the item is not a repeatable stage, the alias is the program stage + item name
-    String alias =
-        getAlias(item).orElse("%s.%s".formatted(item.getProgramStage().getUid(), item.getItemId()));
-    columns.add("%s.value as %s".formatted(cteDef.getAlias(programStageOffset), quote(alias)));
-
-    // For stage.ou dimensions, conditionally select ouname/oucode columns
-    if (isStageOuDimension(item) && params.hasHeaders()) {
-      String stageUid = item.getProgramStage().getUid();
-      if (params.getHeaders().contains(stageUid + ".ouname")) {
-        columns.add(
-            "%s.%s as %s"
-                .formatted(
-                    cteDef.getAlias(programStageOffset),
-                    STAGE_OU_NAME_COLUMN,
-                    quote(stageUid + ".ouname")));
-      }
-      if (params.getHeaders().contains(stageUid + ".oucode")) {
-        columns.add(
-            "%s.%s as %s"
-                .formatted(
-                    cteDef.getAlias(programStageOffset),
-                    STAGE_OU_CODE_COLUMN,
-                    quote(stageUid + ".oucode")));
-      }
-    }
-
-    if (cteDef.isRowContext()) {
-      // Add additional status and exists columns for row context
-      columns.add(
-          "coalesce(%s.rn = %s, false) as %s"
-              .formatted(
-                  cteDef.getAlias(programStageOffset),
-                  programStageOffset + 1,
-                  quote(alias + ".exists")));
-      columns.add(
-          "%s.eventstatus as %s"
-              .formatted(cteDef.getAlias(programStageOffset), quote(alias + ".status")));
-    }
-    return String.join(",\n", columns);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -40,10 +40,7 @@ import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.common.ColumnHeader.LATITUDE;
 import static org.hisp.dhis.analytics.common.ColumnHeader.LONGITUDE;
-import static org.hisp.dhis.analytics.common.CteUtils.computeKey;
 import static org.hisp.dhis.analytics.event.data.OrgUnitTableJoiner.joinOrgUnitTables;
-import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_CODE_COLUMN;
-import static org.hisp.dhis.analytics.event.data.OrganisationUnitResolver.STAGE_OU_NAME_COLUMN;
 import static org.hisp.dhis.analytics.table.ColumnPostfix.OU_GEOMETRY_COL_POSTFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
 import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
@@ -58,7 +55,6 @@ import static org.postgresql.util.PSQLState.DIVISION_BY_ZERO;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +68,6 @@ import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.common.CteContext;
-import org.hisp.dhis.analytics.common.CteDefinition;
 import org.hisp.dhis.analytics.common.EndpointItem;
 import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EventAnalyticsManager;
@@ -91,7 +86,6 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.FallbackCoordinateFieldType;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryRuntimeException;
@@ -101,7 +95,6 @@ import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.AnalyticsType;
@@ -359,59 +352,6 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
   // -------------------------------------------------------------------------
   // Supportive methods
   // -------------------------------------------------------------------------
-
-  @Override
-  protected String getColumnWithCte(
-      QueryItem item, CteContext cteContext, EventQueryParams params) {
-    Set<String> columns = new LinkedHashSet<>();
-
-    // Get the CTE definition for the item
-    CteDefinition cteDef = cteContext.getDefinitionByItemUid(computeKey(item));
-    if (cteDef == null) {
-      throw new IllegalQueryException(ErrorCode.E7148, item.getItemId());
-    }
-    int programStageOffset = computeRowNumberOffset(item.getProgramStageOffset());
-    // calculate the alias for the column
-    // if the item is not a repeatable stage, the alias is the program stage + item name
-    String alias =
-        getAlias(item).orElse("%s.%s".formatted(item.getProgramStage().getUid(), item.getItemId()));
-    columns.add("%s.value as %s".formatted(cteDef.getAlias(programStageOffset), quote(alias)));
-
-    // For stage.ou dimensions, conditionally select ouname/oucode columns
-    if (isStageOuDimension(item) && params.hasHeaders()) {
-      String stageUid = item.getProgramStage().getUid();
-      if (params.getHeaders().contains(stageUid + ".ouname")) {
-        columns.add(
-            "%s.%s as %s"
-                .formatted(
-                    cteDef.getAlias(programStageOffset),
-                    STAGE_OU_NAME_COLUMN,
-                    quote(stageUid + ".ouname")));
-      }
-      if (params.getHeaders().contains(stageUid + ".oucode")) {
-        columns.add(
-            "%s.%s as %s"
-                .formatted(
-                    cteDef.getAlias(programStageOffset),
-                    STAGE_OU_CODE_COLUMN,
-                    quote(stageUid + ".oucode")));
-      }
-    }
-
-    if (cteDef.isRowContext()) {
-      // Add additional status and exists columns for row context
-      columns.add(
-          "coalesce(%s.rn = %s, false) as %s"
-              .formatted(
-                  cteDef.getAlias(programStageOffset),
-                  programStageOffset + 1,
-                  quote(alias + ".exists")));
-      columns.add(
-          "%s.eventstatus as %s"
-              .formatted(cteDef.getAlias(programStageOffset), quote(alias + ".status")));
-    }
-    return String.join(",\n", columns);
-  }
 
   @Override
   void addFromClause(SelectBuilder sb, EventQueryParams params) {


### PR DESCRIPTION
## Summary

- De-duplicate `getColumnWithCte` by pulling the identical method bodies in `JdbcEventAnalyticsManager` and `JdbcEnrollmentAnalyticsManager` into their common parent `AbstractJdbcEventAnalyticsManager`.
- Simplify the moved method by introducing a small private `CteColumn` record and splitting the body into three single-purpose helpers (`valueColumn`, `stageOuHelperColumns`, `rowContextColumns`).
