### PR TITLE
test: allow duration-based import opt-in in TrackerTest DHIS2-20965

### DIFF
--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -6,6 +6,11 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Force c3p0 on 2.43 (2.43 defaults to HikariCP).
+# Used to run the 2.43 import sweep against c3p0 so users who opt out of
+# HikariCP can compare. Reverted in the next commit.
+db.pool.type = c3p0
+
 # Debugging: prepend SQL comments with request context for query attribution.
 # This can influence performance as unique comments prevent prepared statement caching.
 #monitoring.sql.context = on

--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -6,6 +6,11 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Force HikariCP on pre-2.43 releases (2.43+ already defaults to HikariCP).
+# Used to run concurrency-sweep runs against 2.42.x / 2.41.x with the same
+# pool as 2.43 so the comparison isolates other changes from pool overhead.
+db.pool.type = hikari
+
 # Debugging: prepend SQL comments with request context for query attribution.
 # This can influence performance as unique comments prevent prepared statement caching.
 #monitoring.sql.context = on

--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -6,11 +6,6 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
-# Force HikariCP on pre-2.43 releases (2.43+ already defaults to HikariCP).
-# Used to run concurrency-sweep runs against 2.42.x / 2.41.x with the same
-# pool as 2.43 so the comparison isolates other changes from pool overhead.
-db.pool.type = hikari
-
 # Debugging: prepend SQL comments with request context for query attribution.
 # This can influence performance as unique comments prevent prepared statement caching.
 #monitoring.sql.context = on

--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -6,11 +6,6 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
-# Force c3p0 on 2.43 (2.43 defaults to HikariCP).
-# Used to run the 2.43 import sweep against c3p0 so users who opt out of
-# HikariCP can compare. Reverted in the next commit.
-db.pool.type = c3p0
-
 # Debugging: prepend SQL comments with request context for query attribution.
 # This can influence performance as unique comments prevent prepared statement caching.
 #monitoring.sql.context = on

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/NdjsonFeeder.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/NdjsonFeeder.java
@@ -36,14 +36,17 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gatling feeder that streams pre-generated ndjson.gz payloads for tracker bulk imports.
+ * Circular Gatling feeder that loads pre-generated ndjson.gz payloads into memory for tracker bulk
+ * imports.
  *
  * <h3>How chunking works</h3>
  *
@@ -53,15 +56,12 @@ import org.slf4j.LoggerFactory;
  * {@code List<String>} of JSON strings, which {@code wrapPayload} joins into the tracker import
  * envelope: {@code {"trackedEntities":[line1,line2,...lineN]}}.
  *
- * <p>The caller must ensure that the total number of lines consumed ({@code linesPerRequest *
- * requestsPerUser * importUsers}) does not exceed {@code lineCount()}. If the feeder runs out of
- * lines mid-request, Gatling crashes and stops the entire simulation.
+ * <h3>Circular behavior</h3>
  *
- * <h3>Line counting</h3>
- *
- * The constructor decompresses the gzip file twice: once to count lines, once to open the streaming
- * reader. This is needed because Gatling's {@code feed(feeder, N)} requires exactly N records per
- * call, and we must know the total to calculate the repeat count.
+ * All lines are loaded into memory on construction. The feeder wraps around when it reaches the
+ * end, so it never runs out of data. This allows duration-based import scenarios ({@code during()})
+ * to run indefinitely. Since the payloads contain no entity UIDs, DHIS2 generates new UIDs for each
+ * import request, so replayed data always creates new entities.
  *
  * <h3>Thread safety</h3>
  *
@@ -74,57 +74,42 @@ class NdjsonFeeder implements Iterator<Map<String, Object>> {
 
   private static final Logger logger = LoggerFactory.getLogger(NdjsonFeeder.class);
 
-  private final int lineCount;
-  private final BufferedReader reader;
-  private String pendingLine;
+  private final List<String> lines;
+  private int index;
 
   NdjsonFeeder(Path ndjsonGzFile) {
-    try {
-      // First pass: count lines so we can calculate how many chunk-sized requests fit.
-      // This decompresses the gzip once without retaining the data. Avoids needing a sidecar
-      // metadata file or coupling chunk size to generation time.
-      int count = 0;
-      try (var countReader =
-          new BufferedReader(
-              new InputStreamReader(
-                  new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
-                  StandardCharsets.UTF_8))) {
-        while (countReader.readLine() != null) count++;
+    try (var reader =
+        new BufferedReader(
+            new InputStreamReader(
+                new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
+                StandardCharsets.UTF_8))) {
+      List<String> loaded = new ArrayList<>();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        loaded.add(line);
       }
-      this.lineCount = count;
-
-      // Second pass: open for streaming. Records are read one at a time by Gatling's
-      // FeedActor as import requests are built.
-      this.reader =
-          new BufferedReader(
-              new InputStreamReader(
-                  new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
-                  StandardCharsets.UTF_8));
-      this.pendingLine = reader.readLine();
-      logger.debug("ndjson feeder initialized: {} ({} lines)", ndjsonGzFile, lineCount);
+      this.lines = loaded;
+      this.index = 0;
+      logger.debug("ndjson feeder initialized: {} ({} lines)", ndjsonGzFile, lines.size());
     } catch (IOException e) {
-      throw new UncheckedIOException("Failed to open ndjson feeder: " + ndjsonGzFile, e);
+      throw new UncheckedIOException("Failed to load ndjson feeder: " + ndjsonGzFile, e);
     }
   }
 
   /** Total number of lines (records) in the file. */
   int lineCount() {
-    return lineCount;
+    return lines.size();
   }
 
   @Override
   public boolean hasNext() {
-    return pendingLine != null;
+    return !lines.isEmpty();
   }
 
   @Override
   public Map<String, Object> next() {
-    String line = pendingLine;
-    try {
-      pendingLine = reader.readLine();
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to read ndjson line", e);
-    }
+    String line = lines.get(index);
+    index = (index + 1) % lines.size();
     return Map.of("payload", line);
   }
 }

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/NdjsonFeeder.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/NdjsonFeeder.java
@@ -37,13 +37,15 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gatling feeder that streams pre-generated ndjson.gz payloads for tracker bulk imports.
+ * Circular Gatling feeder that loads pre-generated ndjson.gz payloads into memory for tracker bulk
+ * imports.
  *
  * <h3>How chunking works</h3>
  *
@@ -53,15 +55,12 @@ import org.slf4j.LoggerFactory;
  * {@code List<String>} of JSON strings, which {@code wrapPayload} joins into the tracker import
  * envelope: {@code {"trackedEntities":[line1,line2,...lineN]}}.
  *
- * <p>The caller must ensure that the total number of lines consumed ({@code linesPerRequest *
- * requestsPerUser * importUsers}) does not exceed {@code lineCount()}. If the feeder runs out of
- * lines mid-request, Gatling crashes and stops the entire simulation.
+ * <h3>Circular behavior</h3>
  *
- * <h3>Line counting</h3>
- *
- * The constructor decompresses the gzip file twice: once to count lines, once to open the streaming
- * reader. This is needed because Gatling's {@code feed(feeder, N)} requires exactly N records per
- * call, and we must know the total to calculate the repeat count.
+ * All lines are loaded into memory on construction. The feeder wraps around when it reaches the
+ * end, so it never runs out of data. This allows duration-based import scenarios ({@code during()})
+ * to run indefinitely. Since the payloads contain no entity UIDs, DHIS2 generates new UIDs for each
+ * import request, so replayed data always creates new entities.
  *
  * <h3>Thread safety</h3>
  *
@@ -74,57 +73,37 @@ class NdjsonFeeder implements Iterator<Map<String, Object>> {
 
   private static final Logger logger = LoggerFactory.getLogger(NdjsonFeeder.class);
 
-  private final int lineCount;
-  private final BufferedReader reader;
-  private String pendingLine;
+  private final List<String> lines;
+  private int index;
 
   NdjsonFeeder(Path ndjsonGzFile) {
-    try {
-      // First pass: count lines so we can calculate how many chunk-sized requests fit.
-      // This decompresses the gzip once without retaining the data. Avoids needing a sidecar
-      // metadata file or coupling chunk size to generation time.
-      int count = 0;
-      try (var countReader =
-          new BufferedReader(
-              new InputStreamReader(
-                  new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
-                  StandardCharsets.UTF_8))) {
-        while (countReader.readLine() != null) count++;
-      }
-      this.lineCount = count;
-
-      // Second pass: open for streaming. Records are read one at a time by Gatling's
-      // FeedActor as import requests are built.
-      this.reader =
-          new BufferedReader(
-              new InputStreamReader(
-                  new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
-                  StandardCharsets.UTF_8));
-      this.pendingLine = reader.readLine();
-      logger.debug("ndjson feeder initialized: {} ({} lines)", ndjsonGzFile, lineCount);
+    try (var reader =
+        new BufferedReader(
+            new InputStreamReader(
+                new GZIPInputStream(new FileInputStream(ndjsonGzFile.toFile())),
+                StandardCharsets.UTF_8))) {
+      this.lines = reader.lines().toList();
+      this.index = 0;
+      logger.debug("ndjson feeder initialized: {} ({} lines)", ndjsonGzFile, lines.size());
     } catch (IOException e) {
-      throw new UncheckedIOException("Failed to open ndjson feeder: " + ndjsonGzFile, e);
+      throw new UncheckedIOException("Failed to load ndjson feeder: " + ndjsonGzFile, e);
     }
   }
 
   /** Total number of lines (records) in the file. */
   int lineCount() {
-    return lineCount;
+    return lines.size();
   }
 
   @Override
   public boolean hasNext() {
-    return pendingLine != null;
+    return !lines.isEmpty();
   }
 
   @Override
   public Map<String, Object> next() {
-    String line = pendingLine;
-    try {
-      pendingLine = reader.readLine();
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to read ndjson line", e);
-    }
+    String line = lines.get(index);
+    index = (index + 1) % lines.size();
     return Map.of("payload", line);
   }
 }

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -105,15 +105,26 @@ import org.slf4j.LoggerFactory;
  *   <li>{@code export} -- export only, skip import (DB must be seeded)
  * </ul>
  *
- * <p><b>Import parameters:</b>
+ * <p><b>Import parameters (common):</b>
  *
  * <ul>
  *   <li>{@code -DimportEntitiesPerRequest} -- target entities (TEs + enrollments + events) per HTTP
  *       request (default: 500 for load, 50 for smoke)
- *   <li>{@code -DimportMaxEntitiesPerProgram} -- cap on entities imported per program. The actual
- *       count may be lower due to integer division rounding -- this is a cap, not a target.
- *       (default: 30,000 for load, 500 for smoke)
  *   <li>{@code -DimportUsers} -- concurrent import users (default: 4 for load, 1 for smoke)
+ * </ul>
+ *
+ * <p><b>Import parameters (smoke only, repeat-based):</b>
+ *
+ * <ul>
+ *   <li>{@code -DimportRequestsPerUser} -- how many import requests each user makes per program
+ *       (default: 10). Setting this on load/capacity profiles fails the simulation.
+ * </ul>
+ *
+ * <p><b>Import parameters (load/capacity only, duration-based):</b>
+ *
+ * <ul>
+ *   <li>{@code -DimportDurationSec} -- how long each program's import phase runs (default: 180).
+ *       The circular feeder replays data as needed. Setting this on smoke fails the simulation.
  * </ul>
  *
  * <p><b>Profiles:</b>
@@ -176,7 +187,8 @@ public class TrackerTest extends Simulation {
   private final int steps;
   private final TestMode testMode;
   private final int importEntitiesPerRequest;
-  private final int importMaxEntitiesPerProgram;
+  private final int importRequestsPerUser;
+  private final int importDurationSec;
   private final int importUsers;
   private NdjsonFeeder mnchFeeder;
   private NdjsonFeeder childFeeder;
@@ -249,13 +261,14 @@ public class TrackerTest extends Simulation {
         int durationSec,
         int steps,
         int importEntitiesPerRequest,
-        int importMaxEntitiesPerProgram,
+        int importRequestsPerUser,
+        int importDurationSec,
         int importUsers) {}
     ProfileDefaults defaults =
         switch (this.profile) {
-          case SMOKE -> new ProfileDefaults(1, 1, 100, 1, 1, 1, 50, 500, 1);
-          case LOAD -> new ProfileDefaults(4, 4, 1, 15, 180, 1, 500, 30_000, 4);
-          case CAPACITY -> new ProfileDefaults(8, 8, 1, 10, 30, 4, 500, 30_000, 4);
+          case SMOKE -> new ProfileDefaults(1, 1, 100, 1, 1, 1, 50, 10, 0, 1);
+          case LOAD -> new ProfileDefaults(4, 4, 1, 15, 180, 1, 500, 0, 180, 4);
+          case CAPACITY -> new ProfileDefaults(8, 8, 1, 10, 30, 4, 500, 0, 180, 4);
         };
     this.concurrentUsers = Integer.getInteger("concurrentUsers", defaults.concurrentUsers());
     this.repeat = Integer.getInteger("repeat", defaults.repeat());
@@ -266,9 +279,19 @@ public class TrackerTest extends Simulation {
     this.testMode = TestMode.fromString(System.getProperty("testMode", "all"));
     this.importEntitiesPerRequest =
         Integer.getInteger("importEntitiesPerRequest", defaults.importEntitiesPerRequest());
-    this.importMaxEntitiesPerProgram =
-        Integer.getInteger("importMaxEntitiesPerProgram", defaults.importMaxEntitiesPerProgram());
+    this.importRequestsPerUser =
+        Integer.getInteger("importRequestsPerUser", defaults.importRequestsPerUser());
+    this.importDurationSec = Integer.getInteger("importDurationSec", defaults.importDurationSec());
     this.importUsers = Integer.getInteger("importUsers", defaults.importUsers());
+
+    if (this.profile == Profile.SMOKE && System.getProperty("importDurationSec") != null) {
+      throw new IllegalArgumentException(
+          "importDurationSec is for load/capacity profiles. Use importRequestsPerUser for smoke.");
+    }
+    if (this.profile != Profile.SMOKE && System.getProperty("importRequestsPerUser") != null) {
+      throw new IllegalArgumentException(
+          "importRequestsPerUser is for smoke profile. Use importDurationSec for load/capacity.");
+    }
 
     if (this.testMode != TestMode.EXPORT) {
       String s3Base =
@@ -445,55 +468,63 @@ public class TrackerTest extends Simulation {
   }
 
   /**
-   * Builds an import scenario for a single program. Each ndjson line may contain multiple entities
-   * (e.g. 1 TE + enrollments + events). The number of import requests per user is derived from
-   * {@code importMaxEntitiesPerProgram}, {@code importEntitiesPerRequest}, and {@code importUsers}.
-   * The actual number of imported entities is capped at {@code importMaxEntitiesPerProgram} but may
-   * undershoot due to integer division rounding -- it is not a target.
+   * Builds an import scenario for a single program. Each ndjson line is a complete JSON object (one
+   * tracked entity or one event). Lines are batched into requests of {@code
+   * importEntitiesPerRequest} entities.
    *
-   * <p>Example for MNCH (entitiesPerLine=9, feeder lineCount=94538) with
-   * importEntitiesPerRequest=500, importMaxEntitiesPerProgram=5000, importUsers=4:
+   * <p>On load/capacity profiles, the scenario uses {@code during(importDurationSec)} with a closed
+   * injection model: a fixed pool of {@code importUsers} concurrent users loop for the given
+   * duration. The circular {@link NdjsonFeeder} replays data as needed since payloads contain no
+   * entity UIDs (DHIS2 generates them), so every request creates new entities.
    *
-   * <pre>
-   *   linesPerRequest   = importEntitiesPerRequest / entitiesPerLine     = 500 / 9              = 55
-   *   availableEntities = feeder.lineCount * entitiesPerLine             = 94538 * 9            = 850842
-   *   entitiesPerUser   = min(importMaxEntitiesPerProgram, available) / importUsers = min(5000, 850842) / 4 = 1250
-   *   requestsPerUser   = entitiesPerUser / importEntitiesPerRequest     = 1250 / 500           = 2
-   *   actual entities   = requestsPerUser * linesPerRequest * entitiesPerLine * importUsers = 2 * 55 * 9 * 4 = 3960
-   * </pre>
+   * <p>On smoke, the scenario uses {@code repeat(importRequestsPerUser)} for deterministic
+   * iteration counts.
    */
   private PopulationBuilder importProgram(
       String name, NdjsonFeeder feeder, int entitiesPerLine, String wrapperKey) {
     int linesPerRequest = this.importEntitiesPerRequest / entitiesPerLine;
-    int availableEntities = feeder.lineCount() * entitiesPerLine;
-    int entitiesPerUser =
-        Math.min(this.importMaxEntitiesPerProgram, availableEntities) / this.importUsers;
-    int requestsPerUser = entitiesPerUser / this.importEntitiesPerRequest;
     logger.debug(
-        "Import {}: {} lines, {} lines/request, {} requests/user, {} users",
+        "Import {}: {} lines, {} lines/request, {} users, {}",
         name,
         feeder.lineCount(),
         linesPerRequest,
-        requestsPerUser,
-        this.importUsers);
-    return scenario(name)
-        .exec(
-            session -> session.set("username", this.adminUser).set("password", this.adminPassword))
-        .exec(login())
-        .exitHereIfFailed()
-        .repeat(requestsPerUser)
-        .on(
-            feed(feeder, linesPerRequest)
-                .exec(
-                    http(name)
-                        .post("/api/tracker?async=false&importStrategy=CREATE_AND_UPDATE")
-                        .header("Content-Type", "application/json")
-                        .header("X-Request-ID", session -> nextRequestId(name))
-                        .body(
-                            StringBody(
-                                session -> wrapPayload(session.getList("payload"), wrapperKey)))
-                        .check(status().is(200))))
-        .injectOpen(atOnceUsers(this.importUsers));
+        this.importUsers,
+        this.profile == Profile.SMOKE
+            ? "repeat=" + this.importRequestsPerUser
+            : "duration=" + this.importDurationSec + "s");
+
+    ChainBuilder importRequest =
+        feed(feeder, linesPerRequest)
+            .exec(
+                http(name)
+                    .post("/api/tracker?async=false")
+                    .header("Content-Type", "application/json")
+                    .header("X-Request-ID", session -> nextRequestId(name))
+                    .body(
+                        StringBody(session -> wrapPayload(session.getList("payload"), wrapperKey)))
+                    .check(status().is(200)));
+
+    ScenarioBuilder scenario =
+        scenario(name)
+            .exec(
+                session ->
+                    session.set("username", this.adminUser).set("password", this.adminPassword))
+            .exec(login())
+            .exitHereIfFailed();
+
+    if (this.profile == Profile.SMOKE) {
+      return scenario
+          .repeat(this.importRequestsPerUser)
+          .on(importRequest)
+          .injectOpen(atOnceUsers(this.importUsers));
+    }
+
+    return scenario
+        .during(Duration.ofSeconds(this.importDurationSec))
+        .on(importRequest)
+        .injectClosed(
+            constantConcurrentUsers(this.importUsers)
+                .during(Duration.ofSeconds(this.importDurationSec)));
   }
 
   /** Wraps a list of pre-built JSON objects into a tracker import envelope. */

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -121,11 +121,9 @@ import org.slf4j.LoggerFactory;
  *       of wall time. Same workload across versions; wall time varies. Default path.
  *   <li>{@code -DimportDurationSec} -- how long each program's import phase runs. Duration-based:
  *       each user loops for the given duration; the circular feeder replays data as needed. Same
- *       wall time across versions; workload varies. Opt in by setting this; setting it disables
- *       {@code importRequestsPerUser}.
+ *       wall time across versions; workload varies. Opt in by setting this instead of {@code
+ *       importRequestsPerUser}; setting both fails the simulation at startup.
  * </ul>
- *
- * <p>Setting both fails the simulation.
  *
  * <p><b>Profiles:</b>
  *

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -113,19 +113,19 @@ import org.slf4j.LoggerFactory;
  *   <li>{@code -DimportUsers} -- concurrent import users (default: 4 for load, 1 for smoke)
  * </ul>
  *
- * <p><b>Import parameters (smoke only, repeat-based):</b>
+ * <p><b>Import parameters (mutually exclusive):</b>
  *
  * <ul>
  *   <li>{@code -DimportRequestsPerUser} -- how many import requests each user makes per program
- *       (default: 10). Setting this on load/capacity profiles fails the simulation.
+ *       (default: 10 on smoke, 15 on load/capacity). Repeat-based: deterministic count regardless
+ *       of wall time. Same workload across versions; wall time varies. Default path.
+ *   <li>{@code -DimportDurationSec} -- how long each program's import phase runs. Duration-based:
+ *       each user loops for the given duration; the circular feeder replays data as needed. Same
+ *       wall time across versions; workload varies. Opt in by setting this; setting it disables
+ *       {@code importRequestsPerUser}.
  * </ul>
  *
- * <p><b>Import parameters (load/capacity only, duration-based):</b>
- *
- * <ul>
- *   <li>{@code -DimportDurationSec} -- how long each program's import phase runs (default: 180).
- *       The circular feeder replays data as needed. Setting this on smoke fails the simulation.
- * </ul>
+ * <p>Setting both fails the simulation.
  *
  * <p><b>Profiles:</b>
  *
@@ -267,8 +267,8 @@ public class TrackerTest extends Simulation {
     ProfileDefaults defaults =
         switch (this.profile) {
           case SMOKE -> new ProfileDefaults(1, 1, 100, 1, 1, 1, 50, 10, 0, 1);
-          case LOAD -> new ProfileDefaults(4, 4, 1, 15, 180, 1, 500, 0, 180, 4);
-          case CAPACITY -> new ProfileDefaults(8, 8, 1, 10, 30, 4, 500, 0, 180, 4);
+          case LOAD -> new ProfileDefaults(4, 4, 1, 15, 180, 1, 500, 15, 0, 4);
+          case CAPACITY -> new ProfileDefaults(8, 8, 1, 10, 30, 4, 500, 15, 0, 4);
         };
     this.concurrentUsers = Integer.getInteger("concurrentUsers", defaults.concurrentUsers());
     this.repeat = Integer.getInteger("repeat", defaults.repeat());
@@ -284,13 +284,10 @@ public class TrackerTest extends Simulation {
     this.importDurationSec = Integer.getInteger("importDurationSec", defaults.importDurationSec());
     this.importUsers = Integer.getInteger("importUsers", defaults.importUsers());
 
-    if (this.profile == Profile.SMOKE && System.getProperty("importDurationSec") != null) {
+    if (System.getProperty("importRequestsPerUser") != null
+        && System.getProperty("importDurationSec") != null) {
       throw new IllegalArgumentException(
-          "importDurationSec is for load/capacity profiles. Use importRequestsPerUser for smoke.");
-    }
-    if (this.profile != Profile.SMOKE && System.getProperty("importRequestsPerUser") != null) {
-      throw new IllegalArgumentException(
-          "importRequestsPerUser is for smoke profile. Use importDurationSec for load/capacity.");
+          "importRequestsPerUser and importDurationSec are mutually exclusive.");
     }
 
     if (this.testMode != TestMode.EXPORT) {
@@ -489,7 +486,7 @@ public class TrackerTest extends Simulation {
         feeder.lineCount(),
         linesPerRequest,
         this.importUsers,
-        this.profile == Profile.SMOKE
+        this.importRequestsPerUser > 0
             ? "repeat=" + this.importRequestsPerUser
             : "duration=" + this.importDurationSec + "s");
 
@@ -512,7 +509,7 @@ public class TrackerTest extends Simulation {
             .exec(login())
             .exitHereIfFailed();
 
-    if (this.profile == Profile.SMOKE) {
+    if (this.importRequestsPerUser > 0) {
       return scenario
           .repeat(this.importRequestsPerUser)
           .on(importRequest)


### PR DESCRIPTION
Allow duration-based import in `TrackerTest` as an opt-in alongside the existing repeat-based default.

## Why

Repeat-based imports do the same amount of work regardless of version, so different versions finish at different wall-clock times. For the 2.43 release-notes runs we needed the opposite: same wall clock, measure how much work each version gets done.

Both modes stay available:

* **Repeat (default)**: fixed workload across versions. CI assertions stay stable.
* **Duration (opt-in)**: fixed wall clock across versions. For version-to-version throughput comparisons, soak tests, release-notes runs.

## What changed

* `NdjsonFeeder` is now circular. All lines loaded into memory, index wraps. Safe to replay because Synthea payloads have no entity UIDs, so DHIS2 generates a new UID for every request and every replay creates new entities. Required for duration-based import, which would otherwise exhaust the feeder.
* New mutually exclusive parameters (one must be set, setting both fails at startup):
  * `-DimportRequestsPerUser` -- repeat-based (default). 10 on smoke, 15 on load/capacity.
  * `-DimportDurationSec` -- duration-based (opt-in). Each user loops for the given duration, per program. Programs run sequentially (MNCH → Child → ANC), so total wall time is ~3x this value.
* Removed `importMaxEntitiesPerProgram` (replaced by explicit `importRequestsPerUser`; load default 15 matches the old ceiling of 30,000 / 500 / 4 = 15).
* Dropped explicit `importStrategy=CREATE_AND_UPDATE` from the URL (it is the default).

## Data

Sierra Leone 2.42.0 dump, per program the test touches (totals across all programs: 73k TEs, 73k enrollments, 374k events):

| Program | Type | TEs | Enrollments | Events |
|---|---|---|---|---|
| MNCH / PNC (`uy2gU8kT1jF`) | tracker | 3 | 3 | 14 |
| Child Programme (`IpHINAT79UW`) | tracker | 19,030 | 19,031 | 37,643 |
| ANC visit (`lxAQ7Zs9VYR`) | event | — | — | 3 |

Import data is pre-generated Synthea patient data. Each file is ndjson where one line is one top-level entity (one tracked entity with its enrollments/events for tracker programs, one single event for ANC):

| Program | Entities per line |
|---|---|
| MNCH / PNC | 1 TE + 2 enrollments + 6 events |
| Child Programme | 1 TE + 1 enrollment + 2 events |
| ANC visit | 1 single event |

What each profile imports per run (repeat-based default), and the wall time observed in the nightly `performance-tests-scheduled.yml` run on 2026-04-20:

| Profile | Users | Requests/user | Entities/request | Entities/program | Total entities | Wall time |
|---|---|---|---|---|---|---|
| tracker-smoke | 1 | 10 | 50 | 500 | 1,500 | ~4 min |
| tracker-load | 4 | 15 | 500 | 30,000 | 90,000 | ~17 min |

Duration-based opt-in (no fixed total, varies with version throughput): at `importDurationSec=300` on 2.43 load/4u we observed ~60 MNCH + ~430 Child + ~360 ANC requests (~425k entities total).

## Scale (known limitation + fix)

When we added the [import tests](https://github.com/dhis2/dhis2-core/pull/23232) we needed a source of realistic tracker data and [Synthea](https://github.com/synthetichealth/synthea) was the best fit we found. We mapped its output to the three programs above. The issue today is that those programs are thin in the Sierra Leone demo DB (see the first table), so the test mostly measures insert cost on an almost-empty program rather than the cost of growing an already-large dataset.

Trade-off with this PR: bumping `importRequestsPerUser` (or switching to the duration-based opt-in) adds more data and more test time but doesn't change the underlying starting point.

Real fix (next): build a dedicated tracker performance DB where the baseline is already grown out of Synthea data, then keep using Synthea for the on-top import in tests. Same generator for seed and test payloads, and seeding happens once offline instead of inside every run.

