### PR TITLE
fix: update same analyticsTableHooks return error

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AnalyticsTableHookObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AnalyticsTableHookObjectBundleHook.java
@@ -70,7 +70,8 @@ public class AnalyticsTableHookObjectBundleHook
 
     analyticsTableHooks.forEach(
         existingAnalyticsTableHook -> {
-          if (areEqual(analyticsTableHook, existingAnalyticsTableHook)) {
+          if (!existingAnalyticsTableHook.getUid().equals(analyticsTableHook.getUid())
+              && areEqual(analyticsTableHook, existingAnalyticsTableHook)) {
             addReports.accept(
                 new ErrorReport(
                     AnalyticsTableHook.class,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsTableHookControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsTableHookControllerTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonErrorReport;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,20 @@ class AnalyticsTableHookControllerTest extends H2ControllerIntegrationTestBase {
         POST(
             "/analyticsTableHooks/",
             "{'name':'NameA', 'phase':'RESOURCE_TABLE_POPULATED', 'resourceTableType':'ORG_UNIT_STRUCTURE', 'sql':'update analytics_rs_orgunitstructure set organisationunitid=3'}"));
+  }
+
+  @Test
+  void testUpdateExistingAnalyticsTableHook() {
+    JsonMixed response =
+        POST(
+                "/analyticsTableHooks/",
+                "{'name':'NameA', 'phase':'RESOURCE_TABLE_POPULATED', 'resourceTableType':'ORG_UNIT_STRUCTURE', 'sql':'update analytics_rs_orgunitstructure set organisationunitid=3'}")
+            .content(HttpStatus.CREATED);
+    String id = response.getObject("response").getString("uid").string();
+    PUT(
+            "/analyticsTableHooks/" + id,
+            "{'name':'NameB', 'phase':'RESOURCE_TABLE_POPULATED', 'resourceTableType':'ORG_UNIT_STRUCTURE', 'sql':'update analytics_rs_orgunitstructure set organisationunitid=3'}")
+        .content(HttpStatus.OK);
   }
 
   @Test


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-21291
- Fix for cannot update only name of an existing Analytics Table Hook because the duplicate name validator doesn't filter out the same object that is being updated.