### PR TITLE
chore: update async-profiler from 4.3 to 4.4 DHIS2-19797

### DIFF
--- a/dhis-2/dhis-test-performance/docker-compose.profile.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.profile.yml
@@ -32,11 +32,11 @@ services:
       sh -c '
         if [ ! -f /opt/async-profiler/bin/asprof ]; then
           echo "Downloading async-profiler..."
-          wget -O /tmp/async-profiler.tar.gz https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-x64.tar.gz &&
+          wget -O /tmp/async-profiler.tar.gz https://github.com/async-profiler/async-profiler/releases/download/v4.4/async-profiler-4.4-linux-x64.tar.gz &&
           mkdir -p /opt/async-profiler/bin /opt/async-profiler/lib &&
           tar -xzf /tmp/async-profiler.tar.gz -C /tmp &&
-          cp /tmp/async-profiler-4.3-linux-x64/bin/* /opt/async-profiler/bin/ &&
-          cp /tmp/async-profiler-4.3-linux-x64/lib/* /opt/async-profiler/lib/ &&
+          cp /tmp/async-profiler-4.4-linux-x64/bin/* /opt/async-profiler/bin/ &&
+          cp /tmp/async-profiler-4.4-linux-x64/lib/* /opt/async-profiler/lib/ &&
           chmod +x /opt/async-profiler/bin/asprof &&
           chmod +x /opt/async-profiler/bin/jfrconv &&
           echo "async-profiler installed to /opt/async-profiler"


### PR DESCRIPTION
Update async-profiler from 4.3 to 4.4 in the performance test module.

Release notes: https://github.com/async-profiler/async-profiler/releases/tag/v4.4

Notable in v4.4:

* [Differential flame graphs](https://github.com/async-profiler/async-profiler/blob/master/docs/ConverterUsage.md#differential-flame-graph) for comparing profiles
