### PR TITLE
fix: Make attribute validation & value reservation case insensitive [DHIS2-21357]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/hibernate/HibernateReservedValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/hibernate/HibernateReservedValueStore.java
@@ -152,7 +152,8 @@ public class HibernateReservedValueStore extends HibernateGenericStore<ReservedV
 
   @Override
   public boolean useReservedValue(String ownerUID, String value) {
-    return getQuery("DELETE FROM ReservedValue WHERE owneruid = :uid AND value = :value")
+    return getQuery(
+                "DELETE FROM ReservedValue WHERE owneruid = :uid AND lower(value) = lower(:value)")
             .setParameter("uid", ownerUID)
             .setParameter("value", value)
             .executeUpdate()
@@ -170,7 +171,7 @@ public class HibernateReservedValueStore extends HibernateGenericStore<ReservedV
   public boolean isReserved(String ownerObject, String ownerUID, String value) {
     String hql =
         "from ReservedValue rv where rv.ownerObject =:ownerObject and rv.ownerUid =:ownerUid "
-            + "and rv.value =:value";
+            + "and lower(rv.value) = lower(:value)";
 
     return !getQuery(hql)
         .setParameter("ownerObject", ownerObject)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/reservedvalue/hibernate/HibernateReservedValueStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/reservedvalue/hibernate/HibernateReservedValueStoreTest.java
@@ -132,6 +132,22 @@ class HibernateReservedValueStoreTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldBeReservedWhenValueHasDifferentCase() {
+    ReservedValue rv = reservedValue.value("ABC").build();
+    reservedValueStore.save(rv);
+    assertTrue(reservedValueStore.isReserved(rv.getOwnerObject(), rv.getOwnerUid(), "abc"));
+    assertTrue(reservedValueStore.isReserved(rv.getOwnerObject(), rv.getOwnerUid(), "ABC"));
+  }
+
+  @Test
+  void shouldUseReservedValueWhenValueHasDifferentCase() {
+    ReservedValue rv = reservedValue.value("ABC").build();
+    saveReservedValue(rv);
+    assertTrue(reservedValueStore.useReservedValue(rv.getOwnerUid(), "abc"));
+    assertFalse(reservedValueStore.isReserved(rv.getOwnerObject(), rv.getOwnerUid(), "ABC"));
+  }
+
+  @Test
   void reserveValuesMultipleValues() {
     saveReservedValue(reservedValue.value(prog001).build());
     int count = reservedValueStore.getCount();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/AttributeValidator.java
@@ -96,7 +96,8 @@ public abstract class AttributeValidator {
               || uniqueAttributeValue.getOrgUnit().isEqualTo(organisationUnit);
 
       boolean isTheSameTea = uniqueAttributeValue.getAttribute().isEqualTo(trackedEntityAttribute);
-      boolean hasTheSameValue = Objects.equals(uniqueAttributeValue.getValue(), value);
+      boolean hasTheSameValue =
+          value != null && value.equalsIgnoreCase(uniqueAttributeValue.getValue());
       boolean isNotSameTei =
           trackedEntity == null
               || !Objects.equals(trackedEntity.getUID(), uniqueAttributeValue.getTe());

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.common.CodeGenerator;
@@ -60,6 +61,7 @@ import org.hisp.dhis.tracker.imports.domain.Attribute;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.imports.util.Constant;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -642,6 +644,90 @@ class AttributeValidatorTest {
     validator.validate(reporter, bundle, trackedEntity);
 
     assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldFailValidationWhenImportingUniqueAttributeValueWithDifferentCaseThanExistingValue() {
+    String teaUid = "UniqueTeaA1";
+
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setUid(teaUid);
+    tea.setValueType(ValueType.TEXT);
+    tea.setUnique(true);
+    tea.setOrgunitScope(false);
+
+    when(preheat.getUniqueAttributeValues())
+        .thenReturn(
+            List.of(
+                new UniqueAttributeValue(
+                    UID.generate(),
+                    MetadataIdentifier.ofUid(teaUid),
+                    "Abc",
+                    MetadataIdentifier.ofUid("OrgUnit0001"))));
+    when(preheat.getTrackedEntityAttribute(MetadataIdentifier.ofUid(teaUid))).thenReturn(tea);
+    when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
+        .thenReturn(new TrackedEntityType());
+
+    TrackedEntity trackedEntity =
+        TrackedEntity.builder()
+            .trackedEntity(UID.generate())
+            .attributes(
+                Collections.singletonList(
+                    Attribute.builder()
+                        .attribute(MetadataIdentifier.ofUid(teaUid))
+                        .value("ABC")
+                        .build()))
+            .trackedEntityType(MetadataIdentifier.ofUid("trackedEntityType"))
+            .build();
+
+    validator.validate(reporter, bundle, trackedEntity);
+
+    assertHasError(reporter, trackedEntity, ValidationCode.E1064);
+  }
+
+  @Test
+  void shouldPassValidationWhenUniqueAttributeValueWithDifferentCaseBelongsToSameTrackedEntity() {
+    String teaUid = "UniqueTeaA1";
+    UID teUid = UID.generate();
+
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setUid(teaUid);
+    tea.setValueType(ValueType.TEXT);
+    tea.setUnique(true);
+    tea.setOrgunitScope(false);
+
+    org.hisp.dhis.tracker.model.TrackedEntity storedTe =
+        new org.hisp.dhis.tracker.model.TrackedEntity();
+    storedTe.setUid(teUid.getValue());
+
+    when(preheat.getUniqueAttributeValues())
+        .thenReturn(
+            List.of(
+                new UniqueAttributeValue(
+                    teUid,
+                    MetadataIdentifier.ofUid(teaUid),
+                    "Abc",
+                    MetadataIdentifier.ofUid("OrgUnit0001"))));
+    when(preheat.getTrackedEntityAttribute(MetadataIdentifier.ofUid(teaUid))).thenReturn(tea);
+    when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
+        .thenReturn(new TrackedEntityType());
+    when(preheat.getTrackedEntity(teUid)).thenReturn(storedTe);
+
+    TrackedEntity trackedEntity =
+        TrackedEntity.builder()
+            .trackedEntity(teUid)
+            .attributes(
+                Collections.singletonList(
+                    Attribute.builder()
+                        .attribute(MetadataIdentifier.ofUid(teaUid))
+                        .value("ABC")
+                        .build()))
+            .trackedEntityType(MetadataIdentifier.ofUid("trackedEntityType"))
+            .build();
+
+    validator.validate(reporter, bundle, trackedEntity);
+
+    assertNoErrors(reporter);
   }
 
   private TrackedEntityAttribute getTrackedEntityAttributeWithOptionSet() {


### PR DESCRIPTION
Makes `AttributeValidator` uniqueness check case-insensitive, consistent with the rest of Tracker. 
While at it, it also makes `isReserved` and `useReservedValue` case-insensitive in `HibernateReservedValueStore`, consistent with the other methods in the same class that already use `lower()` for value comparisons.