### PR TITLE
fix: promote stage-prefixed data element headers to query items [DHIS-21344]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -113,6 +113,10 @@ import org.springframework.util.Assert;
 public class DefaultEventDataQueryService implements EventDataQueryService {
   private static final String EVENT_DATE_DIMENSION = "EVENT_DATE";
 
+  private static final String EVENT_STATUS_DIMENSION = "EVENT_STATUS";
+
+  private static final String SCHEDULED_DATE_DIMENSION = "SCHEDULED_DATE";
+
   private static final String ENROLLMENT_OU_DIMENSION = "ENROLLMENT_OU";
   private static final String LEVEL_PREFIX = "LEVEL-";
 
@@ -502,6 +506,30 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       return true;
     }
 
+    if (enrollment && isStageEventStatusSuffix(suffix)) {
+      promoteStageDimension(
+          params,
+          request,
+          pr,
+          prefix,
+          EVENT_STATUS_DIMENSION,
+          EventAnalyticsColumnName.EVENT_STATUS_COLUMN_NAME,
+          existingKeys);
+      return true;
+    }
+
+    if (enrollment && isStageScheduledDateSuffix(suffix)) {
+      promoteStageDimension(
+          params,
+          request,
+          pr,
+          prefix,
+          SCHEDULED_DATE_DIMENSION,
+          EventAnalyticsColumnName.SCHEDULED_DATE_COLUMN_NAME,
+          existingKeys);
+      return true;
+    }
+
     return isStaticColumnSuffix(suffix);
   }
 
@@ -594,6 +622,14 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
 
   private static boolean isStageEventDateSuffix(String suffix) {
     return ColumnHeader.EVENT_DATE.getItem().equalsIgnoreCase(suffix);
+  }
+
+  private static boolean isStageEventStatusSuffix(String suffix) {
+    return ColumnHeader.EVENT_STATUS.getItem().equalsIgnoreCase(suffix);
+  }
+
+  private static boolean isStageScheduledDateSuffix(String suffix) {
+    return ColumnHeader.SCHEDULED_DATE.getItem().equalsIgnoreCase(suffix);
   }
 
   private static boolean isStaticColumnSuffix(String suffix) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -398,11 +398,11 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
    * Promotes each {@code headers=} entry of the form {@code {stageUid}.{itemUid}} into a {@link
    * QueryItem} when it doesn't already exist as a dimension or item and its suffix isn't a known
    * static column. This lets clients request stage-scoped data element / attribute columns without
-   * having to repeat them in {@code dimension=}. Stage-OU helper suffixes ({@code ou}, {@code
-   * ouname}, {@code oucode}) are promoted by synthesising an unfiltered {@code {stageUid}.ou}
-   * dimension item, which is what the CTE generator uses to emit the stage-scoped {@code
-   * ouname}/{@code oucode} columns. Resolver failures are swallowed so unresolvable suffixes
-   * surface as E7230 downstream in the usual way.
+   * having to repeat them in {@code dimension=}. On the enrollment endpoint, stage-scoped static
+   * column headers (e.g. {@code {stageUid}.ouname}, {@code {stageUid}.eventdate}) are promoted by
+   * synthesising the corresponding unfiltered stage dimension item so the CTE generator emits the
+   * matching output column. Resolver failures are swallowed so unresolvable suffixes surface as
+   * E7230 downstream in the usual way.
    */
   private void addHeaderOnlyItemsToParams(
       EventQueryParams.Builder params, EventDataQueryRequest request, Program pr) {
@@ -416,6 +416,8 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
             .map(DefaultEventDataQueryService::itemKey)
             .collect(Collectors.toSet());
 
+    boolean enrollment = request.getEndpointItem() == RequestTypeAware.EndpointItem.ENROLLMENT;
+
     for (String header : headers) {
       int dot = header.lastIndexOf('.');
       if (dot <= 0 || dot >= header.length() - 1) {
@@ -425,9 +427,27 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       String prefix = header.substring(0, dot);
       String suffix = header.substring(dot + 1);
 
-      if (isStageOuHelperSuffix(suffix)
-          && request.getEndpointItem() == RequestTypeAware.EndpointItem.ENROLLMENT) {
-        promoteStageOuDimension(params, request, pr, prefix, existingKeys);
+      if (enrollment && isStageOuHelperSuffix(suffix)) {
+        promoteStageDimension(
+            params,
+            request,
+            pr,
+            prefix,
+            EventAnalyticsColumnName.OU_COLUMN_NAME,
+            EventAnalyticsColumnName.OU_COLUMN_NAME,
+            existingKeys);
+        continue;
+      }
+
+      if (enrollment && isStageEventDateSuffix(suffix)) {
+        promoteStageDimension(
+            params,
+            request,
+            pr,
+            prefix,
+            EVENT_DATE_DIMENSION,
+            EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME,
+            existingKeys);
         continue;
       }
 
@@ -452,22 +472,25 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
     }
   }
 
-  private void promoteStageOuDimension(
+  private void promoteStageDimension(
       EventQueryParams.Builder params,
       EventDataQueryRequest request,
       Program pr,
       String stagePrefix,
+      String dimensionSuffix,
+      String itemIdSuffix,
       Set<String> existingKeys) {
-    String stageOuKey = stagePrefix + "." + EventAnalyticsColumnName.OU_COLUMN_NAME;
-    if (existingKeys.contains(stageOuKey)) {
+    String quickKey = stagePrefix + "." + itemIdSuffix;
+    if (existingKeys.contains(quickKey)) {
       return;
     }
+    String dimension = stagePrefix + "." + dimensionSuffix;
     try {
-      QueryItem stageOuItem =
-          getQueryItem(stageOuKey, pr, request.getOutputType(), request.getRelativePeriodDate());
-      if (stageOuItem != null) {
-        params.addItem(stageOuItem);
-        existingKeys.add(itemKey(stageOuItem));
+      QueryItem item =
+          getQueryItem(dimension, pr, request.getOutputType(), request.getRelativePeriodDate());
+      if (item != null) {
+        params.addItem(item);
+        existingKeys.add(itemKey(item));
       }
     } catch (IllegalQueryException ignored) {
       // Unknown stage prefix — leave it to the downstream grid retain check.
@@ -483,6 +506,10 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
     return EventAnalyticsColumnName.OU_COLUMN_NAME.equalsIgnoreCase(suffix)
         || EventAnalyticsColumnName.OU_NAME_COLUMN_NAME.equalsIgnoreCase(suffix)
         || EventAnalyticsColumnName.OU_CODE_COLUMN_NAME.equalsIgnoreCase(suffix);
+  }
+
+  private static boolean isStageEventDateSuffix(String suffix) {
+    return ColumnHeader.EVENT_DATE.getItem().equalsIgnoreCase(suffix);
   }
 
   private static boolean isStaticColumnSuffix(String suffix) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -398,8 +398,11 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
    * Promotes each {@code headers=} entry of the form {@code {stageUid}.{itemUid}} into a {@link
    * QueryItem} when it doesn't already exist as a dimension or item and its suffix isn't a known
    * static column. This lets clients request stage-scoped data element / attribute columns without
-   * having to repeat them in {@code dimension=}. Resolver failures are swallowed so unresolvable
-   * suffixes surface as E7230 downstream in the usual way.
+   * having to repeat them in {@code dimension=}. Stage-OU helper suffixes ({@code ou}, {@code
+   * ouname}, {@code oucode}) are promoted by synthesising an unfiltered {@code {stageUid}.ou}
+   * dimension item, which is what the CTE generator uses to emit the stage-scoped {@code
+   * ouname}/{@code oucode} columns. Resolver failures are swallowed so unresolvable suffixes
+   * surface as E7230 downstream in the usual way.
    */
   private void addHeaderOnlyItemsToParams(
       EventQueryParams.Builder params, EventDataQueryRequest request, Program pr) {
@@ -419,7 +422,16 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
         continue;
       }
 
-      if (isStaticColumnSuffix(header.substring(dot + 1))) {
+      String prefix = header.substring(0, dot);
+      String suffix = header.substring(dot + 1);
+
+      if (isStageOuHelperSuffix(suffix)
+          && request.getEndpointItem() == RequestTypeAware.EndpointItem.ENROLLMENT) {
+        promoteStageOuDimension(params, request, pr, prefix, existingKeys);
+        continue;
+      }
+
+      if (isStaticColumnSuffix(suffix)) {
         continue;
       }
 
@@ -440,9 +452,37 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
     }
   }
 
+  private void promoteStageOuDimension(
+      EventQueryParams.Builder params,
+      EventDataQueryRequest request,
+      Program pr,
+      String stagePrefix,
+      Set<String> existingKeys) {
+    String stageOuKey = stagePrefix + "." + EventAnalyticsColumnName.OU_COLUMN_NAME;
+    if (existingKeys.contains(stageOuKey)) {
+      return;
+    }
+    try {
+      QueryItem stageOuItem =
+          getQueryItem(stageOuKey, pr, request.getOutputType(), request.getRelativePeriodDate());
+      if (stageOuItem != null) {
+        params.addItem(stageOuItem);
+        existingKeys.add(itemKey(stageOuItem));
+      }
+    } catch (IllegalQueryException ignored) {
+      // Unknown stage prefix — leave it to the downstream grid retain check.
+    }
+  }
+
   private static String itemKey(QueryItem item) {
     String uid = item.getItemId();
     return item.hasProgramStage() ? item.getProgramStage().getUid() + "." + uid : uid;
+  }
+
+  private static boolean isStageOuHelperSuffix(String suffix) {
+    return EventAnalyticsColumnName.OU_COLUMN_NAME.equalsIgnoreCase(suffix)
+        || EventAnalyticsColumnName.OU_NAME_COLUMN_NAME.equalsIgnoreCase(suffix)
+        || EventAnalyticsColumnName.OU_CODE_COLUMN_NAME.equalsIgnoreCase(suffix);
   }
 
   private static boolean isStaticColumnSuffix(String suffix) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -395,14 +395,20 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
   }
 
   /**
-   * Promotes each {@code headers=} entry of the form {@code {stageUid}.{itemUid}} into a {@link
-   * QueryItem} when it doesn't already exist as a dimension or item and its suffix isn't a known
-   * static column. This lets clients request stage-scoped data element / attribute columns without
-   * having to repeat them in {@code dimension=}. On the enrollment endpoint, stage-scoped static
-   * column headers (e.g. {@code {stageUid}.ouname}, {@code {stageUid}.eventdate}) are promoted by
-   * synthesising the corresponding unfiltered stage dimension item so the CTE generator emits the
-   * matching output column. Resolver failures are swallowed so unresolvable suffixes surface as
-   * E7230 downstream in the usual way.
+   * Promotes a {@code headers=} entry into a {@link QueryItem} when it isn't already present as a
+   * dimension or item and isn't a known static column. Two shapes are supported:
+   *
+   * <ul>
+   *   <li>{@code {stageUid}.{itemUid}} — stage-scoped data element / attribute. On the enrollment
+   *       endpoint, stage-scoped static column headers (e.g. {@code {stageUid}.ouname}, {@code
+   *       {stageUid}.eventdate}) are promoted by synthesising the corresponding unfiltered stage
+   *       dimension item so the CTE generator emits the matching output column.
+   *   <li>Flat {@code itemUid} — program-level tracked entity attribute or data element. Only
+   *       promoted on query endpoints; aggregate endpoints don't use {@code headers=} this way.
+   * </ul>
+   *
+   * <p>Resolver failures are swallowed so truly unknown headers surface as E7230 downstream in the
+   * usual way.
    */
   private void addHeaderOnlyItemsToParams(
       EventQueryParams.Builder params, EventDataQueryRequest request, Program pr) {
@@ -411,64 +417,130 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       return;
     }
 
-    Set<String> existingKeys =
-        params.build().getItems().stream()
-            .map(DefaultEventDataQueryService::itemKey)
-            .collect(Collectors.toSet());
-
-    boolean enrollment = request.getEndpointItem() == RequestTypeAware.EndpointItem.ENROLLMENT;
+    Set<String> existingKeys = collectExistingHeaderKeys(params);
 
     for (String header : headers) {
-      int dot = header.lastIndexOf('.');
-      if (dot <= 0 || dot >= header.length() - 1) {
-        continue;
-      }
+      if (handleStagePrefixedSpecialCase(header, params, request, pr, existingKeys)) continue;
+      if (shouldSkipHeader(header, request)) continue;
+      promoteHeaderToItem(header, params, request, pr, existingKeys);
+    }
+  }
 
-      String prefix = header.substring(0, dot);
-      String suffix = header.substring(dot + 1);
+  /**
+   * Collects identifiers for every column the grid will already produce — both items and
+   * dimensions. Stage-prefixed categories / COGS land on {@code params.getDimensions()} (their
+   * {@code getDimension()} returns the full {@code stage.uid} key); items contribute their {@link
+   * #itemKey} form. Headers that match either are left to the existing column rather than promoted
+   * into a duplicate {@link QueryItem}.
+   */
+  private static Set<String> collectExistingHeaderKeys(EventQueryParams.Builder params) {
+    EventQueryParams built = params.build();
+    Set<String> keys = new LinkedHashSet<>();
+    built.getItems().stream().map(DefaultEventDataQueryService::itemKey).forEach(keys::add);
+    built.getDimensions().stream()
+        .map(DimensionalObject::getDimension)
+        .filter(Objects::nonNull)
+        .forEach(keys::add);
+    return keys;
+  }
 
-      if (enrollment && isStageOuHelperSuffix(suffix)) {
-        promoteStageDimension(
-            params,
-            request,
-            pr,
-            prefix,
-            EventAnalyticsColumnName.OU_COLUMN_NAME,
-            EventAnalyticsColumnName.OU_COLUMN_NAME,
-            existingKeys);
-        continue;
-      }
+  /**
+   * Handles every stage-prefixed shape that should short-circuit the main loop: enrollment-only OU
+   * helpers and {@code eventdate} (which synthesise a stage dimension), and any stage-prefixed
+   * static column header (which is left to natural grid resolution). Returns {@code true} when the
+   * header was claimed and the caller should {@code continue}; {@code false} otherwise — including
+   * for stage-prefixed real items, which fall through to the generic promotion path.
+   */
+  private boolean handleStagePrefixedSpecialCase(
+      String header,
+      EventQueryParams.Builder params,
+      EventDataQueryRequest request,
+      Program pr,
+      Set<String> existingKeys) {
+    if (!isStagePrefixed(header)) {
+      return false;
+    }
 
-      if (enrollment && isStageEventDateSuffix(suffix)) {
-        promoteStageDimension(
-            params,
-            request,
-            pr,
-            prefix,
-            EVENT_DATE_DIMENSION,
-            EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME,
-            existingKeys);
-        continue;
-      }
+    int dot = header.lastIndexOf('.');
+    String prefix = header.substring(0, dot);
+    String suffix = header.substring(dot + 1);
+    boolean enrollment = request.getEndpointItem() == RequestTypeAware.EndpointItem.ENROLLMENT;
 
-      if (isStaticColumnSuffix(suffix)) {
-        continue;
-      }
+    if (enrollment && isStageOuHelperSuffix(suffix)) {
+      promoteStageDimension(
+          params,
+          request,
+          pr,
+          prefix,
+          EventAnalyticsColumnName.OU_COLUMN_NAME,
+          EventAnalyticsColumnName.OU_COLUMN_NAME,
+          existingKeys);
+      return true;
+    }
 
-      if (existingKeys.contains(header)) {
-        continue;
-      }
+    if (enrollment && isStageEventDateSuffix(suffix)) {
+      promoteStageDimension(
+          params,
+          request,
+          pr,
+          prefix,
+          EVENT_DATE_DIMENSION,
+          EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME,
+          existingKeys);
+      return true;
+    }
 
-      try {
-        QueryItem queryItem =
-            getQueryItem(header, pr, request.getOutputType(), request.getRelativePeriodDate());
-        if (queryItem != null) {
-          params.addItem(queryItem);
-          existingKeys.add(itemKey(queryItem));
-        }
-      } catch (IllegalQueryException ignored) {
-        // Let the downstream grid retain check surface the usual E7230 for truly unknown headers.
+    return isStaticColumnSuffix(suffix);
+  }
+
+  /**
+   * Returns {@code true} for flat headers that should be ignored — non-query endpoints (aggregate
+   * doesn't use {@code headers=} this way) and static {@link ColumnHeader} names that the grid
+   * already produces. Stage-prefixed headers always return {@code false} here; they're handled by
+   * {@link #handleStagePrefixedSpecialCase}.
+   */
+  private static boolean shouldSkipHeader(String header, EventDataQueryRequest request) {
+    if (isStagePrefixed(header)) {
+      return false;
+    }
+    if (request.getEndpointAction() != RequestTypeAware.EndpointAction.QUERY) {
+      return true;
+    }
+    return isStaticColumnSuffix(header);
+  }
+
+  /**
+   * Returns {@code true} when the header has the {@code {stageUid}.{suffix}} shape — i.e. an
+   * interior dot with non-empty text on both sides. A leading or trailing dot doesn't count.
+   */
+  private static boolean isStagePrefixed(String header) {
+    int dot = header.lastIndexOf('.');
+    return dot > 0 && dot < header.length() - 1;
+  }
+
+  /**
+   * Resolves the header against {@link #getQueryItem} and adds the resulting {@link QueryItem} to
+   * the params, skipping headers already present in {@code existingKeys}. {@link
+   * IllegalQueryException}s are swallowed so unresolvable headers surface as E7230 downstream.
+   */
+  private void promoteHeaderToItem(
+      String header,
+      EventQueryParams.Builder params,
+      EventDataQueryRequest request,
+      Program pr,
+      Set<String> existingKeys) {
+    if (existingKeys.contains(header)) {
+      return;
+    }
+    try {
+      QueryItem queryItem =
+          getQueryItem(header, pr, request.getOutputType(), request.getRelativePeriodDate());
+      if (queryItem != null) {
+        params.addItem(queryItem);
+        existingKeys.add(itemKey(queryItem));
       }
+    } catch (IllegalQueryException ignored) {
+      // Let the downstream grid retain check surface the usual E7230 for truly unknown headers.
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -175,6 +175,8 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
 
     addFiltersToParams(params, request, userOrgUnits, pr, idScheme, enrollmentStatuses);
 
+    addHeaderOnlyItemsToParams(params, request, pr);
+
     addSortToParams(params, request, pr);
 
     if (request.getAggregationType() != null) {
@@ -390,6 +392,67 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
   @Override
   public QueryItem getQueryItem(String dimensionString, Program program, EventOutputType type) {
     return getQueryItem(dimensionString, program, type, null);
+  }
+
+  /**
+   * Promotes each {@code headers=} entry of the form {@code {stageUid}.{itemUid}} into a {@link
+   * QueryItem} when it doesn't already exist as a dimension or item and its suffix isn't a known
+   * static column. This lets clients request stage-scoped data element / attribute columns without
+   * having to repeat them in {@code dimension=}. Resolver failures are swallowed so unresolvable
+   * suffixes surface as E7230 downstream in the usual way.
+   */
+  private void addHeaderOnlyItemsToParams(
+      EventQueryParams.Builder params, EventDataQueryRequest request, Program pr) {
+    Set<String> headers = request.getHeaders();
+    if (headers == null || headers.isEmpty() || pr == null) {
+      return;
+    }
+
+    Set<String> existingKeys =
+        params.build().getItems().stream()
+            .map(DefaultEventDataQueryService::itemKey)
+            .collect(Collectors.toSet());
+
+    for (String header : headers) {
+      int dot = header.lastIndexOf('.');
+      if (dot <= 0 || dot >= header.length() - 1) {
+        continue;
+      }
+
+      if (isStaticColumnSuffix(header.substring(dot + 1))) {
+        continue;
+      }
+
+      if (existingKeys.contains(header)) {
+        continue;
+      }
+
+      try {
+        QueryItem queryItem =
+            getQueryItem(header, pr, request.getOutputType(), request.getRelativePeriodDate());
+        if (queryItem != null) {
+          params.addItem(queryItem);
+          existingKeys.add(itemKey(queryItem));
+        }
+      } catch (IllegalQueryException ignored) {
+        // Let the downstream grid retain check surface the usual E7230 for truly unknown headers.
+      }
+    }
+  }
+
+  private static String itemKey(QueryItem item) {
+    String uid = item.getItemId();
+    return item.hasProgramStage() ? item.getProgramStage().getUid() + "." + uid : uid;
+  }
+
+  private static boolean isStaticColumnSuffix(String suffix) {
+    for (ColumnHeader candidate : ColumnHeader.values()) {
+      if (candidate.getItem().equalsIgnoreCase(suffix)
+          || candidate.name().equalsIgnoreCase(suffix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void addSortToParams(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -427,16 +427,28 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
   }
 
   /**
-   * Collects identifiers for every column the grid will already produce — both items and
-   * dimensions. Stage-prefixed categories / COGS land on {@code params.getDimensions()} (their
-   * {@code getDimension()} returns the full {@code stage.uid} key); items contribute their {@link
-   * #itemKey} form. Headers that match either are left to the existing column rather than promoted
-   * into a duplicate {@link QueryItem}.
+   * Collects identifiers for every column the grid will already produce, so a header naming any of
+   * them is left alone instead of being promoted into a duplicate {@link QueryItem}. Three forms
+   * are emitted per source:
+   *
+   * <ul>
+   *   <li>{@link #itemKey(QueryItem)} for each item — matches plain {@code stage.uid} headers.
+   *   <li>{@code RepeatableStageParams.getDimension()} for repeatable-stage offset items — matches
+   *       {@code stage[N].uid} headers, which would otherwise bypass dedup and trigger E7243.
+   *   <li>{@link DimensionalObject#getDimension()} for each dimension — matches stage-prefixed
+   *       categories / COGS that land on {@code params.getDimensions()} rather than items.
+   * </ul>
    */
   private static Set<String> collectExistingHeaderKeys(EventQueryParams.Builder params) {
     EventQueryParams built = params.build();
     Set<String> keys = new LinkedHashSet<>();
-    built.getItems().stream().map(DefaultEventDataQueryService::itemKey).forEach(keys::add);
+    for (QueryItem item : built.getItems()) {
+      keys.add(itemKey(item));
+      if (item.hasRepeatableStageParams()
+          && item.getRepeatableStageParams().getDimension() != null) {
+        keys.add(item.getRepeatableStageParams().getDimension());
+      }
+    }
     built.getDimensions().stream()
         .map(DimensionalObject::getDimension)
         .filter(Objects::nonNull)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -884,13 +884,17 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
         if (params.hasHeaders()) {
           if (params.getHeaders().contains(stageUid + ".ouname")) {
             columns.add(
-                quote(EventAnalyticsColumnName.OU_NAME_COLUMN_NAME)
+                sqlBuilder.quote(
+                        getStageOuValueColumnTableAlias(params),
+                        EventAnalyticsColumnName.OU_NAME_COLUMN_NAME)
                     + " as "
                     + quote(stageUid + ".ouname"));
           }
           if (params.getHeaders().contains(stageUid + ".oucode")) {
             columns.add(
-                quote(EventAnalyticsColumnName.OU_CODE_COLUMN_NAME)
+                sqlBuilder.quote(
+                        getStageOuValueColumnTableAlias(params),
+                        EventAnalyticsColumnName.OU_CODE_COLUMN_NAME)
                     + " as "
                     + quote(stageUid + ".oucode"));
           }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.analytics.common.EndpointItem;
 import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EventAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlConstants;
 import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlCoordinator;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagInfoInitializer;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagQueryGenerator;
@@ -874,9 +875,10 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
       if (ValueType.ORGANISATION_UNIT == queryItem.getValueType()
           && OrganisationUnitResolver.isStageOuDimension(queryItem)) {
         String stageUid = queryItem.getProgramStage().getUid();
-        // Main value column (uidlevelX from the event table)
+        // Main value column (uidlevelX), qualified to avoid ambiguity when ENROLLMENT_OU joins.
         OrganisationUnitResolver.StageOuCteContext stageOuContext =
-            organisationUnitResolver.buildStageOuCteContext(queryItem, params);
+            organisationUnitResolver.buildStageOuCteContext(
+                queryItem, params, getStageOuValueColumnTableAlias(params));
         columns.add(stageOuContext.valueColumn() + " as " + quote(stageUid + ".ou"));
         // Conditionally add ouname/oucode columns
         if (params.hasHeaders()) {
@@ -904,6 +906,12 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
         handleRowContext(columns, params, queryItem, columnAndAlias);
       }
     }
+  }
+
+  private String getStageOuValueColumnTableAlias(EventQueryParams params) {
+    return params.hasEnrollmentOu()
+        ? OrgUnitSqlConstants.ENROLLMENT_TABLE_ALIAS
+        : ANALYTICS_TBL_ALIAS;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/OrganisationUnitResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/OrganisationUnitResolver.java
@@ -270,6 +270,20 @@ public class OrganisationUnitResolver {
    * @return a {@link StageOuCteContext} containing the value column and filter condition
    */
   public StageOuCteContext buildStageOuCteContext(QueryItem item, EventQueryParams params) {
+    return buildStageOuCteContext(item, params, null);
+  }
+
+  /**
+   * Builds stage.ou filter conditions using uidlevelX columns, optionally qualifying the SELECT
+   * value column with a table alias.
+   *
+   * @param item the {@link QueryItem} representing the stage.ou dimension
+   * @param params the {@link EventQueryParams} used to resolve org unit keywords
+   * @param tableAlias optional table alias used for the value column
+   * @return a {@link StageOuCteContext} containing the value column and filter condition
+   */
+  public StageOuCteContext buildStageOuCteContext(
+      QueryItem item, EventQueryParams params, String tableAlias) {
     Map<Integer, List<OrganisationUnit>> orgUnitsByLevel =
         resolveOrgUnitsGroupedByLevel(params, item);
 
@@ -286,7 +300,9 @@ public class OrganisationUnitResolver {
 
     if (orgUnitsByLevel.isEmpty()) {
       return new StageOuCteContext(
-          sqlBuilder.quote("ou"), "", additionalSelectColumns); // fallback to raw ou column
+          quoteStageOuColumn("ou", tableAlias),
+          "",
+          additionalSelectColumns); // fallback to raw ou column
     }
 
     // Sort levels from most specific (highest) to least specific (lowest)
@@ -297,13 +313,13 @@ public class OrganisationUnitResolver {
     String valueColumn;
     if (sortedLevels.size() == 1) {
       // Single level: just use the column directly
-      valueColumn = sqlBuilder.quote("uidlevel" + sortedLevels.get(0));
+      valueColumn = quoteStageOuColumn("uidlevel" + sortedLevels.get(0), tableAlias);
     } else {
       // Multiple levels: use CASE to return the matching value
       StringBuilder caseExpr = new StringBuilder("case");
       for (int level : sortedLevels) {
         List<OrganisationUnit> orgUnits = orgUnitsByLevel.get(level);
-        String column = sqlBuilder.quote("uidlevel" + level);
+        String column = quoteStageOuColumn("uidlevel" + level, tableAlias);
         String quotedUids =
             orgUnits.stream()
                 .map(OrganisationUnit::getUid)
@@ -342,6 +358,12 @@ public class OrganisationUnitResolver {
         sortedLevels.size() > 1 ? "(" + conditions + ")" : conditions.toString();
 
     return new StageOuCteContext(valueColumn, filterCondition, additionalSelectColumns);
+  }
+
+  private String quoteStageOuColumn(String column, String tableAlias) {
+    return StringUtils.isBlank(tableAlias)
+        ? sqlBuilder.quote(column)
+        : sqlBuilder.quote(tableAlias, column);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
@@ -326,14 +326,16 @@ public class TrackedEntityFields {
 
   /**
    * Checks if the given {@link DimensionIdentifier} is eligible to be added as a header. It is
-   * eligible if it is a static dimension, and it is either an event or enrollment dimension.
+   * eligible if it is a data element, or if it is a static dimension and it is either an event or
+   * enrollment dimension.
    *
    * @param parsedHeader the {@link DimensionIdentifier}.
    * @return true if it is eligible, false otherwise.
    */
   private static boolean isEligible(DimensionIdentifier<DimensionParam> parsedHeader) {
-    return parsedHeader.getDimension().isStaticDimension()
-        && (parsedHeader.isEventDimension() || parsedHeader.isEnrollmentDimension());
+    return isDataElement(parsedHeader)
+        || (parsedHeader.getDimension().isStaticDimension()
+            && (parsedHeader.isEventDimension() || parsedHeader.isEnrollmentDimension()));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/HeaderHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/HeaderHelper.java
@@ -78,6 +78,23 @@ public class HeaderHelper {
           new GridHeader(PROGRAM_STATUS.getItem(), PROGRAM_STATUS.getName(), TEXT, false, true));
     }
 
+    if (params.hasEnrollmentOuDimension()) {
+      grid.addHeader(
+          new GridHeader(
+              ColumnHeader.ENROLLMENT_OU.getItem(),
+              ColumnHeader.ENROLLMENT_OU.getName(),
+              TEXT,
+              false,
+              true));
+      grid.addHeader(
+          new GridHeader(
+              ColumnHeader.ENROLLMENT_OU_NAME.getItem(),
+              ColumnHeader.ENROLLMENT_OU_NAME.getName(),
+              TEXT,
+              false,
+              true));
+    }
+
     DisplayProperty displayProperty = params.getDisplayProperty();
     HeaderBuildContext context = HeaderBuildContext.of(params, displayProperty);
 
@@ -113,23 +130,6 @@ public class HeaderHelper {
                   null));
         }
       }
-    }
-
-    if (params.hasEnrollmentOuDimension()) {
-      grid.addHeader(
-          new GridHeader(
-              ColumnHeader.ENROLLMENT_OU.getItem(),
-              ColumnHeader.ENROLLMENT_OU.getName(),
-              TEXT,
-              false,
-              true));
-      grid.addHeader(
-          new GridHeader(
-              ColumnHeader.ENROLLMENT_OU_NAME.getItem(),
-              ColumnHeader.ENROLLMENT_OU_NAME.getName(),
-              TEXT,
-              false,
-              true));
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/HeaderParamsHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/HeaderParamsHandlerTest.java
@@ -209,6 +209,49 @@ class HeaderParamsHandlerTest {
   }
 
   @Test
+  void testHandleWithHeaderOnlyStageScopedDataElementShortHeader() {
+    // Given
+    String stageUid = "A03MvHHogjR";
+    String programUid = "IpHINAT79UW";
+    String dataElementUid = "bx6fsa0t90x";
+    String shortHeader = stageUid + "." + dataElementUid;
+    Program program = new Program("program");
+    program.setUid(programUid);
+    ProgramStage stage = new ProgramStage("stage", program);
+    stage.setUid(stageUid);
+    DataElement dataElement = new DataElement("data element");
+    dataElement.setUid(dataElementUid);
+    dataElement.setValueType(ValueType.TEXT);
+    QueryItem queryItem = new QueryItem(dataElement, null, ValueType.TEXT, null, null);
+    DimensionIdentifier<DimensionParam> dataElementHeader =
+        DimensionIdentifier.of(
+            ElementWithOffset.of(program),
+            ElementWithOffset.of(stage),
+            DimensionParam.ofObject(
+                queryItem, DimensionParamType.HEADERS, IdScheme.UID, List.of()));
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setHeaders(new LinkedHashSet<>(List.of(shortHeader)));
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .commonRaw(requestParams)
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .parsedHeaders(new LinkedHashSet<>(List.of(dataElementHeader)))
+                    .build())
+            .build();
+    List<Field> fields = List.of(ofUnquoted("ev", of("anyName"), dataElementHeader.getKey()));
+    Grid grid = new ListGrid();
+
+    // When
+    headerParamsHandler.handle(grid, contextParams, fields);
+
+    // Then
+    assertEquals(1, grid.getHeaders().size());
+    assertEquals(shortHeader, grid.getHeaders().get(0).getName());
+  }
+
+  @Test
   void testHandleWithStageScopedDataElementFullHeader() {
     // Given
     String stageUid = "A03MvHHogjR";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -1441,6 +1441,43 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
+  void testExperimentalSelectClauseQualifiesStageOuLevelWhenEnrollmentOuJoinIsUsed() {
+    OrganisationUnit ouA = createOrganisationUnit('A');
+    ProgramStage stage = createProgramStage('B', programA);
+    stage.setUid("ZkbAXlQUYJG");
+
+    QueryItem stageOuItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OU_COLUMN_NAME),
+            programA,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            AggregationType.NONE,
+            null);
+    stageOuItem.setProgramStage(stage);
+
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withStartDate(from)
+            .withEndDate(to)
+            .withEnrollmentOuDimension(List.of(ouA))
+            .addItem(stageOuItem)
+            .build();
+
+    when(organisationUnitResolver.buildStageOuCteContext(stageOuItem, params, "enrl"))
+        .thenReturn(new OrganisationUnitResolver.StageOuCteContext("enrl.\"uidlevel1\"", "", ""));
+
+    SelectBuilder sb = new SelectBuilder();
+    eventSubject.addSelectClause(
+        sb, params, new CteContext(org.hisp.dhis.analytics.common.EndpointItem.EVENT));
+    String selectClause = sb.build();
+
+    assertThat(selectClause, containsString("enrl.\"uidlevel1\" as \"ZkbAXlQUYJG.ou\""));
+    assertTrue(!selectClause.contains(", \"uidlevel1\" as \"ZkbAXlQUYJG.ou\""));
+  }
+
+  @Test
   void testEnrollmentOuLevelConstraintUsesOrgUnitLevelColumn() {
     EventQueryParams params =
         new EventQueryParams.Builder()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -1478,6 +1478,44 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   }
 
   @Test
+  void testExperimentalSelectClauseQualifiesStageOuHeadersWhenEnrollmentOuJoinIsUsed() {
+    OrganisationUnit ouA = createOrganisationUnit('A');
+    ProgramStage stage = createProgramStage('B', programA);
+    stage.setUid("ZkbAXlQUYJG");
+
+    QueryItem stageOuItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OU_COLUMN_NAME),
+            programA,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            AggregationType.NONE,
+            null);
+    stageOuItem.setProgramStage(stage);
+
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withStartDate(from)
+            .withEndDate(to)
+            .withEnrollmentOuDimension(List.of(ouA))
+            .addItem(stageOuItem)
+            .withHeaders(Set.of("enrollmentouname", "ZkbAXlQUYJG.ouname"))
+            .build();
+
+    when(organisationUnitResolver.buildStageOuCteContext(stageOuItem, params, "enrl"))
+        .thenReturn(new OrganisationUnitResolver.StageOuCteContext("enrl.\"uidlevel1\"", "", ""));
+
+    SelectBuilder sb = new SelectBuilder();
+    eventSubject.addSelectClause(
+        sb, params, new CteContext(org.hisp.dhis.analytics.common.EndpointItem.EVENT));
+    String selectClause = sb.build();
+
+    assertThat(selectClause, containsString("enrl.\"ouname\" as \"ZkbAXlQUYJG.ouname\""));
+    assertTrue(!selectClause.contains(", \"ouname\" as \"ZkbAXlQUYJG.ouname\""));
+  }
+
+  @Test
   void testEnrollmentOuLevelConstraintUsesOrgUnitLevelColumn() {
     EventQueryParams params =
         new EventQueryParams.Builder()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -1263,6 +1263,70 @@ class DefaultEventDataQueryServiceTest {
   }
 
   @Test
+  void getFromRequestPromotesStageEventStatusDimensionFromStagePrefixedEventStatusHeader() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageEventStatusItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.EVENT_STATUS_COLUMN_NAME),
+            program,
+            null,
+            ValueType.TEXT,
+            AggregationType.NONE,
+            null);
+    stageEventStatusItem.setProgramStage(programStage);
+
+    String stageEventStatusDim = programStage.getUid() + ".EVENT_STATUS";
+    String stageEventStatusHeader = programStage.getUid() + ".eventstatus";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageEventStatusDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageEventStatusItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).headers(Set.of(stageEventStatusHeader)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(
+        EventAnalyticsColumnName.EVENT_STATUS_COLUMN_NAME, params.getItems().get(0).getItemId());
+    assertEquals(programStage.getUid(), params.getItems().get(0).getProgramStage().getUid());
+  }
+
+  @Test
+  void getFromRequestPromotesStageScheduledDateDimensionFromStagePrefixedScheduledDateHeader() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageScheduledDateItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.SCHEDULED_DATE_COLUMN_NAME),
+            program,
+            null,
+            ValueType.DATE,
+            AggregationType.NONE,
+            null);
+    stageScheduledDateItem.setProgramStage(programStage);
+
+    String stageScheduledDateDim = programStage.getUid() + ".SCHEDULED_DATE";
+    String stageScheduledDateHeader = programStage.getUid() + ".scheduleddate";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageScheduledDateDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageScheduledDateItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).headers(Set.of(stageScheduledDateHeader)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(
+        EventAnalyticsColumnName.SCHEDULED_DATE_COLUMN_NAME, params.getItems().get(0).getItemId());
+    assertEquals(programStage.getUid(), params.getItems().get(0).getProgramStage().getUid());
+  }
+
+  @Test
   void getFromRequestRejectsNonNumericAndNonBooleanValueTypes() {
     DataElement textElement = createDataElement('X', ValueType.TEXT, AggregationType.NONE);
     DataElement dateElement = createDataElement('D', ValueType.DATE, AggregationType.NONE);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -814,6 +814,96 @@ class DefaultEventDataQueryServiceTest {
   }
 
   @Test
+  void getFromRequestPromotesStagePrefixedHeaderIntoItemWhenNotInDimensions() {
+    ProgramStage programStage = createProgramStage('S', program);
+    DataElement dataElement = createDataElement('D', ValueType.NUMBER, AggregationType.SUM);
+    QueryItem dataElementItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(dataElement.getUid()),
+            program,
+            null,
+            ValueType.NUMBER,
+            AggregationType.SUM,
+            null);
+    dataElementItem.setProgramStage(programStage);
+
+    String headerAlias = programStage.getUid() + "." + dataElement.getUid();
+    when(queryItemLocator.getQueryItemFromDimension(headerAlias, program, EventOutputType.EVENT))
+        .thenReturn(dataElementItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT)
+            .headers(new LinkedHashSet<>(List.of("enrollmentouname", headerAlias)))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(dataElement.getUid(), params.getItems().get(0).getItemId());
+    assertEquals(programStage.getUid(), params.getItems().get(0).getProgramStage().getUid());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteStagePrefixedHeaderWhenSuffixIsStaticColumn() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    String headerAlias = programStage.getUid() + ".eventstatus";
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).headers(Set.of(headerAlias)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+    verify(queryItemLocator, times(0)).getQueryItemFromDimension(eq(headerAlias), any(), any());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteStagePrefixedHeaderAlreadyPresentAsItem() {
+    ProgramStage programStage = createProgramStage('S', program);
+    DataElement dataElement = createDataElement('D', ValueType.NUMBER, AggregationType.SUM);
+    QueryItem dataElementItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(dataElement.getUid()),
+            program,
+            null,
+            ValueType.NUMBER,
+            AggregationType.SUM,
+            null);
+    dataElementItem.setProgramStage(programStage);
+
+    String alias = programStage.getUid() + "." + dataElement.getUid();
+    when(queryItemLocator.getQueryItemFromDimension(alias, program, EventOutputType.EVENT))
+        .thenReturn(dataElementItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT)
+            .dimension(Set.of(Set.of(alias)))
+            .headers(Set.of(alias))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+  }
+
+  @Test
+  void getFromRequestSwallowsLocatorFailureForUnresolvableHeaderSuffix() {
+    ProgramStage programStage = createProgramStage('S', program);
+    String headerAlias = programStage.getUid() + ".notADataElement";
+
+    when(queryItemLocator.getQueryItemFromDimension(headerAlias, program, EventOutputType.EVENT))
+        .thenThrow(new IllegalQueryException(ErrorCode.E7224, headerAlias));
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).headers(Set.of(headerAlias)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+  }
+
+  @Test
   void getFromRequestRejectsNonNumericAndNonBooleanValueTypes() {
     DataElement textElement = createDataElement('X', ValueType.TEXT, AggregationType.NONE);
     DataElement dateElement = createDataElement('D', ValueType.DATE, AggregationType.NONE);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -904,6 +904,113 @@ class DefaultEventDataQueryServiceTest {
   }
 
   @Test
+  void getFromRequestPromotesStageOuDimensionFromStagePrefixedOuNameHeader() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageOuQueryItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OU_COLUMN_NAME),
+            program,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            AggregationType.NONE,
+            null);
+    stageOuQueryItem.setProgramStage(programStage);
+
+    String stageOuDim = programStage.getUid() + "." + EventAnalyticsColumnName.OU_COLUMN_NAME;
+    String stageOuNameHeader = programStage.getUid() + ".ouname";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageOuDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageOuQueryItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT)
+            .headers(new LinkedHashSet<>(List.of("ouname", stageOuNameHeader)))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(EventAnalyticsColumnName.OU_COLUMN_NAME, params.getItems().get(0).getItemId());
+    assertEquals(programStage.getUid(), params.getItems().get(0).getProgramStage().getUid());
+  }
+
+  @Test
+  void getFromRequestPromotesStageOuDimensionFromStagePrefixedOuCodeHeader() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageOuQueryItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OU_COLUMN_NAME),
+            program,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            AggregationType.NONE,
+            null);
+    stageOuQueryItem.setProgramStage(programStage);
+
+    String stageOuDim = programStage.getUid() + "." + EventAnalyticsColumnName.OU_COLUMN_NAME;
+    String stageOuCodeHeader = programStage.getUid() + ".oucode";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageOuDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageOuQueryItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).headers(Set.of(stageOuCodeHeader)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(EventAnalyticsColumnName.OU_COLUMN_NAME, params.getItems().get(0).getItemId());
+  }
+
+  @Test
+  void getFromRequestDoesNotDuplicateStageOuItemWhenAlreadyPresent() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageOuQueryItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OU_COLUMN_NAME),
+            program,
+            null,
+            ValueType.ORGANISATION_UNIT,
+            AggregationType.NONE,
+            null);
+    stageOuQueryItem.setProgramStage(programStage);
+
+    String stageOuDim = programStage.getUid() + "." + EventAnalyticsColumnName.OU_COLUMN_NAME;
+    String stageOuNameHeader = programStage.getUid() + ".ouname";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageOuDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageOuQueryItem);
+
+    // Force addDimensionsToParams to fall through to the QueryItem path so the stage.ou
+    // dimension ends up in params.getItems() (matches real production behaviour — the central
+    // dataQueryService does not recognise stage-prefixed ou dimensions).
+    when(dataQueryService.getDimension(
+            eq(stageOuDim),
+            anyList(),
+            any(EventDataQueryRequest.class),
+            anyList(),
+            anyBoolean(),
+            any()))
+        .thenReturn(null);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT)
+            .dimension(Set.of(Set.of(stageOuDim)))
+            .headers(Set.of(stageOuNameHeader))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+  }
+
+  @Test
   void getFromRequestRejectsNonNumericAndNonBooleanValueTypes() {
     DataElement textElement = createDataElement('X', ValueType.TEXT, AggregationType.NONE);
     DataElement dateElement = createDataElement('D', ValueType.DATE, AggregationType.NONE);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -71,6 +71,7 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -1104,6 +1105,74 @@ class DefaultEventDataQueryServiceTest {
     EventQueryParams params = subject.getFromRequest(request);
 
     assertTrue(params.getItems().isEmpty());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteRepeatableStageOffsetHeaderAlreadyPresentAsItem() {
+    // Repeatable-stage offset dimensions like uvMKOn1oWvd[0].DX4LVYeP7bw land on
+    // params.getItems() with their RepeatableStageParams set. Headers using the same [N].uid
+    // notation must dedup against them, otherwise a second QueryItem with the same offset is
+    // promoted and the validator raises E7243 (duplicate stage dimension identifier).
+    ProgramStage programStage = createProgramStage('S', program);
+    DataElement dataElement = createDataElement('D', ValueType.NUMBER, AggregationType.SUM);
+
+    String offsetDim0 = programStage.getUid() + "[0]." + dataElement.getUid();
+    String offsetDim1 = programStage.getUid() + "[1]." + dataElement.getUid();
+
+    // Force the dimension path to fall through to getQueryItem so the offset items land on
+    // params.getItems() with their RepeatableStageParams — matching production behaviour where
+    // dataQueryService.getDimension does not recognise stage-offset notation.
+    when(dataQueryService.getDimension(
+            eq(offsetDim0),
+            anyList(),
+            any(EventDataQueryRequest.class),
+            anyList(),
+            anyBoolean(),
+            any()))
+        .thenReturn(null);
+    when(dataQueryService.getDimension(
+            eq(offsetDim1),
+            anyList(),
+            any(EventDataQueryRequest.class),
+            anyList(),
+            anyBoolean(),
+            any()))
+        .thenReturn(null);
+
+    when(queryItemLocator.getQueryItemFromDimension(offsetDim0, program, EventOutputType.EVENT))
+        .thenAnswer(inv -> newOffsetItem(programStage, dataElement, 0, offsetDim0));
+    when(queryItemLocator.getQueryItemFromDimension(offsetDim1, program, EventOutputType.EVENT))
+        .thenAnswer(inv -> newOffsetItem(programStage, dataElement, 1, offsetDim1));
+
+    Set<Set<String>> dimension = new LinkedHashSet<>();
+    dimension.add(Set.of(offsetDim0));
+    dimension.add(Set.of(offsetDim1));
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT)
+            .dimension(dimension)
+            .headers(new LinkedHashSet<>(List.of(offsetDim0, offsetDim1)))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(2, params.getItems().size());
+    assertTrue(params.getDuplicateStageDimensionIdentifiers().isEmpty());
+  }
+
+  private QueryItem newOffsetItem(
+      ProgramStage stage, DataElement de, int offset, String dimension) {
+    QueryItem qi =
+        new QueryItem(
+            new BaseDimensionalItemObject(de.getUid()),
+            program,
+            null,
+            ValueType.NUMBER,
+            AggregationType.SUM,
+            null);
+    qi.setProgramStage(stage);
+    qi.setRepeatableStageParams(RepeatableStageParams.of(offset, dimension));
+    return qi;
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -1011,6 +1011,157 @@ class DefaultEventDataQueryServiceTest {
   }
 
   @Test
+  void getFromRequestPromotesFlatTrackedEntityAttributeHeaderIntoItem() {
+    QueryItem teaItem =
+        new QueryItem(
+            new BaseDimensionalItemObject("cejWyOfXge6"),
+            program,
+            null,
+            ValueType.TEXT,
+            AggregationType.NONE,
+            null);
+
+    when(queryItemLocator.getQueryItemFromDimension("cejWyOfXge6", program, EventOutputType.EVENT))
+        .thenReturn(teaItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).headers(Set.of("cejWyOfXge6")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals("cejWyOfXge6", params.getItems().get(0).getItemId());
+  }
+
+  @Test
+  void getFromRequestPromotesFlatTrackedEntityAttributeHeaderForEnrollmentEndpoint() {
+    QueryItem teaItem =
+        new QueryItem(
+            new BaseDimensionalItemObject("cejWyOfXge6"),
+            program,
+            null,
+            ValueType.TEXT,
+            AggregationType.NONE,
+            null);
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            "cejWyOfXge6", program, EventOutputType.ENROLLMENT))
+        .thenReturn(teaItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).headers(Set.of("cejWyOfXge6")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals("cejWyOfXge6", params.getItems().get(0).getItemId());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteFlatHeaderWhenStaticColumn() {
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).headers(Set.of("eventdate")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+    verify(queryItemLocator, times(0)).getQueryItemFromDimension(eq("eventdate"), any(), any());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteFlatHeaderAlreadyPresentAsItem() {
+    QueryItem teaItem =
+        new QueryItem(
+            new BaseDimensionalItemObject("cejWyOfXge6"),
+            program,
+            null,
+            ValueType.TEXT,
+            AggregationType.NONE,
+            null);
+
+    when(queryItemLocator.getQueryItemFromDimension("cejWyOfXge6", program, EventOutputType.EVENT))
+        .thenReturn(teaItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT)
+            .dimension(Set.of(Set.of("cejWyOfXge6")))
+            .headers(Set.of("cejWyOfXge6"))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+  }
+
+  @Test
+  void getFromRequestSwallowsLocatorFailureForUnresolvableFlatHeader() {
+    when(queryItemLocator.getQueryItemFromDimension("notReal", program, EventOutputType.EVENT))
+        .thenThrow(new IllegalQueryException(ErrorCode.E7224, "notReal"));
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).headers(Set.of("notReal")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteStagePrefixedHeaderAlreadyPresentAsDimension() {
+    // Stage-prefixed category / COGS dimensions are stored on params.getDimensions(), not on
+    // params.getItems(). The header dedup must still recognise them so we don't synthesise a
+    // duplicate (and value-type-less) QueryItem that crashes downstream grid header building.
+    String stageCategory = "kO3z4Dhc038.LFsZ8v5v7rq";
+
+    BaseDimensionalObject stageCategoryDim = new BaseDimensionalObject();
+    stageCategoryDim.setUid(stageCategory);
+    stageCategoryDim.setDimensionType(DimensionType.CATEGORY);
+    stageCategoryDim.setDimensionName("LFsZ8v5v7rq");
+
+    when(dataQueryService.getDimension(
+            eq(stageCategory),
+            anyList(),
+            any(EventDataQueryRequest.class),
+            anyList(),
+            anyBoolean(),
+            any()))
+        .thenReturn(stageCategoryDim);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT)
+            .dimension(Set.of(Set.of(stageCategory + ":CW81uF03hvV;B3nxOazOO2G")))
+            .headers(Set.of(stageCategory))
+            .build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+    verify(queryItemLocator, times(0)).getQueryItemFromDimension(eq(stageCategory), any(), any());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteFlatHeaderOnEventAggregateEndpoint() {
+    EventDataQueryRequest request =
+        baseRequestBuilder(AGGREGATE, EVENT).headers(Set.of("cejWyOfXge6")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+    verify(queryItemLocator, times(0)).getQueryItemFromDimension(eq("cejWyOfXge6"), any(), any());
+  }
+
+  @Test
+  void getFromRequestDoesNotPromoteFlatHeaderOnEnrollmentAggregateEndpoint() {
+    EventDataQueryRequest request =
+        baseRequestBuilder(AGGREGATE, ENROLLMENT).headers(Set.of("cejWyOfXge6")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertTrue(params.getItems().isEmpty());
+    verify(queryItemLocator, times(0)).getQueryItemFromDimension(eq("cejWyOfXge6"), any(), any());
+  }
+
+  @Test
   void getFromRequestPromotesStageEventDateDimensionFromStagePrefixedEventDateHeader() {
     ProgramStage programStage = createProgramStage('S', program);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -1011,6 +1011,38 @@ class DefaultEventDataQueryServiceTest {
   }
 
   @Test
+  void getFromRequestPromotesStageEventDateDimensionFromStagePrefixedEventDateHeader() {
+    ProgramStage programStage = createProgramStage('S', program);
+
+    QueryItem stageEventDateItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME),
+            program,
+            null,
+            ValueType.DATE,
+            AggregationType.NONE,
+            null);
+    stageEventDateItem.setProgramStage(programStage);
+
+    String stageEventDateDim = programStage.getUid() + ".EVENT_DATE";
+    String stageEventDateHeader = programStage.getUid() + ".eventdate";
+
+    when(queryItemLocator.getQueryItemFromDimension(
+            stageEventDateDim, program, EventOutputType.ENROLLMENT))
+        .thenReturn(stageEventDateItem);
+
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).headers(Set.of(stageEventDateHeader)).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getItems().size());
+    assertEquals(
+        EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME, params.getItems().get(0).getItemId());
+    assertEquals(programStage.getUid(), params.getItems().get(0).getProgramStage().getUid());
+  }
+
+  @Test
   void getFromRequestRejectsNonNumericAndNonBooleanValueTypes() {
     DataElement textElement = createDataElement('X', ValueType.TEXT, AggregationType.NONE);
     DataElement dateElement = createDataElement('D', ValueType.DATE, AggregationType.NONE);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageOrgUnitSqlServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageOrgUnitSqlServiceTest.java
@@ -118,6 +118,45 @@ class StageOrgUnitSqlServiceTest {
     assertEquals("", subject.whereClause(item, params, AnalyticsType.EVENT));
   }
 
+  @Test
+  void shouldQualifySingleLevelStageOuValueColumnWhenAliasIsProvided() {
+    AliasAwareResolver resolver = new AliasAwareResolver();
+    resolver.orgUnitsByLevel = Map.of(1, List.of(orgUnit("ouL1AAAAAAA")));
+
+    OrganisationUnitResolver.StageOuCteContext context =
+        resolver.buildStageOuCteContext(
+            createStageOuItem(), new EventQueryParams.Builder().build(), "enrl");
+
+    assertEquals("enrl.\"uidlevel1\"", context.valueColumn());
+  }
+
+  @Test
+  void shouldQualifyFallbackStageOuValueColumnWhenAliasIsProvided() {
+    AliasAwareResolver resolver = new AliasAwareResolver();
+
+    OrganisationUnitResolver.StageOuCteContext context =
+        resolver.buildStageOuCteContext(
+            createStageOuItem(), new EventQueryParams.Builder().build(), "enrl");
+
+    assertEquals("enrl.\"ou\"", context.valueColumn());
+  }
+
+  @Test
+  void shouldQualifyMultiLevelStageOuCaseExpressionWhenAliasIsProvided() {
+    AliasAwareResolver resolver = new AliasAwareResolver();
+    resolver.orgUnitsByLevel =
+        Map.of(2, List.of(orgUnit("ouL2AAAAAAA")), 3, List.of(orgUnit("ouL3BBBBBBB")));
+
+    OrganisationUnitResolver.StageOuCteContext context =
+        resolver.buildStageOuCteContext(
+            createStageOuItem(), new EventQueryParams.Builder().build(), "enrl");
+
+    assertEquals(
+        "case when enrl.\"uidlevel3\" in ('ouL3BBBBBBB') THEN enrl.\"uidlevel3\""
+            + " when enrl.\"uidlevel2\" in ('ouL2AAAAAAA') THEN enrl.\"uidlevel2\" end",
+        context.valueColumn());
+  }
+
   private QueryItem createStageOuItem() {
     DataElement dataElement = new DataElement();
     dataElement.setUid("ou");
@@ -126,6 +165,12 @@ class StageOrgUnitSqlServiceTest {
     programStage.setUid("s1234567890");
     item.setProgramStage(programStage);
     return item;
+  }
+
+  private OrganisationUnit orgUnit(String uid) {
+    OrganisationUnit orgUnit = new OrganisationUnit();
+    orgUnit.setUid(uid);
+    return orgUnit;
   }
 
   private static class TestResolver extends OrganisationUnitResolver {
@@ -145,6 +190,20 @@ class StageOrgUnitSqlServiceTest {
     @Override
     public StageOuCteContext buildStageOuCteContext(QueryItem item, EventQueryParams params) {
       return stageOuCteContext;
+    }
+  }
+
+  private static class AliasAwareResolver extends OrganisationUnitResolver {
+    private Map<Integer, List<OrganisationUnit>> orgUnitsByLevel = Map.of();
+
+    private AliasAwareResolver() {
+      super(null, null, null, new PostgreSqlAnalyticsSqlBuilder());
+    }
+
+    @Override
+    public Map<Integer, List<OrganisationUnit>> resolveOrgUnitsGroupedByLevel(
+        EventQueryParams params, QueryItem item) {
+      return orgUnitsByLevel;
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/HeaderHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/HeaderHelperTest.java
@@ -347,6 +347,32 @@ class HeaderHelperTest {
   }
 
   @Test
+  @DisplayName("enrollmentou/enrollmentouname headers must precede item headers to match SQL order")
+  void enrollmentOuHeadersPrecedeItemHeaders() {
+    Grid grid = new ListGrid();
+
+    QueryItem item = queryItem("deUidA001", "Item A", TEXT);
+
+    BaseDimensionalItemObject ouItem = new BaseDimensionalItemObject("ouUid", "ou", "Ngelehun");
+
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addItem(item)
+            .withEnrollmentOuDimension(List.of(ouItem))
+            .withDisplayProperty(DisplayProperty.NAME)
+            .build();
+
+    HeaderHelper.addCommonHeaders(grid, params, List.of());
+
+    List<GridHeader> headers = grid.getHeaders();
+
+    assertEquals(3, headers.size());
+    assertEquals("enrollmentou", headers.get(0).getName());
+    assertEquals("enrollmentouname", headers.get(1).getName());
+    assertEquals("deUidA001", headers.get(2).getName());
+  }
+
+  @Test
   @DisplayName("stage.ou without headers param should only add ou header")
   void stageOuWithNoHeadersParam() {
     Grid grid = new ListGrid();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
@@ -1193,45 +1193,70 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     boolean expectPostgis = isPostgres();
 
     // Given
-    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
             .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
             .add("displayProperty=NAME")
             .add("totalPages=false")
             .add("pageSize=100")
             .add("page=1")
             .add("dimension=pe:202301")
-            .add("desc=enrollmentdate,ouname")
-            ;
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 100, 2, 2); // Pass runtime flag, row count, and expected header counts
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        100,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
             .map(obj -> (Map<String, Object>) obj) // Ensure correct type
             .collect(Collectors.toList());
 
-
     // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(response, actualHeaders,"enrollmentdate", "Date of enrollment", "DATETIME", "java.time.LocalDateTime", false, true);
-    validateHeaderPropertiesByName(response, actualHeaders,"ZzYYXq4fJie.ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
     // 7. Assert row values by name at specific indices (sorted results).
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
-    validateRowValueByName(response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+    validateRowValueByName(
+        response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2023-01-31 12:05:00.0");
@@ -1255,7 +1280,8 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2023-01-29 12:05:00.0");
-    validateRowValueByName(response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
+    validateRowValueByName(
+        response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2023-01-29 12:05:00.0");

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
@@ -1188,6 +1188,97 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
   }
 
   @Test
+  public void validateStagePrefixedOuNameHeaderAlongsideEnrollmentOuName() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+            .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=pe:202301")
+            .add("desc=enrollmentdate,ouname")
+            ;
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 100, 2, 2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(response, actualHeaders,"enrollmentdate", "Date of enrollment", "DATETIME", "java.time.LocalDateTime", false, true);
+    validateHeaderPropertiesByName(response, actualHeaders,"ZzYYXq4fJie.ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2023-01-31 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 9, "ZzYYXq4fJie.ouname", "Mendewa MCHP");
+
+    // Validate selected values for row index 18
+    validateRowValueByName(response, actualHeaders, 18, "enrollmentdate", "2023-01-31 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 18, "ZzYYXq4fJie.ouname", "Kambawama MCHP");
+
+    // Validate selected values for row index 27
+    validateRowValueByName(response, actualHeaders, 27, "enrollmentdate", "2023-01-30 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 27, "ZzYYXq4fJie.ouname", "Seria MCHP");
+
+    // Validate selected values for row index 36
+    validateRowValueByName(response, actualHeaders, 36, "enrollmentdate", "2023-01-30 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 36, "ZzYYXq4fJie.ouname", "Masamboi MCHP");
+
+    // Validate selected values for row index 45
+    validateRowValueByName(response, actualHeaders, 45, "enrollmentdate", "2023-01-30 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 45, "ZzYYXq4fJie.ouname", "Hinistas CHC");
+
+    // Validate selected values for row index 54
+    validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2023-01-29 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
+
+    // Validate selected values for row index 63
+    validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2023-01-29 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 63, "ZzYYXq4fJie.ouname", "Mamusa MCHP");
+
+    // Validate selected values for row index 72
+    validateRowValueByName(response, actualHeaders, 72, "enrollmentdate", "2023-01-29 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 72, "ZzYYXq4fJie.ouname", "Kakoya MCHP");
+
+    // Validate selected values for row index 81
+    validateRowValueByName(response, actualHeaders, 81, "enrollmentdate", "2023-01-28 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 81, "ZzYYXq4fJie.ouname", "Ngaiya MCHP");
+
+    // Validate selected values for row index 90
+    validateRowValueByName(response, actualHeaders, 90, "enrollmentdate", "2023-01-28 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 90, "ZzYYXq4fJie.ouname", "Karleh MCHP");
+
+    // Validate selected values for row index 99
+    validateRowValueByName(response, actualHeaders, 99, "enrollmentdate", "2023-01-27 12:05:00.0");
+    validateRowValueByName(response, actualHeaders, 99, "ZzYYXq4fJie.ouname", "Yoni CHC");
+  }
+
+  @Test
   public void ouMultipleLevels() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -56,16 +56,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,A03MvHHogjR.eventdate")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("outputType=ENROLLMENT")
-                    .add("pageSize=10")
-                    .add("page=1")
-                    .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.EVENT_DATE:2021")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,A03MvHHogjR.eventdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=10")
+            .add("page=1")
+            .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.EVENT_DATE:2021")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -75,52 +75,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            10,
-            3,
-            3); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        10,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.eventdate",
-            "Report date",
-            "DATE",
-            "java.time.LocalDate",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventdate",
+        "Report date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -128,13 +128,13 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
     validateRowValueByName(
-            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
   }
 
@@ -146,16 +146,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,A03MvHHogjR.scheduleddate")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("outputType=ENROLLMENT")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.SCHEDULED_DATE:2021")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,A03MvHHogjR.scheduleddate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.SCHEDULED_DATE:2021")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -165,52 +165,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            3,
-            3); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR.SCHEDULED_DATE\":{\"name\":\"Scheduled date, Birth\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR.SCHEDULED_DATE\":{\"name\":\"Scheduled date, Birth\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.scheduleddate",
-            "scheduleddate",
-            "DATE",
-            "java.time.LocalDate",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.scheduleddate",
+        "scheduleddate",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -225,13 +225,13 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-            response, actualHeaders, 0, "A03MvHHogjR.scheduleddate", "2021-12-29 12:05:00.0");
+        response, actualHeaders, 0, "A03MvHHogjR.scheduleddate", "2021-12-29 12:05:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 99
     validateRowValueByName(response, actualHeaders, 99, "ouname", "MCH Static/U5");
     validateRowValueByName(
-            response, actualHeaders, 99, "A03MvHHogjR.scheduleddate", "2021-12-26 12:05:00.0");
+        response, actualHeaders, 99, "A03MvHHogjR.scheduleddate", "2021-12-26 12:05:00.0");
     validateRowValueByName(response, actualHeaders, 99, "enrollmentdate", "2022-12-26 12:05:00.0");
   }
 
@@ -242,15 +242,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -260,52 +260,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            7,
-            3,
-            3); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        7,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
+        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -335,15 +335,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -353,43 +353,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            7,
-            2,
-            2); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        7,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -414,15 +414,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ou")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8;PMa2VCrupOd,pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ou")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8;PMa2VCrupOd,pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -432,52 +432,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            45,
-            3,
-            3); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        45,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"PMa2VCrupOd\":{\"uid\":\"PMa2VCrupOd\",\"code\":\"OU_211212\",\"name\":\"Kambia\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\",\"PMa2VCrupOd\"],\"pe\":[]}}";
+        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"PMa2VCrupOd\":{\"uid\":\"PMa2VCrupOd\",\"code\":\"OU_211212\",\"name\":\"Kambia\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\",\"PMa2VCrupOd\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.ou",
-            "Organisation unit",
-            "ORGANISATION_UNIT",
-            "org.hisp.dhis.organisationunit.OrganisationUnit",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ou",
+        "Organisation unit",
+        "ORGANISATION_UNIT",
+        "org.hisp.dhis.organisationunit.OrganisationUnit",
+        false,
+        true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -507,15 +507,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.oucode,ZzYYXq4fJie.ouname")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.ou:LEVEL-tTUf91fCytl;USER_ORGUNIT;cgqkFdShPzg,pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.oucode,ZzYYXq4fJie.ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.ou:LEVEL-tTUf91fCytl;USER_ORGUNIT;cgqkFdShPzg,pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -525,61 +525,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            4,
-            4); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        4,
+        4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"yu4N82FFeLm\":{\"uid\":\"yu4N82FFeLm\",\"code\":\"OU_204910\",\"name\":\"Mandu\"},\"KXSqt7jv6DU\":{\"uid\":\"KXSqt7jv6DU\",\"code\":\"OU_222627\",\"name\":\"Gorama Mende\"},\"lY93YpCxJqf\":{\"uid\":\"lY93YpCxJqf\",\"code\":\"OU_193249\",\"name\":\"Makari Gbanti\"},\"eROJsBwxQHt\":{\"uid\":\"eROJsBwxQHt\",\"code\":\"OU_222743\",\"name\":\"Gaura\"},\"DxAPPqXvwLy\":{\"uid\":\"DxAPPqXvwLy\",\"code\":\"OU_204929\",\"name\":\"Peje Bongre\"},\"PaqugoqjRIj\":{\"uid\":\"PaqugoqjRIj\",\"code\":\"OU_226225\",\"name\":\"Sulima (Koinadugu)\"},\"gy8rmvYT4cj\":{\"uid\":\"gy8rmvYT4cj\",\"code\":\"OU_247037\",\"name\":\"Ribbi\"},\"RzKeCma9qb1\":{\"uid\":\"RzKeCma9qb1\",\"code\":\"OU_260428\",\"name\":\"Barri\"},\"vULnao2hV5v\":{\"uid\":\"vULnao2hV5v\",\"code\":\"OU_247086\",\"name\":\"Fakunya\"},\"EfWCa0Cc8WW\":{\"uid\":\"EfWCa0Cc8WW\",\"code\":\"OU_255030\",\"name\":\"Masimera\"},\"AovmOHadayb\":{\"uid\":\"AovmOHadayb\",\"code\":\"OU_247044\",\"name\":\"Timidale\"},\"hjpHnHZIniP\":{\"uid\":\"hjpHnHZIniP\",\"code\":\"OU_204887\",\"name\":\"Kissi Tongi\"},\"U6Kr7Gtpidn\":{\"uid\":\"U6Kr7Gtpidn\",\"code\":\"OU_546\",\"name\":\"Kakua\"},\"EYt6ThQDagn\":{\"uid\":\"EYt6ThQDagn\",\"code\":\"OU_222642\",\"name\":\"Koya (kenema)\"},\"iUauWFeH8Qp\":{\"uid\":\"iUauWFeH8Qp\",\"code\":\"OU_197402\",\"name\":\"Bum\"},\"Jiyc4ekaMMh\":{\"uid\":\"Jiyc4ekaMMh\",\"code\":\"OU_247080\",\"name\":\"Kongbora\"},\"FlBemv1NfEC\":{\"uid\":\"FlBemv1NfEC\",\"code\":\"OU_211256\",\"name\":\"Masungbala\"},\"XrF5AvaGcuw\":{\"uid\":\"XrF5AvaGcuw\",\"code\":\"OU_226240\",\"name\":\"Wara Wara Bafodia\"},\"LhaAPLxdSFH\":{\"uid\":\"LhaAPLxdSFH\",\"code\":\"OU_233348\",\"name\":\"Lei\"},\"BmYyh9bZ0sr\":{\"uid\":\"BmYyh9bZ0sr\",\"code\":\"OU_268197\",\"name\":\"Kafe Simira\"},\"pk7bUK5c1Uf\":{\"uid\":\"pk7bUK5c1Uf\",\"code\":\"OU_260397\",\"name\":\"Ya Kpukumu Krim\"},\"zSNUViKdkk3\":{\"uid\":\"zSNUViKdkk3\",\"code\":\"OU_260440\",\"name\":\"Kpaka\"},\"r06ohri9wA9\":{\"uid\":\"r06ohri9wA9\",\"code\":\"OU_211243\",\"name\":\"Samu\"},\"ERmBhYkhV6Y\":{\"uid\":\"ERmBhYkhV6Y\",\"code\":\"OU_204877\",\"name\":\"Njaluahun\"},\"Z9QaI6sxTwW\":{\"uid\":\"Z9QaI6sxTwW\",\"code\":\"OU_247068\",\"name\":\"Kargboro\"},\"daJPPxtIrQn\":{\"uid\":\"daJPPxtIrQn\",\"code\":\"OU_545\",\"name\":\"Jaiama Bongor\"},\"W5fN3G6y1VI\":{\"uid\":\"W5fN3G6y1VI\",\"code\":\"OU_247012\",\"name\":\"Lower Banta\"},\"r1RUyfVBkLp\":{\"uid\":\"r1RUyfVBkLp\",\"code\":\"OU_268169\",\"name\":\"Sambaia Bendugu\"},\"cgqkFdShPzg\":{\"uid\":\"cgqkFdShPzg\",\"code\":\"OU_193213\",\"name\":\"Loreto Clinic\"},\"NNE0YMCDZkO\":{\"uid\":\"NNE0YMCDZkO\",\"code\":\"OU_268225\",\"name\":\"Yoni\"},\"ENHOJz3UH5L\":{\"uid\":\"ENHOJz3UH5L\",\"code\":\"OU_197440\",\"name\":\"BMC\"},\"QywkxFudXrC\":{\"uid\":\"QywkxFudXrC\",\"code\":\"OU_211227\",\"name\":\"Magbema\"},\"jWSIbtKfURj\":{\"uid\":\"jWSIbtKfURj\",\"code\":\"OU_222751\",\"name\":\"Langrama\"},\"J4GiUImJZoE\":{\"uid\":\"J4GiUImJZoE\",\"code\":\"OU_226269\",\"name\":\"Nieni\"},\"CF243RPvNY7\":{\"uid\":\"CF243RPvNY7\",\"code\":\"OU_233359\",\"name\":\"Fiama\"},\"I4jWcnFmgEC\":{\"uid\":\"I4jWcnFmgEC\",\"code\":\"OU_549\",\"name\":\"Niawa Lenga\"},\"cM2BKSrj9F9\":{\"uid\":\"cM2BKSrj9F9\",\"code\":\"OU_204894\",\"name\":\"Luawa\"},\"kvkDWg42lHR\":{\"uid\":\"kvkDWg42lHR\",\"code\":\"OU_233339\",\"name\":\"Kamara\"},\"jPidqyo7cpF\":{\"uid\":\"jPidqyo7cpF\",\"code\":\"OU_247049\",\"name\":\"Bagruwa\"},\"BGGmAwx33dj\":{\"uid\":\"BGGmAwx33dj\",\"code\":\"OU_543\",\"name\":\"Bumpe Ngao\"},\"iGHlidSFdpu\":{\"uid\":\"iGHlidSFdpu\",\"code\":\"OU_233317\",\"name\":\"Soa\"},\"g8DdBm7EmUt\":{\"uid\":\"g8DdBm7EmUt\",\"code\":\"OU_197397\",\"name\":\"Sittia\"},\"ZiOVcrSjSYe\":{\"uid\":\"ZiOVcrSjSYe\",\"code\":\"OU_254976\",\"name\":\"Dibia\"},\"vn9KJsLyP5f\":{\"uid\":\"vn9KJsLyP5f\",\"code\":\"OU_255005\",\"name\":\"Kaffu Bullom\"},\"QlCIp2S9NHs\":{\"uid\":\"QlCIp2S9NHs\",\"code\":\"OU_222682\",\"name\":\"Dodo\"},\"j43EZb15rjI\":{\"uid\":\"j43EZb15rjI\",\"code\":\"OU_193285\",\"name\":\"Sella Limba\"},\"202301\":{\"name\":\"January 2023\"},\"bQiBfA2j5cw\":{\"uid\":\"bQiBfA2j5cw\",\"code\":\"OU_204857\",\"name\":\"Penguia\"},\"NqWaKXcg01b\":{\"uid\":\"NqWaKXcg01b\",\"code\":\"OU_260384\",\"name\":\"Sowa\"},\"VP397wRvePm\":{\"uid\":\"VP397wRvePm\",\"code\":\"OU_197445\",\"name\":\"Nongoba Bullum\"},\"fwxkctgmffZ\":{\"uid\":\"fwxkctgmffZ\",\"code\":\"OU_268163\",\"name\":\"Kholifa Mabang\"},\"QwMiPiME3bA\":{\"uid\":\"QwMiPiME3bA\",\"code\":\"OU_260400\",\"name\":\"Kpanga Kabonde\"},\"Qhmi8IZyPyD\":{\"uid\":\"Qhmi8IZyPyD\",\"code\":\"OU_193245\",\"name\":\"Tambaka\"},\"OTFepb1k9Db\":{\"uid\":\"OTFepb1k9Db\",\"code\":\"OU_226244\",\"name\":\"Mongo\"},\"DBs6e2Oxaj1\":{\"uid\":\"DBs6e2Oxaj1\",\"code\":\"OU_247002\",\"name\":\"Upper Banta\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"eV4cuxniZgP\":{\"uid\":\"eV4cuxniZgP\",\"code\":\"OU_193224\",\"name\":\"Magbaimba Ndowahun\"},\"xhyjU2SVewz\":{\"uid\":\"xhyjU2SVewz\",\"code\":\"OU_268217\",\"name\":\"Tane\"},\"dGheVylzol6\":{\"uid\":\"dGheVylzol6\",\"code\":\"OU_541\",\"name\":\"Bargbe\"},\"vWbkYPRmKyS\":{\"uid\":\"vWbkYPRmKyS\",\"code\":\"OU_540\",\"name\":\"Baoma\"},\"npWGUj37qDe\":{\"uid\":\"npWGUj37qDe\",\"code\":\"OU_552\",\"name\":\"Valunia\"},\"TA7NvKjsn4A\":{\"uid\":\"TA7NvKjsn4A\",\"code\":\"OU_255041\",\"name\":\"Bureh Kasseh Maconteh\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"tTUf91fCytl\":{\"uid\":\"tTUf91fCytl\",\"valueType\":\"NUMBER\",\"name\":\"Chiefdom\",\"totalAggregationType\":\"SUM\"},\"myQ4q1W6B4y\":{\"uid\":\"myQ4q1W6B4y\",\"code\":\"OU_222731\",\"name\":\"Dama\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"nV3OkyzF4US\":{\"uid\":\"nV3OkyzF4US\",\"code\":\"OU_246991\",\"name\":\"Kori\"},\"X7dWcGerQIm\":{\"uid\":\"X7dWcGerQIm\",\"code\":\"OU_222677\",\"name\":\"Wandor\"},\"qIRCo0MfuGb\":{\"uid\":\"qIRCo0MfuGb\",\"code\":\"OU_211213\",\"name\":\"Gbinleh Dixion\"},\"kbPmt60yi0L\":{\"uid\":\"kbPmt60yi0L\",\"code\":\"OU_211220\",\"name\":\"Bramaia\"},\"eNtRuQrrZeo\":{\"uid\":\"eNtRuQrrZeo\",\"code\":\"OU_260420\",\"name\":\"Galliness Perri\"},\"HV8RTzgcFH3\":{\"uid\":\"HV8RTzgcFH3\",\"code\":\"OU_197432\",\"name\":\"Kwamabai Krim\"},\"KKkLOTpMXGV\":{\"uid\":\"KKkLOTpMXGV\",\"code\":\"OU_193198\",\"name\":\"Bombali Sebora\"},\"Pc3JTyqnsmL\":{\"uid\":\"Pc3JTyqnsmL\",\"code\":\"OU_255020\",\"name\":\"Buya Romende\"},\"hdEuw2ugkVF\":{\"uid\":\"hdEuw2ugkVF\",\"code\":\"OU_222652\",\"name\":\"Lower Bambara\"},\"l7pFejMtUoF\":{\"uid\":\"l7pFejMtUoF\",\"code\":\"OU_222634\",\"name\":\"Tunkia\"},\"K1r3uF6eZ8n\":{\"uid\":\"K1r3uF6eZ8n\",\"code\":\"OU_222725\",\"name\":\"Kandu Lepiema\"},\"VGAFxBXz16y\":{\"uid\":\"VGAFxBXz16y\",\"code\":\"OU_226231\",\"name\":\"Sengbeh\"},\"GE25DpSrqpB\":{\"uid\":\"GE25DpSrqpB\",\"code\":\"OU_204869\",\"name\":\"Malema\"},\"ARZ4y5i4reU\":{\"uid\":\"ARZ4y5i4reU\",\"code\":\"OU_553\",\"name\":\"Wonde\"},\"byp7w6Xd9Df\":{\"uid\":\"byp7w6Xd9Df\",\"code\":\"OU_204933\",\"name\":\"Yawei\"},\"BXJdOLvUrZB\":{\"uid\":\"BXJdOLvUrZB\",\"code\":\"OU_193277\",\"name\":\"Gbendembu Ngowahun\"},\"uKC54fzxRzO\":{\"uid\":\"uKC54fzxRzO\",\"code\":\"OU_222648\",\"name\":\"Niawa\"},\"TQkG0sX9nca\":{\"uid\":\"TQkG0sX9nca\",\"code\":\"OU_233375\",\"name\":\"Gbense\"},\"hRZOIgQ0O1m\":{\"uid\":\"hRZOIgQ0O1m\",\"code\":\"OU_193302\",\"name\":\"Libeisaygahun\"},\"PrJQHI6q7w2\":{\"uid\":\"PrJQHI6q7w2\",\"code\":\"OU_255061\",\"name\":\"Tainkatopa Makama Safrokoh\"},\"USQdmvrHh1Q\":{\"uid\":\"USQdmvrHh1Q\",\"code\":\"OU_247055\",\"name\":\"Kaiyamba\"},\"xGMGhjA3y6J\":{\"uid\":\"xGMGhjA3y6J\",\"code\":\"OU_211262\",\"name\":\"Mambolo\"},\"nOYt1LtFSyU\":{\"uid\":\"nOYt1LtFSyU\",\"code\":\"OU_247025\",\"name\":\"Bumpeh\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"e1eIKM1GIF3\":{\"uid\":\"e1eIKM1GIF3\",\"code\":\"OU_193215\",\"name\":\"Gbanti Kamaranka\"},\"lYIM1MXbSYS\":{\"uid\":\"lYIM1MXbSYS\",\"code\":\"OU_204920\",\"name\":\"Dea\"},\"sxRd2XOzFbz\":{\"uid\":\"sxRd2XOzFbz\",\"code\":\"OU_551\",\"name\":\"Tikonko\"},\"d9iMR1MpuIO\":{\"uid\":\"d9iMR1MpuIO\",\"code\":\"OU_260410\",\"name\":\"Soro-Gbeima\"},\"qgQ49DH9a0v\":{\"uid\":\"qgQ49DH9a0v\",\"code\":\"OU_233332\",\"name\":\"Nimiyama\"},\"U09TSwIjG0s\":{\"uid\":\"U09TSwIjG0s\",\"code\":\"OU_222617\",\"name\":\"Nomo\"},\"zFDYIgyGmXG\":{\"uid\":\"zFDYIgyGmXG\",\"code\":\"OU_542\",\"name\":\"Bargbo\"},\"M2qEv692lS6\":{\"uid\":\"M2qEv692lS6\",\"code\":\"OU_233324\",\"name\":\"Tankoro\"},\"qtr8GGlm4gg\":{\"uid\":\"qtr8GGlm4gg\",\"code\":\"OU_278366\",\"name\":\"Rural Western Area\"},\"pRHGAROvuyI\":{\"uid\":\"pRHGAROvuyI\",\"code\":\"OU_254960\",\"name\":\"Koya\"},\"xIKjidMrico\":{\"uid\":\"xIKjidMrico\",\"code\":\"OU_247033\",\"name\":\"Kowa\"},\"GWTIxJO9pRo\":{\"uid\":\"GWTIxJO9pRo\",\"code\":\"OU_233355\",\"name\":\"Gorama Kono\"},\"HWjrSuoNPte\":{\"uid\":\"HWjrSuoNPte\",\"code\":\"OU_254999\",\"name\":\"Sanda Magbolonthor\"},\"UhHipWG7J8b\":{\"uid\":\"UhHipWG7J8b\",\"code\":\"OU_193191\",\"name\":\"Sanda Tendaren\"},\"rXLor9Knq6l\":{\"uid\":\"rXLor9Knq6l\",\"code\":\"OU_268212\",\"name\":\"Kunike Barina\"},\"kU8vhUkAGaT\":{\"uid\":\"kU8vhUkAGaT\",\"code\":\"OU_548\",\"name\":\"Lugbu\"},\"C9uduqDZr9d\":{\"uid\":\"C9uduqDZr9d\",\"code\":\"OU_278311\",\"name\":\"Freetown\"},\"YmmeuGbqOwR\":{\"uid\":\"YmmeuGbqOwR\",\"code\":\"OU_544\",\"name\":\"Gbo\"},\"iEkBZnMDarP\":{\"uid\":\"iEkBZnMDarP\",\"code\":\"OU_226253\",\"name\":\"Folosaba Dembelia\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"JsxnA2IywRo\":{\"uid\":\"JsxnA2IywRo\",\"code\":\"OU_204875\",\"name\":\"Kissi Kama\"},\"nlt6j60tCHF\":{\"uid\":\"nlt6j60tCHF\",\"code\":\"OU_260437\",\"name\":\"Mano Sakrim\"},\"g5ptsn0SFX8\":{\"uid\":\"g5ptsn0SFX8\",\"code\":\"OU_233365\",\"name\":\"Sandor\"},\"XG8HGAbrbbL\":{\"uid\":\"XG8HGAbrbbL\",\"code\":\"OU_193267\",\"name\":\"Safroko Limba\"},\"pmxZm7klXBy\":{\"uid\":\"pmxZm7klXBy\",\"code\":\"OU_204924\",\"name\":\"Peje West\"},\"l0ccv2yzfF3\":{\"uid\":\"l0ccv2yzfF3\",\"code\":\"OU_268174\",\"name\":\"Kunike\"},\"YuQRtpLP10I\":{\"uid\":\"YuQRtpLP10I\",\"code\":\"OU_539\",\"name\":\"Badjia\"},\"LfTkc0S4b5k\":{\"uid\":\"LfTkc0S4b5k\",\"code\":\"OU_204915\",\"name\":\"Upper Bambara\"},\"KSdZwrU7Hh6\":{\"uid\":\"KSdZwrU7Hh6\",\"code\":\"OU_204861\",\"name\":\"Jawi\"},\"ajILkI0cfxn\":{\"uid\":\"ajILkI0cfxn\",\"code\":\"OU_233390\",\"name\":\"Gbane\"},\"y5X4mP5XylL\":{\"uid\":\"y5X4mP5XylL\",\"code\":\"OU_211270\",\"name\":\"Tonko Limba\"},\"fwH9ipvXde9\":{\"uid\":\"fwH9ipvXde9\",\"code\":\"OU_193228\",\"name\":\"Biriwa\"},\"KIUCimTXf8Q\":{\"uid\":\"KIUCimTXf8Q\",\"code\":\"OU_222690\",\"name\":\"Nongowa\"},\"vEvs2ckGNQj\":{\"uid\":\"vEvs2ckGNQj\",\"code\":\"OU_226219\",\"name\":\"Kasonko\"},\"XEyIRFd9pct\":{\"uid\":\"XEyIRFd9pct\",\"code\":\"OU_197413\",\"name\":\"Imperi\"},\"cgOy0hRMGu9\":{\"uid\":\"cgOy0hRMGu9\",\"code\":\"OU_197408\",\"name\":\"Sogbini\"},\"EjnIQNVAXGp\":{\"uid\":\"EjnIQNVAXGp\",\"code\":\"OU_233344\",\"name\":\"Mafindor\"},\"x4HaBHHwBML\":{\"uid\":\"x4HaBHHwBML\",\"code\":\"OU_222672\",\"name\":\"Malegohun\"},\"EZPwuUTeIIG\":{\"uid\":\"EZPwuUTeIIG\",\"code\":\"OU_226258\",\"name\":\"Wara Wara Yagala\"},\"N233eZJZ1bh\":{\"uid\":\"N233eZJZ1bh\",\"code\":\"OU_260388\",\"name\":\"Pejeh\"},\"smoyi1iYNK6\":{\"uid\":\"smoyi1iYNK6\",\"code\":\"OU_268191\",\"name\":\"Kalansogoia\"},\"DNRAeXT9IwS\":{\"uid\":\"DNRAeXT9IwS\",\"code\":\"OU_197421\",\"name\":\"Dema\"},\"fRLX08WHWpL\":{\"uid\":\"fRLX08WHWpL\",\"code\":\"OU_254982\",\"name\":\"Lokomasama\"},\"Zoy23SSHCPs\":{\"uid\":\"Zoy23SSHCPs\",\"code\":\"OU_233311\",\"name\":\"Gbane Kandor\"},\"LsYpCyYxSLY\":{\"uid\":\"LsYpCyYxSLY\",\"code\":\"OU_247008\",\"name\":\"Kamaje\"},\"JdqfYTIFZXN\":{\"uid\":\"JdqfYTIFZXN\",\"code\":\"OU_254946\",\"name\":\"Maforki\"},\"EB1zRKdYjdY\":{\"uid\":\"EB1zRKdYjdY\",\"code\":\"OU_197429\",\"name\":\"Bendu Cha\"},\"CG4QD1HC3h4\":{\"uid\":\"CG4QD1HC3h4\",\"code\":\"OU_197436\",\"name\":\"Yawbeko\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\"},\"YpVol7asWvd\":{\"uid\":\"YpVol7asWvd\",\"code\":\"OU_260417\",\"name\":\"Kpanga Krim\"},\"RndxKqQGzUl\":{\"uid\":\"RndxKqQGzUl\",\"code\":\"OU_247018\",\"name\":\"Dasse\"},\"P69SId31eDp\":{\"uid\":\"P69SId31eDp\",\"code\":\"OU_268202\",\"name\":\"Gbonkonlenken\"},\"aWQTfvgPA5v\":{\"uid\":\"aWQTfvgPA5v\",\"code\":\"OU_197424\",\"name\":\"Kpanda Kemoh\"},\"KctpIIucige\":{\"uid\":\"KctpIIucige\",\"code\":\"OU_550\",\"name\":\"Selenga\"},\"Mr4au3jR9bt\":{\"uid\":\"Mr4au3jR9bt\",\"code\":\"OU_226214\",\"name\":\"Dembelia Sinkunia\"},\"L8iA6eLwKNb\":{\"uid\":\"L8iA6eLwKNb\",\"code\":\"OU_193295\",\"name\":\"Paki Masabong\"},\"j0Mtr3xTMjM\":{\"uid\":\"j0Mtr3xTMjM\",\"code\":\"OU_204939\",\"name\":\"Kissi Teng\"},\"DmaLM8WYmWv\":{\"uid\":\"DmaLM8WYmWv\",\"code\":\"OU_233394\",\"name\":\"Nimikoro\"},\"DfUfwjM9am5\":{\"uid\":\"DfUfwjM9am5\",\"code\":\"OU_260392\",\"name\":\"Malen\"},\"FRxcUEwktoV\":{\"uid\":\"FRxcUEwktoV\",\"code\":\"OU_233314\",\"name\":\"Toli\"},\"VCtF1DbspR5\":{\"uid\":\"VCtF1DbspR5\",\"code\":\"OU_197386\",\"name\":\"Jong\"},\"BD9gU0GKlr2\":{\"uid\":\"BD9gU0GKlr2\",\"code\":\"OU_260378\",\"name\":\"Makpele\"},\"GFk45MOxzJJ\":{\"uid\":\"GFk45MOxzJJ\",\"code\":\"OU_226275\",\"name\":\"Neya\"},\"A3Fh37HWBWE\":{\"uid\":\"A3Fh37HWBWE\",\"code\":\"OU_222687\",\"name\":\"Simbaru\"},\"vzup1f6ynON\":{\"uid\":\"vzup1f6ynON\",\"code\":\"OU_222619\",\"name\":\"Small Bo\"},\"Lt8U7GVWvSR\":{\"uid\":\"Lt8U7GVWvSR\",\"code\":\"OU_226263\",\"name\":\"Diang\"},\"JdhagCUEMbj\":{\"uid\":\"JdhagCUEMbj\",\"code\":\"OU_547\",\"name\":\"Komboya\"},\"EVkm2xYcf6Z\":{\"uid\":\"EVkm2xYcf6Z\",\"code\":\"OU_268184\",\"name\":\"Malal Mara\"},\"PQZJPIpTepd\":{\"uid\":\"PQZJPIpTepd\",\"code\":\"OU_268150\",\"name\":\"Kholifa Rowalla\"},\"WXnNDWTiE9r\":{\"uid\":\"WXnNDWTiE9r\",\"code\":\"OU_193239\",\"name\":\"Sanda Loko\"},\"RWvG1aFrr0r\":{\"uid\":\"RWvG1aFrr0r\",\"code\":\"OU_255053\",\"name\":\"Marampa\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"ImspTQPwCqd\",\"cgqkFdShPzg\",\"YuQRtpLP10I\",\"jPidqyo7cpF\",\"vWbkYPRmKyS\",\"dGheVylzol6\",\"zFDYIgyGmXG\",\"RzKeCma9qb1\",\"EB1zRKdYjdY\",\"fwH9ipvXde9\",\"ENHOJz3UH5L\",\"KKkLOTpMXGV\",\"kbPmt60yi0L\",\"iUauWFeH8Qp\",\"BGGmAwx33dj\",\"nOYt1LtFSyU\",\"TA7NvKjsn4A\",\"Pc3JTyqnsmL\",\"myQ4q1W6B4y\",\"RndxKqQGzUl\",\"lYIM1MXbSYS\",\"DNRAeXT9IwS\",\"Mr4au3jR9bt\",\"Lt8U7GVWvSR\",\"ZiOVcrSjSYe\",\"QlCIp2S9NHs\",\"vULnao2hV5v\",\"CF243RPvNY7\",\"iEkBZnMDarP\",\"C9uduqDZr9d\",\"eNtRuQrrZeo\",\"eROJsBwxQHt\",\"ajILkI0cfxn\",\"Zoy23SSHCPs\",\"e1eIKM1GIF3\",\"BXJdOLvUrZB\",\"TQkG0sX9nca\",\"qIRCo0MfuGb\",\"YmmeuGbqOwR\",\"P69SId31eDp\",\"GWTIxJO9pRo\",\"KXSqt7jv6DU\",\"XEyIRFd9pct\",\"daJPPxtIrQn\",\"KSdZwrU7Hh6\",\"VCtF1DbspR5\",\"BmYyh9bZ0sr\",\"vn9KJsLyP5f\",\"USQdmvrHh1Q\",\"U6Kr7Gtpidn\",\"smoyi1iYNK6\",\"LsYpCyYxSLY\",\"kvkDWg42lHR\",\"K1r3uF6eZ8n\",\"Z9QaI6sxTwW\",\"vEvs2ckGNQj\",\"fwxkctgmffZ\",\"PQZJPIpTepd\",\"JsxnA2IywRo\",\"j0Mtr3xTMjM\",\"hjpHnHZIniP\",\"JdhagCUEMbj\",\"Jiyc4ekaMMh\",\"nV3OkyzF4US\",\"xIKjidMrico\",\"pRHGAROvuyI\",\"EYt6ThQDagn\",\"zSNUViKdkk3\",\"aWQTfvgPA5v\",\"QwMiPiME3bA\",\"YpVol7asWvd\",\"l0ccv2yzfF3\",\"rXLor9Knq6l\",\"HV8RTzgcFH3\",\"jWSIbtKfURj\",\"LhaAPLxdSFH\",\"hRZOIgQ0O1m\",\"fRLX08WHWpL\",\"hdEuw2ugkVF\",\"W5fN3G6y1VI\",\"cM2BKSrj9F9\",\"kU8vhUkAGaT\",\"EjnIQNVAXGp\",\"JdqfYTIFZXN\",\"eV4cuxniZgP\",\"QywkxFudXrC\",\"lY93YpCxJqf\",\"BD9gU0GKlr2\",\"EVkm2xYcf6Z\",\"x4HaBHHwBML\",\"GE25DpSrqpB\",\"DfUfwjM9am5\",\"xGMGhjA3y6J\",\"yu4N82FFeLm\",\"nlt6j60tCHF\",\"RWvG1aFrr0r\",\"EfWCa0Cc8WW\",\"FlBemv1NfEC\",\"OTFepb1k9Db\",\"GFk45MOxzJJ\",\"uKC54fzxRzO\",\"I4jWcnFmgEC\",\"J4GiUImJZoE\",\"DmaLM8WYmWv\",\"qgQ49DH9a0v\",\"ERmBhYkhV6Y\",\"U09TSwIjG0s\",\"VP397wRvePm\",\"KIUCimTXf8Q\",\"L8iA6eLwKNb\",\"DxAPPqXvwLy\",\"pmxZm7klXBy\",\"N233eZJZ1bh\",\"bQiBfA2j5cw\",\"gy8rmvYT4cj\",\"qtr8GGlm4gg\",\"XG8HGAbrbbL\",\"r1RUyfVBkLp\",\"r06ohri9wA9\",\"WXnNDWTiE9r\",\"HWjrSuoNPte\",\"UhHipWG7J8b\",\"g5ptsn0SFX8\",\"KctpIIucige\",\"j43EZb15rjI\",\"VGAFxBXz16y\",\"A3Fh37HWBWE\",\"g8DdBm7EmUt\",\"vzup1f6ynON\",\"iGHlidSFdpu\",\"cgOy0hRMGu9\",\"d9iMR1MpuIO\",\"NqWaKXcg01b\",\"PaqugoqjRIj\",\"PrJQHI6q7w2\",\"Qhmi8IZyPyD\",\"xhyjU2SVewz\",\"M2qEv692lS6\",\"sxRd2XOzFbz\",\"AovmOHadayb\",\"FRxcUEwktoV\",\"y5X4mP5XylL\",\"l7pFejMtUoF\",\"LfTkc0S4b5k\",\"DBs6e2Oxaj1\",\"npWGUj37qDe\",\"X7dWcGerQIm\",\"XrF5AvaGcuw\",\"EZPwuUTeIIG\",\"ARZ4y5i4reU\",\"pk7bUK5c1Uf\",\"CG4QD1HC3h4\",\"byp7w6Xd9Df\",\"NNE0YMCDZkO\"],\"pe\":[]}}";
+        "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"yu4N82FFeLm\":{\"uid\":\"yu4N82FFeLm\",\"code\":\"OU_204910\",\"name\":\"Mandu\"},\"KXSqt7jv6DU\":{\"uid\":\"KXSqt7jv6DU\",\"code\":\"OU_222627\",\"name\":\"Gorama Mende\"},\"lY93YpCxJqf\":{\"uid\":\"lY93YpCxJqf\",\"code\":\"OU_193249\",\"name\":\"Makari Gbanti\"},\"eROJsBwxQHt\":{\"uid\":\"eROJsBwxQHt\",\"code\":\"OU_222743\",\"name\":\"Gaura\"},\"DxAPPqXvwLy\":{\"uid\":\"DxAPPqXvwLy\",\"code\":\"OU_204929\",\"name\":\"Peje Bongre\"},\"PaqugoqjRIj\":{\"uid\":\"PaqugoqjRIj\",\"code\":\"OU_226225\",\"name\":\"Sulima (Koinadugu)\"},\"gy8rmvYT4cj\":{\"uid\":\"gy8rmvYT4cj\",\"code\":\"OU_247037\",\"name\":\"Ribbi\"},\"RzKeCma9qb1\":{\"uid\":\"RzKeCma9qb1\",\"code\":\"OU_260428\",\"name\":\"Barri\"},\"vULnao2hV5v\":{\"uid\":\"vULnao2hV5v\",\"code\":\"OU_247086\",\"name\":\"Fakunya\"},\"EfWCa0Cc8WW\":{\"uid\":\"EfWCa0Cc8WW\",\"code\":\"OU_255030\",\"name\":\"Masimera\"},\"AovmOHadayb\":{\"uid\":\"AovmOHadayb\",\"code\":\"OU_247044\",\"name\":\"Timidale\"},\"hjpHnHZIniP\":{\"uid\":\"hjpHnHZIniP\",\"code\":\"OU_204887\",\"name\":\"Kissi Tongi\"},\"U6Kr7Gtpidn\":{\"uid\":\"U6Kr7Gtpidn\",\"code\":\"OU_546\",\"name\":\"Kakua\"},\"EYt6ThQDagn\":{\"uid\":\"EYt6ThQDagn\",\"code\":\"OU_222642\",\"name\":\"Koya (kenema)\"},\"iUauWFeH8Qp\":{\"uid\":\"iUauWFeH8Qp\",\"code\":\"OU_197402\",\"name\":\"Bum\"},\"Jiyc4ekaMMh\":{\"uid\":\"Jiyc4ekaMMh\",\"code\":\"OU_247080\",\"name\":\"Kongbora\"},\"FlBemv1NfEC\":{\"uid\":\"FlBemv1NfEC\",\"code\":\"OU_211256\",\"name\":\"Masungbala\"},\"XrF5AvaGcuw\":{\"uid\":\"XrF5AvaGcuw\",\"code\":\"OU_226240\",\"name\":\"Wara Wara Bafodia\"},\"LhaAPLxdSFH\":{\"uid\":\"LhaAPLxdSFH\",\"code\":\"OU_233348\",\"name\":\"Lei\"},\"BmYyh9bZ0sr\":{\"uid\":\"BmYyh9bZ0sr\",\"code\":\"OU_268197\",\"name\":\"Kafe Simira\"},\"pk7bUK5c1Uf\":{\"uid\":\"pk7bUK5c1Uf\",\"code\":\"OU_260397\",\"name\":\"Ya Kpukumu Krim\"},\"zSNUViKdkk3\":{\"uid\":\"zSNUViKdkk3\",\"code\":\"OU_260440\",\"name\":\"Kpaka\"},\"r06ohri9wA9\":{\"uid\":\"r06ohri9wA9\",\"code\":\"OU_211243\",\"name\":\"Samu\"},\"ERmBhYkhV6Y\":{\"uid\":\"ERmBhYkhV6Y\",\"code\":\"OU_204877\",\"name\":\"Njaluahun\"},\"Z9QaI6sxTwW\":{\"uid\":\"Z9QaI6sxTwW\",\"code\":\"OU_247068\",\"name\":\"Kargboro\"},\"daJPPxtIrQn\":{\"uid\":\"daJPPxtIrQn\",\"code\":\"OU_545\",\"name\":\"Jaiama Bongor\"},\"W5fN3G6y1VI\":{\"uid\":\"W5fN3G6y1VI\",\"code\":\"OU_247012\",\"name\":\"Lower Banta\"},\"r1RUyfVBkLp\":{\"uid\":\"r1RUyfVBkLp\",\"code\":\"OU_268169\",\"name\":\"Sambaia Bendugu\"},\"cgqkFdShPzg\":{\"uid\":\"cgqkFdShPzg\",\"code\":\"OU_193213\",\"name\":\"Loreto Clinic\"},\"NNE0YMCDZkO\":{\"uid\":\"NNE0YMCDZkO\",\"code\":\"OU_268225\",\"name\":\"Yoni\"},\"ENHOJz3UH5L\":{\"uid\":\"ENHOJz3UH5L\",\"code\":\"OU_197440\",\"name\":\"BMC\"},\"QywkxFudXrC\":{\"uid\":\"QywkxFudXrC\",\"code\":\"OU_211227\",\"name\":\"Magbema\"},\"jWSIbtKfURj\":{\"uid\":\"jWSIbtKfURj\",\"code\":\"OU_222751\",\"name\":\"Langrama\"},\"J4GiUImJZoE\":{\"uid\":\"J4GiUImJZoE\",\"code\":\"OU_226269\",\"name\":\"Nieni\"},\"CF243RPvNY7\":{\"uid\":\"CF243RPvNY7\",\"code\":\"OU_233359\",\"name\":\"Fiama\"},\"I4jWcnFmgEC\":{\"uid\":\"I4jWcnFmgEC\",\"code\":\"OU_549\",\"name\":\"Niawa Lenga\"},\"cM2BKSrj9F9\":{\"uid\":\"cM2BKSrj9F9\",\"code\":\"OU_204894\",\"name\":\"Luawa\"},\"kvkDWg42lHR\":{\"uid\":\"kvkDWg42lHR\",\"code\":\"OU_233339\",\"name\":\"Kamara\"},\"jPidqyo7cpF\":{\"uid\":\"jPidqyo7cpF\",\"code\":\"OU_247049\",\"name\":\"Bagruwa\"},\"BGGmAwx33dj\":{\"uid\":\"BGGmAwx33dj\",\"code\":\"OU_543\",\"name\":\"Bumpe Ngao\"},\"iGHlidSFdpu\":{\"uid\":\"iGHlidSFdpu\",\"code\":\"OU_233317\",\"name\":\"Soa\"},\"g8DdBm7EmUt\":{\"uid\":\"g8DdBm7EmUt\",\"code\":\"OU_197397\",\"name\":\"Sittia\"},\"ZiOVcrSjSYe\":{\"uid\":\"ZiOVcrSjSYe\",\"code\":\"OU_254976\",\"name\":\"Dibia\"},\"vn9KJsLyP5f\":{\"uid\":\"vn9KJsLyP5f\",\"code\":\"OU_255005\",\"name\":\"Kaffu Bullom\"},\"QlCIp2S9NHs\":{\"uid\":\"QlCIp2S9NHs\",\"code\":\"OU_222682\",\"name\":\"Dodo\"},\"j43EZb15rjI\":{\"uid\":\"j43EZb15rjI\",\"code\":\"OU_193285\",\"name\":\"Sella Limba\"},\"202301\":{\"name\":\"January 2023\"},\"bQiBfA2j5cw\":{\"uid\":\"bQiBfA2j5cw\",\"code\":\"OU_204857\",\"name\":\"Penguia\"},\"NqWaKXcg01b\":{\"uid\":\"NqWaKXcg01b\",\"code\":\"OU_260384\",\"name\":\"Sowa\"},\"VP397wRvePm\":{\"uid\":\"VP397wRvePm\",\"code\":\"OU_197445\",\"name\":\"Nongoba Bullum\"},\"fwxkctgmffZ\":{\"uid\":\"fwxkctgmffZ\",\"code\":\"OU_268163\",\"name\":\"Kholifa Mabang\"},\"QwMiPiME3bA\":{\"uid\":\"QwMiPiME3bA\",\"code\":\"OU_260400\",\"name\":\"Kpanga Kabonde\"},\"Qhmi8IZyPyD\":{\"uid\":\"Qhmi8IZyPyD\",\"code\":\"OU_193245\",\"name\":\"Tambaka\"},\"OTFepb1k9Db\":{\"uid\":\"OTFepb1k9Db\",\"code\":\"OU_226244\",\"name\":\"Mongo\"},\"DBs6e2Oxaj1\":{\"uid\":\"DBs6e2Oxaj1\",\"code\":\"OU_247002\",\"name\":\"Upper Banta\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"eV4cuxniZgP\":{\"uid\":\"eV4cuxniZgP\",\"code\":\"OU_193224\",\"name\":\"Magbaimba Ndowahun\"},\"xhyjU2SVewz\":{\"uid\":\"xhyjU2SVewz\",\"code\":\"OU_268217\",\"name\":\"Tane\"},\"dGheVylzol6\":{\"uid\":\"dGheVylzol6\",\"code\":\"OU_541\",\"name\":\"Bargbe\"},\"vWbkYPRmKyS\":{\"uid\":\"vWbkYPRmKyS\",\"code\":\"OU_540\",\"name\":\"Baoma\"},\"npWGUj37qDe\":{\"uid\":\"npWGUj37qDe\",\"code\":\"OU_552\",\"name\":\"Valunia\"},\"TA7NvKjsn4A\":{\"uid\":\"TA7NvKjsn4A\",\"code\":\"OU_255041\",\"name\":\"Bureh Kasseh Maconteh\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"tTUf91fCytl\":{\"uid\":\"tTUf91fCytl\",\"valueType\":\"NUMBER\",\"name\":\"Chiefdom\",\"totalAggregationType\":\"SUM\"},\"myQ4q1W6B4y\":{\"uid\":\"myQ4q1W6B4y\",\"code\":\"OU_222731\",\"name\":\"Dama\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"nV3OkyzF4US\":{\"uid\":\"nV3OkyzF4US\",\"code\":\"OU_246991\",\"name\":\"Kori\"},\"X7dWcGerQIm\":{\"uid\":\"X7dWcGerQIm\",\"code\":\"OU_222677\",\"name\":\"Wandor\"},\"qIRCo0MfuGb\":{\"uid\":\"qIRCo0MfuGb\",\"code\":\"OU_211213\",\"name\":\"Gbinleh Dixion\"},\"kbPmt60yi0L\":{\"uid\":\"kbPmt60yi0L\",\"code\":\"OU_211220\",\"name\":\"Bramaia\"},\"eNtRuQrrZeo\":{\"uid\":\"eNtRuQrrZeo\",\"code\":\"OU_260420\",\"name\":\"Galliness Perri\"},\"HV8RTzgcFH3\":{\"uid\":\"HV8RTzgcFH3\",\"code\":\"OU_197432\",\"name\":\"Kwamabai Krim\"},\"KKkLOTpMXGV\":{\"uid\":\"KKkLOTpMXGV\",\"code\":\"OU_193198\",\"name\":\"Bombali Sebora\"},\"Pc3JTyqnsmL\":{\"uid\":\"Pc3JTyqnsmL\",\"code\":\"OU_255020\",\"name\":\"Buya Romende\"},\"hdEuw2ugkVF\":{\"uid\":\"hdEuw2ugkVF\",\"code\":\"OU_222652\",\"name\":\"Lower Bambara\"},\"l7pFejMtUoF\":{\"uid\":\"l7pFejMtUoF\",\"code\":\"OU_222634\",\"name\":\"Tunkia\"},\"K1r3uF6eZ8n\":{\"uid\":\"K1r3uF6eZ8n\",\"code\":\"OU_222725\",\"name\":\"Kandu Lepiema\"},\"VGAFxBXz16y\":{\"uid\":\"VGAFxBXz16y\",\"code\":\"OU_226231\",\"name\":\"Sengbeh\"},\"GE25DpSrqpB\":{\"uid\":\"GE25DpSrqpB\",\"code\":\"OU_204869\",\"name\":\"Malema\"},\"ARZ4y5i4reU\":{\"uid\":\"ARZ4y5i4reU\",\"code\":\"OU_553\",\"name\":\"Wonde\"},\"byp7w6Xd9Df\":{\"uid\":\"byp7w6Xd9Df\",\"code\":\"OU_204933\",\"name\":\"Yawei\"},\"BXJdOLvUrZB\":{\"uid\":\"BXJdOLvUrZB\",\"code\":\"OU_193277\",\"name\":\"Gbendembu Ngowahun\"},\"uKC54fzxRzO\":{\"uid\":\"uKC54fzxRzO\",\"code\":\"OU_222648\",\"name\":\"Niawa\"},\"TQkG0sX9nca\":{\"uid\":\"TQkG0sX9nca\",\"code\":\"OU_233375\",\"name\":\"Gbense\"},\"hRZOIgQ0O1m\":{\"uid\":\"hRZOIgQ0O1m\",\"code\":\"OU_193302\",\"name\":\"Libeisaygahun\"},\"PrJQHI6q7w2\":{\"uid\":\"PrJQHI6q7w2\",\"code\":\"OU_255061\",\"name\":\"Tainkatopa Makama Safrokoh\"},\"USQdmvrHh1Q\":{\"uid\":\"USQdmvrHh1Q\",\"code\":\"OU_247055\",\"name\":\"Kaiyamba\"},\"xGMGhjA3y6J\":{\"uid\":\"xGMGhjA3y6J\",\"code\":\"OU_211262\",\"name\":\"Mambolo\"},\"nOYt1LtFSyU\":{\"uid\":\"nOYt1LtFSyU\",\"code\":\"OU_247025\",\"name\":\"Bumpeh\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"e1eIKM1GIF3\":{\"uid\":\"e1eIKM1GIF3\",\"code\":\"OU_193215\",\"name\":\"Gbanti Kamaranka\"},\"lYIM1MXbSYS\":{\"uid\":\"lYIM1MXbSYS\",\"code\":\"OU_204920\",\"name\":\"Dea\"},\"sxRd2XOzFbz\":{\"uid\":\"sxRd2XOzFbz\",\"code\":\"OU_551\",\"name\":\"Tikonko\"},\"d9iMR1MpuIO\":{\"uid\":\"d9iMR1MpuIO\",\"code\":\"OU_260410\",\"name\":\"Soro-Gbeima\"},\"qgQ49DH9a0v\":{\"uid\":\"qgQ49DH9a0v\",\"code\":\"OU_233332\",\"name\":\"Nimiyama\"},\"U09TSwIjG0s\":{\"uid\":\"U09TSwIjG0s\",\"code\":\"OU_222617\",\"name\":\"Nomo\"},\"zFDYIgyGmXG\":{\"uid\":\"zFDYIgyGmXG\",\"code\":\"OU_542\",\"name\":\"Bargbo\"},\"M2qEv692lS6\":{\"uid\":\"M2qEv692lS6\",\"code\":\"OU_233324\",\"name\":\"Tankoro\"},\"qtr8GGlm4gg\":{\"uid\":\"qtr8GGlm4gg\",\"code\":\"OU_278366\",\"name\":\"Rural Western Area\"},\"pRHGAROvuyI\":{\"uid\":\"pRHGAROvuyI\",\"code\":\"OU_254960\",\"name\":\"Koya\"},\"xIKjidMrico\":{\"uid\":\"xIKjidMrico\",\"code\":\"OU_247033\",\"name\":\"Kowa\"},\"GWTIxJO9pRo\":{\"uid\":\"GWTIxJO9pRo\",\"code\":\"OU_233355\",\"name\":\"Gorama Kono\"},\"HWjrSuoNPte\":{\"uid\":\"HWjrSuoNPte\",\"code\":\"OU_254999\",\"name\":\"Sanda Magbolonthor\"},\"UhHipWG7J8b\":{\"uid\":\"UhHipWG7J8b\",\"code\":\"OU_193191\",\"name\":\"Sanda Tendaren\"},\"rXLor9Knq6l\":{\"uid\":\"rXLor9Knq6l\",\"code\":\"OU_268212\",\"name\":\"Kunike Barina\"},\"kU8vhUkAGaT\":{\"uid\":\"kU8vhUkAGaT\",\"code\":\"OU_548\",\"name\":\"Lugbu\"},\"C9uduqDZr9d\":{\"uid\":\"C9uduqDZr9d\",\"code\":\"OU_278311\",\"name\":\"Freetown\"},\"YmmeuGbqOwR\":{\"uid\":\"YmmeuGbqOwR\",\"code\":\"OU_544\",\"name\":\"Gbo\"},\"iEkBZnMDarP\":{\"uid\":\"iEkBZnMDarP\",\"code\":\"OU_226253\",\"name\":\"Folosaba Dembelia\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"JsxnA2IywRo\":{\"uid\":\"JsxnA2IywRo\",\"code\":\"OU_204875\",\"name\":\"Kissi Kama\"},\"nlt6j60tCHF\":{\"uid\":\"nlt6j60tCHF\",\"code\":\"OU_260437\",\"name\":\"Mano Sakrim\"},\"g5ptsn0SFX8\":{\"uid\":\"g5ptsn0SFX8\",\"code\":\"OU_233365\",\"name\":\"Sandor\"},\"XG8HGAbrbbL\":{\"uid\":\"XG8HGAbrbbL\",\"code\":\"OU_193267\",\"name\":\"Safroko Limba\"},\"pmxZm7klXBy\":{\"uid\":\"pmxZm7klXBy\",\"code\":\"OU_204924\",\"name\":\"Peje West\"},\"l0ccv2yzfF3\":{\"uid\":\"l0ccv2yzfF3\",\"code\":\"OU_268174\",\"name\":\"Kunike\"},\"YuQRtpLP10I\":{\"uid\":\"YuQRtpLP10I\",\"code\":\"OU_539\",\"name\":\"Badjia\"},\"LfTkc0S4b5k\":{\"uid\":\"LfTkc0S4b5k\",\"code\":\"OU_204915\",\"name\":\"Upper Bambara\"},\"KSdZwrU7Hh6\":{\"uid\":\"KSdZwrU7Hh6\",\"code\":\"OU_204861\",\"name\":\"Jawi\"},\"ajILkI0cfxn\":{\"uid\":\"ajILkI0cfxn\",\"code\":\"OU_233390\",\"name\":\"Gbane\"},\"y5X4mP5XylL\":{\"uid\":\"y5X4mP5XylL\",\"code\":\"OU_211270\",\"name\":\"Tonko Limba\"},\"fwH9ipvXde9\":{\"uid\":\"fwH9ipvXde9\",\"code\":\"OU_193228\",\"name\":\"Biriwa\"},\"KIUCimTXf8Q\":{\"uid\":\"KIUCimTXf8Q\",\"code\":\"OU_222690\",\"name\":\"Nongowa\"},\"vEvs2ckGNQj\":{\"uid\":\"vEvs2ckGNQj\",\"code\":\"OU_226219\",\"name\":\"Kasonko\"},\"XEyIRFd9pct\":{\"uid\":\"XEyIRFd9pct\",\"code\":\"OU_197413\",\"name\":\"Imperi\"},\"cgOy0hRMGu9\":{\"uid\":\"cgOy0hRMGu9\",\"code\":\"OU_197408\",\"name\":\"Sogbini\"},\"EjnIQNVAXGp\":{\"uid\":\"EjnIQNVAXGp\",\"code\":\"OU_233344\",\"name\":\"Mafindor\"},\"x4HaBHHwBML\":{\"uid\":\"x4HaBHHwBML\",\"code\":\"OU_222672\",\"name\":\"Malegohun\"},\"EZPwuUTeIIG\":{\"uid\":\"EZPwuUTeIIG\",\"code\":\"OU_226258\",\"name\":\"Wara Wara Yagala\"},\"N233eZJZ1bh\":{\"uid\":\"N233eZJZ1bh\",\"code\":\"OU_260388\",\"name\":\"Pejeh\"},\"smoyi1iYNK6\":{\"uid\":\"smoyi1iYNK6\",\"code\":\"OU_268191\",\"name\":\"Kalansogoia\"},\"DNRAeXT9IwS\":{\"uid\":\"DNRAeXT9IwS\",\"code\":\"OU_197421\",\"name\":\"Dema\"},\"fRLX08WHWpL\":{\"uid\":\"fRLX08WHWpL\",\"code\":\"OU_254982\",\"name\":\"Lokomasama\"},\"Zoy23SSHCPs\":{\"uid\":\"Zoy23SSHCPs\",\"code\":\"OU_233311\",\"name\":\"Gbane Kandor\"},\"LsYpCyYxSLY\":{\"uid\":\"LsYpCyYxSLY\",\"code\":\"OU_247008\",\"name\":\"Kamaje\"},\"JdqfYTIFZXN\":{\"uid\":\"JdqfYTIFZXN\",\"code\":\"OU_254946\",\"name\":\"Maforki\"},\"EB1zRKdYjdY\":{\"uid\":\"EB1zRKdYjdY\",\"code\":\"OU_197429\",\"name\":\"Bendu Cha\"},\"CG4QD1HC3h4\":{\"uid\":\"CG4QD1HC3h4\",\"code\":\"OU_197436\",\"name\":\"Yawbeko\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\"},\"YpVol7asWvd\":{\"uid\":\"YpVol7asWvd\",\"code\":\"OU_260417\",\"name\":\"Kpanga Krim\"},\"RndxKqQGzUl\":{\"uid\":\"RndxKqQGzUl\",\"code\":\"OU_247018\",\"name\":\"Dasse\"},\"P69SId31eDp\":{\"uid\":\"P69SId31eDp\",\"code\":\"OU_268202\",\"name\":\"Gbonkonlenken\"},\"aWQTfvgPA5v\":{\"uid\":\"aWQTfvgPA5v\",\"code\":\"OU_197424\",\"name\":\"Kpanda Kemoh\"},\"KctpIIucige\":{\"uid\":\"KctpIIucige\",\"code\":\"OU_550\",\"name\":\"Selenga\"},\"Mr4au3jR9bt\":{\"uid\":\"Mr4au3jR9bt\",\"code\":\"OU_226214\",\"name\":\"Dembelia Sinkunia\"},\"L8iA6eLwKNb\":{\"uid\":\"L8iA6eLwKNb\",\"code\":\"OU_193295\",\"name\":\"Paki Masabong\"},\"j0Mtr3xTMjM\":{\"uid\":\"j0Mtr3xTMjM\",\"code\":\"OU_204939\",\"name\":\"Kissi Teng\"},\"DmaLM8WYmWv\":{\"uid\":\"DmaLM8WYmWv\",\"code\":\"OU_233394\",\"name\":\"Nimikoro\"},\"DfUfwjM9am5\":{\"uid\":\"DfUfwjM9am5\",\"code\":\"OU_260392\",\"name\":\"Malen\"},\"FRxcUEwktoV\":{\"uid\":\"FRxcUEwktoV\",\"code\":\"OU_233314\",\"name\":\"Toli\"},\"VCtF1DbspR5\":{\"uid\":\"VCtF1DbspR5\",\"code\":\"OU_197386\",\"name\":\"Jong\"},\"BD9gU0GKlr2\":{\"uid\":\"BD9gU0GKlr2\",\"code\":\"OU_260378\",\"name\":\"Makpele\"},\"GFk45MOxzJJ\":{\"uid\":\"GFk45MOxzJJ\",\"code\":\"OU_226275\",\"name\":\"Neya\"},\"A3Fh37HWBWE\":{\"uid\":\"A3Fh37HWBWE\",\"code\":\"OU_222687\",\"name\":\"Simbaru\"},\"vzup1f6ynON\":{\"uid\":\"vzup1f6ynON\",\"code\":\"OU_222619\",\"name\":\"Small Bo\"},\"Lt8U7GVWvSR\":{\"uid\":\"Lt8U7GVWvSR\",\"code\":\"OU_226263\",\"name\":\"Diang\"},\"JdhagCUEMbj\":{\"uid\":\"JdhagCUEMbj\",\"code\":\"OU_547\",\"name\":\"Komboya\"},\"EVkm2xYcf6Z\":{\"uid\":\"EVkm2xYcf6Z\",\"code\":\"OU_268184\",\"name\":\"Malal Mara\"},\"PQZJPIpTepd\":{\"uid\":\"PQZJPIpTepd\",\"code\":\"OU_268150\",\"name\":\"Kholifa Rowalla\"},\"WXnNDWTiE9r\":{\"uid\":\"WXnNDWTiE9r\",\"code\":\"OU_193239\",\"name\":\"Sanda Loko\"},\"RWvG1aFrr0r\":{\"uid\":\"RWvG1aFrr0r\",\"code\":\"OU_255053\",\"name\":\"Marampa\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"ImspTQPwCqd\",\"cgqkFdShPzg\",\"YuQRtpLP10I\",\"jPidqyo7cpF\",\"vWbkYPRmKyS\",\"dGheVylzol6\",\"zFDYIgyGmXG\",\"RzKeCma9qb1\",\"EB1zRKdYjdY\",\"fwH9ipvXde9\",\"ENHOJz3UH5L\",\"KKkLOTpMXGV\",\"kbPmt60yi0L\",\"iUauWFeH8Qp\",\"BGGmAwx33dj\",\"nOYt1LtFSyU\",\"TA7NvKjsn4A\",\"Pc3JTyqnsmL\",\"myQ4q1W6B4y\",\"RndxKqQGzUl\",\"lYIM1MXbSYS\",\"DNRAeXT9IwS\",\"Mr4au3jR9bt\",\"Lt8U7GVWvSR\",\"ZiOVcrSjSYe\",\"QlCIp2S9NHs\",\"vULnao2hV5v\",\"CF243RPvNY7\",\"iEkBZnMDarP\",\"C9uduqDZr9d\",\"eNtRuQrrZeo\",\"eROJsBwxQHt\",\"ajILkI0cfxn\",\"Zoy23SSHCPs\",\"e1eIKM1GIF3\",\"BXJdOLvUrZB\",\"TQkG0sX9nca\",\"qIRCo0MfuGb\",\"YmmeuGbqOwR\",\"P69SId31eDp\",\"GWTIxJO9pRo\",\"KXSqt7jv6DU\",\"XEyIRFd9pct\",\"daJPPxtIrQn\",\"KSdZwrU7Hh6\",\"VCtF1DbspR5\",\"BmYyh9bZ0sr\",\"vn9KJsLyP5f\",\"USQdmvrHh1Q\",\"U6Kr7Gtpidn\",\"smoyi1iYNK6\",\"LsYpCyYxSLY\",\"kvkDWg42lHR\",\"K1r3uF6eZ8n\",\"Z9QaI6sxTwW\",\"vEvs2ckGNQj\",\"fwxkctgmffZ\",\"PQZJPIpTepd\",\"JsxnA2IywRo\",\"j0Mtr3xTMjM\",\"hjpHnHZIniP\",\"JdhagCUEMbj\",\"Jiyc4ekaMMh\",\"nV3OkyzF4US\",\"xIKjidMrico\",\"pRHGAROvuyI\",\"EYt6ThQDagn\",\"zSNUViKdkk3\",\"aWQTfvgPA5v\",\"QwMiPiME3bA\",\"YpVol7asWvd\",\"l0ccv2yzfF3\",\"rXLor9Knq6l\",\"HV8RTzgcFH3\",\"jWSIbtKfURj\",\"LhaAPLxdSFH\",\"hRZOIgQ0O1m\",\"fRLX08WHWpL\",\"hdEuw2ugkVF\",\"W5fN3G6y1VI\",\"cM2BKSrj9F9\",\"kU8vhUkAGaT\",\"EjnIQNVAXGp\",\"JdqfYTIFZXN\",\"eV4cuxniZgP\",\"QywkxFudXrC\",\"lY93YpCxJqf\",\"BD9gU0GKlr2\",\"EVkm2xYcf6Z\",\"x4HaBHHwBML\",\"GE25DpSrqpB\",\"DfUfwjM9am5\",\"xGMGhjA3y6J\",\"yu4N82FFeLm\",\"nlt6j60tCHF\",\"RWvG1aFrr0r\",\"EfWCa0Cc8WW\",\"FlBemv1NfEC\",\"OTFepb1k9Db\",\"GFk45MOxzJJ\",\"uKC54fzxRzO\",\"I4jWcnFmgEC\",\"J4GiUImJZoE\",\"DmaLM8WYmWv\",\"qgQ49DH9a0v\",\"ERmBhYkhV6Y\",\"U09TSwIjG0s\",\"VP397wRvePm\",\"KIUCimTXf8Q\",\"L8iA6eLwKNb\",\"DxAPPqXvwLy\",\"pmxZm7klXBy\",\"N233eZJZ1bh\",\"bQiBfA2j5cw\",\"gy8rmvYT4cj\",\"qtr8GGlm4gg\",\"XG8HGAbrbbL\",\"r1RUyfVBkLp\",\"r06ohri9wA9\",\"WXnNDWTiE9r\",\"HWjrSuoNPte\",\"UhHipWG7J8b\",\"g5ptsn0SFX8\",\"KctpIIucige\",\"j43EZb15rjI\",\"VGAFxBXz16y\",\"A3Fh37HWBWE\",\"g8DdBm7EmUt\",\"vzup1f6ynON\",\"iGHlidSFdpu\",\"cgOy0hRMGu9\",\"d9iMR1MpuIO\",\"NqWaKXcg01b\",\"PaqugoqjRIj\",\"PrJQHI6q7w2\",\"Qhmi8IZyPyD\",\"xhyjU2SVewz\",\"M2qEv692lS6\",\"sxRd2XOzFbz\",\"AovmOHadayb\",\"FRxcUEwktoV\",\"y5X4mP5XylL\",\"l7pFejMtUoF\",\"LfTkc0S4b5k\",\"DBs6e2Oxaj1\",\"npWGUj37qDe\",\"X7dWcGerQIm\",\"XrF5AvaGcuw\",\"EZPwuUTeIIG\",\"ARZ4y5i4reU\",\"pk7bUK5c1Uf\",\"CG4QD1HC3h4\",\"byp7w6Xd9Df\",\"NNE0YMCDZkO\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.oucode",
-            "Organisation unit code",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.oucode",
+        "Organisation unit code",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -594,7 +594,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Under five (Luawa) Clinic");
     validateRowValueByName(
-            response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+        response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
 
     // Validate selected values for row index 99
@@ -610,15 +610,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname,ZzYYXq4fJie.oucode")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.ou:OU_GROUP-CXw2yu5fodb,pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname,ZzYYXq4fJie.oucode")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.ou:OU_GROUP-CXw2yu5fodb,pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -628,61 +628,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            4,
-            4); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        4,
+        4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"FNnj3jKGS7i\":{\"uid\":\"FNnj3jKGS7i\",\"code\":\"OU_260387\",\"name\":\"Bandajuma Clinic CHC\"},\"Q2USZSJmcNK\":{\"uid\":\"Q2USZSJmcNK\",\"code\":\"OU_268195\",\"name\":\"Bumbuna CHC\"},\"sLKHXoBIqSs\":{\"uid\":\"sLKHXoBIqSs\",\"code\":\"OU_233362\",\"name\":\"Njagbwema Fiama CHC\"},\"mwN7QuEfT8m\":{\"uid\":\"mwN7QuEfT8m\",\"code\":\"OU_820\",\"name\":\"Koribondo CHC\"},\"jGYT5U5qJP6\":{\"uid\":\"jGYT5U5qJP6\",\"code\":\"OU_653\",\"name\":\"Gbaiima CHC\"},\"agM0BKQlTh3\":{\"uid\":\"agM0BKQlTh3\",\"code\":\"OU_193303\",\"name\":\"Batkanu CHC\"},\"MuZJ8lprGqK\":{\"uid\":\"MuZJ8lprGqK\",\"code\":\"OU_247089\",\"name\":\"Moyamba Junction CHC\"},\"e2WgqiasKnD\":{\"uid\":\"e2WgqiasKnD\",\"code\":\"OU_246997\",\"name\":\"Taiama (Kori) CHC\"},\"KcCbIDzRcui\":{\"uid\":\"KcCbIDzRcui\",\"code\":\"OU_268221\",\"name\":\"Matotoka CHC\"},\"Jyv7sjpl9bA\":{\"uid\":\"Jyv7sjpl9bA\",\"code\":\"OU_222650\",\"name\":\"Sendumei CHC\"},\"zEsMdeJOty4\":{\"uid\":\"zEsMdeJOty4\",\"code\":\"OU_278331\",\"name\":\"Moyiba CHC\"},\"mshIal30ffW\":{\"uid\":\"mshIal30ffW\",\"code\":\"OU_193301\",\"name\":\"Mapaki CHC\"},\"uFp0ztDOFbI\":{\"uid\":\"uFp0ztDOFbI\",\"code\":\"OU_197430\",\"name\":\"Bendu CHC\"},\"scc4QyxenJd\":{\"uid\":\"scc4QyxenJd\",\"code\":\"OU_268215\",\"name\":\"Makali CHC\"},\"aHs9PLxIdbr\":{\"uid\":\"aHs9PLxIdbr\",\"code\":\"OU_268203\",\"name\":\"Mayepoh CHC\"},\"PA1spYiNZfv\":{\"uid\":\"PA1spYiNZfv\",\"code\":\"OU_233398\",\"name\":\"Yengema CHC\"},\"LnToY3ExKxL\":{\"uid\":\"LnToY3ExKxL\",\"code\":\"OU_255018\",\"name\":\"Mahera CHC\"},\"IlMQTFvcq9r\":{\"uid\":\"IlMQTFvcq9r\",\"code\":\"OU_222656\",\"name\":\"Lowoma CHC\"},\"jhtj3eQa1pM\":{\"uid\":\"jhtj3eQa1pM\",\"code\":\"OU_1100\",\"name\":\"Gondama (Tikonko) CHC\"},\"QsAwd531Cpd\":{\"uid\":\"QsAwd531Cpd\",\"code\":\"OU_1038\",\"name\":\"Njala CHC\"},\"pNPmNeqyrim\":{\"uid\":\"pNPmNeqyrim\",\"code\":\"OU_222666\",\"name\":\"Foindu (Lower Bamabara) CHC\"},\"K00jR5dmoFZ\":{\"uid\":\"K00jR5dmoFZ\",\"code\":\"OU_260399\",\"name\":\"Karlu CHC\"},\"xa4F6gesVJm\":{\"uid\":\"xa4F6gesVJm\",\"code\":\"OU_278400\",\"name\":\"York CHC\"},\"zQpYVEyAM2t\":{\"uid\":\"zQpYVEyAM2t\",\"code\":\"OU_278377\",\"name\":\"Hastings Health Centre\"},\"hzf90qz08AW\":{\"uid\":\"hzf90qz08AW\",\"code\":\"OU_247034\",\"name\":\"Njama CHC\"},\"CFPrsD3dNeb\":{\"uid\":\"CFPrsD3dNeb\",\"code\":\"OU_197423\",\"name\":\"Tissana CHC\"},\"MpcMjLmbATv\":{\"uid\":\"MpcMjLmbATv\",\"code\":\"OU_204938\",\"name\":\"Bandajuma Yawei CHC\"},\"KYXbIQBQgP1\":{\"uid\":\"KYXbIQBQgP1\",\"code\":\"OU_1103\",\"name\":\"Tikonko CHC\"},\"lxxASQqPUqd\":{\"uid\":\"lxxASQqPUqd\",\"code\":\"OU_233341\",\"name\":\"Tombodu CHC\"},\"oRncQGhLYNE\":{\"uid\":\"oRncQGhLYNE\",\"code\":\"OU_278376\",\"name\":\"Regent (RWA) CHC\"},\"RhJbg8UD75Q\":{\"uid\":\"RhJbg8UD75Q\",\"code\":\"OU_1027\",\"name\":\"Yemoh Town CHC\"},\"EUUkKEDoNsf\":{\"uid\":\"EUUkKEDoNsf\",\"code\":\"OU_278343\",\"name\":\"Wilberforce CHC\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"FbD5Z8z22Yb\":{\"uid\":\"FbD5Z8z22Yb\",\"code\":\"OU_260385\",\"name\":\"Geoma Jagor CHC\"},\"ua5GXy2uhBR\":{\"uid\":\"ua5GXy2uhBR\",\"code\":\"OU_197412\",\"name\":\"Tihun CHC\"},\"QpRIPul20Sb\":{\"uid\":\"QpRIPul20Sb\",\"code\":\"OU_222637\",\"name\":\"Gorahun CHC\"},\"mt47bcb0Rcj\":{\"uid\":\"mt47bcb0Rcj\",\"code\":\"OU_193231\",\"name\":\"Kamabai CHC\"},\"uDzWmUDHKeR\":{\"uid\":\"uDzWmUDHKeR\",\"code\":\"OU_260389\",\"name\":\"Futa CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"OjXNuYyLaCJ\":{\"uid\":\"OjXNuYyLaCJ\",\"code\":\"OU_255004\",\"name\":\"Sendugu CHC\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZdPkczYqeIY\":{\"uid\":\"ZdPkczYqeIY\",\"code\":\"OU_247092\",\"name\":\"Gandorhun CHC\"},\"p310xqwAJge\":{\"uid\":\"p310xqwAJge\",\"code\":\"OU_226268\",\"name\":\"Kondembaia CHC\"},\"HcB2W6Fgp7i\":{\"uid\":\"HcB2W6Fgp7i\",\"code\":\"OU_255065\",\"name\":\"Melekuray CHC\"},\"lOv6IFgr6Fs\":{\"uid\":\"lOv6IFgr6Fs\",\"code\":\"OU_832\",\"name\":\"Manjama Shellmingo CHC\"},\"amgb83zVxp5\":{\"uid\":\"amgb83zVxp5\",\"code\":\"OU_222674\",\"name\":\"Bendu Mameima CHC\"},\"K6oyIMh7Lee\":{\"uid\":\"K6oyIMh7Lee\",\"code\":\"OU_226224\",\"name\":\"Fadugu CHC\"},\"m0XorV4WWg0\":{\"uid\":\"m0XorV4WWg0\",\"code\":\"OU_278361\",\"name\":\"Ginger Hall Health Centre\"},\"bSj2UnYhTFb\":{\"uid\":\"bSj2UnYhTFb\",\"code\":\"OU_193218\",\"name\":\"Kamaranka CHC\"},\"CvBAqD6RzLZ\":{\"uid\":\"CvBAqD6RzLZ\",\"code\":\"OU_595\",\"name\":\"Ngalu CHC\"},\"k6lOze3vTzP\":{\"uid\":\"k6lOze3vTzP\",\"code\":\"OU_260435\",\"name\":\"Potoru CHC\"},\"p9KfD6eaRvu\":{\"uid\":\"p9KfD6eaRvu\",\"code\":\"OU_247069\",\"name\":\"Shenge CHC\"},\"K3jhn3TXF3a\":{\"uid\":\"K3jhn3TXF3a\",\"code\":\"OU_222665\",\"name\":\"Tongo Field CHC\"},\"HNv1aLPdMYb\":{\"uid\":\"HNv1aLPdMYb\",\"code\":\"OU_193242\",\"name\":\"Kamalo CHC\"},\"yMCshbaVExv\":{\"uid\":\"yMCshbaVExv\",\"code\":\"OU_254991\",\"name\":\"Babara CHC\"},\"pJv8NJlJNhU\":{\"uid\":\"pJv8NJlJNhU\",\"code\":\"OU_204916\",\"name\":\"Pendembu CHC\"},\"YAuJ3fyoEuI\":{\"uid\":\"YAuJ3fyoEuI\",\"code\":\"OU_193281\",\"name\":\"Gbendembu Wesleyan CHC\"},\"g5A3hiJlwmI\":{\"uid\":\"g5A3hiJlwmI\",\"code\":\"OU_233397\",\"name\":\"UMC Mitchener Memorial Maternity & Health Centre\"},\"jKZ0U8Og5aV\":{\"uid\":\"jKZ0U8Og5aV\",\"code\":\"OU_222683\",\"name\":\"Dodo CHC\"},\"EXbPGmEUdnc\":{\"uid\":\"EXbPGmEUdnc\",\"code\":\"OU_193197\",\"name\":\"Mateboi CHC\"},\"nX05QLraDhO\":{\"uid\":\"nX05QLraDhO\",\"code\":\"OU_585\",\"name\":\"Yamandu CHC\"},\"Umh4HKqqFp6\":{\"uid\":\"Umh4HKqqFp6\",\"code\":\"OU_578\",\"name\":\"Jembe CHC\"},\"ubsjwFFBaJM\":{\"uid\":\"ubsjwFFBaJM\",\"code\":\"OU_247016\",\"name\":\"Gbangbatoke CHC\"},\"rm60vuHyQXj\":{\"uid\":\"rm60vuHyQXj\",\"code\":\"OU_1082\",\"name\":\"Nengbema CHC\"},\"iOA3z6Y3cq5\":{\"uid\":\"iOA3z6Y3cq5\",\"code\":\"OU_222699\",\"name\":\"Largo CHC\"},\"sIVFEyNfOg4\":{\"uid\":\"sIVFEyNfOg4\",\"code\":\"OU_247073\",\"name\":\"Mokandor CHP\"},\"k8ZPul89UDm\":{\"uid\":\"k8ZPul89UDm\",\"code\":\"OU_233370\",\"name\":\"Kayima CHC\"},\"iMZihUMzH92\":{\"uid\":\"iMZihUMzH92\",\"code\":\"OU_247083\",\"name\":\"Bauya (Kongbora) CHC\"},\"MXdbul7bBqV\":{\"uid\":\"MXdbul7bBqV\",\"code\":\"OU_204912\",\"name\":\"Mobai CHC\"},\"dkmpOuVhBba\":{\"uid\":\"dkmpOuVhBba\",\"code\":\"OU_268226\",\"name\":\"Mathoir CHC\"},\"q56204kKXgZ\":{\"uid\":\"q56204kKXgZ\",\"code\":\"OU_255057\",\"name\":\"Lunsar CHC\"},\"kuqKh33SPgg\":{\"uid\":\"kuqKh33SPgg\",\"code\":\"OU_226230\",\"name\":\"Falaba CHC\"},\"NjyJYiIuKIG\":{\"uid\":\"NjyJYiIuKIG\",\"code\":\"OU_193291\",\"name\":\"Kathanta Yimbor CHC\"},\"fAsj6a4nudH\":{\"uid\":\"fAsj6a4nudH\",\"code\":\"OU_197398\",\"name\":\"Yoni CHC\"},\"a04CZxe0PSe\":{\"uid\":\"a04CZxe0PSe\",\"code\":\"OU_278333\",\"name\":\"Murray Town CHC\"},\"qxbsDd9QYv6\":{\"uid\":\"qxbsDd9QYv6\",\"code\":\"OU_226274\",\"name\":\"Yiffin CHC\"},\"Mi4dWRtfIOC\":{\"uid\":\"Mi4dWRtfIOC\",\"code\":\"OU_204860\",\"name\":\"Sandaru CHC\"},\"QzPf0qKBU4n\":{\"uid\":\"QzPf0qKBU4n\",\"code\":\"OU_260411\",\"name\":\"Jendema CHC\"},\"mzsOsz0NwNY\":{\"uid\":\"mzsOsz0NwNY\",\"code\":\"OU_836\",\"name\":\"New Police Barracks CHC\"},\"vELbGdEphPd\":{\"uid\":\"vELbGdEphPd\",\"code\":\"OU_614\",\"name\":\"Jimmi CHC\"},\"qVvitxEF2ck\":{\"uid\":\"qVvitxEF2ck\",\"code\":\"OU_254949\",\"name\":\"Rogbere CHC\"},\"RAsstekPRco\":{\"uid\":\"RAsstekPRco\",\"code\":\"OU_211269\",\"name\":\"Mambolo CHC\"},\"va2lE4FiVVb\":{\"uid\":\"va2lE4FiVVb\",\"code\":\"OU_247019\",\"name\":\"Mano CHC\"},\"cNAp6CJeLxk\":{\"uid\":\"cNAp6CJeLxk\",\"code\":\"OU_247015\",\"name\":\"Mokanji CHC\"},\"wByqtWCCuDJ\":{\"uid\":\"wByqtWCCuDJ\",\"code\":\"OU_1095\",\"name\":\"Damballa CHC\"},\"PcADvhvcaI2\":{\"uid\":\"PcADvhvcaI2\",\"code\":\"OU_211253\",\"name\":\"Kychom CHC\"},\"n7wN9gMFfZ5\":{\"uid\":\"n7wN9gMFfZ5\",\"code\":\"OU_197435\",\"name\":\"Benduma CHC\"},\"kUzpbgPCwVA\":{\"uid\":\"kUzpbgPCwVA\",\"code\":\"OU_222624\",\"name\":\"Blama CHC\"},\"rCKWdLr4B8K\":{\"uid\":\"rCKWdLr4B8K\",\"code\":\"OU_197427\",\"name\":\"Motuo CHC\"},\"DMxw0SASFih\":{\"uid\":\"DMxw0SASFih\",\"code\":\"OU_204941\",\"name\":\"Koindu CHC\"},\"PQEpIeuSTCN\":{\"uid\":\"PQEpIeuSTCN\",\"code\":\"OU_222623\",\"name\":\"Tobanda CHC\"},\"inpc5QsFRTm\":{\"uid\":\"inpc5QsFRTm\",\"code\":\"OU_211274\",\"name\":\"Kamassasa CHC\"},\"aSxNNRxPuBP\":{\"uid\":\"aSxNNRxPuBP\",\"code\":\"OU_193278\",\"name\":\"Kalangba CHC\"},\"O1KFJmM6HUx\":{\"uid\":\"O1KFJmM6HUx\",\"code\":\"OU_260438\",\"name\":\"Mano Gbonjeima CHC\"},\"s5aXfzOL456\":{\"uid\":\"s5aXfzOL456\",\"code\":\"OU_197437\",\"name\":\"Talia CHC\"},\"tSBcgrTDdB8\":{\"uid\":\"tSBcgrTDdB8\",\"code\":\"OU_834\",\"name\":\"Paramedical CHC\"},\"KiheEgvUZ0i\":{\"uid\":\"KiheEgvUZ0i\",\"code\":\"OU_278357\",\"name\":\"Calaba town CHC\"},\"d9zRBAoM8OC\":{\"uid\":\"d9zRBAoM8OC\",\"code\":\"OU_260423\",\"name\":\"Bumpeh Perri CHC\"},\"sesv0eXljBq\":{\"uid\":\"sesv0eXljBq\",\"code\":\"OU_268207\",\"name\":\"Yele CHC\"},\"L4Tw4NlaMjn\":{\"uid\":\"L4Tw4NlaMjn\",\"code\":\"OU_222705\",\"name\":\"Nekabo CHC\"},\"sznCEDMABa2\":{\"uid\":\"sznCEDMABa2\",\"code\":\"OU_204903\",\"name\":\"Ngiehun CHC\"},\"E497Rk80ivZ\":{\"uid\":\"E497Rk80ivZ\",\"code\":\"OU_651\",\"name\":\"Bumpe CHC\"},\"CXw2yu5fodb\":{\"uid\":\"CXw2yu5fodb\",\"code\":\"CHC\",\"valueType\":\"NUMBER\",\"name\":\"CHC\",\"dimensionItemType\":\"ORGANISATION_UNIT_GROUP\",\"totalAggregationType\":\"SUM\"},\"W7ekX3gi0ut\":{\"uid\":\"W7ekX3gi0ut\",\"code\":\"OU_233333\",\"name\":\"Jaiama Sewafe CHC\"},\"roGdTjEqLZQ\":{\"uid\":\"roGdTjEqLZQ\",\"code\":\"OU_233371\",\"name\":\"Yormandu CHC\"},\"Jiymtq0A01x\":{\"uid\":\"Jiymtq0A01x\",\"code\":\"OU_226243\",\"name\":\"Bafodia CHC\"},\"aIsnJuZbmVA\":{\"uid\":\"aIsnJuZbmVA\",\"code\":\"OU_226256\",\"name\":\"Dogoloya CHP\"},\"IlnqGuxfQAw\":{\"uid\":\"IlnqGuxfQAw\",\"code\":\"OU_226216\",\"name\":\"Sinkunia CHC\"},\"lpQvlm9czYE\":{\"uid\":\"lpQvlm9czYE\",\"code\":\"OU_222631\",\"name\":\"Tungie CHC\"},\"uedNhvYPMNu\":{\"uid\":\"uedNhvYPMNu\",\"code\":\"OU_193216\",\"name\":\"Gbanti CHC\"},\"KKoPh1lDd9j\":{\"uid\":\"KKoPh1lDd9j\",\"code\":\"OU_233321\",\"name\":\"Kainkordu CHC\"},\"xKaB8tfbTzm\":{\"uid\":\"xKaB8tfbTzm\",\"code\":\"OU_193247\",\"name\":\"Fintonia CHC\"},\"TEVtOFKcLAP\":{\"uid\":\"TEVtOFKcLAP\",\"code\":\"OU_197447\",\"name\":\"Gbap CHC\"},\"pXDcgDRz8Od\":{\"uid\":\"pXDcgDRz8Od\",\"code\":\"OU_278402\",\"name\":\"Songo CHC\"},\"NaVzm59XKGf\":{\"uid\":\"NaVzm59XKGf\",\"code\":\"OU_254980\",\"name\":\"Gbinti CHC\"},\"Ahh47q8AkId\":{\"uid\":\"Ahh47q8AkId\",\"code\":\"OU_268167\",\"name\":\"Mabang CHC\"},\"QZtMuEEV9Vv\":{\"uid\":\"QZtMuEEV9Vv\",\"code\":\"OU_211237\",\"name\":\"Rokupr CHC\"},\"U4FzUXMvbI8\":{\"uid\":\"U4FzUXMvbI8\",\"code\":\"OU_255009\",\"name\":\"Conakry Dee CHC\"},\"o0BgK1dLhF8\":{\"uid\":\"o0BgK1dLhF8\",\"code\":\"OU_268170\",\"name\":\"Bendugu CHC\"},\"agEKP19IUKI\":{\"uid\":\"agEKP19IUKI\",\"code\":\"OU_193280\",\"name\":\"Tambiama CHC\"},\"qIpBLa1SCZt\":{\"uid\":\"qIpBLa1SCZt\",\"code\":\"OU_222714\",\"name\":\"Talia (Nongowa) CHC\"},\"H97XE5Ea089\":{\"uid\":\"H97XE5Ea089\",\"code\":\"OU_247045\",\"name\":\"Bomotoke CHC\"},\"nv41sOz8IVM\":{\"uid\":\"nv41sOz8IVM\",\"code\":\"OU_204927\",\"name\":\"Pejewa CHC\"},\"202301\":{\"name\":\"January 2023\"},\"NMcx2jmra3c\":{\"uid\":\"NMcx2jmra3c\",\"code\":\"OU_226273\",\"name\":\"Firawa CHC\"},\"m3VnSQbE8CD\":{\"uid\":\"m3VnSQbE8CD\",\"code\":\"OU_278382\",\"name\":\"Newton CHC\"},\"OY7mYDATra3\":{\"uid\":\"OY7mYDATra3\",\"code\":\"OU_268176\",\"name\":\"Massingbi CHC\"},\"RQgXBKxgvHf\":{\"uid\":\"RQgXBKxgvHf\",\"code\":\"OU_211248\",\"name\":\"Mapotolon CHC\"},\"YvwYw7GilkP\":{\"uid\":\"YvwYw7GilkP\",\"code\":\"OU_222726\",\"name\":\"Levuma (Kandu Lep) CHC\"},\"PduUQmdt0pB\":{\"uid\":\"PduUQmdt0pB\",\"code\":\"OU_211273\",\"name\":\"Numea CHC\"},\"U514Dz4v9pv\":{\"uid\":\"U514Dz4v9pv\",\"code\":\"OU_278330\",\"name\":\"George Brook Health Centre\"},\"PuZOFApTSeo\":{\"uid\":\"PuZOFApTSeo\",\"code\":\"OU_952\",\"name\":\"Sahn CHC\"},\"wUmVUKhnPuy\":{\"uid\":\"wUmVUKhnPuy\",\"code\":\"OU_247057\",\"name\":\"Kangahun CHC\"},\"RaQGHRti7JM\":{\"uid\":\"RaQGHRti7JM\",\"code\":\"OU_278335\",\"name\":\"Gods Favour health Center\"},\"xMn4Wki9doK\":{\"uid\":\"xMn4Wki9doK\",\"code\":\"OU_197417\",\"name\":\"Moriba Town CHC\"},\"JQJjsXvHE5M\":{\"uid\":\"JQJjsXvHE5M\",\"code\":\"OU_247007\",\"name\":\"Mokelleh CHC\"},\"m5BX6CvJ6Ex\":{\"uid\":\"m5BX6CvJ6Ex\",\"code\":\"OU_204865\",\"name\":\"Daru CHC\"},\"D2rB1GRuh8C\":{\"uid\":\"D2rB1GRuh8C\",\"code\":\"OU_197418\",\"name\":\"Gbamgbama CHC\"},\"Gm7YUjhVi9Q\":{\"uid\":\"Gm7YUjhVi9Q\",\"code\":\"OU_260415\",\"name\":\"Fairo CHC\"},\"gE3gEGZbQMi\":{\"uid\":\"gE3gEGZbQMi\",\"code\":\"OU_197407\",\"name\":\"Madina (BUM) CHC\"},\"zuXW98AEbE7\":{\"uid\":\"zuXW98AEbE7\",\"code\":\"OU_255023\",\"name\":\"Kamasondo CHC\"},\"TjZwphhxCuV\":{\"uid\":\"TjZwphhxCuV\",\"code\":\"OU_193225\",\"name\":\"Kagbere CHC\"},\"g5lonXJ9ndA\":{\"uid\":\"g5lonXJ9ndA\",\"code\":\"OU_268237\",\"name\":\"Hinistas CHC\"},\"r5WWF9WDzoa\":{\"uid\":\"r5WWF9WDzoa\",\"code\":\"OU_222681\",\"name\":\"Baama CHC\"},\"VhRX5JDVo7R\":{\"uid\":\"VhRX5JDVo7R\",\"code\":\"OU_278397\",\"name\":\"Waterloo CHC\"},\"PMsF64R6OJX\":{\"uid\":\"PMsF64R6OJX\",\"code\":\"OU_226248\",\"name\":\"Bendugu (Mongo) CHC\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"azRICFoILuh\":{\"uid\":\"azRICFoILuh\",\"code\":\"OU_577\",\"name\":\"Golu MCHP\"},\"HQoxFu4lYPS\":{\"uid\":\"HQoxFu4lYPS\",\"code\":\"OU_204868\",\"name\":\"Pellie CHC\"},\"JrSIoCOdTH2\":{\"uid\":\"JrSIoCOdTH2\",\"code\":\"OU_278403\",\"name\":\"Tombo CHC\"},\"ke2gwHKHP3z\":{\"uid\":\"ke2gwHKHP3z\",\"code\":\"OU_254983\",\"name\":\"Petifu CHC\"},\"TSyzvBiovKh\":{\"uid\":\"TSyzvBiovKh\",\"code\":\"OU_576\",\"name\":\"Gerehun CHC\"},\"g10jm7jPdzf\":{\"uid\":\"g10jm7jPdzf\",\"code\":\"OU_222707\",\"name\":\"Hangha CHC\"},\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"bPqP6eRfkyn\":{\"uid\":\"bPqP6eRfkyn\",\"code\":\"OU_278318\",\"name\":\"Ross Road Health Centre\"},\"EURoFVjowXs\":{\"uid\":\"EURoFVjowXs\",\"code\":\"OU_254964\",\"name\":\"Masiaka CHC\"},\"ii2KMnWMx2L\":{\"uid\":\"ii2KMnWMx2L\",\"code\":\"OU_233392\",\"name\":\"Gandorhun (Gbane) CHC\"},\"J42QfNe0GJZ\":{\"uid\":\"J42QfNe0GJZ\",\"code\":\"OU_268185\",\"name\":\"Mara CHC\"},\"gUPhNWkSXvD\":{\"uid\":\"gUPhNWkSXvD\",\"code\":\"OU_247032\",\"name\":\"Rotifunk CHC\"},\"FLjwMPWLrL2\":{\"uid\":\"FLjwMPWLrL2\",\"code\":\"OU_1126\",\"name\":\"Baomahun CHC\"},\"FclfbEFMcf3\":{\"uid\":\"FclfbEFMcf3\",\"code\":\"OU_278340\",\"name\":\"Kissy Health Centre\"},\"lL2LBkhlsmV\":{\"uid\":\"lL2LBkhlsmV\",\"code\":\"OU_278336\",\"name\":\"Grassfield CHC\"},\"NRPCjDljVtu\":{\"uid\":\"NRPCjDljVtu\",\"code\":\"OU_278404\",\"name\":\"Lakka\\/Ogoo Farm CHC\"},\"egjrZ1PHNtT\":{\"uid\":\"egjrZ1PHNtT\",\"code\":\"OU_247053\",\"name\":\"Sembehun CHC\"},\"PC3Ag91n82e\":{\"uid\":\"PC3Ag91n82e\",\"code\":\"OU_1122\",\"name\":\"Mongere CHC\"},\"X79FDd4EAgo\":{\"uid\":\"X79FDd4EAgo\",\"code\":\"OU_193196\",\"name\":\"Rokulan CHC\"},\"sM0Us0NkSez\":{\"uid\":\"sM0Us0NkSez\",\"code\":\"OU_278359\",\"name\":\"Kroo Bay CHC\"},\"bHcw141PTsE\":{\"uid\":\"bHcw141PTsE\",\"code\":\"OU_260407\",\"name\":\"Gbondapi CHC\"},\"O63vIA5MVn6\":{\"uid\":\"O63vIA5MVn6\",\"code\":\"OU_255014\",\"name\":\"Tagrin CHC\"},\"HWXk4EBHUyk\":{\"uid\":\"HWXk4EBHUyk\",\"code\":\"OU_260393\",\"name\":\"Sahn (Malen) CHC\"},\"W2KnxOMvmgE\":{\"uid\":\"W2KnxOMvmgE\",\"code\":\"OU_1050\",\"name\":\"Sumbuya CHC\"},\"tO01bqIipeD\":{\"uid\":\"tO01bqIipeD\",\"code\":\"OU_204892\",\"name\":\"Buedu CHC\"},\"w3mBVfrWhXl\":{\"uid\":\"w3mBVfrWhXl\",\"code\":\"OU_255043\",\"name\":\"Mange CHC\"},\"TljiT6C5D0J\":{\"uid\":\"TljiT6C5D0J\",\"code\":\"OU_222740\",\"name\":\"Kpandebu CHC\"},\"TmCsvdJLHoX\":{\"uid\":\"TmCsvdJLHoX\",\"code\":\"OU_193195\",\"name\":\"Mabunduka CHC\"},\"BNFrspDBKel\":{\"uid\":\"BNFrspDBKel\",\"code\":\"OU_260382\",\"name\":\"Zimmi CHC\"},\"N3tpEjZcPm9\":{\"uid\":\"N3tpEjZcPm9\",\"code\":\"OU_204879\",\"name\":\"Laleihun Kovoma CHC\"},\"Qc9lf4VM9bD\":{\"uid\":\"Qc9lf4VM9bD\",\"code\":\"OU_278317\",\"name\":\"Wellington Health Centre\"},\"cMFi8lYbXHY\":{\"uid\":\"cMFi8lYbXHY\",\"code\":\"OU_233402\",\"name\":\"Bumpeh (Nimikoro) CHC\"},\"P4upLKrpkHP\":{\"uid\":\"P4upLKrpkHP\",\"code\":\"OU_222641\",\"name\":\"Ngegbwema CHC\"},\"Yj2ni275yPJ\":{\"uid\":\"Yj2ni275yPJ\",\"code\":\"OU_222647\",\"name\":\"Baoma (Koya) CHC\"},\"SnCrOCRrxGX\":{\"uid\":\"SnCrOCRrxGX\",\"code\":\"OU_233327\",\"name\":\"Koakoyima CHC\"},\"Z9ny6QeqsgX\":{\"uid\":\"Z9ny6QeqsgX\",\"code\":\"OU_969\",\"name\":\"Manjama UMC CHC\"},\"wtdBuXDwZYQ\":{\"uid\":\"wtdBuXDwZYQ\",\"code\":\"OU_1006\",\"name\":\"Praise Foundation CHC\"},\"oLuhRyYPxRO\":{\"uid\":\"oLuhRyYPxRO\",\"code\":\"OU_247011\",\"name\":\"Senehun CHC\"},\"PaNv9VyD06n\":{\"uid\":\"PaNv9VyD06n\",\"code\":\"OU_204930\",\"name\":\"Manowa CHC\"},\"uRQj8WRK0Py\":{\"uid\":\"uRQj8WRK0Py\",\"code\":\"OU_193255\",\"name\":\"Masongbo CHC\"},\"Y8foq27WLti\":{\"uid\":\"Y8foq27WLti\",\"code\":\"OU_222728\",\"name\":\"Baoma Oil Mill CHC\"},\"mepHuAA9l51\":{\"uid\":\"mepHuAA9l51\",\"code\":\"OU_193205\",\"name\":\"Rokonta CHC\"},\"k1Y0oNqPlmy\":{\"uid\":\"k1Y0oNqPlmy\",\"code\":\"OU_1161\",\"name\":\"Gboyama CHC\"},\"UOJlcpPnBat\":{\"uid\":\"UOJlcpPnBat\",\"code\":\"OU_172174\",\"name\":\"Needy CHC\"},\"CKkE4GBJekz\":{\"uid\":\"CKkE4GBJekz\",\"code\":\"OU_222671\",\"name\":\"Weima CHC\"},\"GHHvGp7tgtZ\":{\"uid\":\"GHHvGp7tgtZ\",\"code\":\"OU_193275\",\"name\":\"Binkolo CHC\"},\"dQggcljEImF\":{\"uid\":\"dQggcljEImF\",\"code\":\"OU_278392\",\"name\":\"Goderich Health Centre\"},\"DvzKyuC0G4w\":{\"uid\":\"DvzKyuC0G4w\",\"code\":\"OU_204872\",\"name\":\"Jojoima CHC\"},\"Luv2kmWWgoG\":{\"uid\":\"Luv2kmWWgoG\",\"code\":\"OU_222632\",\"name\":\"Mondema CHC\"},\"cw0Wm1QTHRq\":{\"uid\":\"cw0Wm1QTHRq\",\"code\":\"OU_222750\",\"name\":\"Joru CHC\"},\"Ep5iWL1UKvF\":{\"uid\":\"Ep5iWL1UKvF\",\"code\":\"OU_226276\",\"name\":\"Kurubonla CHC\"},\"EH0dXLB4nZg\":{\"uid\":\"EH0dXLB4nZg\",\"code\":\"OU_255032\",\"name\":\"Masimera CHC\"},\"L5gENbBNNup\":{\"uid\":\"L5gENbBNNup\",\"code\":\"OU_222689\",\"name\":\"Boajibu CHC\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"r5WWF9WDzoa\",\"yMCshbaVExv\",\"Jiymtq0A01x\",\"FNnj3jKGS7i\",\"MpcMjLmbATv\",\"Yj2ni275yPJ\",\"Y8foq27WLti\",\"FLjwMPWLrL2\",\"agM0BKQlTh3\",\"iMZihUMzH92\",\"uFp0ztDOFbI\",\"amgb83zVxp5\",\"PMsF64R6OJX\",\"o0BgK1dLhF8\",\"n7wN9gMFfZ5\",\"GHHvGp7tgtZ\",\"kUzpbgPCwVA\",\"L5gENbBNNup\",\"H97XE5Ea089\",\"tO01bqIipeD\",\"Q2USZSJmcNK\",\"E497Rk80ivZ\",\"cMFi8lYbXHY\",\"d9zRBAoM8OC\",\"KiheEgvUZ0i\",\"U4FzUXMvbI8\",\"wByqtWCCuDJ\",\"m5BX6CvJ6Ex\",\"jKZ0U8Og5aV\",\"aIsnJuZbmVA\",\"K6oyIMh7Lee\",\"Gm7YUjhVi9Q\",\"kuqKh33SPgg\",\"xKaB8tfbTzm\",\"NMcx2jmra3c\",\"pNPmNeqyrim\",\"uDzWmUDHKeR\",\"ii2KMnWMx2L\",\"ZdPkczYqeIY\",\"jGYT5U5qJP6\",\"D2rB1GRuh8C\",\"ubsjwFFBaJM\",\"uedNhvYPMNu\",\"TEVtOFKcLAP\",\"YAuJ3fyoEuI\",\"NaVzm59XKGf\",\"bHcw141PTsE\",\"k1Y0oNqPlmy\",\"FbD5Z8z22Yb\",\"U514Dz4v9pv\",\"TSyzvBiovKh\",\"m0XorV4WWg0\",\"dQggcljEImF\",\"RaQGHRti7JM\",\"azRICFoILuh\",\"jhtj3eQa1pM\",\"QpRIPul20Sb\",\"lL2LBkhlsmV\",\"g10jm7jPdzf\",\"zQpYVEyAM2t\",\"g5lonXJ9ndA\",\"W7ekX3gi0ut\",\"Umh4HKqqFp6\",\"QzPf0qKBU4n\",\"vELbGdEphPd\",\"DvzKyuC0G4w\",\"cw0Wm1QTHRq\",\"TjZwphhxCuV\",\"KKoPh1lDd9j\",\"aSxNNRxPuBP\",\"mt47bcb0Rcj\",\"HNv1aLPdMYb\",\"bSj2UnYhTFb\",\"zuXW98AEbE7\",\"inpc5QsFRTm\",\"wUmVUKhnPuy\",\"K00jR5dmoFZ\",\"NjyJYiIuKIG\",\"k8ZPul89UDm\",\"FclfbEFMcf3\",\"SnCrOCRrxGX\",\"DMxw0SASFih\",\"p310xqwAJge\",\"mwN7QuEfT8m\",\"TljiT6C5D0J\",\"sM0Us0NkSez\",\"Ep5iWL1UKvF\",\"PcADvhvcaI2\",\"NRPCjDljVtu\",\"N3tpEjZcPm9\",\"iOA3z6Y3cq5\",\"YvwYw7GilkP\",\"IlMQTFvcq9r\",\"q56204kKXgZ\",\"Ahh47q8AkId\",\"TmCsvdJLHoX\",\"gE3gEGZbQMi\",\"LnToY3ExKxL\",\"scc4QyxenJd\",\"RAsstekPRco\",\"w3mBVfrWhXl\",\"lOv6IFgr6Fs\",\"Z9ny6QeqsgX\",\"va2lE4FiVVb\",\"O1KFJmM6HUx\",\"PaNv9VyD06n\",\"mshIal30ffW\",\"RQgXBKxgvHf\",\"J42QfNe0GJZ\",\"EURoFVjowXs\",\"EH0dXLB4nZg\",\"uRQj8WRK0Py\",\"OY7mYDATra3\",\"EXbPGmEUdnc\",\"dkmpOuVhBba\",\"KcCbIDzRcui\",\"aHs9PLxIdbr\",\"HcB2W6Fgp7i\",\"MXdbul7bBqV\",\"sIVFEyNfOg4\",\"cNAp6CJeLxk\",\"JQJjsXvHE5M\",\"Luv2kmWWgoG\",\"PC3Ag91n82e\",\"xMn4Wki9doK\",\"rCKWdLr4B8K\",\"MuZJ8lprGqK\",\"zEsMdeJOty4\",\"a04CZxe0PSe\",\"UOJlcpPnBat\",\"L4Tw4NlaMjn\",\"rm60vuHyQXj\",\"mzsOsz0NwNY\",\"m3VnSQbE8CD\",\"CvBAqD6RzLZ\",\"P4upLKrpkHP\",\"DiszpKrYNg8\",\"sznCEDMABa2\",\"sLKHXoBIqSs\",\"QsAwd531Cpd\",\"hzf90qz08AW\",\"PduUQmdt0pB\",\"tSBcgrTDdB8\",\"nv41sOz8IVM\",\"HQoxFu4lYPS\",\"pJv8NJlJNhU\",\"ke2gwHKHP3z\",\"k6lOze3vTzP\",\"wtdBuXDwZYQ\",\"oRncQGhLYNE\",\"qVvitxEF2ck\",\"mepHuAA9l51\",\"X79FDd4EAgo\",\"QZtMuEEV9Vv\",\"bPqP6eRfkyn\",\"gUPhNWkSXvD\",\"HWXk4EBHUyk\",\"PuZOFApTSeo\",\"Mi4dWRtfIOC\",\"egjrZ1PHNtT\",\"OjXNuYyLaCJ\",\"Jyv7sjpl9bA\",\"oLuhRyYPxRO\",\"p9KfD6eaRvu\",\"IlnqGuxfQAw\",\"pXDcgDRz8Od\",\"W2KnxOMvmgE\",\"O63vIA5MVn6\",\"e2WgqiasKnD\",\"qIpBLa1SCZt\",\"s5aXfzOL456\",\"agEKP19IUKI\",\"ua5GXy2uhBR\",\"KYXbIQBQgP1\",\"CFPrsD3dNeb\",\"PQEpIeuSTCN\",\"JrSIoCOdTH2\",\"lxxASQqPUqd\",\"K3jhn3TXF3a\",\"lpQvlm9czYE\",\"g5A3hiJlwmI\",\"VhRX5JDVo7R\",\"CKkE4GBJekz\",\"Qc9lf4VM9bD\",\"EUUkKEDoNsf\",\"nX05QLraDhO\",\"sesv0eXljBq\",\"RhJbg8UD75Q\",\"PA1spYiNZfv\",\"qxbsDd9QYv6\",\"fAsj6a4nudH\",\"xa4F6gesVJm\",\"roGdTjEqLZQ\",\"BNFrspDBKel\"],\"pe\":[]}}";
+        "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"FNnj3jKGS7i\":{\"uid\":\"FNnj3jKGS7i\",\"code\":\"OU_260387\",\"name\":\"Bandajuma Clinic CHC\"},\"Q2USZSJmcNK\":{\"uid\":\"Q2USZSJmcNK\",\"code\":\"OU_268195\",\"name\":\"Bumbuna CHC\"},\"sLKHXoBIqSs\":{\"uid\":\"sLKHXoBIqSs\",\"code\":\"OU_233362\",\"name\":\"Njagbwema Fiama CHC\"},\"mwN7QuEfT8m\":{\"uid\":\"mwN7QuEfT8m\",\"code\":\"OU_820\",\"name\":\"Koribondo CHC\"},\"jGYT5U5qJP6\":{\"uid\":\"jGYT5U5qJP6\",\"code\":\"OU_653\",\"name\":\"Gbaiima CHC\"},\"agM0BKQlTh3\":{\"uid\":\"agM0BKQlTh3\",\"code\":\"OU_193303\",\"name\":\"Batkanu CHC\"},\"MuZJ8lprGqK\":{\"uid\":\"MuZJ8lprGqK\",\"code\":\"OU_247089\",\"name\":\"Moyamba Junction CHC\"},\"e2WgqiasKnD\":{\"uid\":\"e2WgqiasKnD\",\"code\":\"OU_246997\",\"name\":\"Taiama (Kori) CHC\"},\"KcCbIDzRcui\":{\"uid\":\"KcCbIDzRcui\",\"code\":\"OU_268221\",\"name\":\"Matotoka CHC\"},\"Jyv7sjpl9bA\":{\"uid\":\"Jyv7sjpl9bA\",\"code\":\"OU_222650\",\"name\":\"Sendumei CHC\"},\"zEsMdeJOty4\":{\"uid\":\"zEsMdeJOty4\",\"code\":\"OU_278331\",\"name\":\"Moyiba CHC\"},\"mshIal30ffW\":{\"uid\":\"mshIal30ffW\",\"code\":\"OU_193301\",\"name\":\"Mapaki CHC\"},\"uFp0ztDOFbI\":{\"uid\":\"uFp0ztDOFbI\",\"code\":\"OU_197430\",\"name\":\"Bendu CHC\"},\"scc4QyxenJd\":{\"uid\":\"scc4QyxenJd\",\"code\":\"OU_268215\",\"name\":\"Makali CHC\"},\"aHs9PLxIdbr\":{\"uid\":\"aHs9PLxIdbr\",\"code\":\"OU_268203\",\"name\":\"Mayepoh CHC\"},\"PA1spYiNZfv\":{\"uid\":\"PA1spYiNZfv\",\"code\":\"OU_233398\",\"name\":\"Yengema CHC\"},\"LnToY3ExKxL\":{\"uid\":\"LnToY3ExKxL\",\"code\":\"OU_255018\",\"name\":\"Mahera CHC\"},\"IlMQTFvcq9r\":{\"uid\":\"IlMQTFvcq9r\",\"code\":\"OU_222656\",\"name\":\"Lowoma CHC\"},\"jhtj3eQa1pM\":{\"uid\":\"jhtj3eQa1pM\",\"code\":\"OU_1100\",\"name\":\"Gondama (Tikonko) CHC\"},\"QsAwd531Cpd\":{\"uid\":\"QsAwd531Cpd\",\"code\":\"OU_1038\",\"name\":\"Njala CHC\"},\"pNPmNeqyrim\":{\"uid\":\"pNPmNeqyrim\",\"code\":\"OU_222666\",\"name\":\"Foindu (Lower Bamabara) CHC\"},\"K00jR5dmoFZ\":{\"uid\":\"K00jR5dmoFZ\",\"code\":\"OU_260399\",\"name\":\"Karlu CHC\"},\"xa4F6gesVJm\":{\"uid\":\"xa4F6gesVJm\",\"code\":\"OU_278400\",\"name\":\"York CHC\"},\"zQpYVEyAM2t\":{\"uid\":\"zQpYVEyAM2t\",\"code\":\"OU_278377\",\"name\":\"Hastings Health Centre\"},\"hzf90qz08AW\":{\"uid\":\"hzf90qz08AW\",\"code\":\"OU_247034\",\"name\":\"Njama CHC\"},\"CFPrsD3dNeb\":{\"uid\":\"CFPrsD3dNeb\",\"code\":\"OU_197423\",\"name\":\"Tissana CHC\"},\"MpcMjLmbATv\":{\"uid\":\"MpcMjLmbATv\",\"code\":\"OU_204938\",\"name\":\"Bandajuma Yawei CHC\"},\"KYXbIQBQgP1\":{\"uid\":\"KYXbIQBQgP1\",\"code\":\"OU_1103\",\"name\":\"Tikonko CHC\"},\"lxxASQqPUqd\":{\"uid\":\"lxxASQqPUqd\",\"code\":\"OU_233341\",\"name\":\"Tombodu CHC\"},\"oRncQGhLYNE\":{\"uid\":\"oRncQGhLYNE\",\"code\":\"OU_278376\",\"name\":\"Regent (RWA) CHC\"},\"RhJbg8UD75Q\":{\"uid\":\"RhJbg8UD75Q\",\"code\":\"OU_1027\",\"name\":\"Yemoh Town CHC\"},\"EUUkKEDoNsf\":{\"uid\":\"EUUkKEDoNsf\",\"code\":\"OU_278343\",\"name\":\"Wilberforce CHC\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"FbD5Z8z22Yb\":{\"uid\":\"FbD5Z8z22Yb\",\"code\":\"OU_260385\",\"name\":\"Geoma Jagor CHC\"},\"ua5GXy2uhBR\":{\"uid\":\"ua5GXy2uhBR\",\"code\":\"OU_197412\",\"name\":\"Tihun CHC\"},\"QpRIPul20Sb\":{\"uid\":\"QpRIPul20Sb\",\"code\":\"OU_222637\",\"name\":\"Gorahun CHC\"},\"mt47bcb0Rcj\":{\"uid\":\"mt47bcb0Rcj\",\"code\":\"OU_193231\",\"name\":\"Kamabai CHC\"},\"uDzWmUDHKeR\":{\"uid\":\"uDzWmUDHKeR\",\"code\":\"OU_260389\",\"name\":\"Futa CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"OjXNuYyLaCJ\":{\"uid\":\"OjXNuYyLaCJ\",\"code\":\"OU_255004\",\"name\":\"Sendugu CHC\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZdPkczYqeIY\":{\"uid\":\"ZdPkczYqeIY\",\"code\":\"OU_247092\",\"name\":\"Gandorhun CHC\"},\"p310xqwAJge\":{\"uid\":\"p310xqwAJge\",\"code\":\"OU_226268\",\"name\":\"Kondembaia CHC\"},\"HcB2W6Fgp7i\":{\"uid\":\"HcB2W6Fgp7i\",\"code\":\"OU_255065\",\"name\":\"Melekuray CHC\"},\"lOv6IFgr6Fs\":{\"uid\":\"lOv6IFgr6Fs\",\"code\":\"OU_832\",\"name\":\"Manjama Shellmingo CHC\"},\"amgb83zVxp5\":{\"uid\":\"amgb83zVxp5\",\"code\":\"OU_222674\",\"name\":\"Bendu Mameima CHC\"},\"K6oyIMh7Lee\":{\"uid\":\"K6oyIMh7Lee\",\"code\":\"OU_226224\",\"name\":\"Fadugu CHC\"},\"m0XorV4WWg0\":{\"uid\":\"m0XorV4WWg0\",\"code\":\"OU_278361\",\"name\":\"Ginger Hall Health Centre\"},\"bSj2UnYhTFb\":{\"uid\":\"bSj2UnYhTFb\",\"code\":\"OU_193218\",\"name\":\"Kamaranka CHC\"},\"CvBAqD6RzLZ\":{\"uid\":\"CvBAqD6RzLZ\",\"code\":\"OU_595\",\"name\":\"Ngalu CHC\"},\"k6lOze3vTzP\":{\"uid\":\"k6lOze3vTzP\",\"code\":\"OU_260435\",\"name\":\"Potoru CHC\"},\"p9KfD6eaRvu\":{\"uid\":\"p9KfD6eaRvu\",\"code\":\"OU_247069\",\"name\":\"Shenge CHC\"},\"K3jhn3TXF3a\":{\"uid\":\"K3jhn3TXF3a\",\"code\":\"OU_222665\",\"name\":\"Tongo Field CHC\"},\"HNv1aLPdMYb\":{\"uid\":\"HNv1aLPdMYb\",\"code\":\"OU_193242\",\"name\":\"Kamalo CHC\"},\"yMCshbaVExv\":{\"uid\":\"yMCshbaVExv\",\"code\":\"OU_254991\",\"name\":\"Babara CHC\"},\"pJv8NJlJNhU\":{\"uid\":\"pJv8NJlJNhU\",\"code\":\"OU_204916\",\"name\":\"Pendembu CHC\"},\"YAuJ3fyoEuI\":{\"uid\":\"YAuJ3fyoEuI\",\"code\":\"OU_193281\",\"name\":\"Gbendembu Wesleyan CHC\"},\"g5A3hiJlwmI\":{\"uid\":\"g5A3hiJlwmI\",\"code\":\"OU_233397\",\"name\":\"UMC Mitchener Memorial Maternity & Health Centre\"},\"jKZ0U8Og5aV\":{\"uid\":\"jKZ0U8Og5aV\",\"code\":\"OU_222683\",\"name\":\"Dodo CHC\"},\"EXbPGmEUdnc\":{\"uid\":\"EXbPGmEUdnc\",\"code\":\"OU_193197\",\"name\":\"Mateboi CHC\"},\"nX05QLraDhO\":{\"uid\":\"nX05QLraDhO\",\"code\":\"OU_585\",\"name\":\"Yamandu CHC\"},\"Umh4HKqqFp6\":{\"uid\":\"Umh4HKqqFp6\",\"code\":\"OU_578\",\"name\":\"Jembe CHC\"},\"ubsjwFFBaJM\":{\"uid\":\"ubsjwFFBaJM\",\"code\":\"OU_247016\",\"name\":\"Gbangbatoke CHC\"},\"rm60vuHyQXj\":{\"uid\":\"rm60vuHyQXj\",\"code\":\"OU_1082\",\"name\":\"Nengbema CHC\"},\"iOA3z6Y3cq5\":{\"uid\":\"iOA3z6Y3cq5\",\"code\":\"OU_222699\",\"name\":\"Largo CHC\"},\"sIVFEyNfOg4\":{\"uid\":\"sIVFEyNfOg4\",\"code\":\"OU_247073\",\"name\":\"Mokandor CHP\"},\"k8ZPul89UDm\":{\"uid\":\"k8ZPul89UDm\",\"code\":\"OU_233370\",\"name\":\"Kayima CHC\"},\"iMZihUMzH92\":{\"uid\":\"iMZihUMzH92\",\"code\":\"OU_247083\",\"name\":\"Bauya (Kongbora) CHC\"},\"MXdbul7bBqV\":{\"uid\":\"MXdbul7bBqV\",\"code\":\"OU_204912\",\"name\":\"Mobai CHC\"},\"dkmpOuVhBba\":{\"uid\":\"dkmpOuVhBba\",\"code\":\"OU_268226\",\"name\":\"Mathoir CHC\"},\"q56204kKXgZ\":{\"uid\":\"q56204kKXgZ\",\"code\":\"OU_255057\",\"name\":\"Lunsar CHC\"},\"kuqKh33SPgg\":{\"uid\":\"kuqKh33SPgg\",\"code\":\"OU_226230\",\"name\":\"Falaba CHC\"},\"NjyJYiIuKIG\":{\"uid\":\"NjyJYiIuKIG\",\"code\":\"OU_193291\",\"name\":\"Kathanta Yimbor CHC\"},\"fAsj6a4nudH\":{\"uid\":\"fAsj6a4nudH\",\"code\":\"OU_197398\",\"name\":\"Yoni CHC\"},\"a04CZxe0PSe\":{\"uid\":\"a04CZxe0PSe\",\"code\":\"OU_278333\",\"name\":\"Murray Town CHC\"},\"qxbsDd9QYv6\":{\"uid\":\"qxbsDd9QYv6\",\"code\":\"OU_226274\",\"name\":\"Yiffin CHC\"},\"Mi4dWRtfIOC\":{\"uid\":\"Mi4dWRtfIOC\",\"code\":\"OU_204860\",\"name\":\"Sandaru CHC\"},\"QzPf0qKBU4n\":{\"uid\":\"QzPf0qKBU4n\",\"code\":\"OU_260411\",\"name\":\"Jendema CHC\"},\"mzsOsz0NwNY\":{\"uid\":\"mzsOsz0NwNY\",\"code\":\"OU_836\",\"name\":\"New Police Barracks CHC\"},\"vELbGdEphPd\":{\"uid\":\"vELbGdEphPd\",\"code\":\"OU_614\",\"name\":\"Jimmi CHC\"},\"qVvitxEF2ck\":{\"uid\":\"qVvitxEF2ck\",\"code\":\"OU_254949\",\"name\":\"Rogbere CHC\"},\"RAsstekPRco\":{\"uid\":\"RAsstekPRco\",\"code\":\"OU_211269\",\"name\":\"Mambolo CHC\"},\"va2lE4FiVVb\":{\"uid\":\"va2lE4FiVVb\",\"code\":\"OU_247019\",\"name\":\"Mano CHC\"},\"cNAp6CJeLxk\":{\"uid\":\"cNAp6CJeLxk\",\"code\":\"OU_247015\",\"name\":\"Mokanji CHC\"},\"wByqtWCCuDJ\":{\"uid\":\"wByqtWCCuDJ\",\"code\":\"OU_1095\",\"name\":\"Damballa CHC\"},\"PcADvhvcaI2\":{\"uid\":\"PcADvhvcaI2\",\"code\":\"OU_211253\",\"name\":\"Kychom CHC\"},\"n7wN9gMFfZ5\":{\"uid\":\"n7wN9gMFfZ5\",\"code\":\"OU_197435\",\"name\":\"Benduma CHC\"},\"kUzpbgPCwVA\":{\"uid\":\"kUzpbgPCwVA\",\"code\":\"OU_222624\",\"name\":\"Blama CHC\"},\"rCKWdLr4B8K\":{\"uid\":\"rCKWdLr4B8K\",\"code\":\"OU_197427\",\"name\":\"Motuo CHC\"},\"DMxw0SASFih\":{\"uid\":\"DMxw0SASFih\",\"code\":\"OU_204941\",\"name\":\"Koindu CHC\"},\"PQEpIeuSTCN\":{\"uid\":\"PQEpIeuSTCN\",\"code\":\"OU_222623\",\"name\":\"Tobanda CHC\"},\"inpc5QsFRTm\":{\"uid\":\"inpc5QsFRTm\",\"code\":\"OU_211274\",\"name\":\"Kamassasa CHC\"},\"aSxNNRxPuBP\":{\"uid\":\"aSxNNRxPuBP\",\"code\":\"OU_193278\",\"name\":\"Kalangba CHC\"},\"O1KFJmM6HUx\":{\"uid\":\"O1KFJmM6HUx\",\"code\":\"OU_260438\",\"name\":\"Mano Gbonjeima CHC\"},\"s5aXfzOL456\":{\"uid\":\"s5aXfzOL456\",\"code\":\"OU_197437\",\"name\":\"Talia CHC\"},\"tSBcgrTDdB8\":{\"uid\":\"tSBcgrTDdB8\",\"code\":\"OU_834\",\"name\":\"Paramedical CHC\"},\"KiheEgvUZ0i\":{\"uid\":\"KiheEgvUZ0i\",\"code\":\"OU_278357\",\"name\":\"Calaba town CHC\"},\"d9zRBAoM8OC\":{\"uid\":\"d9zRBAoM8OC\",\"code\":\"OU_260423\",\"name\":\"Bumpeh Perri CHC\"},\"sesv0eXljBq\":{\"uid\":\"sesv0eXljBq\",\"code\":\"OU_268207\",\"name\":\"Yele CHC\"},\"L4Tw4NlaMjn\":{\"uid\":\"L4Tw4NlaMjn\",\"code\":\"OU_222705\",\"name\":\"Nekabo CHC\"},\"sznCEDMABa2\":{\"uid\":\"sznCEDMABa2\",\"code\":\"OU_204903\",\"name\":\"Ngiehun CHC\"},\"E497Rk80ivZ\":{\"uid\":\"E497Rk80ivZ\",\"code\":\"OU_651\",\"name\":\"Bumpe CHC\"},\"CXw2yu5fodb\":{\"uid\":\"CXw2yu5fodb\",\"code\":\"CHC\",\"valueType\":\"NUMBER\",\"name\":\"CHC\",\"dimensionItemType\":\"ORGANISATION_UNIT_GROUP\",\"totalAggregationType\":\"SUM\"},\"W7ekX3gi0ut\":{\"uid\":\"W7ekX3gi0ut\",\"code\":\"OU_233333\",\"name\":\"Jaiama Sewafe CHC\"},\"roGdTjEqLZQ\":{\"uid\":\"roGdTjEqLZQ\",\"code\":\"OU_233371\",\"name\":\"Yormandu CHC\"},\"Jiymtq0A01x\":{\"uid\":\"Jiymtq0A01x\",\"code\":\"OU_226243\",\"name\":\"Bafodia CHC\"},\"aIsnJuZbmVA\":{\"uid\":\"aIsnJuZbmVA\",\"code\":\"OU_226256\",\"name\":\"Dogoloya CHP\"},\"IlnqGuxfQAw\":{\"uid\":\"IlnqGuxfQAw\",\"code\":\"OU_226216\",\"name\":\"Sinkunia CHC\"},\"lpQvlm9czYE\":{\"uid\":\"lpQvlm9czYE\",\"code\":\"OU_222631\",\"name\":\"Tungie CHC\"},\"uedNhvYPMNu\":{\"uid\":\"uedNhvYPMNu\",\"code\":\"OU_193216\",\"name\":\"Gbanti CHC\"},\"KKoPh1lDd9j\":{\"uid\":\"KKoPh1lDd9j\",\"code\":\"OU_233321\",\"name\":\"Kainkordu CHC\"},\"xKaB8tfbTzm\":{\"uid\":\"xKaB8tfbTzm\",\"code\":\"OU_193247\",\"name\":\"Fintonia CHC\"},\"TEVtOFKcLAP\":{\"uid\":\"TEVtOFKcLAP\",\"code\":\"OU_197447\",\"name\":\"Gbap CHC\"},\"pXDcgDRz8Od\":{\"uid\":\"pXDcgDRz8Od\",\"code\":\"OU_278402\",\"name\":\"Songo CHC\"},\"NaVzm59XKGf\":{\"uid\":\"NaVzm59XKGf\",\"code\":\"OU_254980\",\"name\":\"Gbinti CHC\"},\"Ahh47q8AkId\":{\"uid\":\"Ahh47q8AkId\",\"code\":\"OU_268167\",\"name\":\"Mabang CHC\"},\"QZtMuEEV9Vv\":{\"uid\":\"QZtMuEEV9Vv\",\"code\":\"OU_211237\",\"name\":\"Rokupr CHC\"},\"U4FzUXMvbI8\":{\"uid\":\"U4FzUXMvbI8\",\"code\":\"OU_255009\",\"name\":\"Conakry Dee CHC\"},\"o0BgK1dLhF8\":{\"uid\":\"o0BgK1dLhF8\",\"code\":\"OU_268170\",\"name\":\"Bendugu CHC\"},\"agEKP19IUKI\":{\"uid\":\"agEKP19IUKI\",\"code\":\"OU_193280\",\"name\":\"Tambiama CHC\"},\"qIpBLa1SCZt\":{\"uid\":\"qIpBLa1SCZt\",\"code\":\"OU_222714\",\"name\":\"Talia (Nongowa) CHC\"},\"H97XE5Ea089\":{\"uid\":\"H97XE5Ea089\",\"code\":\"OU_247045\",\"name\":\"Bomotoke CHC\"},\"nv41sOz8IVM\":{\"uid\":\"nv41sOz8IVM\",\"code\":\"OU_204927\",\"name\":\"Pejewa CHC\"},\"202301\":{\"name\":\"January 2023\"},\"NMcx2jmra3c\":{\"uid\":\"NMcx2jmra3c\",\"code\":\"OU_226273\",\"name\":\"Firawa CHC\"},\"m3VnSQbE8CD\":{\"uid\":\"m3VnSQbE8CD\",\"code\":\"OU_278382\",\"name\":\"Newton CHC\"},\"OY7mYDATra3\":{\"uid\":\"OY7mYDATra3\",\"code\":\"OU_268176\",\"name\":\"Massingbi CHC\"},\"RQgXBKxgvHf\":{\"uid\":\"RQgXBKxgvHf\",\"code\":\"OU_211248\",\"name\":\"Mapotolon CHC\"},\"YvwYw7GilkP\":{\"uid\":\"YvwYw7GilkP\",\"code\":\"OU_222726\",\"name\":\"Levuma (Kandu Lep) CHC\"},\"PduUQmdt0pB\":{\"uid\":\"PduUQmdt0pB\",\"code\":\"OU_211273\",\"name\":\"Numea CHC\"},\"U514Dz4v9pv\":{\"uid\":\"U514Dz4v9pv\",\"code\":\"OU_278330\",\"name\":\"George Brook Health Centre\"},\"PuZOFApTSeo\":{\"uid\":\"PuZOFApTSeo\",\"code\":\"OU_952\",\"name\":\"Sahn CHC\"},\"wUmVUKhnPuy\":{\"uid\":\"wUmVUKhnPuy\",\"code\":\"OU_247057\",\"name\":\"Kangahun CHC\"},\"RaQGHRti7JM\":{\"uid\":\"RaQGHRti7JM\",\"code\":\"OU_278335\",\"name\":\"Gods Favour health Center\"},\"xMn4Wki9doK\":{\"uid\":\"xMn4Wki9doK\",\"code\":\"OU_197417\",\"name\":\"Moriba Town CHC\"},\"JQJjsXvHE5M\":{\"uid\":\"JQJjsXvHE5M\",\"code\":\"OU_247007\",\"name\":\"Mokelleh CHC\"},\"m5BX6CvJ6Ex\":{\"uid\":\"m5BX6CvJ6Ex\",\"code\":\"OU_204865\",\"name\":\"Daru CHC\"},\"D2rB1GRuh8C\":{\"uid\":\"D2rB1GRuh8C\",\"code\":\"OU_197418\",\"name\":\"Gbamgbama CHC\"},\"Gm7YUjhVi9Q\":{\"uid\":\"Gm7YUjhVi9Q\",\"code\":\"OU_260415\",\"name\":\"Fairo CHC\"},\"gE3gEGZbQMi\":{\"uid\":\"gE3gEGZbQMi\",\"code\":\"OU_197407\",\"name\":\"Madina (BUM) CHC\"},\"zuXW98AEbE7\":{\"uid\":\"zuXW98AEbE7\",\"code\":\"OU_255023\",\"name\":\"Kamasondo CHC\"},\"TjZwphhxCuV\":{\"uid\":\"TjZwphhxCuV\",\"code\":\"OU_193225\",\"name\":\"Kagbere CHC\"},\"g5lonXJ9ndA\":{\"uid\":\"g5lonXJ9ndA\",\"code\":\"OU_268237\",\"name\":\"Hinistas CHC\"},\"r5WWF9WDzoa\":{\"uid\":\"r5WWF9WDzoa\",\"code\":\"OU_222681\",\"name\":\"Baama CHC\"},\"VhRX5JDVo7R\":{\"uid\":\"VhRX5JDVo7R\",\"code\":\"OU_278397\",\"name\":\"Waterloo CHC\"},\"PMsF64R6OJX\":{\"uid\":\"PMsF64R6OJX\",\"code\":\"OU_226248\",\"name\":\"Bendugu (Mongo) CHC\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"azRICFoILuh\":{\"uid\":\"azRICFoILuh\",\"code\":\"OU_577\",\"name\":\"Golu MCHP\"},\"HQoxFu4lYPS\":{\"uid\":\"HQoxFu4lYPS\",\"code\":\"OU_204868\",\"name\":\"Pellie CHC\"},\"JrSIoCOdTH2\":{\"uid\":\"JrSIoCOdTH2\",\"code\":\"OU_278403\",\"name\":\"Tombo CHC\"},\"ke2gwHKHP3z\":{\"uid\":\"ke2gwHKHP3z\",\"code\":\"OU_254983\",\"name\":\"Petifu CHC\"},\"TSyzvBiovKh\":{\"uid\":\"TSyzvBiovKh\",\"code\":\"OU_576\",\"name\":\"Gerehun CHC\"},\"g10jm7jPdzf\":{\"uid\":\"g10jm7jPdzf\",\"code\":\"OU_222707\",\"name\":\"Hangha CHC\"},\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"bPqP6eRfkyn\":{\"uid\":\"bPqP6eRfkyn\",\"code\":\"OU_278318\",\"name\":\"Ross Road Health Centre\"},\"EURoFVjowXs\":{\"uid\":\"EURoFVjowXs\",\"code\":\"OU_254964\",\"name\":\"Masiaka CHC\"},\"ii2KMnWMx2L\":{\"uid\":\"ii2KMnWMx2L\",\"code\":\"OU_233392\",\"name\":\"Gandorhun (Gbane) CHC\"},\"J42QfNe0GJZ\":{\"uid\":\"J42QfNe0GJZ\",\"code\":\"OU_268185\",\"name\":\"Mara CHC\"},\"gUPhNWkSXvD\":{\"uid\":\"gUPhNWkSXvD\",\"code\":\"OU_247032\",\"name\":\"Rotifunk CHC\"},\"FLjwMPWLrL2\":{\"uid\":\"FLjwMPWLrL2\",\"code\":\"OU_1126\",\"name\":\"Baomahun CHC\"},\"FclfbEFMcf3\":{\"uid\":\"FclfbEFMcf3\",\"code\":\"OU_278340\",\"name\":\"Kissy Health Centre\"},\"lL2LBkhlsmV\":{\"uid\":\"lL2LBkhlsmV\",\"code\":\"OU_278336\",\"name\":\"Grassfield CHC\"},\"NRPCjDljVtu\":{\"uid\":\"NRPCjDljVtu\",\"code\":\"OU_278404\",\"name\":\"Lakka\\/Ogoo Farm CHC\"},\"egjrZ1PHNtT\":{\"uid\":\"egjrZ1PHNtT\",\"code\":\"OU_247053\",\"name\":\"Sembehun CHC\"},\"PC3Ag91n82e\":{\"uid\":\"PC3Ag91n82e\",\"code\":\"OU_1122\",\"name\":\"Mongere CHC\"},\"X79FDd4EAgo\":{\"uid\":\"X79FDd4EAgo\",\"code\":\"OU_193196\",\"name\":\"Rokulan CHC\"},\"sM0Us0NkSez\":{\"uid\":\"sM0Us0NkSez\",\"code\":\"OU_278359\",\"name\":\"Kroo Bay CHC\"},\"bHcw141PTsE\":{\"uid\":\"bHcw141PTsE\",\"code\":\"OU_260407\",\"name\":\"Gbondapi CHC\"},\"O63vIA5MVn6\":{\"uid\":\"O63vIA5MVn6\",\"code\":\"OU_255014\",\"name\":\"Tagrin CHC\"},\"HWXk4EBHUyk\":{\"uid\":\"HWXk4EBHUyk\",\"code\":\"OU_260393\",\"name\":\"Sahn (Malen) CHC\"},\"W2KnxOMvmgE\":{\"uid\":\"W2KnxOMvmgE\",\"code\":\"OU_1050\",\"name\":\"Sumbuya CHC\"},\"tO01bqIipeD\":{\"uid\":\"tO01bqIipeD\",\"code\":\"OU_204892\",\"name\":\"Buedu CHC\"},\"w3mBVfrWhXl\":{\"uid\":\"w3mBVfrWhXl\",\"code\":\"OU_255043\",\"name\":\"Mange CHC\"},\"TljiT6C5D0J\":{\"uid\":\"TljiT6C5D0J\",\"code\":\"OU_222740\",\"name\":\"Kpandebu CHC\"},\"TmCsvdJLHoX\":{\"uid\":\"TmCsvdJLHoX\",\"code\":\"OU_193195\",\"name\":\"Mabunduka CHC\"},\"BNFrspDBKel\":{\"uid\":\"BNFrspDBKel\",\"code\":\"OU_260382\",\"name\":\"Zimmi CHC\"},\"N3tpEjZcPm9\":{\"uid\":\"N3tpEjZcPm9\",\"code\":\"OU_204879\",\"name\":\"Laleihun Kovoma CHC\"},\"Qc9lf4VM9bD\":{\"uid\":\"Qc9lf4VM9bD\",\"code\":\"OU_278317\",\"name\":\"Wellington Health Centre\"},\"cMFi8lYbXHY\":{\"uid\":\"cMFi8lYbXHY\",\"code\":\"OU_233402\",\"name\":\"Bumpeh (Nimikoro) CHC\"},\"P4upLKrpkHP\":{\"uid\":\"P4upLKrpkHP\",\"code\":\"OU_222641\",\"name\":\"Ngegbwema CHC\"},\"Yj2ni275yPJ\":{\"uid\":\"Yj2ni275yPJ\",\"code\":\"OU_222647\",\"name\":\"Baoma (Koya) CHC\"},\"SnCrOCRrxGX\":{\"uid\":\"SnCrOCRrxGX\",\"code\":\"OU_233327\",\"name\":\"Koakoyima CHC\"},\"Z9ny6QeqsgX\":{\"uid\":\"Z9ny6QeqsgX\",\"code\":\"OU_969\",\"name\":\"Manjama UMC CHC\"},\"wtdBuXDwZYQ\":{\"uid\":\"wtdBuXDwZYQ\",\"code\":\"OU_1006\",\"name\":\"Praise Foundation CHC\"},\"oLuhRyYPxRO\":{\"uid\":\"oLuhRyYPxRO\",\"code\":\"OU_247011\",\"name\":\"Senehun CHC\"},\"PaNv9VyD06n\":{\"uid\":\"PaNv9VyD06n\",\"code\":\"OU_204930\",\"name\":\"Manowa CHC\"},\"uRQj8WRK0Py\":{\"uid\":\"uRQj8WRK0Py\",\"code\":\"OU_193255\",\"name\":\"Masongbo CHC\"},\"Y8foq27WLti\":{\"uid\":\"Y8foq27WLti\",\"code\":\"OU_222728\",\"name\":\"Baoma Oil Mill CHC\"},\"mepHuAA9l51\":{\"uid\":\"mepHuAA9l51\",\"code\":\"OU_193205\",\"name\":\"Rokonta CHC\"},\"k1Y0oNqPlmy\":{\"uid\":\"k1Y0oNqPlmy\",\"code\":\"OU_1161\",\"name\":\"Gboyama CHC\"},\"UOJlcpPnBat\":{\"uid\":\"UOJlcpPnBat\",\"code\":\"OU_172174\",\"name\":\"Needy CHC\"},\"CKkE4GBJekz\":{\"uid\":\"CKkE4GBJekz\",\"code\":\"OU_222671\",\"name\":\"Weima CHC\"},\"GHHvGp7tgtZ\":{\"uid\":\"GHHvGp7tgtZ\",\"code\":\"OU_193275\",\"name\":\"Binkolo CHC\"},\"dQggcljEImF\":{\"uid\":\"dQggcljEImF\",\"code\":\"OU_278392\",\"name\":\"Goderich Health Centre\"},\"DvzKyuC0G4w\":{\"uid\":\"DvzKyuC0G4w\",\"code\":\"OU_204872\",\"name\":\"Jojoima CHC\"},\"Luv2kmWWgoG\":{\"uid\":\"Luv2kmWWgoG\",\"code\":\"OU_222632\",\"name\":\"Mondema CHC\"},\"cw0Wm1QTHRq\":{\"uid\":\"cw0Wm1QTHRq\",\"code\":\"OU_222750\",\"name\":\"Joru CHC\"},\"Ep5iWL1UKvF\":{\"uid\":\"Ep5iWL1UKvF\",\"code\":\"OU_226276\",\"name\":\"Kurubonla CHC\"},\"EH0dXLB4nZg\":{\"uid\":\"EH0dXLB4nZg\",\"code\":\"OU_255032\",\"name\":\"Masimera CHC\"},\"L5gENbBNNup\":{\"uid\":\"L5gENbBNNup\",\"code\":\"OU_222689\",\"name\":\"Boajibu CHC\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"r5WWF9WDzoa\",\"yMCshbaVExv\",\"Jiymtq0A01x\",\"FNnj3jKGS7i\",\"MpcMjLmbATv\",\"Yj2ni275yPJ\",\"Y8foq27WLti\",\"FLjwMPWLrL2\",\"agM0BKQlTh3\",\"iMZihUMzH92\",\"uFp0ztDOFbI\",\"amgb83zVxp5\",\"PMsF64R6OJX\",\"o0BgK1dLhF8\",\"n7wN9gMFfZ5\",\"GHHvGp7tgtZ\",\"kUzpbgPCwVA\",\"L5gENbBNNup\",\"H97XE5Ea089\",\"tO01bqIipeD\",\"Q2USZSJmcNK\",\"E497Rk80ivZ\",\"cMFi8lYbXHY\",\"d9zRBAoM8OC\",\"KiheEgvUZ0i\",\"U4FzUXMvbI8\",\"wByqtWCCuDJ\",\"m5BX6CvJ6Ex\",\"jKZ0U8Og5aV\",\"aIsnJuZbmVA\",\"K6oyIMh7Lee\",\"Gm7YUjhVi9Q\",\"kuqKh33SPgg\",\"xKaB8tfbTzm\",\"NMcx2jmra3c\",\"pNPmNeqyrim\",\"uDzWmUDHKeR\",\"ii2KMnWMx2L\",\"ZdPkczYqeIY\",\"jGYT5U5qJP6\",\"D2rB1GRuh8C\",\"ubsjwFFBaJM\",\"uedNhvYPMNu\",\"TEVtOFKcLAP\",\"YAuJ3fyoEuI\",\"NaVzm59XKGf\",\"bHcw141PTsE\",\"k1Y0oNqPlmy\",\"FbD5Z8z22Yb\",\"U514Dz4v9pv\",\"TSyzvBiovKh\",\"m0XorV4WWg0\",\"dQggcljEImF\",\"RaQGHRti7JM\",\"azRICFoILuh\",\"jhtj3eQa1pM\",\"QpRIPul20Sb\",\"lL2LBkhlsmV\",\"g10jm7jPdzf\",\"zQpYVEyAM2t\",\"g5lonXJ9ndA\",\"W7ekX3gi0ut\",\"Umh4HKqqFp6\",\"QzPf0qKBU4n\",\"vELbGdEphPd\",\"DvzKyuC0G4w\",\"cw0Wm1QTHRq\",\"TjZwphhxCuV\",\"KKoPh1lDd9j\",\"aSxNNRxPuBP\",\"mt47bcb0Rcj\",\"HNv1aLPdMYb\",\"bSj2UnYhTFb\",\"zuXW98AEbE7\",\"inpc5QsFRTm\",\"wUmVUKhnPuy\",\"K00jR5dmoFZ\",\"NjyJYiIuKIG\",\"k8ZPul89UDm\",\"FclfbEFMcf3\",\"SnCrOCRrxGX\",\"DMxw0SASFih\",\"p310xqwAJge\",\"mwN7QuEfT8m\",\"TljiT6C5D0J\",\"sM0Us0NkSez\",\"Ep5iWL1UKvF\",\"PcADvhvcaI2\",\"NRPCjDljVtu\",\"N3tpEjZcPm9\",\"iOA3z6Y3cq5\",\"YvwYw7GilkP\",\"IlMQTFvcq9r\",\"q56204kKXgZ\",\"Ahh47q8AkId\",\"TmCsvdJLHoX\",\"gE3gEGZbQMi\",\"LnToY3ExKxL\",\"scc4QyxenJd\",\"RAsstekPRco\",\"w3mBVfrWhXl\",\"lOv6IFgr6Fs\",\"Z9ny6QeqsgX\",\"va2lE4FiVVb\",\"O1KFJmM6HUx\",\"PaNv9VyD06n\",\"mshIal30ffW\",\"RQgXBKxgvHf\",\"J42QfNe0GJZ\",\"EURoFVjowXs\",\"EH0dXLB4nZg\",\"uRQj8WRK0Py\",\"OY7mYDATra3\",\"EXbPGmEUdnc\",\"dkmpOuVhBba\",\"KcCbIDzRcui\",\"aHs9PLxIdbr\",\"HcB2W6Fgp7i\",\"MXdbul7bBqV\",\"sIVFEyNfOg4\",\"cNAp6CJeLxk\",\"JQJjsXvHE5M\",\"Luv2kmWWgoG\",\"PC3Ag91n82e\",\"xMn4Wki9doK\",\"rCKWdLr4B8K\",\"MuZJ8lprGqK\",\"zEsMdeJOty4\",\"a04CZxe0PSe\",\"UOJlcpPnBat\",\"L4Tw4NlaMjn\",\"rm60vuHyQXj\",\"mzsOsz0NwNY\",\"m3VnSQbE8CD\",\"CvBAqD6RzLZ\",\"P4upLKrpkHP\",\"DiszpKrYNg8\",\"sznCEDMABa2\",\"sLKHXoBIqSs\",\"QsAwd531Cpd\",\"hzf90qz08AW\",\"PduUQmdt0pB\",\"tSBcgrTDdB8\",\"nv41sOz8IVM\",\"HQoxFu4lYPS\",\"pJv8NJlJNhU\",\"ke2gwHKHP3z\",\"k6lOze3vTzP\",\"wtdBuXDwZYQ\",\"oRncQGhLYNE\",\"qVvitxEF2ck\",\"mepHuAA9l51\",\"X79FDd4EAgo\",\"QZtMuEEV9Vv\",\"bPqP6eRfkyn\",\"gUPhNWkSXvD\",\"HWXk4EBHUyk\",\"PuZOFApTSeo\",\"Mi4dWRtfIOC\",\"egjrZ1PHNtT\",\"OjXNuYyLaCJ\",\"Jyv7sjpl9bA\",\"oLuhRyYPxRO\",\"p9KfD6eaRvu\",\"IlnqGuxfQAw\",\"pXDcgDRz8Od\",\"W2KnxOMvmgE\",\"O63vIA5MVn6\",\"e2WgqiasKnD\",\"qIpBLa1SCZt\",\"s5aXfzOL456\",\"agEKP19IUKI\",\"ua5GXy2uhBR\",\"KYXbIQBQgP1\",\"CFPrsD3dNeb\",\"PQEpIeuSTCN\",\"JrSIoCOdTH2\",\"lxxASQqPUqd\",\"K3jhn3TXF3a\",\"lpQvlm9czYE\",\"g5A3hiJlwmI\",\"VhRX5JDVo7R\",\"CKkE4GBJekz\",\"Qc9lf4VM9bD\",\"EUUkKEDoNsf\",\"nX05QLraDhO\",\"sesv0eXljBq\",\"RhJbg8UD75Q\",\"PA1spYiNZfv\",\"qxbsDd9QYv6\",\"fAsj6a4nudH\",\"xa4F6gesVJm\",\"roGdTjEqLZQ\",\"BNFrspDBKel\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.oucode",
-            "Organisation unit code",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.oucode",
+        "Organisation unit code",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -762,16 +762,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("outputType=ENROLLMENT")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ZzYYXq4fJie.EVENT_STATUS:ACTIVE,A03MvHHogjR.EVENT_DATE:2021")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZzYYXq4fJie.EVENT_STATUS:ACTIVE,A03MvHHogjR.EVENT_DATE:2021")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -781,61 +781,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            4,
-            4); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        4,
+        4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.eventstatus",
-            "Event status",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.eventstatus",
+        "Event status",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.eventdate",
-            "Report date",
-            "DATE",
-            "java.time.LocalDate",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventdate",
+        "Report date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -843,67 +843,67 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
     validateRowValueByName(
-            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 18
     validateRowValueByName(response, actualHeaders, 18, "ouname", "Kalainkay MCHP");
     validateRowValueByName(
-            response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 18, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 27
     validateRowValueByName(response, actualHeaders, 27, "ouname", "Moyeamoh CHP");
     validateRowValueByName(
-            response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 27, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 36
     validateRowValueByName(response, actualHeaders, 36, "ouname", "Madina Loko CHP");
     validateRowValueByName(
-            response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 36, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 45
     validateRowValueByName(response, actualHeaders, 45, "ouname", "Kamiendor MCHP");
     validateRowValueByName(
-            response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 45, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "ouname", "Bandajuma Sinneh MCHP");
     validateRowValueByName(
-            response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "ouname", "Needy CHC");
     validateRowValueByName(
-            response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 72
     validateRowValueByName(response, actualHeaders, 72, "ouname", "Konda CHP");
     validateRowValueByName(
-            response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 72, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 81
     validateRowValueByName(response, actualHeaders, 81, "ouname", "Foredugu MCHP");
     validateRowValueByName(
-            response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 81, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 90
     validateRowValueByName(response, actualHeaders, 90, "ouname", "Sindadu MCHP");
     validateRowValueByName(
-            response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
+        response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 90, "enrollmentdate", "2022-12-26 12:05:00.0");
   }
 
@@ -914,16 +914,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("outputType=ENROLLMENT")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=A03MvHHogjR.EVENT_DATE:2021")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=A03MvHHogjR.EVENT_DATE:2021")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -933,61 +933,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            4,
-            4); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        4,
+        4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.eventstatus",
-            "Event status",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.eventstatus",
+        "Event status",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.eventdate",
-            "Report date",
-            "DATE",
-            "java.time.LocalDate",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventdate",
+        "Report date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -995,67 +995,67 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
     validateRowValueByName(
-            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 18
     validateRowValueByName(response, actualHeaders, 18, "ouname", "Kalainkay MCHP");
     validateRowValueByName(
-            response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+        response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 18, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 27
     validateRowValueByName(response, actualHeaders, 27, "ouname", "Moyeamoh CHP");
     validateRowValueByName(
-            response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 27, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 36
     validateRowValueByName(response, actualHeaders, 36, "ouname", "Madina Loko CHP");
     validateRowValueByName(
-            response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 36, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 45
     validateRowValueByName(response, actualHeaders, 45, "ouname", "Kamiendor MCHP");
     validateRowValueByName(
-            response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 45, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "ouname", "Bandajuma Sinneh MCHP");
     validateRowValueByName(
-            response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+        response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "ouname", "Needy CHC");
     validateRowValueByName(
-            response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 72
     validateRowValueByName(response, actualHeaders, 72, "ouname", "Konda CHP");
     validateRowValueByName(
-            response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 72, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 81
     validateRowValueByName(response, actualHeaders, 81, "ouname", "Foredugu MCHP");
     validateRowValueByName(
-            response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+        response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 81, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 90
     validateRowValueByName(response, actualHeaders, 90, "ouname", "Sindadu MCHP");
     validateRowValueByName(
-            response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
+        response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 90, "enrollmentdate", "2022-12-26 12:05:00.0");
   }
 
@@ -1066,18 +1066,18 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,lastupdated")
-                    .add("lastUpdated=2017Feb")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("rowContext=true")
-                    .add("pageSize=100")
-                    .add("outputType=ENROLLMENT")
-                    .add("page=1")
-                    .add("dimension=ou:ImspTQPwCqd")
-                    .add("desc=lastupdated");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,lastupdated")
+            .add("lastUpdated=2017Feb")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("rowContext=true")
+            .add("pageSize=100")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("dimension=ou:ImspTQPwCqd")
+            .add("desc=lastupdated");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1087,43 +1087,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            20,
-            2,
-            2); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        20,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017Feb\":{\"name\":\"February 2017 - January 2018\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017Feb\":{\"name\":\"February 2017 - January 2018\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "lastupdated",
-            "Last updated on",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -1163,17 +1163,17 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
       // Given
       QueryParamsBuilder params =
-              new QueryParamsBuilder()
-                      .add("includeMetadataDetails=true")
-                      .add("headers=ouname,created")
-                      .add("displayProperty=NAME")
-                      .add("totalPages=false")
-                      .add("rowContext=true")
-                      .add("pageSize=10")
-                      .add("outputType=ENROLLMENT")
-                      .add("page=1")
-                      .add("dimension=ou:ImspTQPwCqd,CREATED:2017")
-                      .add("desc=lastupdated,created,ouname");
+          new QueryParamsBuilder()
+              .add("includeMetadataDetails=true")
+              .add("headers=ouname,created")
+              .add("displayProperty=NAME")
+              .add("totalPages=false")
+              .add("rowContext=true")
+              .add("pageSize=10")
+              .add("outputType=ENROLLMENT")
+              .add("page=1")
+              .add("dimension=ou:ImspTQPwCqd,CREATED:2017")
+              .add("desc=lastupdated,created,ouname");
 
       // When
       ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1183,43 +1183,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
       //    This helper checks basic counts and dimensions, adapting based on the runtime
       // 'expectPostgis' flag.
       validateResponseStructure(
-              response,
-              expectPostgis,
-              10,
-              2,
-              2); // Pass runtime flag, row count, and expected header counts
+          response,
+          expectPostgis,
+          10,
+          2,
+          2); // Pass runtime flag, row count, and expected header counts
 
       // 2. Extract Headers into a List of Maps for easy access by name
       List<Map<String, Object>> actualHeaders =
-              response.extractList("headers", Map.class).stream()
-                      .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                      .collect(Collectors.toList());
+          response.extractList("headers", Map.class).stream()
+              .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+              .collect(Collectors.toList());
 
       // 3. Assert metaData.
       String expectedMetaData =
-              "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017\":{\"name\":\"2017\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"created\":{\"name\":\"Created\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"created\":[\"2017\"],\"ou\":[\"ImspTQPwCqd\"]}}";
+          "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017\":{\"name\":\"2017\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"created\":{\"name\":\"Created\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"created\":[\"2017\"],\"ou\":[\"ImspTQPwCqd\"]}}";
       String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
       assertEquals(expectedMetaData, actualMetaData, false);
 
       // 4. Validate Headers By Name (conditionally checking PostGIS headers).
       validateHeaderPropertiesByName(
-              response,
-              actualHeaders,
-              "ouname",
-              "Organisation unit name",
-              "TEXT",
-              "java.lang.String",
-              false,
-              true);
+          response,
+          actualHeaders,
+          "ouname",
+          "Organisation unit name",
+          "TEXT",
+          "java.lang.String",
+          false,
+          true);
       validateHeaderPropertiesByName(
-              response,
-              actualHeaders,
-              "created",
-              "Created on",
-              "DATETIME",
-              "java.time.LocalDateTime",
-              false,
-              true);
+          response,
+          actualHeaders,
+          "created",
+          "Created on",
+          "DATETIME",
+          "java.time.LocalDateTime",
+          false,
+          true);
 
       // rowContext not found or empty in the response, skipping assertions.
 
@@ -1252,16 +1252,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
       // Given
       QueryParamsBuilder params =
-              new QueryParamsBuilder()
-                      .add("includeMetadataDetails=true")
-                      .add("headers=ouname,completed")
-                      .add("displayProperty=NAME")
-                      .add("totalPages=false")
-                      .add("rowContext=true")
-                      .add("pageSize=10")
-                      .add("page=1")
-                      .add("dimension=ou:ImspTQPwCqd,COMPLETED:2023")
-                      .add("desc=lastupdated,completed,ouname");
+          new QueryParamsBuilder()
+              .add("includeMetadataDetails=true")
+              .add("headers=ouname,completed")
+              .add("displayProperty=NAME")
+              .add("totalPages=false")
+              .add("rowContext=true")
+              .add("pageSize=10")
+              .add("page=1")
+              .add("dimension=ou:ImspTQPwCqd,COMPLETED:2023")
+              .add("desc=lastupdated,completed,ouname");
 
       // When
       ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1270,43 +1270,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
       //    This helper checks basic counts and dimensions, adapting based on the runtime
       // 'expectPostgis' flag.
       validateResponseStructure(
-              response,
-              expectPostgis,
-              3,
-              2,
-              2); // Pass runtime flag, row count, and expected header counts
+          response,
+          expectPostgis,
+          3,
+          2,
+          2); // Pass runtime flag, row count, and expected header counts
 
       // 2. Extract Headers into a List of Maps for easy access by name
       List<Map<String, Object>> actualHeaders =
-              response.extractList("headers", Map.class).stream()
-                      .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                      .collect(Collectors.toList());
+          response.extractList("headers", Map.class).stream()
+              .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+              .collect(Collectors.toList());
 
       // 3. Assert metaData.
       String expectedMetaData =
-              "{\"pager\":{\"isLastPage\":true,\"pageSize\":10,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2023\":{\"name\":\"2023\"},\"completed\":{\"name\":\"Completed\"},\"completeddate\":{\"name\":\"Completed date\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"completed\":[\"2023\"]}}";
+          "{\"pager\":{\"isLastPage\":true,\"pageSize\":10,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2023\":{\"name\":\"2023\"},\"completed\":{\"name\":\"Completed\"},\"completeddate\":{\"name\":\"Completed date\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"completed\":[\"2023\"]}}";
       String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
       assertEquals(expectedMetaData, actualMetaData, false);
 
       // 4. Validate Headers By Name (conditionally checking PostGIS headers).
       validateHeaderPropertiesByName(
-              response,
-              actualHeaders,
-              "ouname",
-              "Organisation unit name",
-              "TEXT",
-              "java.lang.String",
-              false,
-              true);
+          response,
+          actualHeaders,
+          "ouname",
+          "Organisation unit name",
+          "TEXT",
+          "java.lang.String",
+          false,
+          true);
       validateHeaderPropertiesByName(
-              response,
-              actualHeaders,
-              "completed",
-              "Completed on",
-              "DATETIME",
-              "java.time.LocalDateTime",
-              false,
-              true);
+          response,
+          actualHeaders,
+          "completed",
+          "Completed on",
+          "DATETIME",
+          "java.time.LocalDateTime",
+          false,
+          true);
 
       // rowContext not found or empty in the response, skipping assertions.
 
@@ -1332,15 +1332,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=pe:202301")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=pe:202301")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1350,43 +1350,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            100,
-            2,
-            2); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        100,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ZzYYXq4fJie.ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ZzYYXq4fJie.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -1394,7 +1394,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
     validateRowValueByName(
-            response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+        response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2023-01-31 12:05:00.0");
@@ -1419,7 +1419,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2023-01-29 12:05:00.0");
     validateRowValueByName(
-            response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
+        response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2023-01-29 12:05:00.0");
@@ -1449,14 +1449,14 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=A03MvHHogjR.eventdate,enrollmentdate,ouname")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("pageSize=20")
-                    .add("page=1")
-                    .add("desc=enrollmentdate,ouname");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=A03MvHHogjR.eventdate,enrollmentdate,ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=20")
+            .add("page=1")
+            .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1466,90 +1466,90 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            20,
-            3,
-            3); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        20,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-            "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.eventdate",
-            "Report date",
-            "DATE",
-            "java.time.LocalDate",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventdate",
+        "Report date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentdate",
-            "Date of enrollment",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
     // 7. Assert row values by name at specific indices (sorted results).
     // Validate selected values for row index 0
     validateRowValueByName(
-            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Yalieboya CHP");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-12-29 12:05:00.0");
 
     // Validate selected values for row index 4
     validateRowValueByName(
-            response, actualHeaders, 4, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 4, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 4, "ouname", "St. Luke's Wellington");
     validateRowValueByName(response, actualHeaders, 4, "enrollmentdate", "2023-12-29 12:05:00.0");
 
     // Validate selected values for row index 8
     validateRowValueByName(
-            response, actualHeaders, 8, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 8, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 8, "ouname", "New Police Barracks CHC");
     validateRowValueByName(response, actualHeaders, 8, "enrollmentdate", "2023-12-29 12:05:00.0");
 
     // Validate selected values for row index 12
     validateRowValueByName(
-            response, actualHeaders, 12, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 12, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(
-            response, actualHeaders, 12, "ouname", "Lungi Govt. Hospital, Port Loko");
+        response, actualHeaders, 12, "ouname", "Lungi Govt. Hospital, Port Loko");
     validateRowValueByName(response, actualHeaders, 12, "enrollmentdate", "2023-12-29 12:05:00.0");
 
     // Validate selected values for row index 16
     validateRowValueByName(
-            response, actualHeaders, 16, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 16, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 16, "ouname", "Govt. Hospital");
     validateRowValueByName(response, actualHeaders, 16, "enrollmentdate", "2023-12-29 12:05:00.0");
 
     // Validate selected values for row index 19
     validateRowValueByName(
-            response, actualHeaders, 19, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+        response, actualHeaders, 19, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 19, "ouname", "Bumpeh CHP");
     validateRowValueByName(response, actualHeaders, 19, "enrollmentdate", "2023-12-29 12:05:00.0");
   }
@@ -1561,17 +1561,17 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("includeMetadataDetails=true")
-                    .add("headers=ouname,lastupdated")
-                    .add("lastUpdated=201707")
-                    .add("displayProperty=NAME")
-                    .add("totalPages=false")
-                    .add("rowContext=true")
-                    .add("pageSize=100")
-                    .add("outputType=ENROLLMENT")
-                    .add("page=1")
-                    .add("dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95");
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,lastupdated")
+            .add("lastUpdated=201707")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("rowContext=true")
+            .add("pageSize=100")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1581,37 +1581,37 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-            response,
-            expectPostgis,
-            1,
-            2,
-            2); // Pass runtime flag, row count, and expected header counts
+        response,
+        expectPostgis,
+        1,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "ouname",
-            "Organisation unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "lastupdated",
-            "Last updated on",
-            "DATETIME",
-            "java.time.LocalDateTime",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -56,16 +56,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,A03MvHHogjR.eventdate")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("outputType=ENROLLMENT")
-            .add("pageSize=10")
-            .add("page=1")
-            .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.EVENT_DATE:2021")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,A03MvHHogjR.eventdate")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("outputType=ENROLLMENT")
+                    .add("pageSize=10")
+                    .add("page=1")
+                    .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.EVENT_DATE:2021")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -75,52 +75,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        10,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            10,
+            3,
+            3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "A03MvHHogjR.eventdate",
-        "Report date",
-        "DATE",
-        "java.time.LocalDate",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "A03MvHHogjR.eventdate",
+            "Report date",
+            "DATE",
+            "java.time.LocalDate",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -128,13 +128,13 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
     validateRowValueByName(
-        response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
   }
 
@@ -146,16 +146,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,A03MvHHogjR.scheduleddate")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("outputType=ENROLLMENT")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.SCHEDULED_DATE:2021")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,A03MvHHogjR.scheduleddate")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("outputType=ENROLLMENT")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ou:ImspTQPwCqd,A03MvHHogjR.SCHEDULED_DATE:2021")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -165,52 +165,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        100,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            100,
+            3,
+            3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR.SCHEDULED_DATE\":{\"name\":\"Scheduled date, Birth\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR.SCHEDULED_DATE\":{\"name\":\"Scheduled date, Birth\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "A03MvHHogjR.scheduleddate",
-        "scheduleddate",
-        "DATE",
-        "java.time.LocalDate",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "A03MvHHogjR.scheduleddate",
+            "scheduleddate",
+            "DATE",
+            "java.time.LocalDate",
+            false,
+            true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -225,13 +225,13 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-        response, actualHeaders, 0, "A03MvHHogjR.scheduleddate", "2021-12-29 12:05:00.0");
+            response, actualHeaders, 0, "A03MvHHogjR.scheduleddate", "2021-12-29 12:05:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 99
     validateRowValueByName(response, actualHeaders, 99, "ouname", "MCH Static/U5");
     validateRowValueByName(
-        response, actualHeaders, 99, "A03MvHHogjR.scheduleddate", "2021-12-26 12:05:00.0");
+            response, actualHeaders, 99, "A03MvHHogjR.scheduleddate", "2021-12-26 12:05:00.0");
     validateRowValueByName(response, actualHeaders, 99, "enrollmentdate", "2022-12-26 12:05:00.0");
   }
 
@@ -242,15 +242,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -260,52 +260,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        7,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            7,
+            3,
+            3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
+            "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -335,15 +335,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8,pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -353,43 +353,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        7,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            7,
+            2,
+            2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -414,15 +414,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ou")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8;PMa2VCrupOd,pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ou")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.ou:DiszpKrYNg8;PMa2VCrupOd,pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -432,52 +432,52 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        45,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            45,
+            3,
+            3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"PMa2VCrupOd\":{\"uid\":\"PMa2VCrupOd\",\"code\":\"OU_211212\",\"name\":\"Kambia\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\",\"PMa2VCrupOd\"],\"pe\":[]}}";
+            "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"PMa2VCrupOd\":{\"uid\":\"PMa2VCrupOd\",\"code\":\"OU_211212\",\"name\":\"Kambia\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"DiszpKrYNg8\",\"PMa2VCrupOd\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.ou",
-        "Organisation unit",
-        "ORGANISATION_UNIT",
-        "org.hisp.dhis.organisationunit.OrganisationUnit",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.ou",
+            "Organisation unit",
+            "ORGANISATION_UNIT",
+            "org.hisp.dhis.organisationunit.OrganisationUnit",
+            false,
+            true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -507,15 +507,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.oucode,ZzYYXq4fJie.ouname")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.ou:LEVEL-tTUf91fCytl;USER_ORGUNIT;cgqkFdShPzg,pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.oucode,ZzYYXq4fJie.ouname")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.ou:LEVEL-tTUf91fCytl;USER_ORGUNIT;cgqkFdShPzg,pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -525,61 +525,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        100,
-        4,
-        4); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            100,
+            4,
+            4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"yu4N82FFeLm\":{\"uid\":\"yu4N82FFeLm\",\"code\":\"OU_204910\",\"name\":\"Mandu\"},\"KXSqt7jv6DU\":{\"uid\":\"KXSqt7jv6DU\",\"code\":\"OU_222627\",\"name\":\"Gorama Mende\"},\"lY93YpCxJqf\":{\"uid\":\"lY93YpCxJqf\",\"code\":\"OU_193249\",\"name\":\"Makari Gbanti\"},\"eROJsBwxQHt\":{\"uid\":\"eROJsBwxQHt\",\"code\":\"OU_222743\",\"name\":\"Gaura\"},\"DxAPPqXvwLy\":{\"uid\":\"DxAPPqXvwLy\",\"code\":\"OU_204929\",\"name\":\"Peje Bongre\"},\"PaqugoqjRIj\":{\"uid\":\"PaqugoqjRIj\",\"code\":\"OU_226225\",\"name\":\"Sulima (Koinadugu)\"},\"gy8rmvYT4cj\":{\"uid\":\"gy8rmvYT4cj\",\"code\":\"OU_247037\",\"name\":\"Ribbi\"},\"RzKeCma9qb1\":{\"uid\":\"RzKeCma9qb1\",\"code\":\"OU_260428\",\"name\":\"Barri\"},\"vULnao2hV5v\":{\"uid\":\"vULnao2hV5v\",\"code\":\"OU_247086\",\"name\":\"Fakunya\"},\"EfWCa0Cc8WW\":{\"uid\":\"EfWCa0Cc8WW\",\"code\":\"OU_255030\",\"name\":\"Masimera\"},\"AovmOHadayb\":{\"uid\":\"AovmOHadayb\",\"code\":\"OU_247044\",\"name\":\"Timidale\"},\"hjpHnHZIniP\":{\"uid\":\"hjpHnHZIniP\",\"code\":\"OU_204887\",\"name\":\"Kissi Tongi\"},\"U6Kr7Gtpidn\":{\"uid\":\"U6Kr7Gtpidn\",\"code\":\"OU_546\",\"name\":\"Kakua\"},\"EYt6ThQDagn\":{\"uid\":\"EYt6ThQDagn\",\"code\":\"OU_222642\",\"name\":\"Koya (kenema)\"},\"iUauWFeH8Qp\":{\"uid\":\"iUauWFeH8Qp\",\"code\":\"OU_197402\",\"name\":\"Bum\"},\"Jiyc4ekaMMh\":{\"uid\":\"Jiyc4ekaMMh\",\"code\":\"OU_247080\",\"name\":\"Kongbora\"},\"FlBemv1NfEC\":{\"uid\":\"FlBemv1NfEC\",\"code\":\"OU_211256\",\"name\":\"Masungbala\"},\"XrF5AvaGcuw\":{\"uid\":\"XrF5AvaGcuw\",\"code\":\"OU_226240\",\"name\":\"Wara Wara Bafodia\"},\"LhaAPLxdSFH\":{\"uid\":\"LhaAPLxdSFH\",\"code\":\"OU_233348\",\"name\":\"Lei\"},\"BmYyh9bZ0sr\":{\"uid\":\"BmYyh9bZ0sr\",\"code\":\"OU_268197\",\"name\":\"Kafe Simira\"},\"pk7bUK5c1Uf\":{\"uid\":\"pk7bUK5c1Uf\",\"code\":\"OU_260397\",\"name\":\"Ya Kpukumu Krim\"},\"zSNUViKdkk3\":{\"uid\":\"zSNUViKdkk3\",\"code\":\"OU_260440\",\"name\":\"Kpaka\"},\"r06ohri9wA9\":{\"uid\":\"r06ohri9wA9\",\"code\":\"OU_211243\",\"name\":\"Samu\"},\"ERmBhYkhV6Y\":{\"uid\":\"ERmBhYkhV6Y\",\"code\":\"OU_204877\",\"name\":\"Njaluahun\"},\"Z9QaI6sxTwW\":{\"uid\":\"Z9QaI6sxTwW\",\"code\":\"OU_247068\",\"name\":\"Kargboro\"},\"daJPPxtIrQn\":{\"uid\":\"daJPPxtIrQn\",\"code\":\"OU_545\",\"name\":\"Jaiama Bongor\"},\"W5fN3G6y1VI\":{\"uid\":\"W5fN3G6y1VI\",\"code\":\"OU_247012\",\"name\":\"Lower Banta\"},\"r1RUyfVBkLp\":{\"uid\":\"r1RUyfVBkLp\",\"code\":\"OU_268169\",\"name\":\"Sambaia Bendugu\"},\"cgqkFdShPzg\":{\"uid\":\"cgqkFdShPzg\",\"code\":\"OU_193213\",\"name\":\"Loreto Clinic\"},\"NNE0YMCDZkO\":{\"uid\":\"NNE0YMCDZkO\",\"code\":\"OU_268225\",\"name\":\"Yoni\"},\"ENHOJz3UH5L\":{\"uid\":\"ENHOJz3UH5L\",\"code\":\"OU_197440\",\"name\":\"BMC\"},\"QywkxFudXrC\":{\"uid\":\"QywkxFudXrC\",\"code\":\"OU_211227\",\"name\":\"Magbema\"},\"jWSIbtKfURj\":{\"uid\":\"jWSIbtKfURj\",\"code\":\"OU_222751\",\"name\":\"Langrama\"},\"J4GiUImJZoE\":{\"uid\":\"J4GiUImJZoE\",\"code\":\"OU_226269\",\"name\":\"Nieni\"},\"CF243RPvNY7\":{\"uid\":\"CF243RPvNY7\",\"code\":\"OU_233359\",\"name\":\"Fiama\"},\"I4jWcnFmgEC\":{\"uid\":\"I4jWcnFmgEC\",\"code\":\"OU_549\",\"name\":\"Niawa Lenga\"},\"cM2BKSrj9F9\":{\"uid\":\"cM2BKSrj9F9\",\"code\":\"OU_204894\",\"name\":\"Luawa\"},\"kvkDWg42lHR\":{\"uid\":\"kvkDWg42lHR\",\"code\":\"OU_233339\",\"name\":\"Kamara\"},\"jPidqyo7cpF\":{\"uid\":\"jPidqyo7cpF\",\"code\":\"OU_247049\",\"name\":\"Bagruwa\"},\"BGGmAwx33dj\":{\"uid\":\"BGGmAwx33dj\",\"code\":\"OU_543\",\"name\":\"Bumpe Ngao\"},\"iGHlidSFdpu\":{\"uid\":\"iGHlidSFdpu\",\"code\":\"OU_233317\",\"name\":\"Soa\"},\"g8DdBm7EmUt\":{\"uid\":\"g8DdBm7EmUt\",\"code\":\"OU_197397\",\"name\":\"Sittia\"},\"ZiOVcrSjSYe\":{\"uid\":\"ZiOVcrSjSYe\",\"code\":\"OU_254976\",\"name\":\"Dibia\"},\"vn9KJsLyP5f\":{\"uid\":\"vn9KJsLyP5f\",\"code\":\"OU_255005\",\"name\":\"Kaffu Bullom\"},\"QlCIp2S9NHs\":{\"uid\":\"QlCIp2S9NHs\",\"code\":\"OU_222682\",\"name\":\"Dodo\"},\"j43EZb15rjI\":{\"uid\":\"j43EZb15rjI\",\"code\":\"OU_193285\",\"name\":\"Sella Limba\"},\"202301\":{\"name\":\"January 2023\"},\"bQiBfA2j5cw\":{\"uid\":\"bQiBfA2j5cw\",\"code\":\"OU_204857\",\"name\":\"Penguia\"},\"NqWaKXcg01b\":{\"uid\":\"NqWaKXcg01b\",\"code\":\"OU_260384\",\"name\":\"Sowa\"},\"VP397wRvePm\":{\"uid\":\"VP397wRvePm\",\"code\":\"OU_197445\",\"name\":\"Nongoba Bullum\"},\"fwxkctgmffZ\":{\"uid\":\"fwxkctgmffZ\",\"code\":\"OU_268163\",\"name\":\"Kholifa Mabang\"},\"QwMiPiME3bA\":{\"uid\":\"QwMiPiME3bA\",\"code\":\"OU_260400\",\"name\":\"Kpanga Kabonde\"},\"Qhmi8IZyPyD\":{\"uid\":\"Qhmi8IZyPyD\",\"code\":\"OU_193245\",\"name\":\"Tambaka\"},\"OTFepb1k9Db\":{\"uid\":\"OTFepb1k9Db\",\"code\":\"OU_226244\",\"name\":\"Mongo\"},\"DBs6e2Oxaj1\":{\"uid\":\"DBs6e2Oxaj1\",\"code\":\"OU_247002\",\"name\":\"Upper Banta\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"eV4cuxniZgP\":{\"uid\":\"eV4cuxniZgP\",\"code\":\"OU_193224\",\"name\":\"Magbaimba Ndowahun\"},\"xhyjU2SVewz\":{\"uid\":\"xhyjU2SVewz\",\"code\":\"OU_268217\",\"name\":\"Tane\"},\"dGheVylzol6\":{\"uid\":\"dGheVylzol6\",\"code\":\"OU_541\",\"name\":\"Bargbe\"},\"vWbkYPRmKyS\":{\"uid\":\"vWbkYPRmKyS\",\"code\":\"OU_540\",\"name\":\"Baoma\"},\"npWGUj37qDe\":{\"uid\":\"npWGUj37qDe\",\"code\":\"OU_552\",\"name\":\"Valunia\"},\"TA7NvKjsn4A\":{\"uid\":\"TA7NvKjsn4A\",\"code\":\"OU_255041\",\"name\":\"Bureh Kasseh Maconteh\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"tTUf91fCytl\":{\"uid\":\"tTUf91fCytl\",\"valueType\":\"NUMBER\",\"name\":\"Chiefdom\",\"totalAggregationType\":\"SUM\"},\"myQ4q1W6B4y\":{\"uid\":\"myQ4q1W6B4y\",\"code\":\"OU_222731\",\"name\":\"Dama\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"nV3OkyzF4US\":{\"uid\":\"nV3OkyzF4US\",\"code\":\"OU_246991\",\"name\":\"Kori\"},\"X7dWcGerQIm\":{\"uid\":\"X7dWcGerQIm\",\"code\":\"OU_222677\",\"name\":\"Wandor\"},\"qIRCo0MfuGb\":{\"uid\":\"qIRCo0MfuGb\",\"code\":\"OU_211213\",\"name\":\"Gbinleh Dixion\"},\"kbPmt60yi0L\":{\"uid\":\"kbPmt60yi0L\",\"code\":\"OU_211220\",\"name\":\"Bramaia\"},\"eNtRuQrrZeo\":{\"uid\":\"eNtRuQrrZeo\",\"code\":\"OU_260420\",\"name\":\"Galliness Perri\"},\"HV8RTzgcFH3\":{\"uid\":\"HV8RTzgcFH3\",\"code\":\"OU_197432\",\"name\":\"Kwamabai Krim\"},\"KKkLOTpMXGV\":{\"uid\":\"KKkLOTpMXGV\",\"code\":\"OU_193198\",\"name\":\"Bombali Sebora\"},\"Pc3JTyqnsmL\":{\"uid\":\"Pc3JTyqnsmL\",\"code\":\"OU_255020\",\"name\":\"Buya Romende\"},\"hdEuw2ugkVF\":{\"uid\":\"hdEuw2ugkVF\",\"code\":\"OU_222652\",\"name\":\"Lower Bambara\"},\"l7pFejMtUoF\":{\"uid\":\"l7pFejMtUoF\",\"code\":\"OU_222634\",\"name\":\"Tunkia\"},\"K1r3uF6eZ8n\":{\"uid\":\"K1r3uF6eZ8n\",\"code\":\"OU_222725\",\"name\":\"Kandu Lepiema\"},\"VGAFxBXz16y\":{\"uid\":\"VGAFxBXz16y\",\"code\":\"OU_226231\",\"name\":\"Sengbeh\"},\"GE25DpSrqpB\":{\"uid\":\"GE25DpSrqpB\",\"code\":\"OU_204869\",\"name\":\"Malema\"},\"ARZ4y5i4reU\":{\"uid\":\"ARZ4y5i4reU\",\"code\":\"OU_553\",\"name\":\"Wonde\"},\"byp7w6Xd9Df\":{\"uid\":\"byp7w6Xd9Df\",\"code\":\"OU_204933\",\"name\":\"Yawei\"},\"BXJdOLvUrZB\":{\"uid\":\"BXJdOLvUrZB\",\"code\":\"OU_193277\",\"name\":\"Gbendembu Ngowahun\"},\"uKC54fzxRzO\":{\"uid\":\"uKC54fzxRzO\",\"code\":\"OU_222648\",\"name\":\"Niawa\"},\"TQkG0sX9nca\":{\"uid\":\"TQkG0sX9nca\",\"code\":\"OU_233375\",\"name\":\"Gbense\"},\"hRZOIgQ0O1m\":{\"uid\":\"hRZOIgQ0O1m\",\"code\":\"OU_193302\",\"name\":\"Libeisaygahun\"},\"PrJQHI6q7w2\":{\"uid\":\"PrJQHI6q7w2\",\"code\":\"OU_255061\",\"name\":\"Tainkatopa Makama Safrokoh\"},\"USQdmvrHh1Q\":{\"uid\":\"USQdmvrHh1Q\",\"code\":\"OU_247055\",\"name\":\"Kaiyamba\"},\"xGMGhjA3y6J\":{\"uid\":\"xGMGhjA3y6J\",\"code\":\"OU_211262\",\"name\":\"Mambolo\"},\"nOYt1LtFSyU\":{\"uid\":\"nOYt1LtFSyU\",\"code\":\"OU_247025\",\"name\":\"Bumpeh\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"e1eIKM1GIF3\":{\"uid\":\"e1eIKM1GIF3\",\"code\":\"OU_193215\",\"name\":\"Gbanti Kamaranka\"},\"lYIM1MXbSYS\":{\"uid\":\"lYIM1MXbSYS\",\"code\":\"OU_204920\",\"name\":\"Dea\"},\"sxRd2XOzFbz\":{\"uid\":\"sxRd2XOzFbz\",\"code\":\"OU_551\",\"name\":\"Tikonko\"},\"d9iMR1MpuIO\":{\"uid\":\"d9iMR1MpuIO\",\"code\":\"OU_260410\",\"name\":\"Soro-Gbeima\"},\"qgQ49DH9a0v\":{\"uid\":\"qgQ49DH9a0v\",\"code\":\"OU_233332\",\"name\":\"Nimiyama\"},\"U09TSwIjG0s\":{\"uid\":\"U09TSwIjG0s\",\"code\":\"OU_222617\",\"name\":\"Nomo\"},\"zFDYIgyGmXG\":{\"uid\":\"zFDYIgyGmXG\",\"code\":\"OU_542\",\"name\":\"Bargbo\"},\"M2qEv692lS6\":{\"uid\":\"M2qEv692lS6\",\"code\":\"OU_233324\",\"name\":\"Tankoro\"},\"qtr8GGlm4gg\":{\"uid\":\"qtr8GGlm4gg\",\"code\":\"OU_278366\",\"name\":\"Rural Western Area\"},\"pRHGAROvuyI\":{\"uid\":\"pRHGAROvuyI\",\"code\":\"OU_254960\",\"name\":\"Koya\"},\"xIKjidMrico\":{\"uid\":\"xIKjidMrico\",\"code\":\"OU_247033\",\"name\":\"Kowa\"},\"GWTIxJO9pRo\":{\"uid\":\"GWTIxJO9pRo\",\"code\":\"OU_233355\",\"name\":\"Gorama Kono\"},\"HWjrSuoNPte\":{\"uid\":\"HWjrSuoNPte\",\"code\":\"OU_254999\",\"name\":\"Sanda Magbolonthor\"},\"UhHipWG7J8b\":{\"uid\":\"UhHipWG7J8b\",\"code\":\"OU_193191\",\"name\":\"Sanda Tendaren\"},\"rXLor9Knq6l\":{\"uid\":\"rXLor9Knq6l\",\"code\":\"OU_268212\",\"name\":\"Kunike Barina\"},\"kU8vhUkAGaT\":{\"uid\":\"kU8vhUkAGaT\",\"code\":\"OU_548\",\"name\":\"Lugbu\"},\"C9uduqDZr9d\":{\"uid\":\"C9uduqDZr9d\",\"code\":\"OU_278311\",\"name\":\"Freetown\"},\"YmmeuGbqOwR\":{\"uid\":\"YmmeuGbqOwR\",\"code\":\"OU_544\",\"name\":\"Gbo\"},\"iEkBZnMDarP\":{\"uid\":\"iEkBZnMDarP\",\"code\":\"OU_226253\",\"name\":\"Folosaba Dembelia\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"JsxnA2IywRo\":{\"uid\":\"JsxnA2IywRo\",\"code\":\"OU_204875\",\"name\":\"Kissi Kama\"},\"nlt6j60tCHF\":{\"uid\":\"nlt6j60tCHF\",\"code\":\"OU_260437\",\"name\":\"Mano Sakrim\"},\"g5ptsn0SFX8\":{\"uid\":\"g5ptsn0SFX8\",\"code\":\"OU_233365\",\"name\":\"Sandor\"},\"XG8HGAbrbbL\":{\"uid\":\"XG8HGAbrbbL\",\"code\":\"OU_193267\",\"name\":\"Safroko Limba\"},\"pmxZm7klXBy\":{\"uid\":\"pmxZm7klXBy\",\"code\":\"OU_204924\",\"name\":\"Peje West\"},\"l0ccv2yzfF3\":{\"uid\":\"l0ccv2yzfF3\",\"code\":\"OU_268174\",\"name\":\"Kunike\"},\"YuQRtpLP10I\":{\"uid\":\"YuQRtpLP10I\",\"code\":\"OU_539\",\"name\":\"Badjia\"},\"LfTkc0S4b5k\":{\"uid\":\"LfTkc0S4b5k\",\"code\":\"OU_204915\",\"name\":\"Upper Bambara\"},\"KSdZwrU7Hh6\":{\"uid\":\"KSdZwrU7Hh6\",\"code\":\"OU_204861\",\"name\":\"Jawi\"},\"ajILkI0cfxn\":{\"uid\":\"ajILkI0cfxn\",\"code\":\"OU_233390\",\"name\":\"Gbane\"},\"y5X4mP5XylL\":{\"uid\":\"y5X4mP5XylL\",\"code\":\"OU_211270\",\"name\":\"Tonko Limba\"},\"fwH9ipvXde9\":{\"uid\":\"fwH9ipvXde9\",\"code\":\"OU_193228\",\"name\":\"Biriwa\"},\"KIUCimTXf8Q\":{\"uid\":\"KIUCimTXf8Q\",\"code\":\"OU_222690\",\"name\":\"Nongowa\"},\"vEvs2ckGNQj\":{\"uid\":\"vEvs2ckGNQj\",\"code\":\"OU_226219\",\"name\":\"Kasonko\"},\"XEyIRFd9pct\":{\"uid\":\"XEyIRFd9pct\",\"code\":\"OU_197413\",\"name\":\"Imperi\"},\"cgOy0hRMGu9\":{\"uid\":\"cgOy0hRMGu9\",\"code\":\"OU_197408\",\"name\":\"Sogbini\"},\"EjnIQNVAXGp\":{\"uid\":\"EjnIQNVAXGp\",\"code\":\"OU_233344\",\"name\":\"Mafindor\"},\"x4HaBHHwBML\":{\"uid\":\"x4HaBHHwBML\",\"code\":\"OU_222672\",\"name\":\"Malegohun\"},\"EZPwuUTeIIG\":{\"uid\":\"EZPwuUTeIIG\",\"code\":\"OU_226258\",\"name\":\"Wara Wara Yagala\"},\"N233eZJZ1bh\":{\"uid\":\"N233eZJZ1bh\",\"code\":\"OU_260388\",\"name\":\"Pejeh\"},\"smoyi1iYNK6\":{\"uid\":\"smoyi1iYNK6\",\"code\":\"OU_268191\",\"name\":\"Kalansogoia\"},\"DNRAeXT9IwS\":{\"uid\":\"DNRAeXT9IwS\",\"code\":\"OU_197421\",\"name\":\"Dema\"},\"fRLX08WHWpL\":{\"uid\":\"fRLX08WHWpL\",\"code\":\"OU_254982\",\"name\":\"Lokomasama\"},\"Zoy23SSHCPs\":{\"uid\":\"Zoy23SSHCPs\",\"code\":\"OU_233311\",\"name\":\"Gbane Kandor\"},\"LsYpCyYxSLY\":{\"uid\":\"LsYpCyYxSLY\",\"code\":\"OU_247008\",\"name\":\"Kamaje\"},\"JdqfYTIFZXN\":{\"uid\":\"JdqfYTIFZXN\",\"code\":\"OU_254946\",\"name\":\"Maforki\"},\"EB1zRKdYjdY\":{\"uid\":\"EB1zRKdYjdY\",\"code\":\"OU_197429\",\"name\":\"Bendu Cha\"},\"CG4QD1HC3h4\":{\"uid\":\"CG4QD1HC3h4\",\"code\":\"OU_197436\",\"name\":\"Yawbeko\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\"},\"YpVol7asWvd\":{\"uid\":\"YpVol7asWvd\",\"code\":\"OU_260417\",\"name\":\"Kpanga Krim\"},\"RndxKqQGzUl\":{\"uid\":\"RndxKqQGzUl\",\"code\":\"OU_247018\",\"name\":\"Dasse\"},\"P69SId31eDp\":{\"uid\":\"P69SId31eDp\",\"code\":\"OU_268202\",\"name\":\"Gbonkonlenken\"},\"aWQTfvgPA5v\":{\"uid\":\"aWQTfvgPA5v\",\"code\":\"OU_197424\",\"name\":\"Kpanda Kemoh\"},\"KctpIIucige\":{\"uid\":\"KctpIIucige\",\"code\":\"OU_550\",\"name\":\"Selenga\"},\"Mr4au3jR9bt\":{\"uid\":\"Mr4au3jR9bt\",\"code\":\"OU_226214\",\"name\":\"Dembelia Sinkunia\"},\"L8iA6eLwKNb\":{\"uid\":\"L8iA6eLwKNb\",\"code\":\"OU_193295\",\"name\":\"Paki Masabong\"},\"j0Mtr3xTMjM\":{\"uid\":\"j0Mtr3xTMjM\",\"code\":\"OU_204939\",\"name\":\"Kissi Teng\"},\"DmaLM8WYmWv\":{\"uid\":\"DmaLM8WYmWv\",\"code\":\"OU_233394\",\"name\":\"Nimikoro\"},\"DfUfwjM9am5\":{\"uid\":\"DfUfwjM9am5\",\"code\":\"OU_260392\",\"name\":\"Malen\"},\"FRxcUEwktoV\":{\"uid\":\"FRxcUEwktoV\",\"code\":\"OU_233314\",\"name\":\"Toli\"},\"VCtF1DbspR5\":{\"uid\":\"VCtF1DbspR5\",\"code\":\"OU_197386\",\"name\":\"Jong\"},\"BD9gU0GKlr2\":{\"uid\":\"BD9gU0GKlr2\",\"code\":\"OU_260378\",\"name\":\"Makpele\"},\"GFk45MOxzJJ\":{\"uid\":\"GFk45MOxzJJ\",\"code\":\"OU_226275\",\"name\":\"Neya\"},\"A3Fh37HWBWE\":{\"uid\":\"A3Fh37HWBWE\",\"code\":\"OU_222687\",\"name\":\"Simbaru\"},\"vzup1f6ynON\":{\"uid\":\"vzup1f6ynON\",\"code\":\"OU_222619\",\"name\":\"Small Bo\"},\"Lt8U7GVWvSR\":{\"uid\":\"Lt8U7GVWvSR\",\"code\":\"OU_226263\",\"name\":\"Diang\"},\"JdhagCUEMbj\":{\"uid\":\"JdhagCUEMbj\",\"code\":\"OU_547\",\"name\":\"Komboya\"},\"EVkm2xYcf6Z\":{\"uid\":\"EVkm2xYcf6Z\",\"code\":\"OU_268184\",\"name\":\"Malal Mara\"},\"PQZJPIpTepd\":{\"uid\":\"PQZJPIpTepd\",\"code\":\"OU_268150\",\"name\":\"Kholifa Rowalla\"},\"WXnNDWTiE9r\":{\"uid\":\"WXnNDWTiE9r\",\"code\":\"OU_193239\",\"name\":\"Sanda Loko\"},\"RWvG1aFrr0r\":{\"uid\":\"RWvG1aFrr0r\",\"code\":\"OU_255053\",\"name\":\"Marampa\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"ImspTQPwCqd\",\"cgqkFdShPzg\",\"YuQRtpLP10I\",\"jPidqyo7cpF\",\"vWbkYPRmKyS\",\"dGheVylzol6\",\"zFDYIgyGmXG\",\"RzKeCma9qb1\",\"EB1zRKdYjdY\",\"fwH9ipvXde9\",\"ENHOJz3UH5L\",\"KKkLOTpMXGV\",\"kbPmt60yi0L\",\"iUauWFeH8Qp\",\"BGGmAwx33dj\",\"nOYt1LtFSyU\",\"TA7NvKjsn4A\",\"Pc3JTyqnsmL\",\"myQ4q1W6B4y\",\"RndxKqQGzUl\",\"lYIM1MXbSYS\",\"DNRAeXT9IwS\",\"Mr4au3jR9bt\",\"Lt8U7GVWvSR\",\"ZiOVcrSjSYe\",\"QlCIp2S9NHs\",\"vULnao2hV5v\",\"CF243RPvNY7\",\"iEkBZnMDarP\",\"C9uduqDZr9d\",\"eNtRuQrrZeo\",\"eROJsBwxQHt\",\"ajILkI0cfxn\",\"Zoy23SSHCPs\",\"e1eIKM1GIF3\",\"BXJdOLvUrZB\",\"TQkG0sX9nca\",\"qIRCo0MfuGb\",\"YmmeuGbqOwR\",\"P69SId31eDp\",\"GWTIxJO9pRo\",\"KXSqt7jv6DU\",\"XEyIRFd9pct\",\"daJPPxtIrQn\",\"KSdZwrU7Hh6\",\"VCtF1DbspR5\",\"BmYyh9bZ0sr\",\"vn9KJsLyP5f\",\"USQdmvrHh1Q\",\"U6Kr7Gtpidn\",\"smoyi1iYNK6\",\"LsYpCyYxSLY\",\"kvkDWg42lHR\",\"K1r3uF6eZ8n\",\"Z9QaI6sxTwW\",\"vEvs2ckGNQj\",\"fwxkctgmffZ\",\"PQZJPIpTepd\",\"JsxnA2IywRo\",\"j0Mtr3xTMjM\",\"hjpHnHZIniP\",\"JdhagCUEMbj\",\"Jiyc4ekaMMh\",\"nV3OkyzF4US\",\"xIKjidMrico\",\"pRHGAROvuyI\",\"EYt6ThQDagn\",\"zSNUViKdkk3\",\"aWQTfvgPA5v\",\"QwMiPiME3bA\",\"YpVol7asWvd\",\"l0ccv2yzfF3\",\"rXLor9Knq6l\",\"HV8RTzgcFH3\",\"jWSIbtKfURj\",\"LhaAPLxdSFH\",\"hRZOIgQ0O1m\",\"fRLX08WHWpL\",\"hdEuw2ugkVF\",\"W5fN3G6y1VI\",\"cM2BKSrj9F9\",\"kU8vhUkAGaT\",\"EjnIQNVAXGp\",\"JdqfYTIFZXN\",\"eV4cuxniZgP\",\"QywkxFudXrC\",\"lY93YpCxJqf\",\"BD9gU0GKlr2\",\"EVkm2xYcf6Z\",\"x4HaBHHwBML\",\"GE25DpSrqpB\",\"DfUfwjM9am5\",\"xGMGhjA3y6J\",\"yu4N82FFeLm\",\"nlt6j60tCHF\",\"RWvG1aFrr0r\",\"EfWCa0Cc8WW\",\"FlBemv1NfEC\",\"OTFepb1k9Db\",\"GFk45MOxzJJ\",\"uKC54fzxRzO\",\"I4jWcnFmgEC\",\"J4GiUImJZoE\",\"DmaLM8WYmWv\",\"qgQ49DH9a0v\",\"ERmBhYkhV6Y\",\"U09TSwIjG0s\",\"VP397wRvePm\",\"KIUCimTXf8Q\",\"L8iA6eLwKNb\",\"DxAPPqXvwLy\",\"pmxZm7klXBy\",\"N233eZJZ1bh\",\"bQiBfA2j5cw\",\"gy8rmvYT4cj\",\"qtr8GGlm4gg\",\"XG8HGAbrbbL\",\"r1RUyfVBkLp\",\"r06ohri9wA9\",\"WXnNDWTiE9r\",\"HWjrSuoNPte\",\"UhHipWG7J8b\",\"g5ptsn0SFX8\",\"KctpIIucige\",\"j43EZb15rjI\",\"VGAFxBXz16y\",\"A3Fh37HWBWE\",\"g8DdBm7EmUt\",\"vzup1f6ynON\",\"iGHlidSFdpu\",\"cgOy0hRMGu9\",\"d9iMR1MpuIO\",\"NqWaKXcg01b\",\"PaqugoqjRIj\",\"PrJQHI6q7w2\",\"Qhmi8IZyPyD\",\"xhyjU2SVewz\",\"M2qEv692lS6\",\"sxRd2XOzFbz\",\"AovmOHadayb\",\"FRxcUEwktoV\",\"y5X4mP5XylL\",\"l7pFejMtUoF\",\"LfTkc0S4b5k\",\"DBs6e2Oxaj1\",\"npWGUj37qDe\",\"X7dWcGerQIm\",\"XrF5AvaGcuw\",\"EZPwuUTeIIG\",\"ARZ4y5i4reU\",\"pk7bUK5c1Uf\",\"CG4QD1HC3h4\",\"byp7w6Xd9Df\",\"NNE0YMCDZkO\"],\"pe\":[]}}";
+            "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"yu4N82FFeLm\":{\"uid\":\"yu4N82FFeLm\",\"code\":\"OU_204910\",\"name\":\"Mandu\"},\"KXSqt7jv6DU\":{\"uid\":\"KXSqt7jv6DU\",\"code\":\"OU_222627\",\"name\":\"Gorama Mende\"},\"lY93YpCxJqf\":{\"uid\":\"lY93YpCxJqf\",\"code\":\"OU_193249\",\"name\":\"Makari Gbanti\"},\"eROJsBwxQHt\":{\"uid\":\"eROJsBwxQHt\",\"code\":\"OU_222743\",\"name\":\"Gaura\"},\"DxAPPqXvwLy\":{\"uid\":\"DxAPPqXvwLy\",\"code\":\"OU_204929\",\"name\":\"Peje Bongre\"},\"PaqugoqjRIj\":{\"uid\":\"PaqugoqjRIj\",\"code\":\"OU_226225\",\"name\":\"Sulima (Koinadugu)\"},\"gy8rmvYT4cj\":{\"uid\":\"gy8rmvYT4cj\",\"code\":\"OU_247037\",\"name\":\"Ribbi\"},\"RzKeCma9qb1\":{\"uid\":\"RzKeCma9qb1\",\"code\":\"OU_260428\",\"name\":\"Barri\"},\"vULnao2hV5v\":{\"uid\":\"vULnao2hV5v\",\"code\":\"OU_247086\",\"name\":\"Fakunya\"},\"EfWCa0Cc8WW\":{\"uid\":\"EfWCa0Cc8WW\",\"code\":\"OU_255030\",\"name\":\"Masimera\"},\"AovmOHadayb\":{\"uid\":\"AovmOHadayb\",\"code\":\"OU_247044\",\"name\":\"Timidale\"},\"hjpHnHZIniP\":{\"uid\":\"hjpHnHZIniP\",\"code\":\"OU_204887\",\"name\":\"Kissi Tongi\"},\"U6Kr7Gtpidn\":{\"uid\":\"U6Kr7Gtpidn\",\"code\":\"OU_546\",\"name\":\"Kakua\"},\"EYt6ThQDagn\":{\"uid\":\"EYt6ThQDagn\",\"code\":\"OU_222642\",\"name\":\"Koya (kenema)\"},\"iUauWFeH8Qp\":{\"uid\":\"iUauWFeH8Qp\",\"code\":\"OU_197402\",\"name\":\"Bum\"},\"Jiyc4ekaMMh\":{\"uid\":\"Jiyc4ekaMMh\",\"code\":\"OU_247080\",\"name\":\"Kongbora\"},\"FlBemv1NfEC\":{\"uid\":\"FlBemv1NfEC\",\"code\":\"OU_211256\",\"name\":\"Masungbala\"},\"XrF5AvaGcuw\":{\"uid\":\"XrF5AvaGcuw\",\"code\":\"OU_226240\",\"name\":\"Wara Wara Bafodia\"},\"LhaAPLxdSFH\":{\"uid\":\"LhaAPLxdSFH\",\"code\":\"OU_233348\",\"name\":\"Lei\"},\"BmYyh9bZ0sr\":{\"uid\":\"BmYyh9bZ0sr\",\"code\":\"OU_268197\",\"name\":\"Kafe Simira\"},\"pk7bUK5c1Uf\":{\"uid\":\"pk7bUK5c1Uf\",\"code\":\"OU_260397\",\"name\":\"Ya Kpukumu Krim\"},\"zSNUViKdkk3\":{\"uid\":\"zSNUViKdkk3\",\"code\":\"OU_260440\",\"name\":\"Kpaka\"},\"r06ohri9wA9\":{\"uid\":\"r06ohri9wA9\",\"code\":\"OU_211243\",\"name\":\"Samu\"},\"ERmBhYkhV6Y\":{\"uid\":\"ERmBhYkhV6Y\",\"code\":\"OU_204877\",\"name\":\"Njaluahun\"},\"Z9QaI6sxTwW\":{\"uid\":\"Z9QaI6sxTwW\",\"code\":\"OU_247068\",\"name\":\"Kargboro\"},\"daJPPxtIrQn\":{\"uid\":\"daJPPxtIrQn\",\"code\":\"OU_545\",\"name\":\"Jaiama Bongor\"},\"W5fN3G6y1VI\":{\"uid\":\"W5fN3G6y1VI\",\"code\":\"OU_247012\",\"name\":\"Lower Banta\"},\"r1RUyfVBkLp\":{\"uid\":\"r1RUyfVBkLp\",\"code\":\"OU_268169\",\"name\":\"Sambaia Bendugu\"},\"cgqkFdShPzg\":{\"uid\":\"cgqkFdShPzg\",\"code\":\"OU_193213\",\"name\":\"Loreto Clinic\"},\"NNE0YMCDZkO\":{\"uid\":\"NNE0YMCDZkO\",\"code\":\"OU_268225\",\"name\":\"Yoni\"},\"ENHOJz3UH5L\":{\"uid\":\"ENHOJz3UH5L\",\"code\":\"OU_197440\",\"name\":\"BMC\"},\"QywkxFudXrC\":{\"uid\":\"QywkxFudXrC\",\"code\":\"OU_211227\",\"name\":\"Magbema\"},\"jWSIbtKfURj\":{\"uid\":\"jWSIbtKfURj\",\"code\":\"OU_222751\",\"name\":\"Langrama\"},\"J4GiUImJZoE\":{\"uid\":\"J4GiUImJZoE\",\"code\":\"OU_226269\",\"name\":\"Nieni\"},\"CF243RPvNY7\":{\"uid\":\"CF243RPvNY7\",\"code\":\"OU_233359\",\"name\":\"Fiama\"},\"I4jWcnFmgEC\":{\"uid\":\"I4jWcnFmgEC\",\"code\":\"OU_549\",\"name\":\"Niawa Lenga\"},\"cM2BKSrj9F9\":{\"uid\":\"cM2BKSrj9F9\",\"code\":\"OU_204894\",\"name\":\"Luawa\"},\"kvkDWg42lHR\":{\"uid\":\"kvkDWg42lHR\",\"code\":\"OU_233339\",\"name\":\"Kamara\"},\"jPidqyo7cpF\":{\"uid\":\"jPidqyo7cpF\",\"code\":\"OU_247049\",\"name\":\"Bagruwa\"},\"BGGmAwx33dj\":{\"uid\":\"BGGmAwx33dj\",\"code\":\"OU_543\",\"name\":\"Bumpe Ngao\"},\"iGHlidSFdpu\":{\"uid\":\"iGHlidSFdpu\",\"code\":\"OU_233317\",\"name\":\"Soa\"},\"g8DdBm7EmUt\":{\"uid\":\"g8DdBm7EmUt\",\"code\":\"OU_197397\",\"name\":\"Sittia\"},\"ZiOVcrSjSYe\":{\"uid\":\"ZiOVcrSjSYe\",\"code\":\"OU_254976\",\"name\":\"Dibia\"},\"vn9KJsLyP5f\":{\"uid\":\"vn9KJsLyP5f\",\"code\":\"OU_255005\",\"name\":\"Kaffu Bullom\"},\"QlCIp2S9NHs\":{\"uid\":\"QlCIp2S9NHs\",\"code\":\"OU_222682\",\"name\":\"Dodo\"},\"j43EZb15rjI\":{\"uid\":\"j43EZb15rjI\",\"code\":\"OU_193285\",\"name\":\"Sella Limba\"},\"202301\":{\"name\":\"January 2023\"},\"bQiBfA2j5cw\":{\"uid\":\"bQiBfA2j5cw\",\"code\":\"OU_204857\",\"name\":\"Penguia\"},\"NqWaKXcg01b\":{\"uid\":\"NqWaKXcg01b\",\"code\":\"OU_260384\",\"name\":\"Sowa\"},\"VP397wRvePm\":{\"uid\":\"VP397wRvePm\",\"code\":\"OU_197445\",\"name\":\"Nongoba Bullum\"},\"fwxkctgmffZ\":{\"uid\":\"fwxkctgmffZ\",\"code\":\"OU_268163\",\"name\":\"Kholifa Mabang\"},\"QwMiPiME3bA\":{\"uid\":\"QwMiPiME3bA\",\"code\":\"OU_260400\",\"name\":\"Kpanga Kabonde\"},\"Qhmi8IZyPyD\":{\"uid\":\"Qhmi8IZyPyD\",\"code\":\"OU_193245\",\"name\":\"Tambaka\"},\"OTFepb1k9Db\":{\"uid\":\"OTFepb1k9Db\",\"code\":\"OU_226244\",\"name\":\"Mongo\"},\"DBs6e2Oxaj1\":{\"uid\":\"DBs6e2Oxaj1\",\"code\":\"OU_247002\",\"name\":\"Upper Banta\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"eV4cuxniZgP\":{\"uid\":\"eV4cuxniZgP\",\"code\":\"OU_193224\",\"name\":\"Magbaimba Ndowahun\"},\"xhyjU2SVewz\":{\"uid\":\"xhyjU2SVewz\",\"code\":\"OU_268217\",\"name\":\"Tane\"},\"dGheVylzol6\":{\"uid\":\"dGheVylzol6\",\"code\":\"OU_541\",\"name\":\"Bargbe\"},\"vWbkYPRmKyS\":{\"uid\":\"vWbkYPRmKyS\",\"code\":\"OU_540\",\"name\":\"Baoma\"},\"npWGUj37qDe\":{\"uid\":\"npWGUj37qDe\",\"code\":\"OU_552\",\"name\":\"Valunia\"},\"TA7NvKjsn4A\":{\"uid\":\"TA7NvKjsn4A\",\"code\":\"OU_255041\",\"name\":\"Bureh Kasseh Maconteh\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"tTUf91fCytl\":{\"uid\":\"tTUf91fCytl\",\"valueType\":\"NUMBER\",\"name\":\"Chiefdom\",\"totalAggregationType\":\"SUM\"},\"myQ4q1W6B4y\":{\"uid\":\"myQ4q1W6B4y\",\"code\":\"OU_222731\",\"name\":\"Dama\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"nV3OkyzF4US\":{\"uid\":\"nV3OkyzF4US\",\"code\":\"OU_246991\",\"name\":\"Kori\"},\"X7dWcGerQIm\":{\"uid\":\"X7dWcGerQIm\",\"code\":\"OU_222677\",\"name\":\"Wandor\"},\"qIRCo0MfuGb\":{\"uid\":\"qIRCo0MfuGb\",\"code\":\"OU_211213\",\"name\":\"Gbinleh Dixion\"},\"kbPmt60yi0L\":{\"uid\":\"kbPmt60yi0L\",\"code\":\"OU_211220\",\"name\":\"Bramaia\"},\"eNtRuQrrZeo\":{\"uid\":\"eNtRuQrrZeo\",\"code\":\"OU_260420\",\"name\":\"Galliness Perri\"},\"HV8RTzgcFH3\":{\"uid\":\"HV8RTzgcFH3\",\"code\":\"OU_197432\",\"name\":\"Kwamabai Krim\"},\"KKkLOTpMXGV\":{\"uid\":\"KKkLOTpMXGV\",\"code\":\"OU_193198\",\"name\":\"Bombali Sebora\"},\"Pc3JTyqnsmL\":{\"uid\":\"Pc3JTyqnsmL\",\"code\":\"OU_255020\",\"name\":\"Buya Romende\"},\"hdEuw2ugkVF\":{\"uid\":\"hdEuw2ugkVF\",\"code\":\"OU_222652\",\"name\":\"Lower Bambara\"},\"l7pFejMtUoF\":{\"uid\":\"l7pFejMtUoF\",\"code\":\"OU_222634\",\"name\":\"Tunkia\"},\"K1r3uF6eZ8n\":{\"uid\":\"K1r3uF6eZ8n\",\"code\":\"OU_222725\",\"name\":\"Kandu Lepiema\"},\"VGAFxBXz16y\":{\"uid\":\"VGAFxBXz16y\",\"code\":\"OU_226231\",\"name\":\"Sengbeh\"},\"GE25DpSrqpB\":{\"uid\":\"GE25DpSrqpB\",\"code\":\"OU_204869\",\"name\":\"Malema\"},\"ARZ4y5i4reU\":{\"uid\":\"ARZ4y5i4reU\",\"code\":\"OU_553\",\"name\":\"Wonde\"},\"byp7w6Xd9Df\":{\"uid\":\"byp7w6Xd9Df\",\"code\":\"OU_204933\",\"name\":\"Yawei\"},\"BXJdOLvUrZB\":{\"uid\":\"BXJdOLvUrZB\",\"code\":\"OU_193277\",\"name\":\"Gbendembu Ngowahun\"},\"uKC54fzxRzO\":{\"uid\":\"uKC54fzxRzO\",\"code\":\"OU_222648\",\"name\":\"Niawa\"},\"TQkG0sX9nca\":{\"uid\":\"TQkG0sX9nca\",\"code\":\"OU_233375\",\"name\":\"Gbense\"},\"hRZOIgQ0O1m\":{\"uid\":\"hRZOIgQ0O1m\",\"code\":\"OU_193302\",\"name\":\"Libeisaygahun\"},\"PrJQHI6q7w2\":{\"uid\":\"PrJQHI6q7w2\",\"code\":\"OU_255061\",\"name\":\"Tainkatopa Makama Safrokoh\"},\"USQdmvrHh1Q\":{\"uid\":\"USQdmvrHh1Q\",\"code\":\"OU_247055\",\"name\":\"Kaiyamba\"},\"xGMGhjA3y6J\":{\"uid\":\"xGMGhjA3y6J\",\"code\":\"OU_211262\",\"name\":\"Mambolo\"},\"nOYt1LtFSyU\":{\"uid\":\"nOYt1LtFSyU\",\"code\":\"OU_247025\",\"name\":\"Bumpeh\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"e1eIKM1GIF3\":{\"uid\":\"e1eIKM1GIF3\",\"code\":\"OU_193215\",\"name\":\"Gbanti Kamaranka\"},\"lYIM1MXbSYS\":{\"uid\":\"lYIM1MXbSYS\",\"code\":\"OU_204920\",\"name\":\"Dea\"},\"sxRd2XOzFbz\":{\"uid\":\"sxRd2XOzFbz\",\"code\":\"OU_551\",\"name\":\"Tikonko\"},\"d9iMR1MpuIO\":{\"uid\":\"d9iMR1MpuIO\",\"code\":\"OU_260410\",\"name\":\"Soro-Gbeima\"},\"qgQ49DH9a0v\":{\"uid\":\"qgQ49DH9a0v\",\"code\":\"OU_233332\",\"name\":\"Nimiyama\"},\"U09TSwIjG0s\":{\"uid\":\"U09TSwIjG0s\",\"code\":\"OU_222617\",\"name\":\"Nomo\"},\"zFDYIgyGmXG\":{\"uid\":\"zFDYIgyGmXG\",\"code\":\"OU_542\",\"name\":\"Bargbo\"},\"M2qEv692lS6\":{\"uid\":\"M2qEv692lS6\",\"code\":\"OU_233324\",\"name\":\"Tankoro\"},\"qtr8GGlm4gg\":{\"uid\":\"qtr8GGlm4gg\",\"code\":\"OU_278366\",\"name\":\"Rural Western Area\"},\"pRHGAROvuyI\":{\"uid\":\"pRHGAROvuyI\",\"code\":\"OU_254960\",\"name\":\"Koya\"},\"xIKjidMrico\":{\"uid\":\"xIKjidMrico\",\"code\":\"OU_247033\",\"name\":\"Kowa\"},\"GWTIxJO9pRo\":{\"uid\":\"GWTIxJO9pRo\",\"code\":\"OU_233355\",\"name\":\"Gorama Kono\"},\"HWjrSuoNPte\":{\"uid\":\"HWjrSuoNPte\",\"code\":\"OU_254999\",\"name\":\"Sanda Magbolonthor\"},\"UhHipWG7J8b\":{\"uid\":\"UhHipWG7J8b\",\"code\":\"OU_193191\",\"name\":\"Sanda Tendaren\"},\"rXLor9Knq6l\":{\"uid\":\"rXLor9Knq6l\",\"code\":\"OU_268212\",\"name\":\"Kunike Barina\"},\"kU8vhUkAGaT\":{\"uid\":\"kU8vhUkAGaT\",\"code\":\"OU_548\",\"name\":\"Lugbu\"},\"C9uduqDZr9d\":{\"uid\":\"C9uduqDZr9d\",\"code\":\"OU_278311\",\"name\":\"Freetown\"},\"YmmeuGbqOwR\":{\"uid\":\"YmmeuGbqOwR\",\"code\":\"OU_544\",\"name\":\"Gbo\"},\"iEkBZnMDarP\":{\"uid\":\"iEkBZnMDarP\",\"code\":\"OU_226253\",\"name\":\"Folosaba Dembelia\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"JsxnA2IywRo\":{\"uid\":\"JsxnA2IywRo\",\"code\":\"OU_204875\",\"name\":\"Kissi Kama\"},\"nlt6j60tCHF\":{\"uid\":\"nlt6j60tCHF\",\"code\":\"OU_260437\",\"name\":\"Mano Sakrim\"},\"g5ptsn0SFX8\":{\"uid\":\"g5ptsn0SFX8\",\"code\":\"OU_233365\",\"name\":\"Sandor\"},\"XG8HGAbrbbL\":{\"uid\":\"XG8HGAbrbbL\",\"code\":\"OU_193267\",\"name\":\"Safroko Limba\"},\"pmxZm7klXBy\":{\"uid\":\"pmxZm7klXBy\",\"code\":\"OU_204924\",\"name\":\"Peje West\"},\"l0ccv2yzfF3\":{\"uid\":\"l0ccv2yzfF3\",\"code\":\"OU_268174\",\"name\":\"Kunike\"},\"YuQRtpLP10I\":{\"uid\":\"YuQRtpLP10I\",\"code\":\"OU_539\",\"name\":\"Badjia\"},\"LfTkc0S4b5k\":{\"uid\":\"LfTkc0S4b5k\",\"code\":\"OU_204915\",\"name\":\"Upper Bambara\"},\"KSdZwrU7Hh6\":{\"uid\":\"KSdZwrU7Hh6\",\"code\":\"OU_204861\",\"name\":\"Jawi\"},\"ajILkI0cfxn\":{\"uid\":\"ajILkI0cfxn\",\"code\":\"OU_233390\",\"name\":\"Gbane\"},\"y5X4mP5XylL\":{\"uid\":\"y5X4mP5XylL\",\"code\":\"OU_211270\",\"name\":\"Tonko Limba\"},\"fwH9ipvXde9\":{\"uid\":\"fwH9ipvXde9\",\"code\":\"OU_193228\",\"name\":\"Biriwa\"},\"KIUCimTXf8Q\":{\"uid\":\"KIUCimTXf8Q\",\"code\":\"OU_222690\",\"name\":\"Nongowa\"},\"vEvs2ckGNQj\":{\"uid\":\"vEvs2ckGNQj\",\"code\":\"OU_226219\",\"name\":\"Kasonko\"},\"XEyIRFd9pct\":{\"uid\":\"XEyIRFd9pct\",\"code\":\"OU_197413\",\"name\":\"Imperi\"},\"cgOy0hRMGu9\":{\"uid\":\"cgOy0hRMGu9\",\"code\":\"OU_197408\",\"name\":\"Sogbini\"},\"EjnIQNVAXGp\":{\"uid\":\"EjnIQNVAXGp\",\"code\":\"OU_233344\",\"name\":\"Mafindor\"},\"x4HaBHHwBML\":{\"uid\":\"x4HaBHHwBML\",\"code\":\"OU_222672\",\"name\":\"Malegohun\"},\"EZPwuUTeIIG\":{\"uid\":\"EZPwuUTeIIG\",\"code\":\"OU_226258\",\"name\":\"Wara Wara Yagala\"},\"N233eZJZ1bh\":{\"uid\":\"N233eZJZ1bh\",\"code\":\"OU_260388\",\"name\":\"Pejeh\"},\"smoyi1iYNK6\":{\"uid\":\"smoyi1iYNK6\",\"code\":\"OU_268191\",\"name\":\"Kalansogoia\"},\"DNRAeXT9IwS\":{\"uid\":\"DNRAeXT9IwS\",\"code\":\"OU_197421\",\"name\":\"Dema\"},\"fRLX08WHWpL\":{\"uid\":\"fRLX08WHWpL\",\"code\":\"OU_254982\",\"name\":\"Lokomasama\"},\"Zoy23SSHCPs\":{\"uid\":\"Zoy23SSHCPs\",\"code\":\"OU_233311\",\"name\":\"Gbane Kandor\"},\"LsYpCyYxSLY\":{\"uid\":\"LsYpCyYxSLY\",\"code\":\"OU_247008\",\"name\":\"Kamaje\"},\"JdqfYTIFZXN\":{\"uid\":\"JdqfYTIFZXN\",\"code\":\"OU_254946\",\"name\":\"Maforki\"},\"EB1zRKdYjdY\":{\"uid\":\"EB1zRKdYjdY\",\"code\":\"OU_197429\",\"name\":\"Bendu Cha\"},\"CG4QD1HC3h4\":{\"uid\":\"CG4QD1HC3h4\",\"code\":\"OU_197436\",\"name\":\"Yawbeko\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\"},\"YpVol7asWvd\":{\"uid\":\"YpVol7asWvd\",\"code\":\"OU_260417\",\"name\":\"Kpanga Krim\"},\"RndxKqQGzUl\":{\"uid\":\"RndxKqQGzUl\",\"code\":\"OU_247018\",\"name\":\"Dasse\"},\"P69SId31eDp\":{\"uid\":\"P69SId31eDp\",\"code\":\"OU_268202\",\"name\":\"Gbonkonlenken\"},\"aWQTfvgPA5v\":{\"uid\":\"aWQTfvgPA5v\",\"code\":\"OU_197424\",\"name\":\"Kpanda Kemoh\"},\"KctpIIucige\":{\"uid\":\"KctpIIucige\",\"code\":\"OU_550\",\"name\":\"Selenga\"},\"Mr4au3jR9bt\":{\"uid\":\"Mr4au3jR9bt\",\"code\":\"OU_226214\",\"name\":\"Dembelia Sinkunia\"},\"L8iA6eLwKNb\":{\"uid\":\"L8iA6eLwKNb\",\"code\":\"OU_193295\",\"name\":\"Paki Masabong\"},\"j0Mtr3xTMjM\":{\"uid\":\"j0Mtr3xTMjM\",\"code\":\"OU_204939\",\"name\":\"Kissi Teng\"},\"DmaLM8WYmWv\":{\"uid\":\"DmaLM8WYmWv\",\"code\":\"OU_233394\",\"name\":\"Nimikoro\"},\"DfUfwjM9am5\":{\"uid\":\"DfUfwjM9am5\",\"code\":\"OU_260392\",\"name\":\"Malen\"},\"FRxcUEwktoV\":{\"uid\":\"FRxcUEwktoV\",\"code\":\"OU_233314\",\"name\":\"Toli\"},\"VCtF1DbspR5\":{\"uid\":\"VCtF1DbspR5\",\"code\":\"OU_197386\",\"name\":\"Jong\"},\"BD9gU0GKlr2\":{\"uid\":\"BD9gU0GKlr2\",\"code\":\"OU_260378\",\"name\":\"Makpele\"},\"GFk45MOxzJJ\":{\"uid\":\"GFk45MOxzJJ\",\"code\":\"OU_226275\",\"name\":\"Neya\"},\"A3Fh37HWBWE\":{\"uid\":\"A3Fh37HWBWE\",\"code\":\"OU_222687\",\"name\":\"Simbaru\"},\"vzup1f6ynON\":{\"uid\":\"vzup1f6ynON\",\"code\":\"OU_222619\",\"name\":\"Small Bo\"},\"Lt8U7GVWvSR\":{\"uid\":\"Lt8U7GVWvSR\",\"code\":\"OU_226263\",\"name\":\"Diang\"},\"JdhagCUEMbj\":{\"uid\":\"JdhagCUEMbj\",\"code\":\"OU_547\",\"name\":\"Komboya\"},\"EVkm2xYcf6Z\":{\"uid\":\"EVkm2xYcf6Z\",\"code\":\"OU_268184\",\"name\":\"Malal Mara\"},\"PQZJPIpTepd\":{\"uid\":\"PQZJPIpTepd\",\"code\":\"OU_268150\",\"name\":\"Kholifa Rowalla\"},\"WXnNDWTiE9r\":{\"uid\":\"WXnNDWTiE9r\",\"code\":\"OU_193239\",\"name\":\"Sanda Loko\"},\"RWvG1aFrr0r\":{\"uid\":\"RWvG1aFrr0r\",\"code\":\"OU_255053\",\"name\":\"Marampa\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"ImspTQPwCqd\",\"cgqkFdShPzg\",\"YuQRtpLP10I\",\"jPidqyo7cpF\",\"vWbkYPRmKyS\",\"dGheVylzol6\",\"zFDYIgyGmXG\",\"RzKeCma9qb1\",\"EB1zRKdYjdY\",\"fwH9ipvXde9\",\"ENHOJz3UH5L\",\"KKkLOTpMXGV\",\"kbPmt60yi0L\",\"iUauWFeH8Qp\",\"BGGmAwx33dj\",\"nOYt1LtFSyU\",\"TA7NvKjsn4A\",\"Pc3JTyqnsmL\",\"myQ4q1W6B4y\",\"RndxKqQGzUl\",\"lYIM1MXbSYS\",\"DNRAeXT9IwS\",\"Mr4au3jR9bt\",\"Lt8U7GVWvSR\",\"ZiOVcrSjSYe\",\"QlCIp2S9NHs\",\"vULnao2hV5v\",\"CF243RPvNY7\",\"iEkBZnMDarP\",\"C9uduqDZr9d\",\"eNtRuQrrZeo\",\"eROJsBwxQHt\",\"ajILkI0cfxn\",\"Zoy23SSHCPs\",\"e1eIKM1GIF3\",\"BXJdOLvUrZB\",\"TQkG0sX9nca\",\"qIRCo0MfuGb\",\"YmmeuGbqOwR\",\"P69SId31eDp\",\"GWTIxJO9pRo\",\"KXSqt7jv6DU\",\"XEyIRFd9pct\",\"daJPPxtIrQn\",\"KSdZwrU7Hh6\",\"VCtF1DbspR5\",\"BmYyh9bZ0sr\",\"vn9KJsLyP5f\",\"USQdmvrHh1Q\",\"U6Kr7Gtpidn\",\"smoyi1iYNK6\",\"LsYpCyYxSLY\",\"kvkDWg42lHR\",\"K1r3uF6eZ8n\",\"Z9QaI6sxTwW\",\"vEvs2ckGNQj\",\"fwxkctgmffZ\",\"PQZJPIpTepd\",\"JsxnA2IywRo\",\"j0Mtr3xTMjM\",\"hjpHnHZIniP\",\"JdhagCUEMbj\",\"Jiyc4ekaMMh\",\"nV3OkyzF4US\",\"xIKjidMrico\",\"pRHGAROvuyI\",\"EYt6ThQDagn\",\"zSNUViKdkk3\",\"aWQTfvgPA5v\",\"QwMiPiME3bA\",\"YpVol7asWvd\",\"l0ccv2yzfF3\",\"rXLor9Knq6l\",\"HV8RTzgcFH3\",\"jWSIbtKfURj\",\"LhaAPLxdSFH\",\"hRZOIgQ0O1m\",\"fRLX08WHWpL\",\"hdEuw2ugkVF\",\"W5fN3G6y1VI\",\"cM2BKSrj9F9\",\"kU8vhUkAGaT\",\"EjnIQNVAXGp\",\"JdqfYTIFZXN\",\"eV4cuxniZgP\",\"QywkxFudXrC\",\"lY93YpCxJqf\",\"BD9gU0GKlr2\",\"EVkm2xYcf6Z\",\"x4HaBHHwBML\",\"GE25DpSrqpB\",\"DfUfwjM9am5\",\"xGMGhjA3y6J\",\"yu4N82FFeLm\",\"nlt6j60tCHF\",\"RWvG1aFrr0r\",\"EfWCa0Cc8WW\",\"FlBemv1NfEC\",\"OTFepb1k9Db\",\"GFk45MOxzJJ\",\"uKC54fzxRzO\",\"I4jWcnFmgEC\",\"J4GiUImJZoE\",\"DmaLM8WYmWv\",\"qgQ49DH9a0v\",\"ERmBhYkhV6Y\",\"U09TSwIjG0s\",\"VP397wRvePm\",\"KIUCimTXf8Q\",\"L8iA6eLwKNb\",\"DxAPPqXvwLy\",\"pmxZm7klXBy\",\"N233eZJZ1bh\",\"bQiBfA2j5cw\",\"gy8rmvYT4cj\",\"qtr8GGlm4gg\",\"XG8HGAbrbbL\",\"r1RUyfVBkLp\",\"r06ohri9wA9\",\"WXnNDWTiE9r\",\"HWjrSuoNPte\",\"UhHipWG7J8b\",\"g5ptsn0SFX8\",\"KctpIIucige\",\"j43EZb15rjI\",\"VGAFxBXz16y\",\"A3Fh37HWBWE\",\"g8DdBm7EmUt\",\"vzup1f6ynON\",\"iGHlidSFdpu\",\"cgOy0hRMGu9\",\"d9iMR1MpuIO\",\"NqWaKXcg01b\",\"PaqugoqjRIj\",\"PrJQHI6q7w2\",\"Qhmi8IZyPyD\",\"xhyjU2SVewz\",\"M2qEv692lS6\",\"sxRd2XOzFbz\",\"AovmOHadayb\",\"FRxcUEwktoV\",\"y5X4mP5XylL\",\"l7pFejMtUoF\",\"LfTkc0S4b5k\",\"DBs6e2Oxaj1\",\"npWGUj37qDe\",\"X7dWcGerQIm\",\"XrF5AvaGcuw\",\"EZPwuUTeIIG\",\"ARZ4y5i4reU\",\"pk7bUK5c1Uf\",\"CG4QD1HC3h4\",\"byp7w6Xd9Df\",\"NNE0YMCDZkO\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.oucode",
-        "Organisation unit code",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.oucode",
+            "Organisation unit code",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -594,7 +594,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Under five (Luawa) Clinic");
     validateRowValueByName(
-        response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+            response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
 
     // Validate selected values for row index 99
@@ -610,15 +610,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname,ZzYYXq4fJie.oucode")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.ou:OU_GROUP-CXw2yu5fodb,pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.ouname,ZzYYXq4fJie.oucode")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.ou:OU_GROUP-CXw2yu5fodb,pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -628,61 +628,61 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        100,
-        4,
-        4); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            100,
+            4,
+            4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"FNnj3jKGS7i\":{\"uid\":\"FNnj3jKGS7i\",\"code\":\"OU_260387\",\"name\":\"Bandajuma Clinic CHC\"},\"Q2USZSJmcNK\":{\"uid\":\"Q2USZSJmcNK\",\"code\":\"OU_268195\",\"name\":\"Bumbuna CHC\"},\"sLKHXoBIqSs\":{\"uid\":\"sLKHXoBIqSs\",\"code\":\"OU_233362\",\"name\":\"Njagbwema Fiama CHC\"},\"mwN7QuEfT8m\":{\"uid\":\"mwN7QuEfT8m\",\"code\":\"OU_820\",\"name\":\"Koribondo CHC\"},\"jGYT5U5qJP6\":{\"uid\":\"jGYT5U5qJP6\",\"code\":\"OU_653\",\"name\":\"Gbaiima CHC\"},\"agM0BKQlTh3\":{\"uid\":\"agM0BKQlTh3\",\"code\":\"OU_193303\",\"name\":\"Batkanu CHC\"},\"MuZJ8lprGqK\":{\"uid\":\"MuZJ8lprGqK\",\"code\":\"OU_247089\",\"name\":\"Moyamba Junction CHC\"},\"e2WgqiasKnD\":{\"uid\":\"e2WgqiasKnD\",\"code\":\"OU_246997\",\"name\":\"Taiama (Kori) CHC\"},\"KcCbIDzRcui\":{\"uid\":\"KcCbIDzRcui\",\"code\":\"OU_268221\",\"name\":\"Matotoka CHC\"},\"Jyv7sjpl9bA\":{\"uid\":\"Jyv7sjpl9bA\",\"code\":\"OU_222650\",\"name\":\"Sendumei CHC\"},\"zEsMdeJOty4\":{\"uid\":\"zEsMdeJOty4\",\"code\":\"OU_278331\",\"name\":\"Moyiba CHC\"},\"mshIal30ffW\":{\"uid\":\"mshIal30ffW\",\"code\":\"OU_193301\",\"name\":\"Mapaki CHC\"},\"uFp0ztDOFbI\":{\"uid\":\"uFp0ztDOFbI\",\"code\":\"OU_197430\",\"name\":\"Bendu CHC\"},\"scc4QyxenJd\":{\"uid\":\"scc4QyxenJd\",\"code\":\"OU_268215\",\"name\":\"Makali CHC\"},\"aHs9PLxIdbr\":{\"uid\":\"aHs9PLxIdbr\",\"code\":\"OU_268203\",\"name\":\"Mayepoh CHC\"},\"PA1spYiNZfv\":{\"uid\":\"PA1spYiNZfv\",\"code\":\"OU_233398\",\"name\":\"Yengema CHC\"},\"LnToY3ExKxL\":{\"uid\":\"LnToY3ExKxL\",\"code\":\"OU_255018\",\"name\":\"Mahera CHC\"},\"IlMQTFvcq9r\":{\"uid\":\"IlMQTFvcq9r\",\"code\":\"OU_222656\",\"name\":\"Lowoma CHC\"},\"jhtj3eQa1pM\":{\"uid\":\"jhtj3eQa1pM\",\"code\":\"OU_1100\",\"name\":\"Gondama (Tikonko) CHC\"},\"QsAwd531Cpd\":{\"uid\":\"QsAwd531Cpd\",\"code\":\"OU_1038\",\"name\":\"Njala CHC\"},\"pNPmNeqyrim\":{\"uid\":\"pNPmNeqyrim\",\"code\":\"OU_222666\",\"name\":\"Foindu (Lower Bamabara) CHC\"},\"K00jR5dmoFZ\":{\"uid\":\"K00jR5dmoFZ\",\"code\":\"OU_260399\",\"name\":\"Karlu CHC\"},\"xa4F6gesVJm\":{\"uid\":\"xa4F6gesVJm\",\"code\":\"OU_278400\",\"name\":\"York CHC\"},\"zQpYVEyAM2t\":{\"uid\":\"zQpYVEyAM2t\",\"code\":\"OU_278377\",\"name\":\"Hastings Health Centre\"},\"hzf90qz08AW\":{\"uid\":\"hzf90qz08AW\",\"code\":\"OU_247034\",\"name\":\"Njama CHC\"},\"CFPrsD3dNeb\":{\"uid\":\"CFPrsD3dNeb\",\"code\":\"OU_197423\",\"name\":\"Tissana CHC\"},\"MpcMjLmbATv\":{\"uid\":\"MpcMjLmbATv\",\"code\":\"OU_204938\",\"name\":\"Bandajuma Yawei CHC\"},\"KYXbIQBQgP1\":{\"uid\":\"KYXbIQBQgP1\",\"code\":\"OU_1103\",\"name\":\"Tikonko CHC\"},\"lxxASQqPUqd\":{\"uid\":\"lxxASQqPUqd\",\"code\":\"OU_233341\",\"name\":\"Tombodu CHC\"},\"oRncQGhLYNE\":{\"uid\":\"oRncQGhLYNE\",\"code\":\"OU_278376\",\"name\":\"Regent (RWA) CHC\"},\"RhJbg8UD75Q\":{\"uid\":\"RhJbg8UD75Q\",\"code\":\"OU_1027\",\"name\":\"Yemoh Town CHC\"},\"EUUkKEDoNsf\":{\"uid\":\"EUUkKEDoNsf\",\"code\":\"OU_278343\",\"name\":\"Wilberforce CHC\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"FbD5Z8z22Yb\":{\"uid\":\"FbD5Z8z22Yb\",\"code\":\"OU_260385\",\"name\":\"Geoma Jagor CHC\"},\"ua5GXy2uhBR\":{\"uid\":\"ua5GXy2uhBR\",\"code\":\"OU_197412\",\"name\":\"Tihun CHC\"},\"QpRIPul20Sb\":{\"uid\":\"QpRIPul20Sb\",\"code\":\"OU_222637\",\"name\":\"Gorahun CHC\"},\"mt47bcb0Rcj\":{\"uid\":\"mt47bcb0Rcj\",\"code\":\"OU_193231\",\"name\":\"Kamabai CHC\"},\"uDzWmUDHKeR\":{\"uid\":\"uDzWmUDHKeR\",\"code\":\"OU_260389\",\"name\":\"Futa CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"OjXNuYyLaCJ\":{\"uid\":\"OjXNuYyLaCJ\",\"code\":\"OU_255004\",\"name\":\"Sendugu CHC\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZdPkczYqeIY\":{\"uid\":\"ZdPkczYqeIY\",\"code\":\"OU_247092\",\"name\":\"Gandorhun CHC\"},\"p310xqwAJge\":{\"uid\":\"p310xqwAJge\",\"code\":\"OU_226268\",\"name\":\"Kondembaia CHC\"},\"HcB2W6Fgp7i\":{\"uid\":\"HcB2W6Fgp7i\",\"code\":\"OU_255065\",\"name\":\"Melekuray CHC\"},\"lOv6IFgr6Fs\":{\"uid\":\"lOv6IFgr6Fs\",\"code\":\"OU_832\",\"name\":\"Manjama Shellmingo CHC\"},\"amgb83zVxp5\":{\"uid\":\"amgb83zVxp5\",\"code\":\"OU_222674\",\"name\":\"Bendu Mameima CHC\"},\"K6oyIMh7Lee\":{\"uid\":\"K6oyIMh7Lee\",\"code\":\"OU_226224\",\"name\":\"Fadugu CHC\"},\"m0XorV4WWg0\":{\"uid\":\"m0XorV4WWg0\",\"code\":\"OU_278361\",\"name\":\"Ginger Hall Health Centre\"},\"bSj2UnYhTFb\":{\"uid\":\"bSj2UnYhTFb\",\"code\":\"OU_193218\",\"name\":\"Kamaranka CHC\"},\"CvBAqD6RzLZ\":{\"uid\":\"CvBAqD6RzLZ\",\"code\":\"OU_595\",\"name\":\"Ngalu CHC\"},\"k6lOze3vTzP\":{\"uid\":\"k6lOze3vTzP\",\"code\":\"OU_260435\",\"name\":\"Potoru CHC\"},\"p9KfD6eaRvu\":{\"uid\":\"p9KfD6eaRvu\",\"code\":\"OU_247069\",\"name\":\"Shenge CHC\"},\"K3jhn3TXF3a\":{\"uid\":\"K3jhn3TXF3a\",\"code\":\"OU_222665\",\"name\":\"Tongo Field CHC\"},\"HNv1aLPdMYb\":{\"uid\":\"HNv1aLPdMYb\",\"code\":\"OU_193242\",\"name\":\"Kamalo CHC\"},\"yMCshbaVExv\":{\"uid\":\"yMCshbaVExv\",\"code\":\"OU_254991\",\"name\":\"Babara CHC\"},\"pJv8NJlJNhU\":{\"uid\":\"pJv8NJlJNhU\",\"code\":\"OU_204916\",\"name\":\"Pendembu CHC\"},\"YAuJ3fyoEuI\":{\"uid\":\"YAuJ3fyoEuI\",\"code\":\"OU_193281\",\"name\":\"Gbendembu Wesleyan CHC\"},\"g5A3hiJlwmI\":{\"uid\":\"g5A3hiJlwmI\",\"code\":\"OU_233397\",\"name\":\"UMC Mitchener Memorial Maternity & Health Centre\"},\"jKZ0U8Og5aV\":{\"uid\":\"jKZ0U8Og5aV\",\"code\":\"OU_222683\",\"name\":\"Dodo CHC\"},\"EXbPGmEUdnc\":{\"uid\":\"EXbPGmEUdnc\",\"code\":\"OU_193197\",\"name\":\"Mateboi CHC\"},\"nX05QLraDhO\":{\"uid\":\"nX05QLraDhO\",\"code\":\"OU_585\",\"name\":\"Yamandu CHC\"},\"Umh4HKqqFp6\":{\"uid\":\"Umh4HKqqFp6\",\"code\":\"OU_578\",\"name\":\"Jembe CHC\"},\"ubsjwFFBaJM\":{\"uid\":\"ubsjwFFBaJM\",\"code\":\"OU_247016\",\"name\":\"Gbangbatoke CHC\"},\"rm60vuHyQXj\":{\"uid\":\"rm60vuHyQXj\",\"code\":\"OU_1082\",\"name\":\"Nengbema CHC\"},\"iOA3z6Y3cq5\":{\"uid\":\"iOA3z6Y3cq5\",\"code\":\"OU_222699\",\"name\":\"Largo CHC\"},\"sIVFEyNfOg4\":{\"uid\":\"sIVFEyNfOg4\",\"code\":\"OU_247073\",\"name\":\"Mokandor CHP\"},\"k8ZPul89UDm\":{\"uid\":\"k8ZPul89UDm\",\"code\":\"OU_233370\",\"name\":\"Kayima CHC\"},\"iMZihUMzH92\":{\"uid\":\"iMZihUMzH92\",\"code\":\"OU_247083\",\"name\":\"Bauya (Kongbora) CHC\"},\"MXdbul7bBqV\":{\"uid\":\"MXdbul7bBqV\",\"code\":\"OU_204912\",\"name\":\"Mobai CHC\"},\"dkmpOuVhBba\":{\"uid\":\"dkmpOuVhBba\",\"code\":\"OU_268226\",\"name\":\"Mathoir CHC\"},\"q56204kKXgZ\":{\"uid\":\"q56204kKXgZ\",\"code\":\"OU_255057\",\"name\":\"Lunsar CHC\"},\"kuqKh33SPgg\":{\"uid\":\"kuqKh33SPgg\",\"code\":\"OU_226230\",\"name\":\"Falaba CHC\"},\"NjyJYiIuKIG\":{\"uid\":\"NjyJYiIuKIG\",\"code\":\"OU_193291\",\"name\":\"Kathanta Yimbor CHC\"},\"fAsj6a4nudH\":{\"uid\":\"fAsj6a4nudH\",\"code\":\"OU_197398\",\"name\":\"Yoni CHC\"},\"a04CZxe0PSe\":{\"uid\":\"a04CZxe0PSe\",\"code\":\"OU_278333\",\"name\":\"Murray Town CHC\"},\"qxbsDd9QYv6\":{\"uid\":\"qxbsDd9QYv6\",\"code\":\"OU_226274\",\"name\":\"Yiffin CHC\"},\"Mi4dWRtfIOC\":{\"uid\":\"Mi4dWRtfIOC\",\"code\":\"OU_204860\",\"name\":\"Sandaru CHC\"},\"QzPf0qKBU4n\":{\"uid\":\"QzPf0qKBU4n\",\"code\":\"OU_260411\",\"name\":\"Jendema CHC\"},\"mzsOsz0NwNY\":{\"uid\":\"mzsOsz0NwNY\",\"code\":\"OU_836\",\"name\":\"New Police Barracks CHC\"},\"vELbGdEphPd\":{\"uid\":\"vELbGdEphPd\",\"code\":\"OU_614\",\"name\":\"Jimmi CHC\"},\"qVvitxEF2ck\":{\"uid\":\"qVvitxEF2ck\",\"code\":\"OU_254949\",\"name\":\"Rogbere CHC\"},\"RAsstekPRco\":{\"uid\":\"RAsstekPRco\",\"code\":\"OU_211269\",\"name\":\"Mambolo CHC\"},\"va2lE4FiVVb\":{\"uid\":\"va2lE4FiVVb\",\"code\":\"OU_247019\",\"name\":\"Mano CHC\"},\"cNAp6CJeLxk\":{\"uid\":\"cNAp6CJeLxk\",\"code\":\"OU_247015\",\"name\":\"Mokanji CHC\"},\"wByqtWCCuDJ\":{\"uid\":\"wByqtWCCuDJ\",\"code\":\"OU_1095\",\"name\":\"Damballa CHC\"},\"PcADvhvcaI2\":{\"uid\":\"PcADvhvcaI2\",\"code\":\"OU_211253\",\"name\":\"Kychom CHC\"},\"n7wN9gMFfZ5\":{\"uid\":\"n7wN9gMFfZ5\",\"code\":\"OU_197435\",\"name\":\"Benduma CHC\"},\"kUzpbgPCwVA\":{\"uid\":\"kUzpbgPCwVA\",\"code\":\"OU_222624\",\"name\":\"Blama CHC\"},\"rCKWdLr4B8K\":{\"uid\":\"rCKWdLr4B8K\",\"code\":\"OU_197427\",\"name\":\"Motuo CHC\"},\"DMxw0SASFih\":{\"uid\":\"DMxw0SASFih\",\"code\":\"OU_204941\",\"name\":\"Koindu CHC\"},\"PQEpIeuSTCN\":{\"uid\":\"PQEpIeuSTCN\",\"code\":\"OU_222623\",\"name\":\"Tobanda CHC\"},\"inpc5QsFRTm\":{\"uid\":\"inpc5QsFRTm\",\"code\":\"OU_211274\",\"name\":\"Kamassasa CHC\"},\"aSxNNRxPuBP\":{\"uid\":\"aSxNNRxPuBP\",\"code\":\"OU_193278\",\"name\":\"Kalangba CHC\"},\"O1KFJmM6HUx\":{\"uid\":\"O1KFJmM6HUx\",\"code\":\"OU_260438\",\"name\":\"Mano Gbonjeima CHC\"},\"s5aXfzOL456\":{\"uid\":\"s5aXfzOL456\",\"code\":\"OU_197437\",\"name\":\"Talia CHC\"},\"tSBcgrTDdB8\":{\"uid\":\"tSBcgrTDdB8\",\"code\":\"OU_834\",\"name\":\"Paramedical CHC\"},\"KiheEgvUZ0i\":{\"uid\":\"KiheEgvUZ0i\",\"code\":\"OU_278357\",\"name\":\"Calaba town CHC\"},\"d9zRBAoM8OC\":{\"uid\":\"d9zRBAoM8OC\",\"code\":\"OU_260423\",\"name\":\"Bumpeh Perri CHC\"},\"sesv0eXljBq\":{\"uid\":\"sesv0eXljBq\",\"code\":\"OU_268207\",\"name\":\"Yele CHC\"},\"L4Tw4NlaMjn\":{\"uid\":\"L4Tw4NlaMjn\",\"code\":\"OU_222705\",\"name\":\"Nekabo CHC\"},\"sznCEDMABa2\":{\"uid\":\"sznCEDMABa2\",\"code\":\"OU_204903\",\"name\":\"Ngiehun CHC\"},\"E497Rk80ivZ\":{\"uid\":\"E497Rk80ivZ\",\"code\":\"OU_651\",\"name\":\"Bumpe CHC\"},\"CXw2yu5fodb\":{\"uid\":\"CXw2yu5fodb\",\"code\":\"CHC\",\"valueType\":\"NUMBER\",\"name\":\"CHC\",\"dimensionItemType\":\"ORGANISATION_UNIT_GROUP\",\"totalAggregationType\":\"SUM\"},\"W7ekX3gi0ut\":{\"uid\":\"W7ekX3gi0ut\",\"code\":\"OU_233333\",\"name\":\"Jaiama Sewafe CHC\"},\"roGdTjEqLZQ\":{\"uid\":\"roGdTjEqLZQ\",\"code\":\"OU_233371\",\"name\":\"Yormandu CHC\"},\"Jiymtq0A01x\":{\"uid\":\"Jiymtq0A01x\",\"code\":\"OU_226243\",\"name\":\"Bafodia CHC\"},\"aIsnJuZbmVA\":{\"uid\":\"aIsnJuZbmVA\",\"code\":\"OU_226256\",\"name\":\"Dogoloya CHP\"},\"IlnqGuxfQAw\":{\"uid\":\"IlnqGuxfQAw\",\"code\":\"OU_226216\",\"name\":\"Sinkunia CHC\"},\"lpQvlm9czYE\":{\"uid\":\"lpQvlm9czYE\",\"code\":\"OU_222631\",\"name\":\"Tungie CHC\"},\"uedNhvYPMNu\":{\"uid\":\"uedNhvYPMNu\",\"code\":\"OU_193216\",\"name\":\"Gbanti CHC\"},\"KKoPh1lDd9j\":{\"uid\":\"KKoPh1lDd9j\",\"code\":\"OU_233321\",\"name\":\"Kainkordu CHC\"},\"xKaB8tfbTzm\":{\"uid\":\"xKaB8tfbTzm\",\"code\":\"OU_193247\",\"name\":\"Fintonia CHC\"},\"TEVtOFKcLAP\":{\"uid\":\"TEVtOFKcLAP\",\"code\":\"OU_197447\",\"name\":\"Gbap CHC\"},\"pXDcgDRz8Od\":{\"uid\":\"pXDcgDRz8Od\",\"code\":\"OU_278402\",\"name\":\"Songo CHC\"},\"NaVzm59XKGf\":{\"uid\":\"NaVzm59XKGf\",\"code\":\"OU_254980\",\"name\":\"Gbinti CHC\"},\"Ahh47q8AkId\":{\"uid\":\"Ahh47q8AkId\",\"code\":\"OU_268167\",\"name\":\"Mabang CHC\"},\"QZtMuEEV9Vv\":{\"uid\":\"QZtMuEEV9Vv\",\"code\":\"OU_211237\",\"name\":\"Rokupr CHC\"},\"U4FzUXMvbI8\":{\"uid\":\"U4FzUXMvbI8\",\"code\":\"OU_255009\",\"name\":\"Conakry Dee CHC\"},\"o0BgK1dLhF8\":{\"uid\":\"o0BgK1dLhF8\",\"code\":\"OU_268170\",\"name\":\"Bendugu CHC\"},\"agEKP19IUKI\":{\"uid\":\"agEKP19IUKI\",\"code\":\"OU_193280\",\"name\":\"Tambiama CHC\"},\"qIpBLa1SCZt\":{\"uid\":\"qIpBLa1SCZt\",\"code\":\"OU_222714\",\"name\":\"Talia (Nongowa) CHC\"},\"H97XE5Ea089\":{\"uid\":\"H97XE5Ea089\",\"code\":\"OU_247045\",\"name\":\"Bomotoke CHC\"},\"nv41sOz8IVM\":{\"uid\":\"nv41sOz8IVM\",\"code\":\"OU_204927\",\"name\":\"Pejewa CHC\"},\"202301\":{\"name\":\"January 2023\"},\"NMcx2jmra3c\":{\"uid\":\"NMcx2jmra3c\",\"code\":\"OU_226273\",\"name\":\"Firawa CHC\"},\"m3VnSQbE8CD\":{\"uid\":\"m3VnSQbE8CD\",\"code\":\"OU_278382\",\"name\":\"Newton CHC\"},\"OY7mYDATra3\":{\"uid\":\"OY7mYDATra3\",\"code\":\"OU_268176\",\"name\":\"Massingbi CHC\"},\"RQgXBKxgvHf\":{\"uid\":\"RQgXBKxgvHf\",\"code\":\"OU_211248\",\"name\":\"Mapotolon CHC\"},\"YvwYw7GilkP\":{\"uid\":\"YvwYw7GilkP\",\"code\":\"OU_222726\",\"name\":\"Levuma (Kandu Lep) CHC\"},\"PduUQmdt0pB\":{\"uid\":\"PduUQmdt0pB\",\"code\":\"OU_211273\",\"name\":\"Numea CHC\"},\"U514Dz4v9pv\":{\"uid\":\"U514Dz4v9pv\",\"code\":\"OU_278330\",\"name\":\"George Brook Health Centre\"},\"PuZOFApTSeo\":{\"uid\":\"PuZOFApTSeo\",\"code\":\"OU_952\",\"name\":\"Sahn CHC\"},\"wUmVUKhnPuy\":{\"uid\":\"wUmVUKhnPuy\",\"code\":\"OU_247057\",\"name\":\"Kangahun CHC\"},\"RaQGHRti7JM\":{\"uid\":\"RaQGHRti7JM\",\"code\":\"OU_278335\",\"name\":\"Gods Favour health Center\"},\"xMn4Wki9doK\":{\"uid\":\"xMn4Wki9doK\",\"code\":\"OU_197417\",\"name\":\"Moriba Town CHC\"},\"JQJjsXvHE5M\":{\"uid\":\"JQJjsXvHE5M\",\"code\":\"OU_247007\",\"name\":\"Mokelleh CHC\"},\"m5BX6CvJ6Ex\":{\"uid\":\"m5BX6CvJ6Ex\",\"code\":\"OU_204865\",\"name\":\"Daru CHC\"},\"D2rB1GRuh8C\":{\"uid\":\"D2rB1GRuh8C\",\"code\":\"OU_197418\",\"name\":\"Gbamgbama CHC\"},\"Gm7YUjhVi9Q\":{\"uid\":\"Gm7YUjhVi9Q\",\"code\":\"OU_260415\",\"name\":\"Fairo CHC\"},\"gE3gEGZbQMi\":{\"uid\":\"gE3gEGZbQMi\",\"code\":\"OU_197407\",\"name\":\"Madina (BUM) CHC\"},\"zuXW98AEbE7\":{\"uid\":\"zuXW98AEbE7\",\"code\":\"OU_255023\",\"name\":\"Kamasondo CHC\"},\"TjZwphhxCuV\":{\"uid\":\"TjZwphhxCuV\",\"code\":\"OU_193225\",\"name\":\"Kagbere CHC\"},\"g5lonXJ9ndA\":{\"uid\":\"g5lonXJ9ndA\",\"code\":\"OU_268237\",\"name\":\"Hinistas CHC\"},\"r5WWF9WDzoa\":{\"uid\":\"r5WWF9WDzoa\",\"code\":\"OU_222681\",\"name\":\"Baama CHC\"},\"VhRX5JDVo7R\":{\"uid\":\"VhRX5JDVo7R\",\"code\":\"OU_278397\",\"name\":\"Waterloo CHC\"},\"PMsF64R6OJX\":{\"uid\":\"PMsF64R6OJX\",\"code\":\"OU_226248\",\"name\":\"Bendugu (Mongo) CHC\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"azRICFoILuh\":{\"uid\":\"azRICFoILuh\",\"code\":\"OU_577\",\"name\":\"Golu MCHP\"},\"HQoxFu4lYPS\":{\"uid\":\"HQoxFu4lYPS\",\"code\":\"OU_204868\",\"name\":\"Pellie CHC\"},\"JrSIoCOdTH2\":{\"uid\":\"JrSIoCOdTH2\",\"code\":\"OU_278403\",\"name\":\"Tombo CHC\"},\"ke2gwHKHP3z\":{\"uid\":\"ke2gwHKHP3z\",\"code\":\"OU_254983\",\"name\":\"Petifu CHC\"},\"TSyzvBiovKh\":{\"uid\":\"TSyzvBiovKh\",\"code\":\"OU_576\",\"name\":\"Gerehun CHC\"},\"g10jm7jPdzf\":{\"uid\":\"g10jm7jPdzf\",\"code\":\"OU_222707\",\"name\":\"Hangha CHC\"},\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"bPqP6eRfkyn\":{\"uid\":\"bPqP6eRfkyn\",\"code\":\"OU_278318\",\"name\":\"Ross Road Health Centre\"},\"EURoFVjowXs\":{\"uid\":\"EURoFVjowXs\",\"code\":\"OU_254964\",\"name\":\"Masiaka CHC\"},\"ii2KMnWMx2L\":{\"uid\":\"ii2KMnWMx2L\",\"code\":\"OU_233392\",\"name\":\"Gandorhun (Gbane) CHC\"},\"J42QfNe0GJZ\":{\"uid\":\"J42QfNe0GJZ\",\"code\":\"OU_268185\",\"name\":\"Mara CHC\"},\"gUPhNWkSXvD\":{\"uid\":\"gUPhNWkSXvD\",\"code\":\"OU_247032\",\"name\":\"Rotifunk CHC\"},\"FLjwMPWLrL2\":{\"uid\":\"FLjwMPWLrL2\",\"code\":\"OU_1126\",\"name\":\"Baomahun CHC\"},\"FclfbEFMcf3\":{\"uid\":\"FclfbEFMcf3\",\"code\":\"OU_278340\",\"name\":\"Kissy Health Centre\"},\"lL2LBkhlsmV\":{\"uid\":\"lL2LBkhlsmV\",\"code\":\"OU_278336\",\"name\":\"Grassfield CHC\"},\"NRPCjDljVtu\":{\"uid\":\"NRPCjDljVtu\",\"code\":\"OU_278404\",\"name\":\"Lakka\\/Ogoo Farm CHC\"},\"egjrZ1PHNtT\":{\"uid\":\"egjrZ1PHNtT\",\"code\":\"OU_247053\",\"name\":\"Sembehun CHC\"},\"PC3Ag91n82e\":{\"uid\":\"PC3Ag91n82e\",\"code\":\"OU_1122\",\"name\":\"Mongere CHC\"},\"X79FDd4EAgo\":{\"uid\":\"X79FDd4EAgo\",\"code\":\"OU_193196\",\"name\":\"Rokulan CHC\"},\"sM0Us0NkSez\":{\"uid\":\"sM0Us0NkSez\",\"code\":\"OU_278359\",\"name\":\"Kroo Bay CHC\"},\"bHcw141PTsE\":{\"uid\":\"bHcw141PTsE\",\"code\":\"OU_260407\",\"name\":\"Gbondapi CHC\"},\"O63vIA5MVn6\":{\"uid\":\"O63vIA5MVn6\",\"code\":\"OU_255014\",\"name\":\"Tagrin CHC\"},\"HWXk4EBHUyk\":{\"uid\":\"HWXk4EBHUyk\",\"code\":\"OU_260393\",\"name\":\"Sahn (Malen) CHC\"},\"W2KnxOMvmgE\":{\"uid\":\"W2KnxOMvmgE\",\"code\":\"OU_1050\",\"name\":\"Sumbuya CHC\"},\"tO01bqIipeD\":{\"uid\":\"tO01bqIipeD\",\"code\":\"OU_204892\",\"name\":\"Buedu CHC\"},\"w3mBVfrWhXl\":{\"uid\":\"w3mBVfrWhXl\",\"code\":\"OU_255043\",\"name\":\"Mange CHC\"},\"TljiT6C5D0J\":{\"uid\":\"TljiT6C5D0J\",\"code\":\"OU_222740\",\"name\":\"Kpandebu CHC\"},\"TmCsvdJLHoX\":{\"uid\":\"TmCsvdJLHoX\",\"code\":\"OU_193195\",\"name\":\"Mabunduka CHC\"},\"BNFrspDBKel\":{\"uid\":\"BNFrspDBKel\",\"code\":\"OU_260382\",\"name\":\"Zimmi CHC\"},\"N3tpEjZcPm9\":{\"uid\":\"N3tpEjZcPm9\",\"code\":\"OU_204879\",\"name\":\"Laleihun Kovoma CHC\"},\"Qc9lf4VM9bD\":{\"uid\":\"Qc9lf4VM9bD\",\"code\":\"OU_278317\",\"name\":\"Wellington Health Centre\"},\"cMFi8lYbXHY\":{\"uid\":\"cMFi8lYbXHY\",\"code\":\"OU_233402\",\"name\":\"Bumpeh (Nimikoro) CHC\"},\"P4upLKrpkHP\":{\"uid\":\"P4upLKrpkHP\",\"code\":\"OU_222641\",\"name\":\"Ngegbwema CHC\"},\"Yj2ni275yPJ\":{\"uid\":\"Yj2ni275yPJ\",\"code\":\"OU_222647\",\"name\":\"Baoma (Koya) CHC\"},\"SnCrOCRrxGX\":{\"uid\":\"SnCrOCRrxGX\",\"code\":\"OU_233327\",\"name\":\"Koakoyima CHC\"},\"Z9ny6QeqsgX\":{\"uid\":\"Z9ny6QeqsgX\",\"code\":\"OU_969\",\"name\":\"Manjama UMC CHC\"},\"wtdBuXDwZYQ\":{\"uid\":\"wtdBuXDwZYQ\",\"code\":\"OU_1006\",\"name\":\"Praise Foundation CHC\"},\"oLuhRyYPxRO\":{\"uid\":\"oLuhRyYPxRO\",\"code\":\"OU_247011\",\"name\":\"Senehun CHC\"},\"PaNv9VyD06n\":{\"uid\":\"PaNv9VyD06n\",\"code\":\"OU_204930\",\"name\":\"Manowa CHC\"},\"uRQj8WRK0Py\":{\"uid\":\"uRQj8WRK0Py\",\"code\":\"OU_193255\",\"name\":\"Masongbo CHC\"},\"Y8foq27WLti\":{\"uid\":\"Y8foq27WLti\",\"code\":\"OU_222728\",\"name\":\"Baoma Oil Mill CHC\"},\"mepHuAA9l51\":{\"uid\":\"mepHuAA9l51\",\"code\":\"OU_193205\",\"name\":\"Rokonta CHC\"},\"k1Y0oNqPlmy\":{\"uid\":\"k1Y0oNqPlmy\",\"code\":\"OU_1161\",\"name\":\"Gboyama CHC\"},\"UOJlcpPnBat\":{\"uid\":\"UOJlcpPnBat\",\"code\":\"OU_172174\",\"name\":\"Needy CHC\"},\"CKkE4GBJekz\":{\"uid\":\"CKkE4GBJekz\",\"code\":\"OU_222671\",\"name\":\"Weima CHC\"},\"GHHvGp7tgtZ\":{\"uid\":\"GHHvGp7tgtZ\",\"code\":\"OU_193275\",\"name\":\"Binkolo CHC\"},\"dQggcljEImF\":{\"uid\":\"dQggcljEImF\",\"code\":\"OU_278392\",\"name\":\"Goderich Health Centre\"},\"DvzKyuC0G4w\":{\"uid\":\"DvzKyuC0G4w\",\"code\":\"OU_204872\",\"name\":\"Jojoima CHC\"},\"Luv2kmWWgoG\":{\"uid\":\"Luv2kmWWgoG\",\"code\":\"OU_222632\",\"name\":\"Mondema CHC\"},\"cw0Wm1QTHRq\":{\"uid\":\"cw0Wm1QTHRq\",\"code\":\"OU_222750\",\"name\":\"Joru CHC\"},\"Ep5iWL1UKvF\":{\"uid\":\"Ep5iWL1UKvF\",\"code\":\"OU_226276\",\"name\":\"Kurubonla CHC\"},\"EH0dXLB4nZg\":{\"uid\":\"EH0dXLB4nZg\",\"code\":\"OU_255032\",\"name\":\"Masimera CHC\"},\"L5gENbBNNup\":{\"uid\":\"L5gENbBNNup\",\"code\":\"OU_222689\",\"name\":\"Boajibu CHC\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"r5WWF9WDzoa\",\"yMCshbaVExv\",\"Jiymtq0A01x\",\"FNnj3jKGS7i\",\"MpcMjLmbATv\",\"Yj2ni275yPJ\",\"Y8foq27WLti\",\"FLjwMPWLrL2\",\"agM0BKQlTh3\",\"iMZihUMzH92\",\"uFp0ztDOFbI\",\"amgb83zVxp5\",\"PMsF64R6OJX\",\"o0BgK1dLhF8\",\"n7wN9gMFfZ5\",\"GHHvGp7tgtZ\",\"kUzpbgPCwVA\",\"L5gENbBNNup\",\"H97XE5Ea089\",\"tO01bqIipeD\",\"Q2USZSJmcNK\",\"E497Rk80ivZ\",\"cMFi8lYbXHY\",\"d9zRBAoM8OC\",\"KiheEgvUZ0i\",\"U4FzUXMvbI8\",\"wByqtWCCuDJ\",\"m5BX6CvJ6Ex\",\"jKZ0U8Og5aV\",\"aIsnJuZbmVA\",\"K6oyIMh7Lee\",\"Gm7YUjhVi9Q\",\"kuqKh33SPgg\",\"xKaB8tfbTzm\",\"NMcx2jmra3c\",\"pNPmNeqyrim\",\"uDzWmUDHKeR\",\"ii2KMnWMx2L\",\"ZdPkczYqeIY\",\"jGYT5U5qJP6\",\"D2rB1GRuh8C\",\"ubsjwFFBaJM\",\"uedNhvYPMNu\",\"TEVtOFKcLAP\",\"YAuJ3fyoEuI\",\"NaVzm59XKGf\",\"bHcw141PTsE\",\"k1Y0oNqPlmy\",\"FbD5Z8z22Yb\",\"U514Dz4v9pv\",\"TSyzvBiovKh\",\"m0XorV4WWg0\",\"dQggcljEImF\",\"RaQGHRti7JM\",\"azRICFoILuh\",\"jhtj3eQa1pM\",\"QpRIPul20Sb\",\"lL2LBkhlsmV\",\"g10jm7jPdzf\",\"zQpYVEyAM2t\",\"g5lonXJ9ndA\",\"W7ekX3gi0ut\",\"Umh4HKqqFp6\",\"QzPf0qKBU4n\",\"vELbGdEphPd\",\"DvzKyuC0G4w\",\"cw0Wm1QTHRq\",\"TjZwphhxCuV\",\"KKoPh1lDd9j\",\"aSxNNRxPuBP\",\"mt47bcb0Rcj\",\"HNv1aLPdMYb\",\"bSj2UnYhTFb\",\"zuXW98AEbE7\",\"inpc5QsFRTm\",\"wUmVUKhnPuy\",\"K00jR5dmoFZ\",\"NjyJYiIuKIG\",\"k8ZPul89UDm\",\"FclfbEFMcf3\",\"SnCrOCRrxGX\",\"DMxw0SASFih\",\"p310xqwAJge\",\"mwN7QuEfT8m\",\"TljiT6C5D0J\",\"sM0Us0NkSez\",\"Ep5iWL1UKvF\",\"PcADvhvcaI2\",\"NRPCjDljVtu\",\"N3tpEjZcPm9\",\"iOA3z6Y3cq5\",\"YvwYw7GilkP\",\"IlMQTFvcq9r\",\"q56204kKXgZ\",\"Ahh47q8AkId\",\"TmCsvdJLHoX\",\"gE3gEGZbQMi\",\"LnToY3ExKxL\",\"scc4QyxenJd\",\"RAsstekPRco\",\"w3mBVfrWhXl\",\"lOv6IFgr6Fs\",\"Z9ny6QeqsgX\",\"va2lE4FiVVb\",\"O1KFJmM6HUx\",\"PaNv9VyD06n\",\"mshIal30ffW\",\"RQgXBKxgvHf\",\"J42QfNe0GJZ\",\"EURoFVjowXs\",\"EH0dXLB4nZg\",\"uRQj8WRK0Py\",\"OY7mYDATra3\",\"EXbPGmEUdnc\",\"dkmpOuVhBba\",\"KcCbIDzRcui\",\"aHs9PLxIdbr\",\"HcB2W6Fgp7i\",\"MXdbul7bBqV\",\"sIVFEyNfOg4\",\"cNAp6CJeLxk\",\"JQJjsXvHE5M\",\"Luv2kmWWgoG\",\"PC3Ag91n82e\",\"xMn4Wki9doK\",\"rCKWdLr4B8K\",\"MuZJ8lprGqK\",\"zEsMdeJOty4\",\"a04CZxe0PSe\",\"UOJlcpPnBat\",\"L4Tw4NlaMjn\",\"rm60vuHyQXj\",\"mzsOsz0NwNY\",\"m3VnSQbE8CD\",\"CvBAqD6RzLZ\",\"P4upLKrpkHP\",\"DiszpKrYNg8\",\"sznCEDMABa2\",\"sLKHXoBIqSs\",\"QsAwd531Cpd\",\"hzf90qz08AW\",\"PduUQmdt0pB\",\"tSBcgrTDdB8\",\"nv41sOz8IVM\",\"HQoxFu4lYPS\",\"pJv8NJlJNhU\",\"ke2gwHKHP3z\",\"k6lOze3vTzP\",\"wtdBuXDwZYQ\",\"oRncQGhLYNE\",\"qVvitxEF2ck\",\"mepHuAA9l51\",\"X79FDd4EAgo\",\"QZtMuEEV9Vv\",\"bPqP6eRfkyn\",\"gUPhNWkSXvD\",\"HWXk4EBHUyk\",\"PuZOFApTSeo\",\"Mi4dWRtfIOC\",\"egjrZ1PHNtT\",\"OjXNuYyLaCJ\",\"Jyv7sjpl9bA\",\"oLuhRyYPxRO\",\"p9KfD6eaRvu\",\"IlnqGuxfQAw\",\"pXDcgDRz8Od\",\"W2KnxOMvmgE\",\"O63vIA5MVn6\",\"e2WgqiasKnD\",\"qIpBLa1SCZt\",\"s5aXfzOL456\",\"agEKP19IUKI\",\"ua5GXy2uhBR\",\"KYXbIQBQgP1\",\"CFPrsD3dNeb\",\"PQEpIeuSTCN\",\"JrSIoCOdTH2\",\"lxxASQqPUqd\",\"K3jhn3TXF3a\",\"lpQvlm9czYE\",\"g5A3hiJlwmI\",\"VhRX5JDVo7R\",\"CKkE4GBJekz\",\"Qc9lf4VM9bD\",\"EUUkKEDoNsf\",\"nX05QLraDhO\",\"sesv0eXljBq\",\"RhJbg8UD75Q\",\"PA1spYiNZfv\",\"qxbsDd9QYv6\",\"fAsj6a4nudH\",\"xa4F6gesVJm\",\"roGdTjEqLZQ\",\"BNFrspDBKel\"],\"pe\":[]}}";
+            "{\"pager\":{\"isLastPage\":false,\"pageSize\":100,\"page\":1},\"items\":{\"FNnj3jKGS7i\":{\"uid\":\"FNnj3jKGS7i\",\"code\":\"OU_260387\",\"name\":\"Bandajuma Clinic CHC\"},\"Q2USZSJmcNK\":{\"uid\":\"Q2USZSJmcNK\",\"code\":\"OU_268195\",\"name\":\"Bumbuna CHC\"},\"sLKHXoBIqSs\":{\"uid\":\"sLKHXoBIqSs\",\"code\":\"OU_233362\",\"name\":\"Njagbwema Fiama CHC\"},\"mwN7QuEfT8m\":{\"uid\":\"mwN7QuEfT8m\",\"code\":\"OU_820\",\"name\":\"Koribondo CHC\"},\"jGYT5U5qJP6\":{\"uid\":\"jGYT5U5qJP6\",\"code\":\"OU_653\",\"name\":\"Gbaiima CHC\"},\"agM0BKQlTh3\":{\"uid\":\"agM0BKQlTh3\",\"code\":\"OU_193303\",\"name\":\"Batkanu CHC\"},\"MuZJ8lprGqK\":{\"uid\":\"MuZJ8lprGqK\",\"code\":\"OU_247089\",\"name\":\"Moyamba Junction CHC\"},\"e2WgqiasKnD\":{\"uid\":\"e2WgqiasKnD\",\"code\":\"OU_246997\",\"name\":\"Taiama (Kori) CHC\"},\"KcCbIDzRcui\":{\"uid\":\"KcCbIDzRcui\",\"code\":\"OU_268221\",\"name\":\"Matotoka CHC\"},\"Jyv7sjpl9bA\":{\"uid\":\"Jyv7sjpl9bA\",\"code\":\"OU_222650\",\"name\":\"Sendumei CHC\"},\"zEsMdeJOty4\":{\"uid\":\"zEsMdeJOty4\",\"code\":\"OU_278331\",\"name\":\"Moyiba CHC\"},\"mshIal30ffW\":{\"uid\":\"mshIal30ffW\",\"code\":\"OU_193301\",\"name\":\"Mapaki CHC\"},\"uFp0ztDOFbI\":{\"uid\":\"uFp0ztDOFbI\",\"code\":\"OU_197430\",\"name\":\"Bendu CHC\"},\"scc4QyxenJd\":{\"uid\":\"scc4QyxenJd\",\"code\":\"OU_268215\",\"name\":\"Makali CHC\"},\"aHs9PLxIdbr\":{\"uid\":\"aHs9PLxIdbr\",\"code\":\"OU_268203\",\"name\":\"Mayepoh CHC\"},\"PA1spYiNZfv\":{\"uid\":\"PA1spYiNZfv\",\"code\":\"OU_233398\",\"name\":\"Yengema CHC\"},\"LnToY3ExKxL\":{\"uid\":\"LnToY3ExKxL\",\"code\":\"OU_255018\",\"name\":\"Mahera CHC\"},\"IlMQTFvcq9r\":{\"uid\":\"IlMQTFvcq9r\",\"code\":\"OU_222656\",\"name\":\"Lowoma CHC\"},\"jhtj3eQa1pM\":{\"uid\":\"jhtj3eQa1pM\",\"code\":\"OU_1100\",\"name\":\"Gondama (Tikonko) CHC\"},\"QsAwd531Cpd\":{\"uid\":\"QsAwd531Cpd\",\"code\":\"OU_1038\",\"name\":\"Njala CHC\"},\"pNPmNeqyrim\":{\"uid\":\"pNPmNeqyrim\",\"code\":\"OU_222666\",\"name\":\"Foindu (Lower Bamabara) CHC\"},\"K00jR5dmoFZ\":{\"uid\":\"K00jR5dmoFZ\",\"code\":\"OU_260399\",\"name\":\"Karlu CHC\"},\"xa4F6gesVJm\":{\"uid\":\"xa4F6gesVJm\",\"code\":\"OU_278400\",\"name\":\"York CHC\"},\"zQpYVEyAM2t\":{\"uid\":\"zQpYVEyAM2t\",\"code\":\"OU_278377\",\"name\":\"Hastings Health Centre\"},\"hzf90qz08AW\":{\"uid\":\"hzf90qz08AW\",\"code\":\"OU_247034\",\"name\":\"Njama CHC\"},\"CFPrsD3dNeb\":{\"uid\":\"CFPrsD3dNeb\",\"code\":\"OU_197423\",\"name\":\"Tissana CHC\"},\"MpcMjLmbATv\":{\"uid\":\"MpcMjLmbATv\",\"code\":\"OU_204938\",\"name\":\"Bandajuma Yawei CHC\"},\"KYXbIQBQgP1\":{\"uid\":\"KYXbIQBQgP1\",\"code\":\"OU_1103\",\"name\":\"Tikonko CHC\"},\"lxxASQqPUqd\":{\"uid\":\"lxxASQqPUqd\",\"code\":\"OU_233341\",\"name\":\"Tombodu CHC\"},\"oRncQGhLYNE\":{\"uid\":\"oRncQGhLYNE\",\"code\":\"OU_278376\",\"name\":\"Regent (RWA) CHC\"},\"RhJbg8UD75Q\":{\"uid\":\"RhJbg8UD75Q\",\"code\":\"OU_1027\",\"name\":\"Yemoh Town CHC\"},\"EUUkKEDoNsf\":{\"uid\":\"EUUkKEDoNsf\",\"code\":\"OU_278343\",\"name\":\"Wilberforce CHC\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"FbD5Z8z22Yb\":{\"uid\":\"FbD5Z8z22Yb\",\"code\":\"OU_260385\",\"name\":\"Geoma Jagor CHC\"},\"ua5GXy2uhBR\":{\"uid\":\"ua5GXy2uhBR\",\"code\":\"OU_197412\",\"name\":\"Tihun CHC\"},\"QpRIPul20Sb\":{\"uid\":\"QpRIPul20Sb\",\"code\":\"OU_222637\",\"name\":\"Gorahun CHC\"},\"mt47bcb0Rcj\":{\"uid\":\"mt47bcb0Rcj\",\"code\":\"OU_193231\",\"name\":\"Kamabai CHC\"},\"uDzWmUDHKeR\":{\"uid\":\"uDzWmUDHKeR\",\"code\":\"OU_260389\",\"name\":\"Futa CHC\"},\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"OjXNuYyLaCJ\":{\"uid\":\"OjXNuYyLaCJ\",\"code\":\"OU_255004\",\"name\":\"Sendugu CHC\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZdPkczYqeIY\":{\"uid\":\"ZdPkczYqeIY\",\"code\":\"OU_247092\",\"name\":\"Gandorhun CHC\"},\"p310xqwAJge\":{\"uid\":\"p310xqwAJge\",\"code\":\"OU_226268\",\"name\":\"Kondembaia CHC\"},\"HcB2W6Fgp7i\":{\"uid\":\"HcB2W6Fgp7i\",\"code\":\"OU_255065\",\"name\":\"Melekuray CHC\"},\"lOv6IFgr6Fs\":{\"uid\":\"lOv6IFgr6Fs\",\"code\":\"OU_832\",\"name\":\"Manjama Shellmingo CHC\"},\"amgb83zVxp5\":{\"uid\":\"amgb83zVxp5\",\"code\":\"OU_222674\",\"name\":\"Bendu Mameima CHC\"},\"K6oyIMh7Lee\":{\"uid\":\"K6oyIMh7Lee\",\"code\":\"OU_226224\",\"name\":\"Fadugu CHC\"},\"m0XorV4WWg0\":{\"uid\":\"m0XorV4WWg0\",\"code\":\"OU_278361\",\"name\":\"Ginger Hall Health Centre\"},\"bSj2UnYhTFb\":{\"uid\":\"bSj2UnYhTFb\",\"code\":\"OU_193218\",\"name\":\"Kamaranka CHC\"},\"CvBAqD6RzLZ\":{\"uid\":\"CvBAqD6RzLZ\",\"code\":\"OU_595\",\"name\":\"Ngalu CHC\"},\"k6lOze3vTzP\":{\"uid\":\"k6lOze3vTzP\",\"code\":\"OU_260435\",\"name\":\"Potoru CHC\"},\"p9KfD6eaRvu\":{\"uid\":\"p9KfD6eaRvu\",\"code\":\"OU_247069\",\"name\":\"Shenge CHC\"},\"K3jhn3TXF3a\":{\"uid\":\"K3jhn3TXF3a\",\"code\":\"OU_222665\",\"name\":\"Tongo Field CHC\"},\"HNv1aLPdMYb\":{\"uid\":\"HNv1aLPdMYb\",\"code\":\"OU_193242\",\"name\":\"Kamalo CHC\"},\"yMCshbaVExv\":{\"uid\":\"yMCshbaVExv\",\"code\":\"OU_254991\",\"name\":\"Babara CHC\"},\"pJv8NJlJNhU\":{\"uid\":\"pJv8NJlJNhU\",\"code\":\"OU_204916\",\"name\":\"Pendembu CHC\"},\"YAuJ3fyoEuI\":{\"uid\":\"YAuJ3fyoEuI\",\"code\":\"OU_193281\",\"name\":\"Gbendembu Wesleyan CHC\"},\"g5A3hiJlwmI\":{\"uid\":\"g5A3hiJlwmI\",\"code\":\"OU_233397\",\"name\":\"UMC Mitchener Memorial Maternity & Health Centre\"},\"jKZ0U8Og5aV\":{\"uid\":\"jKZ0U8Og5aV\",\"code\":\"OU_222683\",\"name\":\"Dodo CHC\"},\"EXbPGmEUdnc\":{\"uid\":\"EXbPGmEUdnc\",\"code\":\"OU_193197\",\"name\":\"Mateboi CHC\"},\"nX05QLraDhO\":{\"uid\":\"nX05QLraDhO\",\"code\":\"OU_585\",\"name\":\"Yamandu CHC\"},\"Umh4HKqqFp6\":{\"uid\":\"Umh4HKqqFp6\",\"code\":\"OU_578\",\"name\":\"Jembe CHC\"},\"ubsjwFFBaJM\":{\"uid\":\"ubsjwFFBaJM\",\"code\":\"OU_247016\",\"name\":\"Gbangbatoke CHC\"},\"rm60vuHyQXj\":{\"uid\":\"rm60vuHyQXj\",\"code\":\"OU_1082\",\"name\":\"Nengbema CHC\"},\"iOA3z6Y3cq5\":{\"uid\":\"iOA3z6Y3cq5\",\"code\":\"OU_222699\",\"name\":\"Largo CHC\"},\"sIVFEyNfOg4\":{\"uid\":\"sIVFEyNfOg4\",\"code\":\"OU_247073\",\"name\":\"Mokandor CHP\"},\"k8ZPul89UDm\":{\"uid\":\"k8ZPul89UDm\",\"code\":\"OU_233370\",\"name\":\"Kayima CHC\"},\"iMZihUMzH92\":{\"uid\":\"iMZihUMzH92\",\"code\":\"OU_247083\",\"name\":\"Bauya (Kongbora) CHC\"},\"MXdbul7bBqV\":{\"uid\":\"MXdbul7bBqV\",\"code\":\"OU_204912\",\"name\":\"Mobai CHC\"},\"dkmpOuVhBba\":{\"uid\":\"dkmpOuVhBba\",\"code\":\"OU_268226\",\"name\":\"Mathoir CHC\"},\"q56204kKXgZ\":{\"uid\":\"q56204kKXgZ\",\"code\":\"OU_255057\",\"name\":\"Lunsar CHC\"},\"kuqKh33SPgg\":{\"uid\":\"kuqKh33SPgg\",\"code\":\"OU_226230\",\"name\":\"Falaba CHC\"},\"NjyJYiIuKIG\":{\"uid\":\"NjyJYiIuKIG\",\"code\":\"OU_193291\",\"name\":\"Kathanta Yimbor CHC\"},\"fAsj6a4nudH\":{\"uid\":\"fAsj6a4nudH\",\"code\":\"OU_197398\",\"name\":\"Yoni CHC\"},\"a04CZxe0PSe\":{\"uid\":\"a04CZxe0PSe\",\"code\":\"OU_278333\",\"name\":\"Murray Town CHC\"},\"qxbsDd9QYv6\":{\"uid\":\"qxbsDd9QYv6\",\"code\":\"OU_226274\",\"name\":\"Yiffin CHC\"},\"Mi4dWRtfIOC\":{\"uid\":\"Mi4dWRtfIOC\",\"code\":\"OU_204860\",\"name\":\"Sandaru CHC\"},\"QzPf0qKBU4n\":{\"uid\":\"QzPf0qKBU4n\",\"code\":\"OU_260411\",\"name\":\"Jendema CHC\"},\"mzsOsz0NwNY\":{\"uid\":\"mzsOsz0NwNY\",\"code\":\"OU_836\",\"name\":\"New Police Barracks CHC\"},\"vELbGdEphPd\":{\"uid\":\"vELbGdEphPd\",\"code\":\"OU_614\",\"name\":\"Jimmi CHC\"},\"qVvitxEF2ck\":{\"uid\":\"qVvitxEF2ck\",\"code\":\"OU_254949\",\"name\":\"Rogbere CHC\"},\"RAsstekPRco\":{\"uid\":\"RAsstekPRco\",\"code\":\"OU_211269\",\"name\":\"Mambolo CHC\"},\"va2lE4FiVVb\":{\"uid\":\"va2lE4FiVVb\",\"code\":\"OU_247019\",\"name\":\"Mano CHC\"},\"cNAp6CJeLxk\":{\"uid\":\"cNAp6CJeLxk\",\"code\":\"OU_247015\",\"name\":\"Mokanji CHC\"},\"wByqtWCCuDJ\":{\"uid\":\"wByqtWCCuDJ\",\"code\":\"OU_1095\",\"name\":\"Damballa CHC\"},\"PcADvhvcaI2\":{\"uid\":\"PcADvhvcaI2\",\"code\":\"OU_211253\",\"name\":\"Kychom CHC\"},\"n7wN9gMFfZ5\":{\"uid\":\"n7wN9gMFfZ5\",\"code\":\"OU_197435\",\"name\":\"Benduma CHC\"},\"kUzpbgPCwVA\":{\"uid\":\"kUzpbgPCwVA\",\"code\":\"OU_222624\",\"name\":\"Blama CHC\"},\"rCKWdLr4B8K\":{\"uid\":\"rCKWdLr4B8K\",\"code\":\"OU_197427\",\"name\":\"Motuo CHC\"},\"DMxw0SASFih\":{\"uid\":\"DMxw0SASFih\",\"code\":\"OU_204941\",\"name\":\"Koindu CHC\"},\"PQEpIeuSTCN\":{\"uid\":\"PQEpIeuSTCN\",\"code\":\"OU_222623\",\"name\":\"Tobanda CHC\"},\"inpc5QsFRTm\":{\"uid\":\"inpc5QsFRTm\",\"code\":\"OU_211274\",\"name\":\"Kamassasa CHC\"},\"aSxNNRxPuBP\":{\"uid\":\"aSxNNRxPuBP\",\"code\":\"OU_193278\",\"name\":\"Kalangba CHC\"},\"O1KFJmM6HUx\":{\"uid\":\"O1KFJmM6HUx\",\"code\":\"OU_260438\",\"name\":\"Mano Gbonjeima CHC\"},\"s5aXfzOL456\":{\"uid\":\"s5aXfzOL456\",\"code\":\"OU_197437\",\"name\":\"Talia CHC\"},\"tSBcgrTDdB8\":{\"uid\":\"tSBcgrTDdB8\",\"code\":\"OU_834\",\"name\":\"Paramedical CHC\"},\"KiheEgvUZ0i\":{\"uid\":\"KiheEgvUZ0i\",\"code\":\"OU_278357\",\"name\":\"Calaba town CHC\"},\"d9zRBAoM8OC\":{\"uid\":\"d9zRBAoM8OC\",\"code\":\"OU_260423\",\"name\":\"Bumpeh Perri CHC\"},\"sesv0eXljBq\":{\"uid\":\"sesv0eXljBq\",\"code\":\"OU_268207\",\"name\":\"Yele CHC\"},\"L4Tw4NlaMjn\":{\"uid\":\"L4Tw4NlaMjn\",\"code\":\"OU_222705\",\"name\":\"Nekabo CHC\"},\"sznCEDMABa2\":{\"uid\":\"sznCEDMABa2\",\"code\":\"OU_204903\",\"name\":\"Ngiehun CHC\"},\"E497Rk80ivZ\":{\"uid\":\"E497Rk80ivZ\",\"code\":\"OU_651\",\"name\":\"Bumpe CHC\"},\"CXw2yu5fodb\":{\"uid\":\"CXw2yu5fodb\",\"code\":\"CHC\",\"valueType\":\"NUMBER\",\"name\":\"CHC\",\"dimensionItemType\":\"ORGANISATION_UNIT_GROUP\",\"totalAggregationType\":\"SUM\"},\"W7ekX3gi0ut\":{\"uid\":\"W7ekX3gi0ut\",\"code\":\"OU_233333\",\"name\":\"Jaiama Sewafe CHC\"},\"roGdTjEqLZQ\":{\"uid\":\"roGdTjEqLZQ\",\"code\":\"OU_233371\",\"name\":\"Yormandu CHC\"},\"Jiymtq0A01x\":{\"uid\":\"Jiymtq0A01x\",\"code\":\"OU_226243\",\"name\":\"Bafodia CHC\"},\"aIsnJuZbmVA\":{\"uid\":\"aIsnJuZbmVA\",\"code\":\"OU_226256\",\"name\":\"Dogoloya CHP\"},\"IlnqGuxfQAw\":{\"uid\":\"IlnqGuxfQAw\",\"code\":\"OU_226216\",\"name\":\"Sinkunia CHC\"},\"lpQvlm9czYE\":{\"uid\":\"lpQvlm9czYE\",\"code\":\"OU_222631\",\"name\":\"Tungie CHC\"},\"uedNhvYPMNu\":{\"uid\":\"uedNhvYPMNu\",\"code\":\"OU_193216\",\"name\":\"Gbanti CHC\"},\"KKoPh1lDd9j\":{\"uid\":\"KKoPh1lDd9j\",\"code\":\"OU_233321\",\"name\":\"Kainkordu CHC\"},\"xKaB8tfbTzm\":{\"uid\":\"xKaB8tfbTzm\",\"code\":\"OU_193247\",\"name\":\"Fintonia CHC\"},\"TEVtOFKcLAP\":{\"uid\":\"TEVtOFKcLAP\",\"code\":\"OU_197447\",\"name\":\"Gbap CHC\"},\"pXDcgDRz8Od\":{\"uid\":\"pXDcgDRz8Od\",\"code\":\"OU_278402\",\"name\":\"Songo CHC\"},\"NaVzm59XKGf\":{\"uid\":\"NaVzm59XKGf\",\"code\":\"OU_254980\",\"name\":\"Gbinti CHC\"},\"Ahh47q8AkId\":{\"uid\":\"Ahh47q8AkId\",\"code\":\"OU_268167\",\"name\":\"Mabang CHC\"},\"QZtMuEEV9Vv\":{\"uid\":\"QZtMuEEV9Vv\",\"code\":\"OU_211237\",\"name\":\"Rokupr CHC\"},\"U4FzUXMvbI8\":{\"uid\":\"U4FzUXMvbI8\",\"code\":\"OU_255009\",\"name\":\"Conakry Dee CHC\"},\"o0BgK1dLhF8\":{\"uid\":\"o0BgK1dLhF8\",\"code\":\"OU_268170\",\"name\":\"Bendugu CHC\"},\"agEKP19IUKI\":{\"uid\":\"agEKP19IUKI\",\"code\":\"OU_193280\",\"name\":\"Tambiama CHC\"},\"qIpBLa1SCZt\":{\"uid\":\"qIpBLa1SCZt\",\"code\":\"OU_222714\",\"name\":\"Talia (Nongowa) CHC\"},\"H97XE5Ea089\":{\"uid\":\"H97XE5Ea089\",\"code\":\"OU_247045\",\"name\":\"Bomotoke CHC\"},\"nv41sOz8IVM\":{\"uid\":\"nv41sOz8IVM\",\"code\":\"OU_204927\",\"name\":\"Pejewa CHC\"},\"202301\":{\"name\":\"January 2023\"},\"NMcx2jmra3c\":{\"uid\":\"NMcx2jmra3c\",\"code\":\"OU_226273\",\"name\":\"Firawa CHC\"},\"m3VnSQbE8CD\":{\"uid\":\"m3VnSQbE8CD\",\"code\":\"OU_278382\",\"name\":\"Newton CHC\"},\"OY7mYDATra3\":{\"uid\":\"OY7mYDATra3\",\"code\":\"OU_268176\",\"name\":\"Massingbi CHC\"},\"RQgXBKxgvHf\":{\"uid\":\"RQgXBKxgvHf\",\"code\":\"OU_211248\",\"name\":\"Mapotolon CHC\"},\"YvwYw7GilkP\":{\"uid\":\"YvwYw7GilkP\",\"code\":\"OU_222726\",\"name\":\"Levuma (Kandu Lep) CHC\"},\"PduUQmdt0pB\":{\"uid\":\"PduUQmdt0pB\",\"code\":\"OU_211273\",\"name\":\"Numea CHC\"},\"U514Dz4v9pv\":{\"uid\":\"U514Dz4v9pv\",\"code\":\"OU_278330\",\"name\":\"George Brook Health Centre\"},\"PuZOFApTSeo\":{\"uid\":\"PuZOFApTSeo\",\"code\":\"OU_952\",\"name\":\"Sahn CHC\"},\"wUmVUKhnPuy\":{\"uid\":\"wUmVUKhnPuy\",\"code\":\"OU_247057\",\"name\":\"Kangahun CHC\"},\"RaQGHRti7JM\":{\"uid\":\"RaQGHRti7JM\",\"code\":\"OU_278335\",\"name\":\"Gods Favour health Center\"},\"xMn4Wki9doK\":{\"uid\":\"xMn4Wki9doK\",\"code\":\"OU_197417\",\"name\":\"Moriba Town CHC\"},\"JQJjsXvHE5M\":{\"uid\":\"JQJjsXvHE5M\",\"code\":\"OU_247007\",\"name\":\"Mokelleh CHC\"},\"m5BX6CvJ6Ex\":{\"uid\":\"m5BX6CvJ6Ex\",\"code\":\"OU_204865\",\"name\":\"Daru CHC\"},\"D2rB1GRuh8C\":{\"uid\":\"D2rB1GRuh8C\",\"code\":\"OU_197418\",\"name\":\"Gbamgbama CHC\"},\"Gm7YUjhVi9Q\":{\"uid\":\"Gm7YUjhVi9Q\",\"code\":\"OU_260415\",\"name\":\"Fairo CHC\"},\"gE3gEGZbQMi\":{\"uid\":\"gE3gEGZbQMi\",\"code\":\"OU_197407\",\"name\":\"Madina (BUM) CHC\"},\"zuXW98AEbE7\":{\"uid\":\"zuXW98AEbE7\",\"code\":\"OU_255023\",\"name\":\"Kamasondo CHC\"},\"TjZwphhxCuV\":{\"uid\":\"TjZwphhxCuV\",\"code\":\"OU_193225\",\"name\":\"Kagbere CHC\"},\"g5lonXJ9ndA\":{\"uid\":\"g5lonXJ9ndA\",\"code\":\"OU_268237\",\"name\":\"Hinistas CHC\"},\"r5WWF9WDzoa\":{\"uid\":\"r5WWF9WDzoa\",\"code\":\"OU_222681\",\"name\":\"Baama CHC\"},\"VhRX5JDVo7R\":{\"uid\":\"VhRX5JDVo7R\",\"code\":\"OU_278397\",\"name\":\"Waterloo CHC\"},\"PMsF64R6OJX\":{\"uid\":\"PMsF64R6OJX\",\"code\":\"OU_226248\",\"name\":\"Bendugu (Mongo) CHC\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"azRICFoILuh\":{\"uid\":\"azRICFoILuh\",\"code\":\"OU_577\",\"name\":\"Golu MCHP\"},\"HQoxFu4lYPS\":{\"uid\":\"HQoxFu4lYPS\",\"code\":\"OU_204868\",\"name\":\"Pellie CHC\"},\"JrSIoCOdTH2\":{\"uid\":\"JrSIoCOdTH2\",\"code\":\"OU_278403\",\"name\":\"Tombo CHC\"},\"ke2gwHKHP3z\":{\"uid\":\"ke2gwHKHP3z\",\"code\":\"OU_254983\",\"name\":\"Petifu CHC\"},\"TSyzvBiovKh\":{\"uid\":\"TSyzvBiovKh\",\"code\":\"OU_576\",\"name\":\"Gerehun CHC\"},\"g10jm7jPdzf\":{\"uid\":\"g10jm7jPdzf\",\"code\":\"OU_222707\",\"name\":\"Hangha CHC\"},\"DiszpKrYNg8\":{\"uid\":\"DiszpKrYNg8\",\"code\":\"OU_559\",\"name\":\"Ngelehun CHC\"},\"bPqP6eRfkyn\":{\"uid\":\"bPqP6eRfkyn\",\"code\":\"OU_278318\",\"name\":\"Ross Road Health Centre\"},\"EURoFVjowXs\":{\"uid\":\"EURoFVjowXs\",\"code\":\"OU_254964\",\"name\":\"Masiaka CHC\"},\"ii2KMnWMx2L\":{\"uid\":\"ii2KMnWMx2L\",\"code\":\"OU_233392\",\"name\":\"Gandorhun (Gbane) CHC\"},\"J42QfNe0GJZ\":{\"uid\":\"J42QfNe0GJZ\",\"code\":\"OU_268185\",\"name\":\"Mara CHC\"},\"gUPhNWkSXvD\":{\"uid\":\"gUPhNWkSXvD\",\"code\":\"OU_247032\",\"name\":\"Rotifunk CHC\"},\"FLjwMPWLrL2\":{\"uid\":\"FLjwMPWLrL2\",\"code\":\"OU_1126\",\"name\":\"Baomahun CHC\"},\"FclfbEFMcf3\":{\"uid\":\"FclfbEFMcf3\",\"code\":\"OU_278340\",\"name\":\"Kissy Health Centre\"},\"lL2LBkhlsmV\":{\"uid\":\"lL2LBkhlsmV\",\"code\":\"OU_278336\",\"name\":\"Grassfield CHC\"},\"NRPCjDljVtu\":{\"uid\":\"NRPCjDljVtu\",\"code\":\"OU_278404\",\"name\":\"Lakka\\/Ogoo Farm CHC\"},\"egjrZ1PHNtT\":{\"uid\":\"egjrZ1PHNtT\",\"code\":\"OU_247053\",\"name\":\"Sembehun CHC\"},\"PC3Ag91n82e\":{\"uid\":\"PC3Ag91n82e\",\"code\":\"OU_1122\",\"name\":\"Mongere CHC\"},\"X79FDd4EAgo\":{\"uid\":\"X79FDd4EAgo\",\"code\":\"OU_193196\",\"name\":\"Rokulan CHC\"},\"sM0Us0NkSez\":{\"uid\":\"sM0Us0NkSez\",\"code\":\"OU_278359\",\"name\":\"Kroo Bay CHC\"},\"bHcw141PTsE\":{\"uid\":\"bHcw141PTsE\",\"code\":\"OU_260407\",\"name\":\"Gbondapi CHC\"},\"O63vIA5MVn6\":{\"uid\":\"O63vIA5MVn6\",\"code\":\"OU_255014\",\"name\":\"Tagrin CHC\"},\"HWXk4EBHUyk\":{\"uid\":\"HWXk4EBHUyk\",\"code\":\"OU_260393\",\"name\":\"Sahn (Malen) CHC\"},\"W2KnxOMvmgE\":{\"uid\":\"W2KnxOMvmgE\",\"code\":\"OU_1050\",\"name\":\"Sumbuya CHC\"},\"tO01bqIipeD\":{\"uid\":\"tO01bqIipeD\",\"code\":\"OU_204892\",\"name\":\"Buedu CHC\"},\"w3mBVfrWhXl\":{\"uid\":\"w3mBVfrWhXl\",\"code\":\"OU_255043\",\"name\":\"Mange CHC\"},\"TljiT6C5D0J\":{\"uid\":\"TljiT6C5D0J\",\"code\":\"OU_222740\",\"name\":\"Kpandebu CHC\"},\"TmCsvdJLHoX\":{\"uid\":\"TmCsvdJLHoX\",\"code\":\"OU_193195\",\"name\":\"Mabunduka CHC\"},\"BNFrspDBKel\":{\"uid\":\"BNFrspDBKel\",\"code\":\"OU_260382\",\"name\":\"Zimmi CHC\"},\"N3tpEjZcPm9\":{\"uid\":\"N3tpEjZcPm9\",\"code\":\"OU_204879\",\"name\":\"Laleihun Kovoma CHC\"},\"Qc9lf4VM9bD\":{\"uid\":\"Qc9lf4VM9bD\",\"code\":\"OU_278317\",\"name\":\"Wellington Health Centre\"},\"cMFi8lYbXHY\":{\"uid\":\"cMFi8lYbXHY\",\"code\":\"OU_233402\",\"name\":\"Bumpeh (Nimikoro) CHC\"},\"P4upLKrpkHP\":{\"uid\":\"P4upLKrpkHP\",\"code\":\"OU_222641\",\"name\":\"Ngegbwema CHC\"},\"Yj2ni275yPJ\":{\"uid\":\"Yj2ni275yPJ\",\"code\":\"OU_222647\",\"name\":\"Baoma (Koya) CHC\"},\"SnCrOCRrxGX\":{\"uid\":\"SnCrOCRrxGX\",\"code\":\"OU_233327\",\"name\":\"Koakoyima CHC\"},\"Z9ny6QeqsgX\":{\"uid\":\"Z9ny6QeqsgX\",\"code\":\"OU_969\",\"name\":\"Manjama UMC CHC\"},\"wtdBuXDwZYQ\":{\"uid\":\"wtdBuXDwZYQ\",\"code\":\"OU_1006\",\"name\":\"Praise Foundation CHC\"},\"oLuhRyYPxRO\":{\"uid\":\"oLuhRyYPxRO\",\"code\":\"OU_247011\",\"name\":\"Senehun CHC\"},\"PaNv9VyD06n\":{\"uid\":\"PaNv9VyD06n\",\"code\":\"OU_204930\",\"name\":\"Manowa CHC\"},\"uRQj8WRK0Py\":{\"uid\":\"uRQj8WRK0Py\",\"code\":\"OU_193255\",\"name\":\"Masongbo CHC\"},\"Y8foq27WLti\":{\"uid\":\"Y8foq27WLti\",\"code\":\"OU_222728\",\"name\":\"Baoma Oil Mill CHC\"},\"mepHuAA9l51\":{\"uid\":\"mepHuAA9l51\",\"code\":\"OU_193205\",\"name\":\"Rokonta CHC\"},\"k1Y0oNqPlmy\":{\"uid\":\"k1Y0oNqPlmy\",\"code\":\"OU_1161\",\"name\":\"Gboyama CHC\"},\"UOJlcpPnBat\":{\"uid\":\"UOJlcpPnBat\",\"code\":\"OU_172174\",\"name\":\"Needy CHC\"},\"CKkE4GBJekz\":{\"uid\":\"CKkE4GBJekz\",\"code\":\"OU_222671\",\"name\":\"Weima CHC\"},\"GHHvGp7tgtZ\":{\"uid\":\"GHHvGp7tgtZ\",\"code\":\"OU_193275\",\"name\":\"Binkolo CHC\"},\"dQggcljEImF\":{\"uid\":\"dQggcljEImF\",\"code\":\"OU_278392\",\"name\":\"Goderich Health Centre\"},\"DvzKyuC0G4w\":{\"uid\":\"DvzKyuC0G4w\",\"code\":\"OU_204872\",\"name\":\"Jojoima CHC\"},\"Luv2kmWWgoG\":{\"uid\":\"Luv2kmWWgoG\",\"code\":\"OU_222632\",\"name\":\"Mondema CHC\"},\"cw0Wm1QTHRq\":{\"uid\":\"cw0Wm1QTHRq\",\"code\":\"OU_222750\",\"name\":\"Joru CHC\"},\"Ep5iWL1UKvF\":{\"uid\":\"Ep5iWL1UKvF\",\"code\":\"OU_226276\",\"name\":\"Kurubonla CHC\"},\"EH0dXLB4nZg\":{\"uid\":\"EH0dXLB4nZg\",\"code\":\"OU_255032\",\"name\":\"Masimera CHC\"},\"L5gENbBNNup\":{\"uid\":\"L5gENbBNNup\",\"code\":\"OU_222689\",\"name\":\"Boajibu CHC\"}},\"dimensions\":{\"ZzYYXq4fJie.ou\":[\"r5WWF9WDzoa\",\"yMCshbaVExv\",\"Jiymtq0A01x\",\"FNnj3jKGS7i\",\"MpcMjLmbATv\",\"Yj2ni275yPJ\",\"Y8foq27WLti\",\"FLjwMPWLrL2\",\"agM0BKQlTh3\",\"iMZihUMzH92\",\"uFp0ztDOFbI\",\"amgb83zVxp5\",\"PMsF64R6OJX\",\"o0BgK1dLhF8\",\"n7wN9gMFfZ5\",\"GHHvGp7tgtZ\",\"kUzpbgPCwVA\",\"L5gENbBNNup\",\"H97XE5Ea089\",\"tO01bqIipeD\",\"Q2USZSJmcNK\",\"E497Rk80ivZ\",\"cMFi8lYbXHY\",\"d9zRBAoM8OC\",\"KiheEgvUZ0i\",\"U4FzUXMvbI8\",\"wByqtWCCuDJ\",\"m5BX6CvJ6Ex\",\"jKZ0U8Og5aV\",\"aIsnJuZbmVA\",\"K6oyIMh7Lee\",\"Gm7YUjhVi9Q\",\"kuqKh33SPgg\",\"xKaB8tfbTzm\",\"NMcx2jmra3c\",\"pNPmNeqyrim\",\"uDzWmUDHKeR\",\"ii2KMnWMx2L\",\"ZdPkczYqeIY\",\"jGYT5U5qJP6\",\"D2rB1GRuh8C\",\"ubsjwFFBaJM\",\"uedNhvYPMNu\",\"TEVtOFKcLAP\",\"YAuJ3fyoEuI\",\"NaVzm59XKGf\",\"bHcw141PTsE\",\"k1Y0oNqPlmy\",\"FbD5Z8z22Yb\",\"U514Dz4v9pv\",\"TSyzvBiovKh\",\"m0XorV4WWg0\",\"dQggcljEImF\",\"RaQGHRti7JM\",\"azRICFoILuh\",\"jhtj3eQa1pM\",\"QpRIPul20Sb\",\"lL2LBkhlsmV\",\"g10jm7jPdzf\",\"zQpYVEyAM2t\",\"g5lonXJ9ndA\",\"W7ekX3gi0ut\",\"Umh4HKqqFp6\",\"QzPf0qKBU4n\",\"vELbGdEphPd\",\"DvzKyuC0G4w\",\"cw0Wm1QTHRq\",\"TjZwphhxCuV\",\"KKoPh1lDd9j\",\"aSxNNRxPuBP\",\"mt47bcb0Rcj\",\"HNv1aLPdMYb\",\"bSj2UnYhTFb\",\"zuXW98AEbE7\",\"inpc5QsFRTm\",\"wUmVUKhnPuy\",\"K00jR5dmoFZ\",\"NjyJYiIuKIG\",\"k8ZPul89UDm\",\"FclfbEFMcf3\",\"SnCrOCRrxGX\",\"DMxw0SASFih\",\"p310xqwAJge\",\"mwN7QuEfT8m\",\"TljiT6C5D0J\",\"sM0Us0NkSez\",\"Ep5iWL1UKvF\",\"PcADvhvcaI2\",\"NRPCjDljVtu\",\"N3tpEjZcPm9\",\"iOA3z6Y3cq5\",\"YvwYw7GilkP\",\"IlMQTFvcq9r\",\"q56204kKXgZ\",\"Ahh47q8AkId\",\"TmCsvdJLHoX\",\"gE3gEGZbQMi\",\"LnToY3ExKxL\",\"scc4QyxenJd\",\"RAsstekPRco\",\"w3mBVfrWhXl\",\"lOv6IFgr6Fs\",\"Z9ny6QeqsgX\",\"va2lE4FiVVb\",\"O1KFJmM6HUx\",\"PaNv9VyD06n\",\"mshIal30ffW\",\"RQgXBKxgvHf\",\"J42QfNe0GJZ\",\"EURoFVjowXs\",\"EH0dXLB4nZg\",\"uRQj8WRK0Py\",\"OY7mYDATra3\",\"EXbPGmEUdnc\",\"dkmpOuVhBba\",\"KcCbIDzRcui\",\"aHs9PLxIdbr\",\"HcB2W6Fgp7i\",\"MXdbul7bBqV\",\"sIVFEyNfOg4\",\"cNAp6CJeLxk\",\"JQJjsXvHE5M\",\"Luv2kmWWgoG\",\"PC3Ag91n82e\",\"xMn4Wki9doK\",\"rCKWdLr4B8K\",\"MuZJ8lprGqK\",\"zEsMdeJOty4\",\"a04CZxe0PSe\",\"UOJlcpPnBat\",\"L4Tw4NlaMjn\",\"rm60vuHyQXj\",\"mzsOsz0NwNY\",\"m3VnSQbE8CD\",\"CvBAqD6RzLZ\",\"P4upLKrpkHP\",\"DiszpKrYNg8\",\"sznCEDMABa2\",\"sLKHXoBIqSs\",\"QsAwd531Cpd\",\"hzf90qz08AW\",\"PduUQmdt0pB\",\"tSBcgrTDdB8\",\"nv41sOz8IVM\",\"HQoxFu4lYPS\",\"pJv8NJlJNhU\",\"ke2gwHKHP3z\",\"k6lOze3vTzP\",\"wtdBuXDwZYQ\",\"oRncQGhLYNE\",\"qVvitxEF2ck\",\"mepHuAA9l51\",\"X79FDd4EAgo\",\"QZtMuEEV9Vv\",\"bPqP6eRfkyn\",\"gUPhNWkSXvD\",\"HWXk4EBHUyk\",\"PuZOFApTSeo\",\"Mi4dWRtfIOC\",\"egjrZ1PHNtT\",\"OjXNuYyLaCJ\",\"Jyv7sjpl9bA\",\"oLuhRyYPxRO\",\"p9KfD6eaRvu\",\"IlnqGuxfQAw\",\"pXDcgDRz8Od\",\"W2KnxOMvmgE\",\"O63vIA5MVn6\",\"e2WgqiasKnD\",\"qIpBLa1SCZt\",\"s5aXfzOL456\",\"agEKP19IUKI\",\"ua5GXy2uhBR\",\"KYXbIQBQgP1\",\"CFPrsD3dNeb\",\"PQEpIeuSTCN\",\"JrSIoCOdTH2\",\"lxxASQqPUqd\",\"K3jhn3TXF3a\",\"lpQvlm9czYE\",\"g5A3hiJlwmI\",\"VhRX5JDVo7R\",\"CKkE4GBJekz\",\"Qc9lf4VM9bD\",\"EUUkKEDoNsf\",\"nX05QLraDhO\",\"sesv0eXljBq\",\"RhJbg8UD75Q\",\"PA1spYiNZfv\",\"qxbsDd9QYv6\",\"fAsj6a4nudH\",\"xa4F6gesVJm\",\"roGdTjEqLZQ\",\"BNFrspDBKel\"],\"pe\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.oucode",
-        "Organisation unit code",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.oucode",
+            "Organisation unit code",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
 
     // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
     if (!expectPostgis) {
@@ -756,23 +756,22 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  @Disabled("Temporarly disabled")
   public void stageAndEventStatusActiveAndEventDate2021() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("outputType=ENROLLMENT")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=ZzYYXq4fJie.EVENT_STATUS:ACTIVE,A03MvHHogjR.EVENT_DATE:2021")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("outputType=ENROLLMENT")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ZzYYXq4fJie.EVENT_STATUS:ACTIVE,A03MvHHogjR.EVENT_DATE:2021")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -782,143 +781,282 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        100,
-        4,
-        4); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            100,
+            4,
+            4); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"ZzYYXq4fJie.EVENT_STATUS\":{\"name\":\"Event status, Baby Postnatal\"},\"A03MvHHogjR.EVENT_DATE\":{\"name\":\"Report date, Birth\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.occurreddate\":[],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.eventstatus",
-        "eventstatus",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.eventstatus",
+            "Event status",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "A03MvHHogjR.eventdate",
-        "occurreddate",
-        "DATE",
-        "java.time.LocalDate",
-        false,
-        true);
-
-    // Assert PostGIS-specific headers DO NOT exist if 'expectPostgis' is false
-    if (!expectPostgis) {
-      validateHeaderExistence(actualHeaders, "geometry", false);
-      validateHeaderExistence(actualHeaders, "longitude", false);
-      validateHeaderExistence(actualHeaders, "latitude", false);
-    }
+            response,
+            actualHeaders,
+            "A03MvHHogjR.eventdate",
+            "Report date",
+            "DATE",
+            "java.time.LocalDate",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
-    // 7. Assert row values by name (sample validation: evenly spaced rows, key columns).
+    // 7. Assert row values by name at specific indices (sorted results).
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-        response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
     validateRowValueByName(
-        response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 18
     validateRowValueByName(response, actualHeaders, 18, "ouname", "Kalainkay MCHP");
     validateRowValueByName(
-        response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+            response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 18, "enrollmentdate", "2022-12-29 12:05:00.0");
 
     // Validate selected values for row index 27
     validateRowValueByName(response, actualHeaders, 27, "ouname", "Moyeamoh CHP");
     validateRowValueByName(
-        response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+            response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 27, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 36
     validateRowValueByName(response, actualHeaders, 36, "ouname", "Madina Loko CHP");
     validateRowValueByName(
-        response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+            response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 36, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 45
     validateRowValueByName(response, actualHeaders, 45, "ouname", "Kamiendor MCHP");
     validateRowValueByName(
-        response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+            response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 45, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "ouname", "Bandajuma Sinneh MCHP");
     validateRowValueByName(
-        response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+            response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2022-12-28 12:05:00.0");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "ouname", "Needy CHC");
     validateRowValueByName(
-        response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+            response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 72
     validateRowValueByName(response, actualHeaders, 72, "ouname", "Konda CHP");
     validateRowValueByName(
-        response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+            response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 72, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 81
     validateRowValueByName(response, actualHeaders, 81, "ouname", "Foredugu MCHP");
     validateRowValueByName(
-        response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+            response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 81, "enrollmentdate", "2022-12-27 12:05:00.0");
 
     // Validate selected values for row index 90
     validateRowValueByName(response, actualHeaders, 90, "ouname", "Sindadu MCHP");
     validateRowValueByName(
-        response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
+            response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
     validateRowValueByName(response, actualHeaders, 90, "enrollmentdate", "2022-12-26 12:05:00.0");
+  }
 
-    // Validate selected values for row index 99
-    validateRowValueByName(response, actualHeaders, 99, "ouname", "MCH Static/U5");
+  @Test
+  public void stageAndEventStatusHeaderOnly() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("outputType=ENROLLMENT")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=A03MvHHogjR.EVENT_DATE:2021")
+                    .add("desc=enrollmentdate,ouname");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+            response,
+            expectPostgis,
+            100,
+            4,
+            4); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.eventstatus\":{\"name\":\"Event status\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"}},\"dimensions\":{\"ZzYYXq4fJie.eventstatus\":[],\"A03MvHHogjR.eventdate\":[\"2021\"],\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.eventstatus",
+            "Event status",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "A03MvHHogjR.eventdate",
+            "Report date",
+            "DATE",
+            "java.time.LocalDate",
+            false,
+            true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Youndu CHP");
     validateRowValueByName(
-        response, actualHeaders, 99, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
-    validateRowValueByName(response, actualHeaders, 99, "enrollmentdate", "2022-12-26 12:05:00.0");
+            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-12-29 12:05:00.0");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "ouname", "Mokobo MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 9, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2022-12-29 12:05:00.0");
+
+    // Validate selected values for row index 18
+    validateRowValueByName(response, actualHeaders, 18, "ouname", "Kalainkay MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 18, "A03MvHHogjR.eventdate", "2021-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 18, "enrollmentdate", "2022-12-29 12:05:00.0");
+
+    // Validate selected values for row index 27
+    validateRowValueByName(response, actualHeaders, 27, "ouname", "Moyeamoh CHP");
+    validateRowValueByName(
+            response, actualHeaders, 27, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 27, "enrollmentdate", "2022-12-28 12:05:00.0");
+
+    // Validate selected values for row index 36
+    validateRowValueByName(response, actualHeaders, 36, "ouname", "Madina Loko CHP");
+    validateRowValueByName(
+            response, actualHeaders, 36, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 36, "enrollmentdate", "2022-12-28 12:05:00.0");
+
+    // Validate selected values for row index 45
+    validateRowValueByName(response, actualHeaders, 45, "ouname", "Kamiendor MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 45, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 45, "enrollmentdate", "2022-12-28 12:05:00.0");
+
+    // Validate selected values for row index 54
+    validateRowValueByName(response, actualHeaders, 54, "ouname", "Bandajuma Sinneh MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 54, "A03MvHHogjR.eventdate", "2021-12-28 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2022-12-28 12:05:00.0");
+
+    // Validate selected values for row index 63
+    validateRowValueByName(response, actualHeaders, 63, "ouname", "Needy CHC");
+    validateRowValueByName(
+            response, actualHeaders, 63, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2022-12-27 12:05:00.0");
+
+    // Validate selected values for row index 72
+    validateRowValueByName(response, actualHeaders, 72, "ouname", "Konda CHP");
+    validateRowValueByName(
+            response, actualHeaders, 72, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 72, "enrollmentdate", "2022-12-27 12:05:00.0");
+
+    // Validate selected values for row index 81
+    validateRowValueByName(response, actualHeaders, 81, "ouname", "Foredugu MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 81, "A03MvHHogjR.eventdate", "2021-12-27 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 81, "enrollmentdate", "2022-12-27 12:05:00.0");
+
+    // Validate selected values for row index 90
+    validateRowValueByName(response, actualHeaders, 90, "ouname", "Sindadu MCHP");
+    validateRowValueByName(
+            response, actualHeaders, 90, "A03MvHHogjR.eventdate", "2021-12-26 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 90, "enrollmentdate", "2022-12-26 12:05:00.0");
   }
 
   @Test
@@ -928,18 +1066,18 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,lastupdated")
-            .add("lastUpdated=2017Feb")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("rowContext=true")
-            .add("pageSize=100")
-            .add("outputType=ENROLLMENT")
-            .add("page=1")
-            .add("dimension=ou:ImspTQPwCqd")
-            .add("desc=lastupdated");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,lastupdated")
+                    .add("lastUpdated=2017Feb")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("rowContext=true")
+                    .add("pageSize=100")
+                    .add("outputType=ENROLLMENT")
+                    .add("page=1")
+                    .add("dimension=ou:ImspTQPwCqd")
+                    .add("desc=lastupdated");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -949,43 +1087,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        20,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            20,
+            2,
+            2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017Feb\":{\"name\":\"February 2017 - January 2018\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017Feb\":{\"name\":\"February 2017 - January 2018\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "lastupdated",
-        "Last updated on",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "lastupdated",
+            "Last updated on",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -1025,17 +1163,17 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
       // Given
       QueryParamsBuilder params =
-          new QueryParamsBuilder()
-              .add("includeMetadataDetails=true")
-              .add("headers=ouname,created")
-              .add("displayProperty=NAME")
-              .add("totalPages=false")
-              .add("rowContext=true")
-              .add("pageSize=10")
-              .add("outputType=ENROLLMENT")
-              .add("page=1")
-              .add("dimension=ou:ImspTQPwCqd,CREATED:2017")
-              .add("desc=lastupdated,created,ouname");
+              new QueryParamsBuilder()
+                      .add("includeMetadataDetails=true")
+                      .add("headers=ouname,created")
+                      .add("displayProperty=NAME")
+                      .add("totalPages=false")
+                      .add("rowContext=true")
+                      .add("pageSize=10")
+                      .add("outputType=ENROLLMENT")
+                      .add("page=1")
+                      .add("dimension=ou:ImspTQPwCqd,CREATED:2017")
+                      .add("desc=lastupdated,created,ouname");
 
       // When
       ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1045,43 +1183,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
       //    This helper checks basic counts and dimensions, adapting based on the runtime
       // 'expectPostgis' flag.
       validateResponseStructure(
-          response,
-          expectPostgis,
-          10,
-          2,
-          2); // Pass runtime flag, row count, and expected header counts
+              response,
+              expectPostgis,
+              10,
+              2,
+              2); // Pass runtime flag, row count, and expected header counts
 
       // 2. Extract Headers into a List of Maps for easy access by name
       List<Map<String, Object>> actualHeaders =
-          response.extractList("headers", Map.class).stream()
-              .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-              .collect(Collectors.toList());
+              response.extractList("headers", Map.class).stream()
+                      .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                      .collect(Collectors.toList());
 
       // 3. Assert metaData.
       String expectedMetaData =
-          "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017\":{\"name\":\"2017\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"created\":{\"name\":\"Created\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"created\":[\"2017\"],\"ou\":[\"ImspTQPwCqd\"]}}";
+              "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2017\":{\"name\":\"2017\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"created\":{\"name\":\"Created\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"created\":[\"2017\"],\"ou\":[\"ImspTQPwCqd\"]}}";
       String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
       assertEquals(expectedMetaData, actualMetaData, false);
 
       // 4. Validate Headers By Name (conditionally checking PostGIS headers).
       validateHeaderPropertiesByName(
-          response,
-          actualHeaders,
-          "ouname",
-          "Organisation unit name",
-          "TEXT",
-          "java.lang.String",
-          false,
-          true);
+              response,
+              actualHeaders,
+              "ouname",
+              "Organisation unit name",
+              "TEXT",
+              "java.lang.String",
+              false,
+              true);
       validateHeaderPropertiesByName(
-          response,
-          actualHeaders,
-          "created",
-          "Created on",
-          "DATETIME",
-          "java.time.LocalDateTime",
-          false,
-          true);
+              response,
+              actualHeaders,
+              "created",
+              "Created on",
+              "DATETIME",
+              "java.time.LocalDateTime",
+              false,
+              true);
 
       // rowContext not found or empty in the response, skipping assertions.
 
@@ -1114,16 +1252,16 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
       // Given
       QueryParamsBuilder params =
-          new QueryParamsBuilder()
-              .add("includeMetadataDetails=true")
-              .add("headers=ouname,completed")
-              .add("displayProperty=NAME")
-              .add("totalPages=false")
-              .add("rowContext=true")
-              .add("pageSize=10")
-              .add("page=1")
-              .add("dimension=ou:ImspTQPwCqd,COMPLETED:2023")
-              .add("desc=lastupdated,completed,ouname");
+              new QueryParamsBuilder()
+                      .add("includeMetadataDetails=true")
+                      .add("headers=ouname,completed")
+                      .add("displayProperty=NAME")
+                      .add("totalPages=false")
+                      .add("rowContext=true")
+                      .add("pageSize=10")
+                      .add("page=1")
+                      .add("dimension=ou:ImspTQPwCqd,COMPLETED:2023")
+                      .add("desc=lastupdated,completed,ouname");
 
       // When
       ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1132,43 +1270,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
       //    This helper checks basic counts and dimensions, adapting based on the runtime
       // 'expectPostgis' flag.
       validateResponseStructure(
-          response,
-          expectPostgis,
-          3,
-          2,
-          2); // Pass runtime flag, row count, and expected header counts
+              response,
+              expectPostgis,
+              3,
+              2,
+              2); // Pass runtime flag, row count, and expected header counts
 
       // 2. Extract Headers into a List of Maps for easy access by name
       List<Map<String, Object>> actualHeaders =
-          response.extractList("headers", Map.class).stream()
-              .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-              .collect(Collectors.toList());
+              response.extractList("headers", Map.class).stream()
+                      .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                      .collect(Collectors.toList());
 
       // 3. Assert metaData.
       String expectedMetaData =
-          "{\"pager\":{\"isLastPage\":true,\"pageSize\":10,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2023\":{\"name\":\"2023\"},\"completed\":{\"name\":\"Completed\"},\"completeddate\":{\"name\":\"Completed date\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"completed\":[\"2023\"]}}";
+              "{\"pager\":{\"isLastPage\":true,\"pageSize\":10,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"2023\":{\"name\":\"2023\"},\"completed\":{\"name\":\"Completed\"},\"completeddate\":{\"name\":\"Completed date\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"completed\":[\"2023\"]}}";
       String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
       assertEquals(expectedMetaData, actualMetaData, false);
 
       // 4. Validate Headers By Name (conditionally checking PostGIS headers).
       validateHeaderPropertiesByName(
-          response,
-          actualHeaders,
-          "ouname",
-          "Organisation unit name",
-          "TEXT",
-          "java.lang.String",
-          false,
-          true);
+              response,
+              actualHeaders,
+              "ouname",
+              "Organisation unit name",
+              "TEXT",
+              "java.lang.String",
+              false,
+              true);
       validateHeaderPropertiesByName(
-          response,
-          actualHeaders,
-          "completed",
-          "Completed on",
-          "DATETIME",
-          "java.time.LocalDateTime",
-          false,
-          true);
+              response,
+              actualHeaders,
+              "completed",
+              "Completed on",
+              "DATETIME",
+              "java.time.LocalDateTime",
+              false,
+              true);
 
       // rowContext not found or empty in the response, skipping assertions.
 
@@ -1194,15 +1332,15 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("pageSize=100")
-            .add("page=1")
-            .add("dimension=pe:202301")
-            .add("desc=enrollmentdate,ouname");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=enrollmentdate,ZzYYXq4fJie.ouname")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=pe:202301")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1212,43 +1350,43 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        100,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            100,
+            2,
+            2); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
+            "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":false},\"items\":{\"ZzYYXq4fJie.ou\":{\"name\":\"Organisation unit\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ZzYYXq4fJie.ou\":[]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "enrollmentdate",
-        "Date of enrollment",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ZzYYXq4fJie.ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "ZzYYXq4fJie.ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
@@ -1256,7 +1394,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-01-31 12:05:00.0");
     validateRowValueByName(
-        response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
+            response, actualHeaders, 0, "ZzYYXq4fJie.ouname", "Under five (Luawa) Clinic");
 
     // Validate selected values for row index 9
     validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2023-01-31 12:05:00.0");
@@ -1281,7 +1419,7 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 54
     validateRowValueByName(response, actualHeaders, 54, "enrollmentdate", "2023-01-29 12:05:00.0");
     validateRowValueByName(
-        response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
+            response, actualHeaders, 54, "ZzYYXq4fJie.ouname", "Sandia (Kissi Tongi) CHP");
 
     // Validate selected values for row index 63
     validateRowValueByName(response, actualHeaders, 63, "enrollmentdate", "2023-01-29 12:05:00.0");
@@ -1305,23 +1443,20 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  public void ouMultipleLevels() throws JSONException {
+  public void validateStagePrefixedEventDateHeaderWithoutDimension() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
 
     // Given
     QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("includeMetadataDetails=true")
-            .add("headers=ouname,lastupdated")
-            .add("lastUpdated=201707")
-            .add("displayProperty=NAME")
-            .add("totalPages=false")
-            .add("rowContext=true")
-            .add("pageSize=100")
-            .add("outputType=ENROLLMENT")
-            .add("page=1")
-            .add("dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95");
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=A03MvHHogjR.eventdate,enrollmentdate,ouname")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("pageSize=20")
+                    .add("page=1")
+                    .add("desc=enrollmentdate,ouname");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -1331,37 +1466,152 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        expectPostgis,
-        1,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
+            response,
+            expectPostgis,
+            20,
+            3,
+            3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+            "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ouname",
-        "Organisation unit name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "A03MvHHogjR.eventdate",
+            "Report date",
+            "DATE",
+            "java.time.LocalDate",
+            false,
+            true);
     validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "lastupdated",
-        "Last updated on",
-        "DATETIME",
-        "java.time.LocalDateTime",
-        false,
-        true);
+            response,
+            actualHeaders,
+            "enrollmentdate",
+            "Date of enrollment",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(
+            response, actualHeaders, 0, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Yalieboya CHP");
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2023-12-29 12:05:00.0");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(
+            response, actualHeaders, 4, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 4, "ouname", "St. Luke's Wellington");
+    validateRowValueByName(response, actualHeaders, 4, "enrollmentdate", "2023-12-29 12:05:00.0");
+
+    // Validate selected values for row index 8
+    validateRowValueByName(
+            response, actualHeaders, 8, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 8, "ouname", "New Police Barracks CHC");
+    validateRowValueByName(response, actualHeaders, 8, "enrollmentdate", "2023-12-29 12:05:00.0");
+
+    // Validate selected values for row index 12
+    validateRowValueByName(
+            response, actualHeaders, 12, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(
+            response, actualHeaders, 12, "ouname", "Lungi Govt. Hospital, Port Loko");
+    validateRowValueByName(response, actualHeaders, 12, "enrollmentdate", "2023-12-29 12:05:00.0");
+
+    // Validate selected values for row index 16
+    validateRowValueByName(
+            response, actualHeaders, 16, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 16, "ouname", "Govt. Hospital");
+    validateRowValueByName(response, actualHeaders, 16, "enrollmentdate", "2023-12-29 12:05:00.0");
+
+    // Validate selected values for row index 19
+    validateRowValueByName(
+            response, actualHeaders, 19, "A03MvHHogjR.eventdate", "2022-12-29 00:00:00.0");
+    validateRowValueByName(response, actualHeaders, 19, "ouname", "Bumpeh CHP");
+    validateRowValueByName(response, actualHeaders, 19, "enrollmentdate", "2023-12-29 12:05:00.0");
+  }
+
+  @Test
+  public void ouMultipleLevels() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+            new QueryParamsBuilder()
+                    .add("includeMetadataDetails=true")
+                    .add("headers=ouname,lastupdated")
+                    .add("lastUpdated=201707")
+                    .add("displayProperty=NAME")
+                    .add("totalPages=false")
+                    .add("rowContext=true")
+                    .add("pageSize=100")
+                    .add("outputType=ENROLLMENT")
+                    .add("page=1")
+                    .add("dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+            response,
+            expectPostgis,
+            1,
+            2,
+            2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+                    .collect(Collectors.toList());
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "ouname",
+            "Organisation unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "lastupdated",
+            "Last updated on",
+            "DATETIME",
+            "java.time.LocalDateTime",
+            false,
+            true);
 
     // rowContext not found or empty in the response, skipping assertions.
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4170,4 +4170,30 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
     ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
     response.validate().statusCode(200).body("headers", hasSize(26));
   }
+
+  @Test
+  public void verifyDimensionAcceptsTeaAttributeAsHeader() {
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("displayProperty=NAME")
+            .add("outputType=EVENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=A03MvHHogjR.ou:USER_ORGUNIT")
+            .add("headers=cejWyOfXge6,A03MvHHogjR.ouname,A03MvHHogjR.eventdate")
+            .add("desc=eventdate,lastupdated");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj)
+            .collect(Collectors.toList());
+
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+    response.validate().statusCode(200).body("headers", hasSize(3));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4151,4 +4151,23 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
     // column ordering so the item value landed in the enrollmentouname cell and vice versa.
     validateRowValueByName(response, actualHeaders, 0, "enrollmentouname", "Baoma Station CHP");
   }
+
+  @Test
+  public void verifyDimensionAcceptsOuAndEnrollmentOu() {
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("displayProperty=NAME")
+            .add("outputType=EVENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ZkbAXlQUYJG.ou:USER_ORGUNIT")
+            .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
+            .add("desc=eventdate,lastupdated");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+    response.validate().statusCode(200).body("headers", hasSize(26));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4101,29 +4101,6 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  @DisplayName("Validate period dimension with stage-specific date dimension is rejected")
-  public void edoardo() {
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("displayProperty=NAME")
-            .add("outputType=EVENT")
-            .add("pageSize=100")
-            .add("page=1")
-            // .add("dimension=Zj7UnCAulEk.EVENT_DATE:THIS_YEAR")
-
-            .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
-            .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6");
-    // .add("desc=eventdate,lastupdated")
-    // .add("relativePeriodDate=2022-12-31");
-
-    // When
-    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
-    System.out.println(response.prettyPrint());
-  }
-
-  @Test
   public void validateStagePrefixedDataElementHeaderWithoutDimension() {
     // Given
     QueryParamsBuilder params =
@@ -4133,12 +4110,16 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
             .add("outputType=EVENT")
             .add("pageSize=100")
             .add("page=1")
-            .add("dimension=ENROLLMENT_OU:O6uvpzGd5pu")
+            .add("dimension=ENROLLMENT_OU:jNb63DIHuwU")
+            .add("dimension=A03MvHHogjR.EVENT_DATE:THIS_YEAR")
+            // .add("dimension=ou:O6uvpzGd5pu")
+
+            .add("relativePeriodDate=2022-12-31")
             .add("totalPages=false");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
-
+    System.out.println(response.prettyPrint());
     // Then
     response.validate().statusCode(200).body("headers", hasSize(2));
 
@@ -4165,5 +4146,9 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
         "java.lang.Double",
         false,
         true);
+
+    // Row cells must align with the requested headers. A prior regression swapped SQL and grid
+    // column ordering so the item value landed in the enrollmentouname cell and vice versa.
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentouname", "Baoma Station CHP");
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.analytics.event.query;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
 import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
@@ -4097,5 +4098,72 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
       validateRowValueByName(response, actualHeaders, 9, "oucode", "OU_559");
       validateRowValueByName(response, actualHeaders, 9, "incidentdate", "2021-09-10 12:27:48.552");
     }
+  }
+
+  @Test
+  @DisplayName("Validate period dimension with stage-specific date dimension is rejected")
+  public void edoardo() {
+
+    // Given
+    QueryParamsBuilder params =
+            new QueryParamsBuilder()
+                    .add("displayProperty=NAME")
+                    .add("outputType=EVENT")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    //.add("dimension=Zj7UnCAulEk.EVENT_DATE:THIS_YEAR")
+
+                    .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
+                    .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6");
+                    //.add("desc=eventdate,lastupdated")
+                    //.add("relativePeriodDate=2022-12-31");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+    System.out.println(response.prettyPrint());
+  }
+
+  @Test
+  public void validateStagePrefixedDataElementHeaderWithoutDimension() {
+    // Given
+    QueryParamsBuilder params =
+            new QueryParamsBuilder()
+                    .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6")
+                    .add("displayProperty=NAME")
+                    .add("outputType=EVENT")
+                    .add("pageSize=100")
+                    .add("page=1")
+                    .add("dimension=ENROLLMENT_OU:O6uvpzGd5pu")
+                    .add("totalPages=false");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    response.validate().statusCode(200).body("headers", hasSize(2));
+
+    List<Map<String, Object>> actualHeaders =
+            response.extractList("headers", Map.class).stream()
+                    .map(obj -> (Map<String, Object>) obj)
+                    .collect(Collectors.toList());
+
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "enrollmentouname",
+            "Enrollment org unit name",
+            "TEXT",
+            "java.lang.String",
+            false,
+            true);
+    validateHeaderPropertiesByName(
+            response,
+            actualHeaders,
+            "A03MvHHogjR.a3kGcGDCuk6",
+            "MCH Apgar Score",
+            "NUMBER",
+            "java.lang.Double",
+            false,
+            true);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4079,8 +4079,6 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
           false,
           true);
 
-      // rowContext not found or empty in the response, skipping assertions.
-
       // 7. Assert row values by name at specific indices (sorted results).
       // Validate selected values for row index 0
       validateRowValueByName(response, actualHeaders, 0, "oucode", "OU_559");

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4164,11 +4164,36 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
             .add("page=1")
             .add("dimension=ZkbAXlQUYJG.ou:USER_ORGUNIT")
             .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
+            .add("headers=enrollmentouname,ZkbAXlQUYJG.ouname")
             .add("desc=eventdate,lastupdated");
 
     // When
     ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
-    response.validate().statusCode(200).body("headers", hasSize(26));
+    response.validate().statusCode(200).body("headers", hasSize(2));
+
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj)
+            .collect(Collectors.toList());
+
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "enrollmentouname",
+        "Enrollment org unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ZkbAXlQUYJG.ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery6AutoTest.java
@@ -4106,17 +4106,17 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
 
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("displayProperty=NAME")
-                    .add("outputType=EVENT")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    //.add("dimension=Zj7UnCAulEk.EVENT_DATE:THIS_YEAR")
+        new QueryParamsBuilder()
+            .add("displayProperty=NAME")
+            .add("outputType=EVENT")
+            .add("pageSize=100")
+            .add("page=1")
+            // .add("dimension=Zj7UnCAulEk.EVENT_DATE:THIS_YEAR")
 
-                    .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
-                    .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6");
-                    //.add("desc=eventdate,lastupdated")
-                    //.add("relativePeriodDate=2022-12-31");
+            .add("dimension=ENROLLMENT_OU:USER_ORGUNIT")
+            .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6");
+    // .add("desc=eventdate,lastupdated")
+    // .add("relativePeriodDate=2022-12-31");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -4127,14 +4127,14 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
   public void validateStagePrefixedDataElementHeaderWithoutDimension() {
     // Given
     QueryParamsBuilder params =
-            new QueryParamsBuilder()
-                    .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6")
-                    .add("displayProperty=NAME")
-                    .add("outputType=EVENT")
-                    .add("pageSize=100")
-                    .add("page=1")
-                    .add("dimension=ENROLLMENT_OU:O6uvpzGd5pu")
-                    .add("totalPages=false");
+        new QueryParamsBuilder()
+            .add("headers=enrollmentouname,A03MvHHogjR.a3kGcGDCuk6")
+            .add("displayProperty=NAME")
+            .add("outputType=EVENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ENROLLMENT_OU:O6uvpzGd5pu")
+            .add("totalPages=false");
 
     // When
     ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
@@ -4143,27 +4143,27 @@ public class EventsQuery6AutoTest extends AnalyticsApiTest {
     response.validate().statusCode(200).body("headers", hasSize(2));
 
     List<Map<String, Object>> actualHeaders =
-            response.extractList("headers", Map.class).stream()
-                    .map(obj -> (Map<String, Object>) obj)
-                    .collect(Collectors.toList());
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj)
+            .collect(Collectors.toList());
 
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "enrollmentouname",
-            "Enrollment org unit name",
-            "TEXT",
-            "java.lang.String",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "enrollmentouname",
+        "Enrollment org unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
     validateHeaderPropertiesByName(
-            response,
-            actualHeaders,
-            "A03MvHHogjR.a3kGcGDCuk6",
-            "MCH Apgar Score",
-            "NUMBER",
-            "java.lang.Double",
-            false,
-            true);
+        response,
+        actualHeaders,
+        "A03MvHHogjR.a3kGcGDCuk6",
+        "MCH Apgar Score",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
@@ -176,6 +176,13 @@
       }
     },
     {
+      "name": "validateStagePrefixedEventDateHeaderWithoutDimension",
+      "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?includeMetadataDetails=true&headers=A03MvHHogjR.eventdate,enrollmentdate,ouname&displayProperty=NAME&totalPages=false&pageSize=100&page=1",
+      "version": {
+        "min": 43
+      }
+    },
+    {
       "name": "ouMultipleLevels",
       "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95&headers=ouname,lastupdated&totalPages=false&rowContext=true&lastUpdated=201707&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=ENROLLMENT",
       "version": {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
@@ -162,6 +162,13 @@
       }
     },
     {
+      "name": "stageAndEventStatusHeaderOnly",
+      "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?includeMetadataDetails=true&headers=ouname,enrollmentdate,ZzYYXq4fJie.eventstatus,A03MvHHogjR.eventdate&displayProperty=NAME&totalPages=false&outputType=ENROLLMENT&pageSize=100&page=1&dimension=A03MvHHogjR.EVENT_DATE:2021&desc=enrollmentdate,ouname",
+      "version": {
+        "min": 43
+      }
+    },
+    {
       "name": "fixedPeriod2017Feb",
       "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?dimension=ou:ImspTQPwCqd&headers=ouname,lastupdated&totalPages=false&rowContext=true&lastUpdated=2017Feb&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=ENROLLMENT&desc=lastupdated",
       "version": {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
@@ -184,7 +184,7 @@
     },
     {
       "name": "validateStagePrefixedEventDateHeaderWithoutDimension",
-      "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?includeMetadataDetails=true&headers=A03MvHHogjR.eventdate,enrollmentdate,ouname&displayProperty=NAME&totalPages=false&pageSize=100&page=1",
+      "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?includeMetadataDetails=true&headers=A03MvHHogjR.eventdate,enrollmentdate,ouname&displayProperty=NAME&totalPages=false&pageSize=20&page=1&desc=enrollmentdate,ouname",
       "version": {
         "min": 43
       }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
@@ -169,6 +169,13 @@
       }
     },
     {
+      "name": "validateStagePrefixedOuNameHeaderAlongsideEnrollmentOuName",
+      "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?includeMetadataDetails=true&headers=enrollmentdate,ZzYYXq4fJie.ouname&displayProperty=NAME&totalPages=false&pageSize=100&page=1&dimension=pe:202301&desc=enrollmentdate,ouname",
+      "version": {
+        "min": 43
+      }
+    },
+    {
       "name": "ouMultipleLevels",
       "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95&headers=ouname,lastupdated&totalPages=false&rowContext=true&lastUpdated=201707&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=ENROLLMENT",
       "version": {


### PR DESCRIPTION
## Sumamry

Extends the DHIS2-21344 fix (#23660) to cover stage-prefixed headers whose suffix is a **data element / attribute UID**, not just a static column name.

## Background — the previous fix (#23660, 6ce33d6)

The earlier PR addressed headers of the form `{stageUid}.{staticColumn}` — e.g. `A03MvHHogjR.eventstatus`. It lived in `ResponseHelper.normalizeHeaderForGrid`, which runs **after** SQL has executed: for each requested header, if the suffix matched an existing grid column (`eventstatus`, `eventdate`, `ouname`, …), the grid header was renamed in place to carry the stage prefix the client had asked for.

That solved the case where the column already existed in the result and just needed a stage-scoped name "reflected" back.

## This Fix

This PR fixes a different issue: headers of the form `{stageUid}.{dataElementUid}` (e.g. `A03MvHHogjR.a3kGcGDCuk6`) when the data element isn't in any `dimension=`. The column doesn't exist in the grid yet, so renaming it is not possible — it has to be selected.
