### PR TITLE
perf: Use Text-views for AttributeValues

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeService.java
@@ -29,10 +29,11 @@
  */
 package org.hisp.dhis.attribute;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 import org.hisp.dhis.attribute.exception.NonUniqueAttributeValueException;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -83,7 +84,7 @@ public interface AttributeService {
    */
   List<Attribute> getAllAttributes();
 
-  List<Attribute> getAttributesByIds(Collection<String> ids);
+  List<Attribute> getAttributesByIds(Stream<UID> ids);
 
   // -------------------------------------------------------------------------
   // AttributeValue

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeValues.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeValues.java
@@ -107,15 +107,15 @@ public sealed interface AttributeValues
    * @return the value or null if the attribute is not contained (undefined)
    */
   @CheckForNull
-  default String get(CharSequence attributeId) {
+  default String get(@CheckForNull CharSequence attributeId) {
     Text res = getText(attributeId);
     return res == null ? null : res.toString();
   }
 
   @CheckForNull
-  Text getText(CharSequence attributeId);
+  Text getText(@CheckForNull CharSequence attributeId);
 
-  default boolean contains(CharSequence attributeId) {
+  default boolean contains(@CheckForNull CharSequence attributeId) {
     return get(attributeId) != null;
   }
 
@@ -164,9 +164,9 @@ public sealed interface AttributeValues
   AttributeValues added(@Nonnull CharSequence attributeId, @CheckForNull CharSequence value);
 
   /**
-   * @param uid the attribute to remove
+   * @param attributeId the attribute to remove
    * @return a new set with the attribute removed
    */
   @Nonnull
-  AttributeValues removed(@Nonnull CharSequence uid);
+  AttributeValues removed(@Nonnull CharSequence attributeId);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeValues.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeValues.java
@@ -31,15 +31,13 @@ package org.hisp.dhis.attribute;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.jsontree.JsonBuilder;
+import org.hisp.dhis.jsontree.Text;
 import org.intellij.lang.annotations.Language;
 
 /**
@@ -56,7 +54,7 @@ import org.intellij.lang.annotations.Language;
  * @since 2.42
  */
 public sealed interface AttributeValues
-    extends Iterable<Map.Entry<String, String>>, Serializable, JsonBuilder.JsonEncodable
+    extends Iterable<Map.Entry<Text, Text>>, Serializable, JsonBuilder.JsonEncodable
     permits LazyAttributeValues {
 
   /**
@@ -68,7 +66,7 @@ public sealed interface AttributeValues
   }
 
   @Nonnull
-  static AttributeValues of(@Nonnull Map<String, String> values) {
+  static AttributeValues of(@Nonnull Map<CharSequence, CharSequence> values) {
     return LazyAttributeValues.of(values);
   }
 
@@ -99,26 +97,29 @@ public sealed interface AttributeValues
   int size();
 
   @Nonnull
-  Set<String> keys();
+  Stream<UID> keys();
 
   @Nonnull
-  Set<String> values();
+  Stream<Text> values();
 
   /**
    * @param attributeId the attribute to read
    * @return the value or null if the attribute is not contained (undefined)
    */
   @CheckForNull
-  String get(String attributeId);
+  default String get(CharSequence attributeId) {
+    Text res = getText(attributeId);
+    return res == null ? null : res.toString();
+  }
 
-  default boolean contains(String attributeId) {
+  @CheckForNull
+  Text getText(CharSequence attributeId);
+
+  default boolean contains(CharSequence attributeId) {
     return get(attributeId) != null;
   }
 
-  void forEach(BiConsumer<String, String> action);
-
-  @Nonnull
-  Stream<Map.Entry<String, String>> stream();
+  void forEach(BiConsumer<Text, Text> action);
 
   /**
    * JSON of the shape
@@ -160,39 +161,12 @@ public sealed interface AttributeValues
    * @return a new set with the attribute value added or changed to the provided value
    */
   @Nonnull
-  AttributeValues added(@Nonnull String attributeId, @CheckForNull String value);
+  AttributeValues added(@Nonnull CharSequence attributeId, @CheckForNull CharSequence value);
 
   /**
    * @param uid the attribute to remove
    * @return a new set with the attribute removed
    */
   @Nonnull
-  AttributeValues removed(@Nonnull String uid);
-
-  /**
-   * @param attributeIdMatches filter for keys
-   * @return a new set with all attributes removed that had a matching attribute ID (match true)
-   */
-  @Nonnull
-  AttributeValues removedAll(Predicate<String> attributeIdMatches);
-
-  /**
-   * @param mapper mapping function for values
-   * @return a new set with same keys but all values transformed by the mapper function
-   */
-  @Nonnull
-  AttributeValues mapValues(@Nonnull UnaryOperator<String> mapper);
-
-  /**
-   * @param mapper mapping function for keys
-   * @return a new set with same values but all keys transformed by the mapper function
-   */
-  @Nonnull
-  AttributeValues mapKeys(@Nonnull UnaryOperator<String> mapper);
-
-  default Map<String, String> toMap() {
-    return isEmpty()
-        ? Map.of()
-        : stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-  }
+  AttributeValues removed(@Nonnull CharSequence uid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
@@ -36,6 +36,8 @@ import static java.util.Arrays.copyOfRange;
 import static org.hisp.dhis.jsontree.JsonBuilder.createArray;
 import static org.hisp.dhis.jsontree.JsonBuilder.createObject;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
@@ -380,5 +382,23 @@ final class LazyAttributeValues implements AttributeValues {
   @Override
   public String toString() {
     return toObjectJson();
+  }
+
+  /*
+  Serialisation
+  */
+
+  @Serial
+  public Object writeReplace() {
+    return new SerializedAttributeValues(toString());
+  }
+
+  record SerializedAttributeValues(String json) implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    @Serial
+    private Object readResolve() {
+      return of(json);
+    }
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
@@ -40,24 +40,17 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonMixed;
-import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonString;
-import org.hisp.dhis.jsontree.JsonValue;
+import org.hisp.dhis.jsontree.JsonNode;
+import org.hisp.dhis.jsontree.Text;
 import org.intellij.lang.annotations.Language;
 
 /**
@@ -81,29 +74,42 @@ final class LazyAttributeValues implements AttributeValues {
 
   @Nonnull
   static AttributeValues of(@Nonnull @Language("json") String json) {
-    if ("{}".equals(json) || "[]".equals(json)) return empty();
+    return of((CharSequence) json);
+  }
+
+  @Nonnull
+  static AttributeValues of(@Nonnull CharSequence json) {
     if (json.isEmpty() || (json.charAt(0) != '{' && json.charAt(0) != '[')) throw illegalJson(json);
+    if (json.length() == 2
+        && ((json.charAt(0) == '{' && json.charAt(1) == '}')
+            || (json.charAt(0) == '[' && json.charAt(1) == ']'))) return empty();
     return new LazyAttributeValues(json, null, null);
   }
 
-  static AttributeValues of(@Nonnull Map<String, String> values) {
+  static AttributeValues of(@Nonnull Map<CharSequence, CharSequence> values) {
     if (values.isEmpty()) return empty();
-    LazyAttributeValues entries = new LazyAttributeValues(null, null, null);
-    if (values instanceof TreeMap<String, String> tm) {
-      entries.init(tm);
-    } else {
-      entries.init(new TreeMap<>(values));
-    }
-    return entries;
+    LazyAttributeValues res = new LazyAttributeValues(null, null, null);
+    res.init(values);
+    return res;
   }
 
-  @Language("json")
-  private String json;
+  private void init(@Nonnull Map<CharSequence, CharSequence> from) {
+    keys = new Text[from.size()];
+    values = new Text[keys.length];
+    int i = 0;
+    for (Map.Entry<CharSequence, CharSequence> e : from.entrySet()) {
+      keys[i] = Text.of(e.getKey());
+      values[i++] = Text.of(e.getValue());
+    }
+    sort2(keys, values);
+  }
 
-  private String[] keys;
-  private String[] values;
+  private CharSequence json;
 
-  private static final String[] NOTHING = new String[0];
+  private Text[] keys;
+  private Text[] values;
+
+  private static final Text[] NOTHING = new Text[0];
 
   private void init() {
     if (keys != null) return;
@@ -125,69 +131,61 @@ final class LazyAttributeValues implements AttributeValues {
    * from JSON multiple threads might concurrently invoke the initialisation wherefore this is
    * synchronized.
    */
-  private synchronized void initSync(@Nonnull String json) {
+  private synchronized void initSync(@Nonnull CharSequence json) {
     if (keys != null) return;
     JsonMixed objOrArr = JsonMixed.of(json);
     if (objOrArr.isNull() || objOrArr.isEmpty()) {
       initEmpty();
       return;
     }
-    // Note that this needs to go via TreeMap to ensure alphabetic ordering;
-    // using JSON value API directly is difficult due to incompatibility of lambdas and i-counters
+    int i = 0;
+    keys = new Text[objOrArr.size()];
+    values = new Text[keys.length];
     if (objOrArr.isObject()) {
-      init(parseObjectJson(objOrArr));
+      for (JsonNode e : objOrArr.node().members(JsonNode.Index.SKIP)) {
+        keys[i] = e.getKey();
+        values[i++] = extractValue(e.getIfExists("value"));
+      }
     } else if (objOrArr.isArray()) {
-      init(parseArrayJson(objOrArr));
+      for (JsonNode e : objOrArr.node().elements(JsonNode.Index.SKIP)) {
+        keys[i] = e.get("attribute").get("id").textValue();
+        values[i++] = extractValue(e.getIfExists("value"));
+      }
     } else throw illegalJson(json);
+    sort2(keys, values);
+  }
+
+  private static void sort2(Text[] keys, Text[] values) {
+    // Use a simple bubble sort for clarity
+    for (int i = 0; i < keys.length - 1; i++) {
+      for (int j = 0; j < keys.length - i - 1; j++) {
+        if (keys[j].compareTo(keys[j + 1]) > 0) {
+          // Swap keys
+          Text tempKey = keys[j];
+          keys[j] = keys[j + 1];
+          keys[j + 1] = tempKey;
+          // Swap values
+          Text tempVal = values[j];
+          values[j] = values[j + 1];
+          values[j + 1] = tempVal;
+        }
+      }
+    }
   }
 
   @Nonnull
-  private static IllegalArgumentException illegalJson(@Nonnull String json) {
+  private static IllegalArgumentException illegalJson(@Nonnull CharSequence json) {
     return new IllegalArgumentException("Not a valid attribute value JSON: " + json);
   }
 
   @Nonnull
-  private static TreeMap<String, String> parseObjectJson(JsonObject map) {
-    return map.entries()
-        .collect(
-            Collectors.toMap(
-                e -> e.getKey().toString(),
-                e -> parseValue(e.getValue().asObject().get("value")),
-                (a, b) -> a,
-                TreeMap::new));
-  }
-
-  @Nonnull
-  private static TreeMap<String, String> parseArrayJson(JsonArray arr) {
-    return arr.stream()
-        .map(JsonValue::asObject)
-        .collect(
-            Collectors.toMap(
-                obj -> obj.getObject("attribute").getString("id").string(),
-                obj -> parseValue(obj.get("value")),
-                (a, b) -> a,
-                TreeMap::new));
-  }
-
-  @Nonnull
-  private static String parseValue(JsonMixed value) {
-    if (value.isUndefined()) return "";
+  private static Text extractValue(JsonNode value) {
+    if (value == null) return Text.EMPTY;
     return switch (value.type()) {
-      case NULL -> "";
-      case STRING -> value.as(JsonString.class).string();
-      default -> value.toJson();
+      case NULL -> Text.EMPTY;
+      case STRING -> value.textValue();
+      default -> value.getDeclaration();
     };
-  }
-
-  private void init(TreeMap<String, String> from) {
-    keys = new String[from.size()];
-    values = new String[keys.length];
-    int i = 0;
-    for (Map.Entry<String, String> e : from.entrySet()) {
-      // Note: intern is used so all keys of the same attribute share a String instance
-      keys[i] = e.getKey().intern();
-      values[i++] = e.getValue();
-    }
   }
 
   @Override
@@ -204,55 +202,58 @@ final class LazyAttributeValues implements AttributeValues {
 
   @Nonnull
   @Override
-  public Set<String> keys() {
+  public Stream<UID> keys() {
     init();
-    return Set.of(keys);
+    return Stream.of(keys).map(UID::of);
   }
 
   @Nonnull
   @Override
-  public Set<String> values() {
+  public Stream<Text> values() {
     init();
-    return Set.of(values);
+    return Stream.of(values);
   }
 
   @CheckForNull
   @Override
-  public String get(String attributeId) {
+  public Text getText(CharSequence attributeId) {
     init();
-    int i = binarySearch(keys, attributeId);
+    Text key = Text.of(attributeId);
+    int i = binarySearch(keys, key);
     return i < 0 ? null : values[i];
   }
 
   @Nonnull
   @Override
-  public AttributeValues added(@Nonnull String attributeId, @CheckForNull String value) {
+  public AttributeValues added(
+      @Nonnull CharSequence attributeId, @CheckForNull CharSequence value) {
     if (value == null) return removed(attributeId);
     init();
-    int i = binarySearch(keys, attributeId);
+    Text key = Text.of(attributeId);
+    int i = binarySearch(keys, key);
     if (i >= 0) { // replace existing value
-      if (values[i].equals(value)) return this;
-      String[] newValues = values.clone();
-      newValues[i] = value;
+      if (values[i].contentEquals(value)) return this;
+      Text[] newValues = values.clone();
+      newValues[i] = Text.of(value);
       return new LazyAttributeValues(null, keys, newValues);
     }
     int insert = -(i + 1);
     int size = keys.length;
     if (insert == size) { // append
-      String[] newKeys = copyOf(keys, size + 1);
-      String[] newValues = copyOf(values, size + 1);
-      newKeys[size] = attributeId;
-      newValues[size] = value;
+      Text[] newKeys = copyOf(keys, size + 1);
+      Text[] newValues = copyOf(values, size + 1);
+      newKeys[size] = key;
+      newValues[size] = Text.of(value);
       return new LazyAttributeValues(null, newKeys, newValues);
     }
-    String[] newKeys = new String[size + 1];
-    String[] newValues = new String[size + 1];
+    Text[] newKeys = new Text[size + 1];
+    Text[] newValues = new Text[size + 1];
     if (insert > 0) {
       arraycopy(keys, 0, newKeys, 0, insert);
       arraycopy(values, 0, newValues, 0, insert);
     }
-    newKeys[insert] = attributeId;
-    newValues[insert] = value;
+    newKeys[insert] = key;
+    newValues[insert] = Text.of(value);
     int remaining = keys.length - insert;
     arraycopy(keys, insert, newKeys, insert + 1, remaining);
     arraycopy(values, insert, newValues, insert + 1, remaining);
@@ -261,9 +262,9 @@ final class LazyAttributeValues implements AttributeValues {
 
   @Nonnull
   @Override
-  public AttributeValues removed(@Nonnull String uid) {
+  public AttributeValues removed(@Nonnull CharSequence attributeId) {
     init();
-    int i = binarySearch(keys, uid);
+    int i = binarySearch(keys, Text.of(attributeId));
     if (i < 0) return this; // not contained
     if (size() == 1) {
       return empty();
@@ -277,8 +278,8 @@ final class LazyAttributeValues implements AttributeValues {
           null, copyOf(keys, keys.length - 1), copyOf(values, values.length - 1));
     }
     // remove in the middle
-    String[] newKeys = new String[keys.length - 1];
-    String[] newValues = new String[newKeys.length];
+    Text[] newKeys = new Text[keys.length - 1];
+    Text[] newValues = new Text[newKeys.length];
     arraycopy(keys, 0, newKeys, 0, i);
     arraycopy(values, 0, newValues, 0, i);
     int remaining = keys.length - i - 1;
@@ -287,73 +288,15 @@ final class LazyAttributeValues implements AttributeValues {
     return new LazyAttributeValues(null, newKeys, newValues);
   }
 
-  @Nonnull
   @Override
-  public AttributeValues removedAll(Predicate<String> attributeIdMatches) {
-    if (Stream.of(keys).noneMatch(attributeIdMatches)) return this;
-    int remove = (int) Stream.of(keys).filter(attributeIdMatches).count();
-    if (remove == size()) return empty();
-    int newSize = keys.length - remove;
-    String[] newKeys = new String[newSize];
-    String[] newValues = new String[newKeys.length];
-    int j = 0;
-    for (int i = 0; i < keys.length; i++) {
-      if (!attributeIdMatches.test(keys[i])) {
-        newKeys[j] = keys[i];
-        newValues[j++] = values[i];
-      }
-    }
-    return new LazyAttributeValues(null, newKeys, newValues);
-  }
-
-  @Nonnull
-  @Override
-  public AttributeValues mapValues(@Nonnull UnaryOperator<String> mapper) {
-    init();
-    return map(values, mapper);
-  }
-
-  @Nonnull
-  @Override
-  public AttributeValues mapKeys(@Nonnull UnaryOperator<String> mapper) {
-    init();
-    return map(keys, mapper);
-  }
-
-  @Nonnull
-  private AttributeValues map(String[] elements, @Nonnull UnaryOperator<String> f) {
-    String[] newElements = null;
-    for (int i = 0; i < elements.length; i++) {
-      String element = elements[i];
-      String mapped = f.apply(element);
-      if (!element.equals(mapped)) {
-        if (newElements == null) newElements = elements.clone();
-        newElements[i] = mapped;
-      }
-    }
-    if (newElements == null) return this; // no change happened
-    return elements == keys
-        ? new LazyAttributeValues(null, newElements, values)
-        : new LazyAttributeValues(null, keys, newElements);
-  }
-
-  @Override
-  public void forEach(BiConsumer<String, String> action) {
+  public void forEach(BiConsumer<Text, Text> action) {
     init();
     for (int i = 0; i < keys.length; i++) action.accept(keys[i], values[i]);
   }
 
   @Nonnull
   @Override
-  public Stream<Map.Entry<String, String>> stream() {
-    init();
-    if (isEmpty()) return Stream.empty();
-    return StreamSupport.stream(spliterator(), false);
-  }
-
-  @Nonnull
-  @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
+  public Iterator<Map.Entry<Text, Text>> iterator() {
     init();
     return new Iterator<>() {
       int i = 0;
@@ -364,7 +307,7 @@ final class LazyAttributeValues implements AttributeValues {
       }
 
       @Override
-      public Map.Entry<String, String> next() {
+      public Map.Entry<Text, Text> next() {
         if (i >= size())
           throw new NoSuchElementException("Next called without checking via hasNext");
         return Map.entry(keys[i], values[i++]);
@@ -391,12 +334,14 @@ final class LazyAttributeValues implements AttributeValues {
   @Nonnull
   @Override
   public String toObjectJson() {
-    if (json != null && json.charAt(0) == '{') return json;
-    init();
     if (isEmpty()) return "{}";
     return createObject(
             map ->
-                forEach((key, value) -> map.addObject(key, obj -> obj.addString("value", value))))
+                forEach(
+                    (key, value) -> {
+                      if (!value.isEmpty())
+                        map.addObject(key, obj -> obj.addString("value", value));
+                    }))
         .getDeclaration()
         .toString();
   }
@@ -404,7 +349,6 @@ final class LazyAttributeValues implements AttributeValues {
   @Nonnull
   @Override
   public String toArrayJson() {
-    init();
     if (isEmpty()) return "[]";
     return createArray(
             arr ->

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/LazyAttributeValues.java
@@ -219,6 +219,7 @@ final class LazyAttributeValues implements AttributeValues {
   @CheckForNull
   @Override
   public Text getText(CharSequence attributeId) {
+    if (attributeId == null) return null;
     init();
     Text key = Text.of(attributeId);
     int i = binarySearch(keys, key);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -89,6 +89,10 @@ public final class UID implements Serializable {
     return new UID(value);
   }
 
+  public static UID of(@Nonnull CharSequence value) {
+    return of(value.toString());
+  }
+
   @CheckForNull
   public static UID ofNullable(@CheckForNull String value) {
     return value == null ? null : of(value);

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/attribute/AttributeValuesTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/attribute/AttributeValuesTest.java
@@ -44,6 +44,7 @@ import java.util.function.BiConsumer;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.jsontree.Text;
 import org.junit.jupiter.api.Test;
+import org.springframework.util.SerializationUtils;
 
 /**
  * Unit test for {@link LazyAttributeValues} implementation.
@@ -221,5 +222,12 @@ class AttributeValuesTest {
     assertEquals(
         "[{\"value\":\"d\",\"attribute\":{\"id\":\"c\"}},{\"value\":\"y\",\"attribute\":{\"id\":\"x\"}}]",
         AttributeValues.of(Map.of("x", "y", "c", "d")).toArrayJson());
+  }
+
+  @Test
+  void testSerialisation() {
+    AttributeValues values = AttributeValues.of(Map.of("a", "b", "c", "d"));
+    AttributeValues copy = SerializationUtils.clone(values);
+    assertEquals(values, copy);
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/attribute/AttributeValuesTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/attribute/AttributeValuesTest.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.attribute;
 
-import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,7 +40,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.function.BiConsumer;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.jsontree.Text;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -79,20 +80,40 @@ class AttributeValuesTest {
 
   @Test
   void testKeys() {
-    assertEquals(Set.of(), AttributeValues.empty().keys());
-    assertEquals(Set.of(), AttributeValues.of(Map.of()).keys());
-    assertEquals(Set.of("a"), AttributeValues.of(Map.of("a", "b")).keys());
-    assertEquals(Set.of("a", "c"), AttributeValues.of(Map.of("a", "b", "c", "d")).keys());
-    assertEquals(Set.of("a"), AttributeValues.of("{\"a\": {\"value\":\"b\"}}").keys());
+    assertEquals(List.of(), AttributeValues.empty().keys().toList());
+    assertEquals(List.of(), AttributeValues.of(Map.of()).keys().toList());
+    assertEquals(
+        List.of(UID.of("a0123456789")),
+        AttributeValues.of(Map.of("a0123456789", "b")).keys().toList());
+    assertEquals(
+        List.of(UID.of("a0123456789"), UID.of("c0123456789")),
+        AttributeValues.of(Map.of("a0123456789", "b", "c0123456789", "d")).keys().toList());
+    assertEquals(
+        List.of(UID.of("a0123456789"), UID.of("c0123456789")),
+        AttributeValues.of(Map.of("c0123456789", "b", "a0123456789", "d")).keys().toList());
+    assertEquals(
+        List.of(UID.of("a0123456789")),
+        AttributeValues.of("{\"a0123456789\": {\"value\":\"b\"}}").keys().toList());
   }
 
   @Test
   void testValues() {
-    assertEquals(Set.of(), AttributeValues.empty().values());
-    assertEquals(Set.of(), AttributeValues.of(Map.of()).values());
-    assertEquals(Set.of("b"), AttributeValues.of(Map.of("a", "b")).values());
-    assertEquals(Set.of("b", "d"), AttributeValues.of(Map.of("a", "b", "c", "d")).values());
-    assertEquals(Set.of("b"), AttributeValues.of("{\"a\": {\"value\":\"b\"}}").values());
+    assertEquals(List.of(), AttributeValues.empty().values().toList());
+    assertEquals(List.of(), AttributeValues.of(Map.of()).values().toList());
+    assertEquals(
+        List.of("b"), AttributeValues.of(Map.of("a", "b")).values().map(Text::toString).toList());
+    assertEquals(
+        List.of("b", "d"),
+        AttributeValues.of(Map.of("a", "b", "c", "d")).values().map(Text::toString).toList());
+    assertEquals(
+        List.of("b"),
+        AttributeValues.of("{\"a\": {\"value\":\"b\"}}").values().map(Text::toString).toList());
+    assertEquals(
+        List.of("1", "2"),
+        AttributeValues.of("{\"y\": {\"value\":\"2\"}, \"x\": {\"value\": \"1\"}}")
+            .values()
+            .map(Text::toString)
+            .toList());
   }
 
   @Test
@@ -110,6 +131,8 @@ class AttributeValuesTest {
     assertFalse(AttributeValues.empty().contains("a"));
     assertFalse(AttributeValues.of("{}").contains("x"));
     assertFalse(AttributeValues.of(Map.of()).contains("y"));
+    assertFalse(AttributeValues.of("{\"a\": {\"value\":\"b\"}}").contains("b"));
+
     assertTrue(AttributeValues.of("{\"a\": {\"value\":\"b\"}}").contains("a"));
     assertTrue(AttributeValues.of(Map.of("a", "b")).contains("a"));
     assertTrue(AttributeValues.of(Map.of("a", "b", "c", "d")).contains("c"));
@@ -124,7 +147,7 @@ class AttributeValuesTest {
     assertEquals(AttributeValues.of(Map.of("c", "z", "b", "y")), by.added("c", "z"));
     assertEquals(AttributeValues.of(Map.of("a", "x", "b", "y", "c", "z")), axby.added("c", "z"));
     assertEquals(AttributeValues.of(Map.of("a", "7", "b", "y")), axby.added("a", "7"));
-    Map<String, String> expected = new HashMap<>();
+    Map<CharSequence, CharSequence> expected = new HashMap<>();
     AttributeValues actual = AttributeValues.empty();
     for (int i = -10; i < 10; i++) {
       String key = "" + ('a' + i);
@@ -154,34 +177,15 @@ class AttributeValuesTest {
     AttributeValues.of("{}").forEach((k, v) -> fail("should not be called"));
     AttributeValues.of(Map.of()).forEach((k, v) -> fail("should not be called"));
     Map<String, String> res = new HashMap<>();
-    AttributeValues.of("{\"a\": {\"value\":\"b\"}}").forEach(res::put);
+    BiConsumer<Text, Text> put = (key, value) -> res.put(key.toString(), value.toString());
+    AttributeValues.of("{\"a\": {\"value\":\"b\"}}").forEach(put);
     assertEquals(Map.of("a", "b"), res);
     res.clear();
-    AttributeValues.of(Map.of("a", "b")).forEach(res::put);
+    AttributeValues.of(Map.of("a", "b")).forEach(put);
     assertEquals(Map.of("a", "b"), res);
     res.clear();
-    AttributeValues.of(Map.of("a", "b", "c", "d")).forEach(res::put);
+    AttributeValues.of(Map.of("a", "b", "c", "d")).forEach(put);
     assertEquals(Map.of("a", "b", "c", "d"), res);
-  }
-
-  @Test
-  void testStream() {
-    assertEquals(List.of(), AttributeValues.empty().stream().toList());
-    assertEquals(List.of(), AttributeValues.of("{}").stream().toList());
-    assertEquals(List.of(), AttributeValues.of(Map.of()).stream().toList());
-    assertEquals(
-        Map.of("a", "b"),
-        AttributeValues.of("{\"a\": {\"value\":\"b\"}}").stream()
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    assertTrue(AttributeValues.of(Map.of("a", "b")).contains("a"));
-    assertEquals(
-        Map.of("a", "b"),
-        AttributeValues.of(Map.of("a", "b")).stream()
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    assertEquals(
-        Map.of("a", "b", "c", "d"),
-        AttributeValues.of(Map.of("a", "b", "c", "d")).stream()
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
   @Test
@@ -190,8 +194,7 @@ class AttributeValuesTest {
     assertEquals("{}", AttributeValues.of("{}").toObjectJson());
     assertEquals("{}", AttributeValues.of(Map.of()).toObjectJson());
     AttributeValues fromJson = AttributeValues.of("{\"a\": {\"value\":\"b\"}}");
-    assertEquals("{\"a\": {\"value\":\"b\"}}", fromJson.toObjectJson());
-    // note that the JSON is different in whitespace because when constructed from JSON the original
+    assertEquals("{\"a\":{\"value\":\"b\"}}", fromJson.toObjectJson());
     // JSON is returned while when constructed from a map the JSON is composed
     assertEquals("{\"a\":{\"value\":\"b\"}}", AttributeValues.of(Map.of("a", "b")).toObjectJson());
     // however, once the JSON got parsed internally the toJson is computed again
@@ -202,6 +205,10 @@ class AttributeValuesTest {
     assertEquals(
         "{\"c\":{\"value\":\"d\"},\"x\":{\"value\":\"y\"}}",
         AttributeValues.of(Map.of("x", "y", "c", "d")).toObjectJson());
+    // empty attributes are stripped
+    AttributeValues values =
+        AttributeValues.of("{\"a\": {\"value\":\"b\"}, \"b\": {\"value\":\"\"}}");
+    assertEquals("{\"a\":{\"value\":\"b\"}}", values.toObjectJson());
   }
 
   @Test
@@ -214,45 +221,5 @@ class AttributeValuesTest {
     assertEquals(
         "[{\"value\":\"d\",\"attribute\":{\"id\":\"c\"}},{\"value\":\"y\",\"attribute\":{\"id\":\"x\"}}]",
         AttributeValues.of(Map.of("x", "y", "c", "d")).toArrayJson());
-  }
-
-  @Test
-  void testMapKeys() {
-    assertEquals(AttributeValues.empty(), AttributeValues.empty().mapKeys(v -> v.repeat(2)));
-    assertEquals(
-        AttributeValues.of(Map.of("aa", "b")),
-        AttributeValues.of(Map.of("a", "b")).mapKeys(v -> v.repeat(2)));
-  }
-
-  @Test
-  void testMapValues() {
-    assertEquals(AttributeValues.empty(), AttributeValues.empty().mapValues(v -> v.repeat(2)));
-    assertEquals(
-        AttributeValues.of(Map.of("a", "bb")),
-        AttributeValues.of(Map.of("a", "b")).mapValues(v -> v.repeat(2)));
-  }
-
-  @Test
-  void testRemovedAll() {
-    assertEquals(AttributeValues.empty(), AttributeValues.empty().removedAll(id -> true));
-    assertEquals(AttributeValues.empty(), AttributeValues.empty().removedAll(id -> false));
-    assertEquals(
-        AttributeValues.of(Map.of("a", "b")),
-        AttributeValues.of(Map.of("a", "b")).removedAll("c"::equals));
-    assertEquals(
-        AttributeValues.empty(), AttributeValues.of(Map.of("a", "b")).removedAll("a"::equals));
-    AttributeValues before = AttributeValues.of(Map.of("a", "x", "b", "y", "c", "z"));
-    assertEquals(AttributeValues.of(Map.of("b", "y", "c", "z")), before.removedAll("a"::equals));
-    assertEquals(AttributeValues.of(Map.of("a", "x", "c", "z")), before.removedAll("b"::endsWith));
-    assertEquals(
-        AttributeValues.of(Map.of("a", "x", "b", "y")), before.removedAll("c"::startsWith));
-    assertEquals(AttributeValues.of(Map.of("b", "y")), before.removedAll(id -> id.matches("[ac]")));
-    assertSame(before, before.removedAll("r"::equals));
-  }
-
-  @Test
-  void testToMap() {
-    assertEquals(Map.of(), AttributeValues.empty().toMap());
-    assertEquals(Map.of("a", "1"), AttributeValues.of(Map.of("a", "1")).toMap());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -31,9 +31,9 @@ package org.hisp.dhis.attribute;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.hisp.dhis.attribute.exception.NonUniqueAttributeValueException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -118,8 +118,8 @@ public class DefaultAttributeService implements AttributeService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<Attribute> getAttributesByIds(Collection<String> ids) {
-    return attributeStore.getByUid(ids);
+  public List<Attribute> getAttributesByIds(Stream<UID> ids) {
+    return attributeStore.getByUid(ids.map(UID::getValue).toList());
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -391,7 +391,8 @@ public class DefaultPreheatService implements PreheatService {
             object
                 .getAttributeValues()
                 .forEach(
-                    (attributeId, value) -> {
+                    (key, value) -> {
+                      String attributeId = key.toString();
                       Set<String> uids = preheat.getUniqueAttributes().get(klass);
                       if (uids != null && uids.contains(attributeId)) {
                         Map<String, Map<String, String>> values =
@@ -399,7 +400,7 @@ public class DefaultPreheatService implements PreheatService {
                         if (!values.containsKey(attributeId)) {
                           values.put(attributeId, new HashMap<>());
                         }
-                        values.get(attributeId).put(value, object.getUid());
+                        values.get(attributeId).put(value.toString(), object.getUid());
                       }
                     }));
   }
@@ -487,7 +488,7 @@ public class DefaultPreheatService implements PreheatService {
                   (attributeId, value) ->
                       map.get(PreheatIdentifier.UID)
                           .computeIfAbsent(Attribute.class, k -> new HashSet<>())
-                          .add(attributeId));
+                          .add(attributeId.toString()));
           identifiableObject
               .getSharing()
               .getUserGroups()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -33,7 +33,6 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.SortableObject;
@@ -70,7 +69,6 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
     }
 
     Schema schema = schemaService.getSchema(HibernateProxyUtils.getRealClass(identifiableObject));
-    handleAttributeValues(identifiableObject, schema);
     handleSkipSharing(identifiableObject, bundle);
     handleSkipTranslation(identifiableObject, bundle);
     handleSortOrder(identifiableObject, bundle, schema);
@@ -136,15 +134,7 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
     handleCreatedByProperty(object, persistedObject, bundle);
 
     Schema schema = schemaService.getSchema(HibernateProxyUtils.getRealClass(object));
-    handleAttributeValues(object, schema);
     handleSortOrder(object, bundle, schema);
-  }
-
-  private void handleAttributeValues(IdentifiableObject object, Schema schema) {
-    if (!schema.hasPersistedProperty("attributeValues")) return;
-
-    object.setAttributeValues(
-        object.getAttributeValues().mapValues(v -> v.replaceAll("\\s{2,}", StringUtils.SPACE)));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.schema.Schema;
 import org.springframework.stereotype.Component;
 
@@ -143,12 +144,13 @@ public class GeoJsonAttributesCheck implements ObjectValidationCheck {
    *
    * <p>If Jackson throws error then create new ErrorReport with ErrorCode.E6004
    *
-   * @param attributeId the ID of the attribute being checked
-   * @param attributeValue the validated value for the attribute with the provided ID
+   * @param key the ID of the attribute being checked
+   * @param value the validated value for the attribute with the provided ID
    * @param addError ErrorReport consumer.
    */
-  private void validateGeoJsonValue(
-      String attributeId, String attributeValue, Consumer<ErrorReport> addError) {
+  private void validateGeoJsonValue(Text key, Text value, Consumer<ErrorReport> addError) {
+    String attributeId = key.toString();
+    String attributeValue = value.toString();
     try {
       validateGeoJsonObject(
           objectMapper.readValue(attributeValue, GeoJsonObject.class), attributeId, addError);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
@@ -131,7 +131,8 @@ public class GeoJsonAttributesCheck implements ObjectValidationCheck {
     object
         .getAttributeValues()
         .forEach(
-            (attributeId, value) -> {
+            (key, value) -> {
+              String attributeId = key.toString();
               if (attributes.contains(attributeId))
                 validateGeoJsonValue(attributeId, value, errorReports::add);
             });
@@ -148,8 +149,8 @@ public class GeoJsonAttributesCheck implements ObjectValidationCheck {
    * @param value the validated value for the attribute with the provided ID
    * @param addError ErrorReport consumer.
    */
-  private void validateGeoJsonValue(Text key, Text value, Consumer<ErrorReport> addError) {
-    String attributeId = key.toString();
+  private void validateGeoJsonValue(
+      String attributeId, Text value, Consumer<ErrorReport> addError) {
     String attributeValue = value.toString();
     try {
       validateGeoJsonObject(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
@@ -96,11 +96,13 @@ public class MetadataAttributeCheck implements ObjectValidationCheck {
       object
           .getAttributeValues()
           .forEach(
-              (attributeId, value) ->
-                  getValueType(attributeId, attributesMap, klass.getSimpleName(), errorReports::add)
-                      .ifPresent(
-                          type -> attributeValidator.validate(type, value, errorReports::add)));
-
+              (key, value) -> {
+                String attributeId = key.toString();
+                getValueType(attributeId, attributesMap, klass.getSimpleName(), errorReports::add)
+                    .ifPresent(
+                        type ->
+                            attributeValidator.validate(type, value.toString(), errorReports::add));
+              });
       if (!errorReports.isEmpty()) {
         addReports.accept(createObjectReport(errorReports, object, bundle));
         ctx.markForRemoval(object);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -265,8 +265,10 @@ public class ReferencesCheck implements ValidationCheck {
       List<PreheatErrorReport> preheatErrorReports) {
     object
         .getAttributeValues()
+        .keys()
         .forEach(
-            (attributeId, value) -> {
+            key -> {
+              String attributeId = key.toString();
               if (preheat.get(PreheatIdentifier.UID, Attribute.class, attributeId) == null) {
                 preheatErrorReports.add(
                     new PreheatErrorReport(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -105,7 +105,9 @@ public class UniqueAttributesCheck implements ObjectValidationCheck {
     object
         .getAttributeValues()
         .forEach(
-            (attributeId, value) -> {
+            (key, val) -> {
+              String attributeId = key.toString();
+              String value = val.toString();
               Attribute attribute = preheat.get(identifier, Attribute.class, attributeId);
 
               if (attribute == null || !attribute.isUnique() || StringUtils.isEmpty(value)) {

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -74,6 +74,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -379,14 +379,15 @@ public class FieldFilterService {
     source
         .getAttributeValues()
         .forEach(
-            (attributeId, value) -> {
+            (key, value) -> {
+              String attributeId = key.toString();
               ObjectNode attrValueNode = attributes.addObject();
-              attrValueNode.put("value", value);
+              attrValueNode.put("value", value.toString());
               attrValueNode.set(
                   "attribute",
                   attributeProperties.computeIfAbsent(
                       attributeId,
-                      key -> {
+                      k -> {
                         Attribute attribute = attributeService.getAttribute(attributeId);
                         List<ObjectNode> res = new ArrayList<>(1);
                         toObjectNodes(


### PR DESCRIPTION
### Summary
Inspired by the `Text`-views utilized by `json-tree` from 1.9 I noticed that `AttributeValues` go through a `TreeMap` during construction and store content as `String` keys and values which makes them far more memory heavy then they need to be.

So in this PR I refactored the code to not utilize the `TreeMap` to apply the alphabetical sorting and to keep keys and values as `Text`. Also the API is mostly now accepting `CharSequence` to avoid unnecessary `toString()` conversions. The main idea is to keep the memory footprint of `AttributeValues` as small as possible since we might have a lot of objects with a lot of attribute values in memory. 

### API Changes
I removed methods that would have needed adjustment but which were only used by tests.
Most methods accepting keys they now do so as `CharSequence` to allow both `String` and e.g. `Text` and do the most efficient for the different usage scenarios. 

### Rewriting in Bundle Hooks
I found that the only place where attributes where re-written was in the bundle hooks. Digging a bit deeper I found that this was originally to remove empty values from the set. With the `AttributeValues` now being a set representation this removal happens transparently in the `toObjectJson()` which is used in the persistence mapping. This is way more efficient and much simpler.  

### Serialization
One type of issues that would pop up after the change was that up until now `AttributeValues` did not have explicit serialization so it would simply be based on the fields. With them changed to `Text` this no longer worked. Also this never was a good serialized form for a value that literally is input and stored in terms of a JSON string. So the natural fix was to use the JSON as the serialized form.  