### PR TITLE
chore: improve perf-test job summary for gstat compare [DHIS2-21360]

### DIFF
--- a/.github/workflows/performance-tests-compare.yml
+++ b/.github/workflows/performance-tests-compare.yml
@@ -330,21 +330,46 @@ jobs:
 
         echo "## 📥 Download Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Download all results from all attempts:" >> $GITHUB_STEP_SUMMARY
+        echo "Recommended (single artifact, layout works directly with [gatling-statistics](https://github.com/dhis2/gatling-statistics)):" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "gh run download --repo dhis2/dhis2-core ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "gh run download ${{ github.run_id }} --repo dhis2/dhis2-core \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --name gatling-report-${{ github.run_id }}-${{ github.sha }}-attempt-${{ github.run_attempt }} \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --dir ./compare-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "All attempts (one wrapper directory per artifact, not readable by gstat directly):" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gh run download ${{ github.run_id }} --repo dhis2/dhis2-core" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         echo "## 📊 View Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Results are in \`gatling-report-${{ github.run_id }}-${{ github.sha }}-attempt-${{ github.run_attempt }}/\` with subdirectories:" >> $GITHUB_STEP_SUMMARY
+        echo "After the recommended download command above, the layout is \`./compare-${{ github.run_id }}/\` containing:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "* **Baseline warmup runs** (if WARMUP > 0): \`<simulation-class>-<timestamp>-baseline-warmup-<number>/\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Baseline**: \`<simulation-class>-<timestamp>-baseline/\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Candidate warmup runs** (if WARMUP > 0): \`<simulation-class>-<timestamp>-candidate-warmup-<number>/\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Candidate**: \`<simulation-class>-<timestamp>-candidate/\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### Per-run percentiles" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gstat ./compare-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### Compare baseline vs candidate" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gstat compare \\" >> $GITHUB_STEP_SUMMARY
+        echo "  ./compare-${{ github.run_id }}/*-baseline  --label baseline \\" >> $GITHUB_STEP_SUMMARY
+        echo "  ./compare-${{ github.run_id }}/*-candidate --label candidate \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --percentile 95 --method tdigest" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Each directory contains:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -228,16 +228,24 @@ jobs:
 
         echo "## 📥 Download Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Download all results from all attempts:" >> $GITHUB_STEP_SUMMARY
+        echo "Recommended (per-test artifact, layout works directly with [gatling-statistics](https://github.com/dhis2/gatling-statistics)):" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "gh run download --repo dhis2/dhis2-core ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "gh run download ${{ github.run_id }} --repo dhis2/dhis2-core \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --name gatling-report-${{ inputs.test_name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }} \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --dir ./${{ inputs.test_name }}-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "All attempts (one wrapper directory per artifact, not readable by gstat directly):" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gh run download ${{ github.run_id }} --repo dhis2/dhis2-core" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         echo "## 📊 View Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Results are in \`gatling-report-${{ inputs.test_name }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}/\` with subdirectories:" >> $GITHUB_STEP_SUMMARY
+        echo "After the recommended download command above, the layout is \`./${{ inputs.test_name }}-${{ github.run_id }}/\` containing:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         if [ "$WARMUP_COUNT" -gt 0 ]; then
           echo "* **Warmup runs**: \`<simulation-class>-<timestamp>-${{ inputs.test_name }}-warmup-<number>/\`" >> $GITHUB_STEP_SUMMARY
@@ -256,6 +264,31 @@ jobs:
         echo "* \`dhis.log\` - DHIS2 application log (if DHIS2 logging enabled)" >> $GITHUB_STEP_SUMMARY
         echo "* \`postgresql.log\` - PostgreSQL query logs (if SQL logging enabled)" >> $GITHUB_STEP_SUMMARY
         echo "* \`pgbadger.html\` - SQL log analysis report (if SQL logging enabled)" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### Per-run percentiles" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gstat ./${{ inputs.test_name }}-${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### Compare with another run" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Download a second run the same way (replace \`<other-run-id>\` and \`<other-test-name>\`), then run \`gstat compare\` with the baseline first:" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "gh run download <other-run-id> --repo dhis2/dhis2-core \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --name gatling-report-<other-test-name>-<other-run-id>-attempt-1 \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --dir ./<other-test-name>-<other-run-id>" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "gstat compare \\" >> $GITHUB_STEP_SUMMARY
+        echo "  ./<other-test-name>-<other-run-id> \\" >> $GITHUB_STEP_SUMMARY
+        echo "  ./${{ inputs.test_name }}-${{ github.run_id }} \\" >> $GITHUB_STEP_SUMMARY
+        echo "  --percentile 95 --method tdigest" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Tip**: \`gstat compare\` uses each input directory's basename as the column header. Pick a short, meaningful \`test_name\` (e.g. \`2.43.0-load-2u\`) so the table reads cleanly. Override per input with \`--label NAME\`." >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         echo "## 🖥️ Environment" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Updates the job summary in both perf-test workflows to print copy-pasteable `gh run download` and `gstat`/`gstat compare` commands. The recommended download form now produces a layout that [gatling-statistics](https://github.com/dhis2/gatling-statistics) reads directly (no manual unwrapping).

* `performance-tests.yml` (single test): adds 'Per-run percentiles' and 'Compare with another run' subsections under '📊 View Results'.
* `performance-tests-compare.yml` (baseline + candidate): adds 'Per-run percentiles' and 'Compare baseline vs candidate' subsections; the compare command resolves both report dirs from the single artifact via `*-baseline` / `*-candidate` globs.

Issue: [DHIS2-21360](https://dhis2.atlassian.net/browse/DHIS2-21360)

## Why these specific commands

The recommended download command is `gh run download <run-id> --name <artifact> --dir ./<test-name>-<run-id>`. Investigation in DHIS2-21360 confirmed:

* Bare `gh run download <run-id>` creates a per-artifact wrapper directory (`gatling-report-<name>-<run-id>-attempt-N/`) that contains the Gatling report dirs. gstat looks one level deep for Gatling report dirs (`<sim>-<17-digit-ts>[-suffix]/`), and the wrapper name doesn't match that pattern, so pointing gstat at the parent fails. The wrapper layout is a `gh` CLI behavior, not configurable in `actions/upload-artifact` v6/v7.
* `--name <artifact>` strips the wrapper; `--dir <path>` chooses the root. Combining both lands the Gatling report dirs directly under a directory named for the test, so `gstat ./<test-name>-<run-id>` works without further moves.
* The bare form is documented as a fallback for users who want all attempts.

## Why `--method tdigest` in the compare command

`gstat compare` defaults to `--method exact` (numpy percentile). The suggested commands explicitly pass `--method tdigest` because Gatling itself uses [t-digest](https://github.com/tdunning/t-digest), so percentiles match what the user sees in the Gatling HTML report (`index.html`) that the run page links to. With `exact` the values can differ by a few ms on long-tail requests, which looks like a bug when cross-checking the table against the HTML report.

## Test plan

* [x] YAML syntax validates (both files load via `yaml.safe_load`)
* [ ] Trigger one `performance-tests.yml` run pointing at this commit; confirm the rendered job summary
* [ ] Trigger one `performance-tests-compare.yml` run pointing at this commit; confirm the rendered job summary, including that the `gstat compare` command resolves baseline/candidate via the glob

## Out of scope (follow-ups)

* Running `gstat compare` inside CI and writing the Markdown table directly into `$GITHUB_STEP_SUMMARY`. Would remove the need to download to see the table; deferred until the gstat side stabilises.
* Recursive Gatling-report discovery in gstat itself, which would make the bare `gh run download` layout work without the `--name --dir` form. Tracked on the gstat side.

[DHIS2-21360]: https://dhis2.atlassian.net/browse/DHIS2-21360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ