### PR TITLE
docs: improve Javadocs for the OAuth2 authorization server

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2GrantTypes.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2GrantTypes.java
@@ -35,6 +35,11 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 /**
  * Shared helpers for Spring Authorization Server {@link AuthorizationGrantType} values.
  *
+ * <p>Used by {@code Dhis2OAuth2ClientServiceImpl} when building a Spring AS {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClient} from a
+ * persisted {@link org.hisp.dhis.security.oauth2.client.Dhis2OAuth2Client}, where the stored
+ * grant-type strings need to be resolved back to Spring's typed constants.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public final class OAuth2GrantTypes {
@@ -44,7 +49,7 @@ public final class OAuth2GrantTypes {
   /**
    * Map a grant-type string back to Spring's canonical {@link AuthorizationGrantType} singleton
    * (authorization_code, client_credentials, refresh_token, device_code). Falls back to a new
-   * instance for any custom value — the equality contract on {@code AuthorizationGrantType} is
+   * instance for any custom value. The equality contract on {@code AuthorizationGrantType} is
    * value-based, but returning the singleton where possible keeps identity comparisons working.
    *
    * <p>Case labels are the RFC-defined grant-type strings (RFC 6749 + RFC 8628); they match

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2Authorization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2Authorization.java
@@ -62,6 +62,8 @@ import org.hisp.dhis.common.SecondaryMetadataObject;
  * /api/metadata} export; token-bearing fields are additionally {@link JsonIgnore}'d so no REST
  * surface can leak them even on explicit requests. Persistence uses Hibernate field access ({@code
  * Dhis2OAuth2Authorization.hbm.xml}) and is independent of the JSON annotations.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Getter
 @Setter
@@ -73,11 +75,32 @@ public class Dhis2OAuth2Authorization extends BaseIdentifiableObject
   /** Required by Hibernate + Jackson for reflective instantiation. */
   public Dhis2OAuth2Authorization() {}
 
+  /**
+   * Reference to the {@link org.hisp.dhis.security.oauth2.client.Dhis2OAuth2Client} this grant was
+   * issued to. Holds the internal id of the registered client, not its public {@code clientId}.
+   */
   @JsonProperty private String registeredClientId;
+
+  /**
+   * Name of the resource owner the grant is tied to. For user-delegated flows this is the DHIS2
+   * username; for {@code client_credentials} it is the client itself.
+   */
   @JsonProperty private String principalName;
+
+  /**
+   * The grant type that produced this authorization (e.g. {@code authorization_code}, {@code
+   * client_credentials}, {@code refresh_token}, {@code
+   * urn:ietf:params:oauth:grant-type:device_code}).
+   */
   @JsonProperty private String authorizationGrantType;
+
+  /** Comma-separated list of scopes that were actually granted for this authorization. */
   @JsonProperty private String authorizedScopes;
+
+  /** JSON-encoded Spring AS attributes map (authenticated principal, request metadata, etc.). */
   @JsonIgnore private String attributes;
+
+  /** Opaque {@code state} value used by Spring AS for OAuth2 CSRF protection during the flow. */
   @JsonIgnore private String state;
 
   @JsonIgnore private String authorizationCodeValue;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationStore.java
@@ -33,7 +33,19 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-/** Store for OAuth2Authorization entities. */
+/**
+ * Persistence store for {@link Dhis2OAuth2Authorization}. These lookup methods back Spring
+ * Authorization Server's {@link
+ * org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService}
+ * implementation, in particular its {@code findByToken(String, OAuth2TokenType)} contract.
+ *
+ * <p>{@link #getByToken(String)} has union semantics: it searches across every token column on
+ * {@link Dhis2OAuth2Authorization} (authorization code, access token, refresh token, OIDC ID token,
+ * user code, device code) and returns the first matching row, which is what Spring AS needs when
+ * asked to resolve a token without knowing its type up-front.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 public interface Dhis2OAuth2AuthorizationStore
     extends IdentifiableObjectStore<Dhis2OAuth2Authorization> {
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2Client.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2Client.java
@@ -38,6 +38,26 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 
+/**
+ * Persisted OAuth2 registered-client entity. Mirrors Spring Authorization Server's {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClient}, mapped to the
+ * {@code oauth2_client} table, and is the DB row that authorizes an app to request tokens from
+ * DHIS2 acting as an Authorization Server.
+ *
+ * <p>Exposed via the admin CRUD endpoints under {@code /api/oAuth2Clients}, gated by the {@code
+ * F_OAUTH2_CLIENT_MANAGE} authority. Clients can also be created dynamically via the Dynamic Client
+ * Registration (RFC 7591) endpoint {@code /connect/register}.
+ *
+ * <p>Several fields are stored as comma-separated strings (for example {@link
+ * #authorizationGrantTypes}, {@link #clientAuthenticationMethods}, {@link #redirectUris}, {@link
+ * #postLogoutRedirectUris}, {@link #scopes}) and are parsed into Spring AS's typed values (e.g.
+ * {@link org.springframework.security.oauth2.core.AuthorizationGrantType}, {@link
+ * org.springframework.security.oauth2.core.ClientAuthenticationMethod}) by {@code
+ * Dhis2OAuth2ClientServiceImpl.toObject} when building a {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClient}.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 @Getter
 @Setter
 @JacksonXmlRootElement(localName = "oauth2Client", namespace = DxfNamespaces.DXF_2_0)
@@ -49,7 +69,7 @@ public class Dhis2OAuth2Client extends BaseIdentifiableObject implements Metadat
    * Override so that the persisted {@code name} column is always populated even if the caller (the
    * settings UI, which has no name field) doesn't supply one. Hibernate uses property access for
    * this entity, so the value returned here is what gets written to the DB and what the schema
-   * validator at {@code POST /api/schemas/oAuth2Client} reads via reflection — letting us keep
+   * validator at {@code POST /api/schemas/oAuth2Client} reads via reflection, letting us keep
    * {@code not-null="true"} on the column without breaking UI pre-validation. Truncated to the
    * column length (230) so the schema-validator's {@code @PropertyRange} check on a long {@code
    * clientId} (max 255) doesn't reject the request.
@@ -75,15 +95,65 @@ public class Dhis2OAuth2Client extends BaseIdentifiableObject implements Metadat
     return super.getName();
   }
 
+  /**
+   * Public OAuth2 {@code client_id} presented by the client at the token and authorize endpoints.
+   */
   @JsonProperty private String clientId;
+
+  /**
+   * Client secret used for the {@code client_secret_basic} / {@code client_secret_post}
+   * authentication methods. Stored hashed; null for public clients and for clients that
+   * authenticate via {@code private_key_jwt}.
+   */
   @JsonProperty private String clientSecret;
+
+  /** Timestamp at which {@link #clientId} was issued. */
   @JsonProperty private Date clientIdIssuedAt;
+
+  /** Optional expiry for {@link #clientSecret}; null means the secret does not expire. */
   @JsonProperty private Date clientSecretExpiresAt;
+
+  /**
+   * Comma-separated list of OAuth2 client authentication methods the client may use at the token
+   * endpoint (e.g. {@code client_secret_basic}, {@code client_secret_post}, {@code
+   * private_key_jwt}, {@code none}). Parsed into Spring AS {@link
+   * org.springframework.security.oauth2.core.ClientAuthenticationMethod} values at load time.
+   */
   @JsonProperty private String clientAuthenticationMethods;
+
+  /**
+   * Comma-separated list of OAuth2 authorization grant types the client is permitted to use (e.g.
+   * {@code authorization_code}, {@code client_credentials}, {@code refresh_token}, {@code
+   * urn:ietf:params:oauth:grant-type:device_code}). Parsed into Spring AS {@link
+   * org.springframework.security.oauth2.core.AuthorizationGrantType} values via {@link
+   * org.hisp.dhis.security.oauth2.OAuth2GrantTypes#resolve(String)}.
+   */
   @JsonProperty private String authorizationGrantTypes;
+
+  /**
+   * Comma-separated list of registered redirect URIs used by the authorization-code and device-code
+   * flows; an incoming {@code redirect_uri} must match one of these exactly.
+   */
   @JsonProperty private String redirectUris;
+
+  /** Comma-separated list of post-logout redirect URIs allowed after OIDC RP-initiated logout. */
   @JsonProperty private String postLogoutRedirectUris;
+
+  /**
+   * Comma-separated list of OAuth2 / OpenID Connect scopes (e.g. {@code openid}, {@code profile},
+   * {@code email}) the client is permitted to request.
+   */
   @JsonProperty private String scopes;
+
+  /**
+   * JSON-encoded Spring AS {@code ClientSettings}; controls client-level options such as whether
+   * user consent is required and PKCE requirements.
+   */
   @JsonProperty private String clientSettings;
+
+  /**
+   * JSON-encoded Spring AS {@code TokenSettings}; controls token lifetimes, access-token format
+   * (opaque vs JWT), refresh-token behavior and ID-token signature algorithm.
+   */
   @JsonProperty private String tokenSettings;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientStore.java
@@ -33,7 +33,13 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-/** Store for OAuth2Client entities. */
+/**
+ * Persistence store for {@link Dhis2OAuth2Client}. Used by the authorization server's {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository}
+ * implementation to load clients at token-endpoint time.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 public interface Dhis2OAuth2ClientStore extends IdentifiableObjectStore<Dhis2OAuth2Client> {
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsent.java
@@ -60,6 +60,8 @@ import org.hisp.dhis.common.SecondaryMetadataObject;
  * <p>Marked {@link SecondaryMetadataObject} so the type is excluded from the default {@code
  * /api/metadata} export. Persistence uses Hibernate field access ({@code
  * Dhis2OAuth2AuthorizationConsent.hbm.xml}) and is independent of the JSON annotations.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Getter
 @Setter

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentStore.java
@@ -33,7 +33,15 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-/** Store for OAuth2AuthorizationConsent entities. */
+/**
+ * Persistence store for {@link Dhis2OAuth2AuthorizationConsent}. Backs Spring Authorization
+ * Server's {@link
+ * org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService}
+ * implementation, which keys consent records on the composite {@code (registeredClientId,
+ * principalName)} pair: one record per (client, user) combination.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 public interface Dhis2OAuth2AuthorizationConsentStore
     extends IdentifiableObjectStore<Dhis2OAuth2AuthorizationConsent> {
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationService.java
@@ -32,19 +32,44 @@ package org.hisp.dhis.security.oauth2.authorization;
 import java.util.List;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 
+/**
+ * DHIS2 service for persisting OAuth2 authorizations (issued grants). Backs Spring Authorization
+ * Server's {@link
+ * org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService}.
+ *
+ * <p>One row is stored per grant and holds every token value issued for that grant for its
+ * lifetime: authorization code, access token, refresh token, OIDC ID token, user code, and device
+ * code. Each is also independently indexed so token-introspection lookups can find the parent
+ * authorization by any of those values.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 public interface Dhis2OAuth2AuthorizationService {
+  /** Persist a new authorization or update the existing row with the same id. */
   void save(
       org.springframework.security.oauth2.server.authorization.OAuth2Authorization authorization);
 
+  /**
+   * Remove the persisted authorization identified by the given Spring-AS {@code
+   * OAuth2Authorization}.
+   */
   void remove(
       org.springframework.security.oauth2.server.authorization.OAuth2Authorization authorization);
 
+  /** Delete the persisted authorization with the given DHIS2 UID. */
   void delete(String uid);
 
+  /** Return all persisted authorizations. */
   List<Dhis2OAuth2Authorization> getAll();
 
+  /** Look up an authorization by its id. Returns {@code null} if no match. */
   org.springframework.security.oauth2.server.authorization.OAuth2Authorization findById(String id);
 
+  /**
+   * Look up an authorization by token value. When {@code tokenType} is {@code null}, all token
+   * columns are searched; otherwise the column matching {@link OAuth2TokenType} (or equivalent
+   * Spring-AS parameter name) is used. Returns {@code null} if no match.
+   */
   org.springframework.security.oauth2.server.authorization.OAuth2Authorization findByToken(
       String token, OAuth2TokenType tokenType);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/Dhis2OAuth2AuthorizationServiceImpl.java
@@ -72,8 +72,19 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * DHIS2 implementation of Spring Authorization Server's OAuth2AuthorizationService that uses
- * HibernateOAuth2AuthorizationStore for persistence.
+ * Spring-bean implementation of {@link Dhis2OAuth2AuthorizationService} and Spring Authorization
+ * Server's {@link OAuth2AuthorizationService}. Persistence is delegated to {@link
+ * Dhis2OAuth2AuthorizationStore} (Hibernate-backed).
+ *
+ * <p>Spring AS models an issued grant as an {@link OAuth2Authorization} aggregate holding up to six
+ * distinct token objects (authorization code, access token, refresh token, OIDC ID token, user
+ * code, device code), each with its own issued-at / expires-at / metadata map. This implementation
+ * flattens that aggregate into a single {@link Dhis2OAuth2Authorization} row with per-token
+ * columns, and {@link #toObject} / {@link #toEntity} translate in both directions.
+ *
+ * <p>The Jackson {@link ObjectMapper} is preloaded with {@link SecurityJackson2Modules} and {@link
+ * OAuth2AuthorizationServerJackson2Module} so the {@code attributes}, per-token metadata, and OIDC
+ * ID-token claims JSON round-trip correctly.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -112,6 +123,15 @@ public class Dhis2OAuth2AuthorizationServiceImpl
     this.objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>If an authorization with the same id already exists it is merged; otherwise a new row is
+   * inserted. The {@code createdBy} user is resolved from the current security context: a {@link
+   * Jwt} principal (the DCR Initial Access Token) resolves to the token's {@code sub} claim; an
+   * {@link OAuth2ClientAuthenticationToken} resolves to the client's registered {@code createdBy}
+   * user; other cases fall through to the default store behaviour.
+   */
   @Transactional
   @Override
   public void save(OAuth2Authorization authorization) {
@@ -173,6 +193,14 @@ public class Dhis2OAuth2AuthorizationServiceImpl
     return entity != null ? toObject(entity) : null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When {@code tokenType} is {@code null} all token columns are searched. Otherwise the column
+   * matching the Spring AS parameter name is used: {@code state}, {@code code}, {@code
+   * access_token}, {@code refresh_token}, {@code id_token}, {@code user_code}, or {@code
+   * device_code}.
+   */
   @Transactional(readOnly = true)
   @Override
   public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/HibernateDhis2OAuth2AuthorizationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/authorization/HibernateDhis2OAuth2AuthorizationStore.java
@@ -40,7 +40,14 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** Hibernate implementation of the OAuth2AuthorizationStore. */
+/**
+ * Hibernate-backed store for {@link Dhis2OAuth2Authorization}. Backs {@link
+ * Dhis2OAuth2AuthorizationServiceImpl} and exposes token-value lookups across the {@code state},
+ * {@code authorization_code}, {@code access_token}, {@code refresh_token}, {@code oidc_id_token},
+ * {@code user_code}, and {@code device_code} columns.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 @Repository
 public class HibernateDhis2OAuth2AuthorizationStore
     extends HibernateIdentifiableObjectStore<Dhis2OAuth2Authorization>
@@ -54,6 +61,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
     super(entityManager, jdbcTemplate, publisher, Dhis2OAuth2Authorization.class, aclService, true);
   }
 
+  /** Look up the authorization holding the given {@code state} value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByState(@Nonnull String state) {
@@ -62,6 +70,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
         builder, newJpaParameters().addPredicate(root -> builder.equal(root.get("state"), state)));
   }
 
+  /** Look up the authorization holding the given authorization-code value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByAuthorizationCode(@Nonnull String authorizationCode) {
@@ -73,6 +82,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
                 root -> builder.equal(root.get("authorizationCodeValue"), authorizationCode)));
   }
 
+  /** Look up the authorization holding the given access-token value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByAccessToken(@Nonnull String accessToken) {
@@ -83,6 +93,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
             .addPredicate(root -> builder.equal(root.get("accessTokenValue"), accessToken)));
   }
 
+  /** Look up the authorization holding the given refresh-token value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByRefreshToken(@Nonnull String refreshToken) {
@@ -93,6 +104,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
             .addPredicate(root -> builder.equal(root.get("refreshTokenValue"), refreshToken)));
   }
 
+  /** Look up the authorization holding the given OIDC ID-token value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByOidcIdToken(@Nonnull String idToken) {
@@ -103,6 +115,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
             .addPredicate(root -> builder.equal(root.get("oidcIdTokenValue"), idToken)));
   }
 
+  /** Look up the authorization holding the given device-flow user-code value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByUserCode(@Nonnull String userCode) {
@@ -113,6 +126,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
             .addPredicate(root -> builder.equal(root.get("userCodeValue"), userCode)));
   }
 
+  /** Look up the authorization holding the given device-flow device-code value. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByDeviceCode(@Nonnull String deviceCode) {
@@ -123,6 +137,11 @@ public class HibernateDhis2OAuth2AuthorizationStore
             .addPredicate(root -> builder.equal(root.get("deviceCodeValue"), deviceCode)));
   }
 
+  /**
+   * Look up an authorization by matching the token value against all token columns ({@code state},
+   * {@code authorization_code}, {@code access_token}, {@code refresh_token}, {@code oidc_id_token},
+   * {@code user_code}, {@code device_code}).
+   */
   @Override
   @CheckForNull
   public Dhis2OAuth2Authorization getByToken(@Nonnull String token) {
@@ -142,6 +161,7 @@ public class HibernateDhis2OAuth2AuthorizationStore
                         builder.equal(root.get("deviceCodeValue"), token))));
   }
 
+  /** Hard-delete the authorization row with the given UID. */
   @Override
   public void deleteByUID(@Nonnull String uid) {
     Query<Dhis2OAuth2Authorization> query =

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientService.java
@@ -40,25 +40,59 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 
 /**
- * Service for managing OAuth2 clients in DHIS2.
+ * Admin-facing service for managing DHIS2 OAuth2 clients and the bridge to Spring Authorization
+ * Server's {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository}.
+ *
+ * <p>Two concerns live on this interface:
+ *
+ * <ul>
+ *   <li>CRUD + lookup used by the metadata import path and the REST controller (see {@code save},
+ *       {@code findByUID}, {@code findByClientId}, {@code getAll}).
+ *   <li>Validation and defaulting hooks ({@link #validateCreate}, {@link #validateUpdate}, {@link
+ *       #applyCreateDefaults}, {@link #applyUpdateDefaults}) invoked by both the CRUD controller
+ *       and the metadata-bundle import so admin input is checked the same way on every entry point.
+ * </ul>
+ *
+ * <p>The token endpoint calls {@link #findByClientId} on every incoming authentication, so this
+ * lookup sits on a hot path.
+ *
+ * <p>Admin callers can only set the {@code authorization_code} and {@code refresh_token} grant
+ * types; {@code client_credentials} is reserved for the DCR system registrar created server-side by
+ * {@code OAuth2DcrService}.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public interface Dhis2OAuth2ClientService {
+  /**
+   * Persist a {@link RegisteredClient}. If the current security context is authenticated with a JWT
+   * (i.e. a DCR Initial Access Token), the token's {@code sub} claim is resolved to a DHIS2 user
+   * and used as {@code createdBy} on the new client; otherwise the caller's current user is used.
+   */
   void save(RegisteredClient registeredClient);
 
+  /** Persist a {@link RegisteredClient} recording the given user as {@code createdBy}. */
   void save(RegisteredClient registeredClient, UserDetails userDetails);
 
+  /** Look up a client by its DHIS2 UID. Returns {@code null} if no match. */
   RegisteredClient findByUID(String uid);
 
+  /** Look up a client by its internal id. Returns {@code null} if no match. */
   RegisteredClient findById(String id);
 
-  /*
-   * Returns the RegisteredClient with the given clientId, or null if not found.
+  /**
+   * Look up a client by OAuth2 {@code client_id}. Called by Spring Authorization Server on every
+   * token-endpoint authentication.
+   *
+   * @return the matching {@link RegisteredClient}, or {@code null} if none.
    */
   @CheckForNull
   RegisteredClient findByClientId(String clientId);
 
+  /**
+   * Look up the raw {@link Dhis2OAuth2Client} entity (not the Spring AS projection) by OAuth2
+   * {@code client_id}. Used where DHIS2-specific fields (e.g. {@code createdBy}) are needed.
+   */
   Dhis2OAuth2Client getAsDhis2OAuth2ClientByClientId(String clientId);
 
   /**
@@ -85,11 +119,12 @@ public interface Dhis2OAuth2ClientService {
    */
   String writeMap(Map<String, Object> data);
 
+  /** Return all persisted clients. */
   List<Dhis2OAuth2Client> getAll();
 
   /**
    * Collect validation errors that would block creating the given client. Errors are reported to
-   * the consumer rather than thrown — callers (REST controller, metadata-import bundle hook) decide
+   * the consumer rather than thrown; callers (REST controller, metadata-import bundle hook) decide
    * whether to translate to a {@code ConflictException} or merge into a bundle report.
    */
   void validateCreate(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors);
@@ -102,7 +137,7 @@ public interface Dhis2OAuth2ClientService {
   void applyCreateDefaults(Dhis2OAuth2Client entity);
 
   /**
-   * Apply update-time defaults — preserves the existing persisted name when the caller didn't send
+   * Apply update-time defaults; preserves the existing persisted name when the caller did not send
    * one (the settings UI has no name field, so a REPLACE merge would otherwise clobber it).
    */
   void applyUpdateDefaults(Dhis2OAuth2Client persisted, Dhis2OAuth2Client newEntity);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -73,8 +73,18 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * DHIS2 implementation of Spring Authorization Server's RegisteredClientRepository that uses
- * HibernateOAuth2ClientStore for persistence.
+ * Spring-bean implementation of {@link Dhis2OAuth2ClientService}. Also implements Spring
+ * Authorization Server's {@link RegisteredClientRepository}, so Spring AS reads clients through
+ * this bean on every token-endpoint authentication. Persistence is delegated to {@link
+ * Dhis2OAuth2ClientStore} ({@link HibernateDhis2OAuth2ClientStore}).
+ *
+ * <p>The Jackson {@link ObjectMapper} is preloaded with {@link SecurityJackson2Modules} and {@link
+ * OAuth2AuthorizationServerJackson2Module} so the {@code clientSettings} / {@code tokenSettings}
+ * JSON round-trips correctly against Spring AS's internal types.
+ *
+ * <p>{@link #save(RegisteredClient)} detects a DCR call by looking for a {@link Jwt} principal in
+ * the security context (i.e. the Initial Access Token); when present, the JWT's {@code sub} claim
+ * is resolved to a DHIS2 user and recorded as {@code createdBy} on the new client.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -84,7 +94,7 @@ public class Dhis2OAuth2ClientServiceImpl
 
   /**
    * Grant types an admin-facing entry point (REST CRUD, bulk metadata import) is allowed to set on
-   * a client. {@code client_credentials} is deliberately excluded — the only legitimate user of it
+   * a client. {@code client_credentials} is deliberately excluded; the only legitimate user of it
    * in this deployment is the DCR system registrar, which is created server-side via {@link
    * Dhis2OAuth2ClientStore#save} and bypasses these validators. See {@link #validateGrantTypes} for
    * the one exception that keeps metadata round-trips working.
@@ -114,6 +124,13 @@ public class Dhis2OAuth2ClientServiceImpl
     this.objectMapper.registerModule(new OAuth2AuthorizationServerJackson2Module());
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>If the current security context's principal is a {@link Jwt} (the DCR Initial Access Token),
+   * the token's {@code sub} claim is resolved to a DHIS2 user and passed as {@code createdBy} so
+   * the new client is owned by the enrolling user.
+   */
   @Transactional
   @Override
   public void save(RegisteredClient registeredClient) {
@@ -315,10 +332,11 @@ public class Dhis2OAuth2ClientServiceImpl
   }
 
   /**
-   * Resolves the ClientAuthenticationMethod from a string value.
+   * Resolves the {@link ClientAuthenticationMethod} from its string value, returning one of the
+   * Spring AS constants when possible and constructing a custom instance otherwise.
    *
-   * @param clientAuthenticationMethod The string value
-   * @return The corresponding ClientAuthenticationMethod
+   * @param clientAuthenticationMethod the string value
+   * @return the corresponding {@link ClientAuthenticationMethod}
    */
   private static ClientAuthenticationMethod resolveClientAuthenticationMethod(
       @Nonnull String clientAuthenticationMethod) {
@@ -410,8 +428,8 @@ public class Dhis2OAuth2ClientServiceImpl
   /**
    * Reject any attempt to use the reserved DCR system-registrar clientId via admin paths. Without
    * this, an admin could squat the reserved clientId while the authorization server is disabled,
-   * and when {@code OAuth2DcrService.init()} later runs DCR would mint initial access tokens
-   * through a client whose secret / redirect URIs the squatter controls.
+   * and when {@code OAuth2DcrService.init()} later runs DCR would mint Initial Access Tokens
+   * through a client whose secret and redirect URIs the squatter controls.
    */
   private static void checkClientIdNotReserved(
       String clientId, String operation, Consumer<ErrorReport> errors) {
@@ -428,6 +446,13 @@ public class Dhis2OAuth2ClientServiceImpl
     }
   }
 
+  /**
+   * Enforce the grant-type admin rule: only {@code authorization_code} and {@code refresh_token}
+   * are accepted on admin-facing paths. The DCR system registrar is the sole legitimate holder of
+   * {@code client_credentials} in this deployment; its re-import from a metadata bundle is allowed
+   * through because admin-initiated creates cannot reach this branch (the reserved clientId is
+   * rejected earlier by {@link #checkClientIdNotReserved}).
+   */
   private void validateGrantTypes(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     // The DCR system registrar legitimately uses client_credentials; skip the check so a full
     // metadata round-trip can re-import it. Admin-initiated creates can't hit this branch because
@@ -450,10 +475,11 @@ public class Dhis2OAuth2ClientServiceImpl
   }
 
   /**
-   * Redirect URI allow-list: http and https are always accepted; any other URI must match verbatim
-   * an entry in the {@code deviceEnrollmentRedirectAllowlist} system setting. Default-to-deny
-   * closes the stored-XSS / token-exfiltration surface that Spring Authorization Server leaves open
-   * when it emits the {@code Location} header without scheme filtering.
+   * Redirect URI allow-list: http and https are always accepted; any other URI (e.g. a custom
+   * scheme like {@code dhis2oauth://oauth}) must match verbatim an entry in the {@code
+   * deviceEnrollmentRedirectAllowlist} system setting. Default-to-deny closes the stored-XSS and
+   * token-exfiltration surface that Spring Authorization Server leaves open when it emits the
+   * {@code Location} header without scheme filtering.
    */
   private void validateRedirectUris(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     if (entity.getRedirectUris() == null) {
@@ -481,6 +507,10 @@ public class Dhis2OAuth2ClientServiceImpl
     }
   }
 
+  /**
+   * Extract and return the URI scheme from the given redirect URI. Reports an {@link ErrorReport}
+   * and returns {@code null} if the URI is malformed or has no scheme.
+   */
   @CheckForNull
   private static String getScheme(Consumer<ErrorReport> errors, String trimmed) {
     String scheme;
@@ -501,6 +531,10 @@ public class Dhis2OAuth2ClientServiceImpl
     return scheme;
   }
 
+  /**
+   * Parse the {@code deviceEnrollmentRedirectAllowlist} system setting into a set of verbatim
+   * redirect-URI strings.
+   */
   private Set<String> parseRedirectAllowList() {
     String raw = systemSettingsService.getCurrentSettings().getDeviceEnrollmentRedirectAllowlist();
     if (raw == null || raw.isBlank()) {
@@ -512,6 +546,7 @@ public class Dhis2OAuth2ClientServiceImpl
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  /** Truncate to {@code CLIENT_NAME_MAX_LENGTH}; returns {@code null} unchanged. */
   private static String truncateName(String value) {
     if (value == null) {
       return null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/HibernateDhis2OAuth2ClientStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/HibernateDhis2OAuth2ClientStore.java
@@ -39,7 +39,14 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** Hibernate implementation of the OAuth2ClientStore. */
+/**
+ * Hibernate-backed store for {@link Dhis2OAuth2Client}. Backs {@link
+ * Dhis2OAuth2ClientServiceImpl}'s {@link
+ * org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository}
+ * implementation.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 @Repository
 public class HibernateDhis2OAuth2ClientStore
     extends HibernateIdentifiableObjectStore<Dhis2OAuth2Client> implements Dhis2OAuth2ClientStore {
@@ -52,6 +59,7 @@ public class HibernateDhis2OAuth2ClientStore
     super(entityManager, jdbcTemplate, publisher, Dhis2OAuth2Client.class, aclService, true);
   }
 
+  /** Look up a client by OAuth2 {@code client_id}; returns {@code null} if none. */
   @Override
   @CheckForNull
   public Dhis2OAuth2Client getByClientId(@Nonnull String clientId) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentService.java
@@ -31,19 +31,41 @@ package org.hisp.dhis.security.oauth2.consent;
 
 import java.util.List;
 
+/**
+ * DHIS2 service for persisting per-(user, client) OAuth2 consent grants. Backs Spring Authorization
+ * Server's {@link
+ * org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService}.
+ *
+ * <p>Identity is the composite {@code (registeredClientId, principalName)}; each row holds the set
+ * of authorities (scopes) the user granted that client. Clients registered via DCR bypass the
+ * consent screen (they are saved with {@code requireAuthorizationConsent=false}) and therefore do
+ * not create rows here.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 public interface Dhis2OAuth2AuthorizationConsentService {
+  /** Persist the consent or update the existing row with the same composite identity. */
   void save(
       org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent
           authorizationConsent);
 
+  /** Delete the consent row matching the given Spring-AS consent's composite identity. */
   void remove(
       org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent
           authorizationConsent);
 
+  /**
+   * Look up a consent by its composite identity. Returns {@code null} if none.
+   *
+   * @param registeredClientId the client's DHIS2 UID
+   * @param principalName the consenting user's principal name
+   */
   org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent findById(
       String registeredClientId, String principalName);
 
+  /** Return all persisted consent rows. */
   List<Dhis2OAuth2AuthorizationConsent> getAll();
 
+  /** Delete the given persisted consent entity. */
   void delete(Dhis2OAuth2AuthorizationConsent consent);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/Dhis2OAuth2AuthorizationConsentServiceImpl.java
@@ -45,8 +45,16 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * DHIS2 implementation of Spring Authorization Server's OAuth2AuthorizationConsentService that uses
- * HibernateOAuth2AuthorizationConsentStore for persistence.
+ * Spring-bean implementation of {@link Dhis2OAuth2AuthorizationConsentService} and Spring
+ * Authorization Server's {@link OAuth2AuthorizationConsentService}. Persistence is delegated to
+ * {@link Dhis2OAuth2AuthorizationConsentStore} (Hibernate-backed).
+ *
+ * <p>Rows are identified by the composite {@code (registeredClientId, principalName)}; {@link
+ * #toObject} / {@link #toEntity} translate between Spring AS's {@link
+ * org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent} and the flat
+ * DHIS2 entity (authorities stored as a comma-delimited string).
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Service
 public class Dhis2OAuth2AuthorizationConsentServiceImpl

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/HibernateDhis2OAuth2AuthorizationConsentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/consent/HibernateDhis2OAuth2AuthorizationConsentStore.java
@@ -39,7 +39,13 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** Hibernate implementation of the OAuth2AuthorizationConsentStore. */
+/**
+ * Hibernate-backed store for {@link Dhis2OAuth2AuthorizationConsent}. Backs {@link
+ * Dhis2OAuth2AuthorizationConsentServiceImpl}; lookups are by the composite {@code
+ * (registeredClientId, principalName)} key.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 @Repository
 public class HibernateDhis2OAuth2AuthorizationConsentStore
     extends HibernateIdentifiableObjectStore<Dhis2OAuth2AuthorizationConsent>
@@ -59,6 +65,7 @@ public class HibernateDhis2OAuth2AuthorizationConsentStore
         true);
   }
 
+  /** Look up the consent row with the given composite identity. Returns {@code null} if none. */
   @Override
   @CheckForNull
   public Dhis2OAuth2AuthorizationConsent getByRegisteredClientIdAndPrincipalName(
@@ -71,6 +78,7 @@ public class HibernateDhis2OAuth2AuthorizationConsentStore
             .addPredicate(root -> builder.equal(root.get("principalName"), principalName)));
   }
 
+  /** Delete the consent row with the given composite identity, if present. */
   @Override
   public void deleteByRegisteredClientIdAndPrincipalName(
       @Nonnull String registeredClientId, @Nonnull String principalName) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
@@ -50,10 +50,23 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- * Controller for managing OAuth2 clients for the DHIS2 OAuth2 authorization server. Validation and
- * defaulting live on {@link Dhis2OAuth2ClientService} — this controller is just the REST pipeline
- * glue: authority gate, list-query filter to hide the system registrar, REST-only delete guard, and
- * translation of the first collected validation error into a {@link ConflictException}.
+ * REST controller that exposes DHIS2 metadata CRUD for registered OAuth2 clients at {@code
+ * /api/oAuth2Clients}. Requires the {@code F_OAUTH2_CLIENT_MANAGE} authority. Behaves like a
+ * standard DHIS2 metadata resource: supports list/get/create/update/delete, import/export, sharing,
+ * and translations via the {@link AbstractCrudController} pipeline.
+ *
+ * <p>Validation and defaulting live on {@link Dhis2OAuth2ClientService}; this controller is the
+ * REST pipeline glue: authority gate, list-query filter to hide the system DCR registrar client,
+ * REST-only guards against mutating that reserved system client, and translation of the first
+ * collected validation error into a {@link ConflictException}.
+ *
+ * <p>Domain rules enforced by the service layer include: only {@code authorization_code} and {@code
+ * refresh_token} grant types are accepted (the {@code client_credentials} grant is rejected with
+ * HTTP 409 and {@link org.hisp.dhis.feedback.ErrorCode#E4000}), redirect URIs with custom schemes
+ * must appear verbatim in the {@code deviceEnrollmentRedirectAllowlist} system setting, and the
+ * reserved system client id {@link
+ * org.hisp.dhis.security.oauth2.OAuth2Constants#SYSTEM_REGISTRAR_CLIENTID} is filtered from list
+ * responses and rejected on create, update, and delete through this controller.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -66,12 +79,33 @@ public class OAuth2ClientController
 
   private final Dhis2OAuth2ClientService clientService;
 
+  /**
+   * Runs create-time validation and applies defaults via {@link Dhis2OAuth2ClientService} before
+   * the client is persisted. The first reported validation error is translated into a {@link
+   * ConflictException} (HTTP 409), for example when a disallowed grant type such as {@code
+   * client_credentials} is submitted or when a custom-scheme redirect URI is not present in the
+   * {@code deviceEnrollmentRedirectAllowlist}.
+   *
+   * @param entity the incoming client payload to validate and default
+   * @throws ConflictException if the service reports one or more validation errors
+   */
   @Override
   protected void preCreateEntity(Dhis2OAuth2Client entity) throws ConflictException {
     throwFirst(errors -> clientService.validateCreate(entity, errors));
     clientService.applyCreateDefaults(entity);
   }
 
+  /**
+   * Runs update-time validation, applies defaults, and blocks attempts to mutate the reserved
+   * system DCR registrar client via REST.
+   *
+   * @param entity the existing persisted client
+   * @param newEntity the incoming update payload
+   * @throws ConflictException if the target is the system registrar client (HTTP 409), or if {@link
+   *     Dhis2OAuth2ClientService} reports a validation error such as renaming the client id to the
+   *     reserved system id, switching to a disallowed grant type, or introducing a custom-scheme
+   *     redirect URI that is not allowlisted
+   */
   @Override
   protected void preUpdateEntity(Dhis2OAuth2Client entity, Dhis2OAuth2Client newEntity)
       throws ConflictException {
@@ -86,6 +120,13 @@ public class OAuth2ClientController
     super.preUpdateEntity(entity, newEntity);
   }
 
+  /**
+   * Blocks deletion of the reserved system DCR registrar client through REST. Other entities are
+   * deleted by the default {@link AbstractCrudController} pipeline.
+   *
+   * @param entity the client targeted for deletion
+   * @throws ConflictException if the target is the system registrar client (HTTP 409)
+   */
   @Override
   protected void preDeleteEntity(Dhis2OAuth2Client entity) throws ConflictException {
     if (entity != null && SYSTEM_REGISTRAR_CLIENTID.equals(entity.getClientId())) {
@@ -97,10 +138,13 @@ public class OAuth2ClientController
   }
 
   /**
-   * Hide the DCR system registrar client from list queries. It's created and owned by the server
-   * itself to bootstrap dynamic client registration; admins should never touch it through the
-   * settings UI. Direct-by-uid fetches are left alone since DCR / other server code may need to
-   * read it, and the UI only discovers client uids via this list.
+   * Hides the DCR system registrar client from list queries. It is created and owned by the server
+   * itself to bootstrap dynamic client registration; administrators should never touch it through
+   * the settings UI. Direct by-uid fetches are left alone since DCR and other server code may need
+   * to read it, and the UI only discovers client uids via this list.
+   *
+   * @param params the incoming list parameters (unmodified)
+   * @param query the underlying query to which the clientId exclusion filter is added
    */
   @Override
   protected void modifyGetObjectList(GetObjectListParams params, Query<Dhis2OAuth2Client> query) {
@@ -108,10 +152,14 @@ public class OAuth2ClientController
   }
 
   /**
-   * Run a collecting validator and translate the first reported error into a {@link
-   * ConflictException}. The full set of errors is available to non-REST callers (e.g. the
-   * metadata-import bundle hook) which prefer to merge them into a bundle report instead of
+   * Runs a collecting validator and translates the first reported error into a {@link
+   * ConflictException}. The full set of errors is available to non-REST callers (for example the
+   * metadata import bundle hook) which prefer to merge them into a bundle report instead of
    * throwing.
+   *
+   * @param validator a consumer that accepts an {@link ErrorReport} collector and populates it with
+   *     any validation failures
+   * @throws ConflictException carrying the message of the first collected error, if any
    */
   private static void throwFirst(Consumer<Consumer<ErrorReport>> validator)
       throws ConflictException {


### PR DESCRIPTION
## Summary

Part 1 of 3 splitting #23734 into smaller PRs per reviewer request. This PR covers DHIS2 as an OAuth2 **Authorization Server** (built on Spring Authorization Server): client, authorization, consent persistence plus the admin CRUD controller.

17 classes, Javadoc only, aligned with the user-facing OAuth2 / OIDC / JWT reference in [dhis2-docs#1739](https://github.com/dhis2/dhis2-docs/pull/1739). Covers the registered-client contract, grant-type admin rule (only `authorization_code` and `refresh_token`), redirect-URI allowlist, and the reserved `system-dcr-registrar-client`.

Companion PRs:
- DCR: docs/javadocs-android-dcr
- OIDC login + JWT bearer: docs/javadocs-oidc-login-jwt



AI Assisted