### PR TITLE
docs: improve Javadocs for OIDC login and JWT bearer authentication

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -65,19 +65,41 @@ import org.springframework.security.oauth2.server.resource.web.DefaultBearerToke
 import org.springframework.stereotype.Component;
 
 /**
- * Represent a custom AuthenticationManagerResolver to resolve authenticate JWT bearer token
- * requests. This class will look up the corresponding issuer configuration ({@link
- * DhisOidcClientRegistration}), based on the JWT "issuer" field information in the token and create
- * a new {@link DhisJwtAuthenticationProvider} with the resolved config looked up in the {@link
- * DhisOidcProviderRepository}
+ * Spring {@link AuthenticationManagerResolver} used by the OAuth2 resource-server filter chain to
+ * authenticate inbound JWT bearer token requests.
  *
- * <p>It will also create the authentication method to be called for authenticating the request.
+ * <p>This resolver implements DHIS2's JWT bearer authentication path, which lets OAuth2 clients
+ * call the DHIS2 API using a JWT access token issued either by DHIS2 itself (when the DHIS2
+ * Authorization Server is enabled) or by a trusted external OIDC IdP. It is only active when JWT
+ * bearer authentication has been enabled via configuration.
  *
- * @author Morten Svanæs <msvanaes@dhis2.org>
- * @see
- *     org.hisp.dhis.security.jwt.Dhis2JwtAuthenticationManagerResolver.DhisJwtAuthenticationProvider
+ * <p>For each incoming request it:
+ *
+ * <ol>
+ *   <li>Extracts the {@code iss} (issuer) claim from the bearer token using {@link
+ *       JwtClaimIssuerConverter}.
+ *   <li>Looks up the matching {@link DhisOidcClientRegistration} in {@link
+ *       DhisOidcProviderRepository} by issuer URI. For DHIS2-issued tokens this resolves to the
+ *       internal DHIS2 provider whose JWKS lives at {@code {server.base.url}/oauth2/jwks}; for
+ *       external-IdP tokens the provider's {@code jwk_uri} is used.
+ *   <li>Caches (per issuer) an {@link AuthenticationManager} that delegates to a {@link
+ *       DhisJwtAuthenticationProvider}. The provider is configured with a {@link JwtDecoder} for
+ *       signature and claim validation and a {@link Converter} that maps a validated {@link Jwt}
+ *       into a {@link DhisJwtAuthenticationToken}.
+ * </ol>
+ *
+ * <p>The token converter enforces an audience check (against the registered client ids, or, for
+ * tokens issued by the DHIS2 Authorization Server itself, against registered OAuth2 clients), then
+ * resolves the DHIS2 user by reading the provider's mapping claim (currently {@code username} or
+ * {@code email}) and looking up the corresponding {@link UserDetails} through {@link UserService}.
+ * If no matching DHIS2 user exists, authentication is rejected with an {@link
+ * InvalidBearerTokenException}. User lookup here is eager so that the authenticated principal is
+ * fully populated before any non-OSIV (Open Session In View) endpoint runs.
+ *
  * @see org.hisp.dhis.security.oidc.DhisOidcProviderRepository
+ * @see DhisJwtAuthenticationToken
  * @see AuthenticationManagerResolver
+ * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Component
 public class Dhis2JwtAuthenticationManagerResolver
@@ -96,10 +118,27 @@ public class Dhis2JwtAuthenticationManagerResolver
 
   private JwtDecoder jwtDecoder;
 
+  /**
+   * Override the {@link JwtDecoder} used to validate bearer tokens. Intended for tests that need a
+   * fixed decoder instead of one resolved from the issuer location. When set, {@link
+   * #getDecoder(String)} returns this decoder for every issuer.
+   *
+   * @param jwtDecoder the decoder to use, or {@code null} to fall back to issuer-based resolution
+   */
   public void setJwtDecoder(JwtDecoder jwtDecoder) {
     this.jwtDecoder = jwtDecoder;
   }
 
+  /**
+   * Resolve the {@link AuthenticationManager} to use for the given request based on the {@code iss}
+   * claim of the bearer token.
+   *
+   * @param request the current HTTP request carrying the bearer token
+   * @return an {@link AuthenticationManager} backed by a {@link DhisJwtAuthenticationProvider}
+   *     configured for the token's issuer
+   * @throws InvalidBearerTokenException if the token is missing, malformed, lacks an {@code iss}
+   *     claim, or the issuer does not match any configured {@link DhisOidcClientRegistration}
+   */
   @Override
   public AuthenticationManager resolve(HttpServletRequest request) {
     String issuer = this.issuerConverter.convert(request);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisBearerJwtTokenAuthenticationEntryPoint.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisBearerJwtTokenAuthenticationEntryPoint.java
@@ -44,6 +44,24 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 /**
+ * Spring {@link AuthenticationEntryPoint} used by the OAuth2 resource-server filter chain to signal
+ * authentication failure for JWT bearer token requests.
+ *
+ * <p>On an unauthenticated or failed JWT request this entry point delegates to Spring Security's
+ * {@link BearerTokenAuthenticationEntryPoint}, which writes an RFC 6750 compliant {@code
+ * WWW-Authenticate: Bearer} challenge to the response. The exact challenge depends on the cause:
+ *
+ * <ul>
+ *   <li>No credentials: a plain {@code Bearer realm="DHIS2"} challenge with HTTP 401.
+ *   <li>Invalid or expired token (for example {@code org.springframework.security.oauth2.server
+ *       .resource.InvalidBearerTokenException}): {@code error="invalid_token"} with HTTP 401.
+ *   <li>Missing or insufficient scopes: {@code error="insufficient_scope"} with HTTP 403.
+ * </ul>
+ *
+ * <p>After emitting the WWW-Authenticate challenge, the entry point also forwards the {@link
+ * AuthenticationException} to the Spring MVC {@code HandlerExceptionResolver} so that DHIS2's
+ * global exception advice can log and translate the failure consistently with other API errors.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Component
@@ -52,6 +70,10 @@ public class DhisBearerJwtTokenAuthenticationEntryPoint
     implements AuthenticationEntryPoint, ApplicationContextAware {
   private ApplicationContext applicationContext;
 
+  /**
+   * Set by the Spring container to supply the {@link ApplicationContext} from which the {@code
+   * HandlerExceptionResolver} bean is looked up at request time.
+   */
   @Override
   public void setApplicationContext(ApplicationContext applicationContext) {
     this.applicationContext = applicationContext;
@@ -60,6 +82,18 @@ public class DhisBearerJwtTokenAuthenticationEntryPoint
   private BearerTokenAuthenticationEntryPoint entryPoint =
       new BearerTokenAuthenticationEntryPoint();
 
+  /**
+   * Commence the authentication failure response: write the RFC 6750 {@code WWW-Authenticate:
+   * Bearer} challenge (with {@code invalid_token} or {@code insufficient_scope} error codes as
+   * applicable) and then forward the exception to the Spring MVC {@code HandlerExceptionResolver}
+   * so DHIS2's global exception handling can render a consistent error payload.
+   *
+   * @param request the current HTTP request
+   * @param response the HTTP response to which the challenge is written
+   * @param authException the authentication failure that triggered this entry point
+   * @throws IOException if writing to the response fails
+   * @throws ServletException if the delegate entry point fails
+   */
   @Override
   public void commence(
       HttpServletRequest request,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationToken.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationToken.java
@@ -38,11 +38,42 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
+ * DHIS2-specific {@link JwtAuthenticationToken} produced after a JWT bearer token has been
+ * validated and mapped to a DHIS2 user.
+ *
+ * <p>Instances are created by {@link Dhis2JwtAuthenticationManagerResolver} once the token
+ * signature has been verified against the issuer's JWKS and the token's mapping claim (typically
+ * {@code username} or {@code email}) has been resolved to a DHIS2 {@link UserDetails}. The mapping
+ * claim has already been consumed upstream by the resolver, so the wrapped {@link DhisOidcUser}
+ * uses {@link IdTokenClaimNames#SUB} as its name attribute. The token wraps three things:
+ *
+ * <ul>
+ *   <li>The raw validated {@link Jwt}, available through {@link #getToken()}.
+ *   <li>The collection of {@link GrantedAuthority} authorities granted to the authenticated DHIS2
+ *       user.
+ *   <li>A {@link DhisOidcUser} principal that carries the full DHIS2 {@link UserDetails}, exposed
+ *       via {@link #getPrincipal()}.
+ * </ul>
+ *
+ * <p>This is the concrete {@code Authentication} instance returned by {@code
+ * SecurityContextHolder.getContext().getAuthentication()} for every JWT-authenticated request, and
+ * the type downstream code should cast to when it needs access to the DHIS2 user and the original
+ * JWT claims.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class DhisJwtAuthenticationToken extends JwtAuthenticationToken {
   private final DhisOidcUser dhisOidcUser;
 
+  /**
+   * Create a new authenticated token for a validated JWT and the DHIS2 user it maps to.
+   *
+   * @param jwt the validated JWT bearer token
+   * @param authorities the authorities granted to the DHIS2 user
+   * @param name the value of the token's mapping claim (used as the {@code name} of the
+   *     authentication)
+   * @param user the DHIS2 {@link UserDetails} the mapping claim resolved to
+   */
   public DhisJwtAuthenticationToken(
       Jwt jwt, Collection<? extends GrantedAuthority> authorities, String name, UserDetails user) {
     super(jwt, authorities, name);
@@ -50,6 +81,11 @@ public class DhisJwtAuthenticationToken extends JwtAuthenticationToken {
     this.dhisOidcUser = new DhisOidcUser(user, jwt.getClaims(), IdTokenClaimNames.SUB, null);
   }
 
+  /**
+   * Return the {@link DhisOidcUser} principal wrapping the resolved DHIS2 {@link UserDetails} and
+   * the JWT claims. Overrides the default {@link JwtAuthenticationToken} behaviour of returning the
+   * raw {@link Jwt} as principal.
+   */
   @Override
   public Object getPrincipal() {
     return this.dhisOidcUser;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisAuthorizationCodeTokenResponseClient.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisAuthorizationCodeTokenResponseClient.java
@@ -59,6 +59,22 @@ import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
 /**
+ * Spring {@link OAuth2AccessTokenResponseClient} used by the DHIS2 Relying Party during the
+ * authorization-code token exchange against an external OIDC Identity Provider.
+ *
+ * <p>This client supports both client authentication modes: standard {@code client_secret_*}
+ * (basic, post, JWT) and {@code private_key_jwt}. When the matched {@link ClientRegistration}
+ * declares {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}, the client builds a JWT client
+ * assertion signed with the per-provider key loaded from {@link DhisOidcClientRegistration} ({@code
+ * jwk}, {@code jwkSetUrl}), using Spring's {@link
+ * NimbusJwtClientAuthenticationParametersConverter}; for all other methods it falls back to the
+ * standard {@link OAuth2AuthorizationCodeGrantRequestEntityConverter}.
+ *
+ * <p>HTTP exchange is performed with a {@link RestTemplate} configured with {@link
+ * FormHttpMessageConverter} and {@link OAuth2AccessTokenResponseHttpMessageConverter}, and {@link
+ * OAuth2ErrorResponseErrorHandler} mapping upstream HTTP errors to {@link
+ * OAuth2AuthorizationException} with the {@code invalid_token_response} error code.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Service
@@ -77,6 +93,10 @@ public class DhisAuthorizationCodeTokenResponseClient
 
   private RestOperations restOperations;
 
+  /**
+   * Builds the two request-entity converters (standard and {@code private_key_jwt}) and the {@link
+   * RestTemplate} used to call the IdP's token endpoint.
+   */
   @PostConstruct
   public void init() {
     Function<ClientRegistration, JWK> jwkResolver =
@@ -123,6 +143,16 @@ public class DhisAuthorizationCodeTokenResponseClient
     this.restOperations = restTemplate;
   }
 
+  /**
+   * Exchanges an authorization code for an access token (and an ID token) at the IdP's token
+   * endpoint. Picks the {@code private_key_jwt} converter when the client registration declares
+   * that authentication method, otherwise uses the standard converter.
+   *
+   * @param authorizationCodeGrantRequest the authorization-code grant request
+   * @return the parsed token response from the IdP
+   * @throws OAuth2AuthorizationException if the HTTP exchange fails or the response cannot be
+   *     parsed
+   */
   @Override
   public OAuth2AccessTokenResponse getTokenResponse(
       @Nonnull OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
@@ -52,6 +52,22 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.stereotype.Component;
 
+/**
+ * Spring {@link OAuth2AuthorizationRequestResolver} that extends the default resolver with two
+ * DHIS2-specific behaviors.
+ *
+ * <p>First, it appends per-provider extra query parameters to the authorization request, sourced
+ * from the provider's {@code extra_request_parameters} map (configured via {@code
+ * oidc.provider.<id>.extra_request_parameters}). Typical uses are IdP-specific hints such as {@code
+ * prompt}, {@code hd}, or {@code login_hint}.
+ *
+ * <p>Second, it enables PKCE ({@link #PKCE_CHALLENGE_METHOD S256}) when the provider opts in with
+ * {@code enable_pkce=on}: a random 96-byte URL-safe {@code code_verifier} is generated, stored as a
+ * request attribute for the token exchange, and the corresponding SHA-256 {@code code_challenge}
+ * plus {@code code_challenge_method} are added to the authorization request.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
 @Component
 public class DhisCustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
   public static final String PKCE_CHALLENGE_METHOD = "S256";
@@ -65,6 +81,7 @@ public class DhisCustomAuthorizationRequestResolver implements OAuth2Authorizati
   private final StringKeyGenerator secureKeyGenerator =
       new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding(), 96);
 
+  /** Wires the default Spring resolver against the DHIS2 client-registration repository. */
   @PostConstruct
   public void init() {
     defaultResolver =

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcClientRegistration.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcClientRegistration.java
@@ -44,6 +44,44 @@ import lombok.Data;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 /**
+ * DHIS2 wrapper around Spring Security's {@link ClientRegistration} that bundles the Spring
+ * registration with DHIS2-specific metadata needed to operate as an OpenID Connect Relying Party
+ * (RP) against an external OIDC Identity Provider (IdP).
+ *
+ * <p>Each registered instance corresponds to one OIDC provider configured in {@code dhis.conf}
+ * (e.g. {@code google}, {@code azure.0}, {@code wso2}, or any generic provider under {@code
+ * oidc.provider.<id>.*}), and becomes a login button on the DHIS2 web login page when {@code
+ * oidc.oauth2.login.enabled=on}. The auto-registered {@code dhis2-internal} provider is the
+ * exception: it is used by the Android Capture app's authorization-code flow against DHIS2 as
+ * authorization server and is not rendered on the web login page.
+ *
+ * <p>Instances are produced by the provider builders (e.g. {@code GoogleProvider}, {@code
+ * AzureAdProvider}, {@code Wso2Provider}, {@code GenericOidcProviderBuilder}, {@code
+ * Dhis2InternalOidcProvider}) and registered in the {@link DhisOidcProviderRepository}, which
+ * exposes them to Spring's {@code oauth2Login} filter chain.
+ *
+ * <p>Fields:
+ *
+ * <ul>
+ *   <li>{@code clientRegistration}: the underlying Spring {@link ClientRegistration} describing
+ *       client id/secret, authorization/token/userinfo/JWK endpoints, scopes, and client
+ *       authentication method.
+ *   <li>{@code mappingClaimKey}: the ID-token/userinfo claim DHIS2 uses to look up the local user
+ *       (default {@code email} for external providers; {@code username} for the internal DHIS2
+ *       provider).
+ *   <li>{@code loginIcon}, {@code loginIconPadding}, {@code loginText}: rendering hints for the
+ *       login button on the DHIS2 web login page.
+ *   <li>{@code jwk}, {@code rsaPublicKey}, {@code keyId}, {@code jwkSetUrl}: per-provider signing
+ *       material used when DHIS2 authenticates to the IdP's token endpoint with a {@code
+ *       private_key_jwt} assertion. Loaded from {@code oidc.provider.<id>.keystore_path}, {@code
+ *       keystore_password}, {@code key_alias}, {@code key_password}. Distinct from the
+ *       authorization-server signing keystore ({@code oauth2.server.jwt.keystore.*}).
+ *   <li>{@code visibleOnLoginPage}: whether this registration renders a button on the web login
+ *       page; {@code false} for the internal DHIS2 provider.
+ *   <li>{@code externalClients}: client ids and secrets for additional clients authorized to
+ *       present tokens issued by the same IdP (used when validating inbound bearer tokens).
+ * </ul>
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Data
@@ -71,6 +109,13 @@ public class DhisOidcClientRegistration {
 
   @Builder.Default private final Map<String, Map<String, String>> externalClients = new HashMap<>();
 
+  /**
+   * Returns the set of client ids associated with this registration: the primary client id from the
+   * underlying {@link ClientRegistration} plus every client id declared for the configured external
+   * clients.
+   *
+   * @return unmodifiable set of client ids accepted for this provider
+   */
   public Collection<String> getClientIds() {
     Set<String> allExternalClientIds =
         externalClients.entrySet().stream()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcLogoutSuccessHandler.java
@@ -54,6 +54,31 @@ import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuc
 import org.springframework.stereotype.Component;
 
 /**
+ * Spring {@link LogoutSuccessHandler} that drives the redirect after a DHIS2 user logs out of a
+ * session backed by an OIDC Identity Provider.
+ *
+ * <p>Pick logic in {@link #init()}:
+ *
+ * <ul>
+ *   <li>When {@code oidc.oauth2.login.enabled=on} and the selected provider exposes an {@code
+ *       end_session_endpoint} ({@code oidc.provider.<id>.end_session_endpoint}) with {@code
+ *       enable_logout=on}, the handler becomes a Spring {@link
+ *       OidcClientInitiatedLogoutSuccessHandler} that redirects the browser to the IdP's
+ *       RP-initiated logout endpoint using {@code oidc.logout.redirect_url} as the post-logout
+ *       redirect URI.
+ *   <li>When the linked-accounts feature is enabled ({@code linked_accounts.enabled=on}), or when
+ *       OIDC login is disabled, logout falls back to a {@link SimpleUrlLogoutSuccessHandler}
+ *       targeting {@code oidc.logout.redirect_url} (or {@code /} when unset).
+ * </ul>
+ *
+ * <p>In addition, {@link #onLogoutSuccess} supports a {@code redirect_uri} query parameter used by
+ * the Android Capture app's deep-link logout flow (e.g. {@code dhis2oauth://oauth}). The value is
+ * accepted only if it matches the configured device-enrollment redirect allowlist, to prevent
+ * open-redirect abuse. When the linked-accounts feature is active and a {@code switch} parameter is
+ * present, the handler switches active linked account via {@code
+ * UserService.setActiveLinkedAccounts} and redirects to {@code linked_accounts.relogin_url};
+ * otherwise it redirects to {@code linked_accounts.logout_url}.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Component

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcProviderRepository.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcProviderRepository.java
@@ -46,6 +46,21 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.stereotype.Component;
 
 /**
+ * Spring-registered {@link ClientRegistrationRepository} holding every configured DHIS2 OIDC
+ * registration, exposed to Spring Security's {@code oauth2Login} filter chain.
+ *
+ * <p>At startup, {@link #init()} parses {@code dhis.conf}: generic providers ({@code
+ * oidc.provider.<id>.*}) are parsed by {@link GenericOidcProviderConfigParser}, and the dedicated
+ * built-in providers ({@code google}, {@code azure.0} / {@code azure.1} / ..., {@code wso2}) are
+ * parsed by their own provider classes. If {@code oauth2.server.enabled=on}, the internal {@code
+ * dhis2-internal} provider is auto-registered; its endpoints are derived from {@code
+ * server.base.url} and it is used by the Android Capture app rather than shown on the web login
+ * page.
+ *
+ * <p>Each registration is keyed by its registration id (the provider id used in redirect URIs and
+ * the login page). Insertion order is preserved via a {@link LinkedHashMap} so login buttons render
+ * in the order providers were parsed.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Component
@@ -54,6 +69,11 @@ public class DhisOidcProviderRepository implements ClientRegistrationRepository 
 
   private final Map<String, DhisOidcClientRegistration> registrationHashMap = new LinkedHashMap<>();
 
+  /**
+   * Builds the repository from {@code dhis.conf} at startup: parses generic OIDC providers, Azure,
+   * Google, and WSO2 configurations, and auto-registers the internal DHIS2 provider when {@code
+   * oauth2.server.enabled=on}.
+   */
   @PostConstruct
   public void init() {
     GenericOidcProviderConfigParser.parse(config.getProperties()).forEach(this::addRegistration);
@@ -67,6 +87,13 @@ public class DhisOidcProviderRepository implements ClientRegistrationRepository 
     }
   }
 
+  /**
+   * Registers a {@link DhisOidcClientRegistration} under its registration id. Null values are
+   * ignored. If a registration with the same id is already present, the existing entry is retained
+   * (first-wins semantics).
+   *
+   * @param registration the registration to add, may be {@code null}
+   */
   public void addRegistration(DhisOidcClientRegistration registration) {
     if (registration == null) {
       return;
@@ -76,10 +103,18 @@ public class DhisOidcProviderRepository implements ClientRegistrationRepository 
         registration.getClientRegistration().getRegistrationId(), registration);
   }
 
+  /** Removes every registered provider from this repository. */
   public void clear() {
     this.registrationHashMap.clear();
   }
 
+  /**
+   * Returns the Spring {@link ClientRegistration} for the given registration id, or {@code null} if
+   * no provider is registered under that id.
+   *
+   * @param registrationId the provider registration id
+   * @return the Spring {@link ClientRegistration}, or {@code null} if unknown
+   */
   @Override
   public ClientRegistration findByRegistrationId(String registrationId) {
     final DhisOidcClientRegistration dhisOidcClientRegistration =
@@ -91,14 +126,35 @@ public class DhisOidcProviderRepository implements ClientRegistrationRepository 
     return dhisOidcClientRegistration.getClientRegistration();
   }
 
+  /**
+   * Returns the DHIS2 wrapper registration for the given registration id, or {@code null} if no
+   * provider is registered under that id. Unlike {@link #findByRegistrationId(String)}, this
+   * returns the DHIS2 wrapper so callers can access DHIS2-specific fields (mapping claim, {@code
+   * private_key_jwt} material, external clients, login button metadata).
+   *
+   * @param registrationId the provider registration id
+   * @return the DHIS2 wrapper, or {@code null} if unknown
+   */
   public DhisOidcClientRegistration getDhisOidcClientRegistration(String registrationId) {
     return registrationHashMap.get(registrationId);
   }
 
+  /**
+   * Returns the set of all registered provider ids, in insertion order.
+   *
+   * @return set of registration ids
+   */
   public Set<String> getAllRegistrationId() {
     return registrationHashMap.keySet();
   }
 
+  /**
+   * Finds the first registered provider whose {@code provider_details.issuer_uri} equals the given
+   * issuer URI. Comparison ignores a single trailing slash on either side.
+   *
+   * @param issuerUri the issuer URI to look up
+   * @return the matching registration, or {@code null} if no provider declares that issuer
+   */
   public DhisOidcClientRegistration findByIssuerUri(String issuerUri) {
     String normalizedInput =
         issuerUri == null

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -44,6 +44,17 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
 /**
+ * Spring-principal object produced by {@link DhisOidcUserService} after a DHIS2 user has been
+ * resolved from an OIDC Identity Provider's claims. It wraps the DHIS2 {@link UserDetails} for the
+ * local account, the validated ID token, and the raw claims returned by the IdP, so that downstream
+ * Spring Security code and DHIS2 authorization checks can treat an OIDC-authenticated principal as
+ * both an {@link OidcUser} and a DHIS2 {@link UserDetails}.
+ *
+ * <p>All {@link UserDetails} accessors (username, authorities, org-unit scopes, two-factor flags,
+ * etc.) delegate to the wrapped DHIS2 user. All {@link OidcUser} accessors return the claims and ID
+ * token supplied at construction time; {@link #getUserInfo()} is not exposed here because the DHIS2
+ * login flow only uses the ID token claims.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, OidcUser {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUserService.java
@@ -46,6 +46,21 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 
 /**
+ * DHIS2 extension of Spring Security's {@link OidcUserService} that runs after a successful
+ * authorization-code exchange against an OIDC Identity Provider. It reads the claim configured by
+ * {@code mapping_claim} on the provider (default {@code email} for external providers, {@code
+ * username} for the internal DHIS2 provider) from the ID token and userinfo response, then resolves
+ * that value to a local DHIS2 user via {@code UserService.getUserByOpenId}.
+ *
+ * <p>The matched DHIS2 user must have the "External authentication only (OpenID or LDAP)" flag set
+ * ({@code isExternalAuth()}), must not be disabled, and must not have an expired account; otherwise
+ * authentication fails with an {@link OAuth2AuthenticationException}. The lookup supports the
+ * linked-accounts feature: when a single IdP claim value maps to multiple DHIS2 users, {@code
+ * getUserByOpenId} returns the most recently signed-in account.
+ *
+ * <p>On success the method returns a {@link DhisOidcUser} wrapping the DHIS2 {@code UserDetails}
+ * together with the raw OIDC claims and the validated ID token.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Slf4j
@@ -55,6 +70,16 @@ public class DhisOidcUserService extends OidcUserService {
 
   @Autowired private DhisOidcProviderRepository clientRegistrationRepository;
 
+  /**
+   * Delegates to {@link OidcUserService#loadUser(OidcUserRequest)} to fetch the OIDC user and then
+   * maps the provider's {@code mapping_claim} value to a local DHIS2 user. Throws {@link
+   * OAuth2AuthenticationException} if the claim is missing, no matching DHIS2 user exists, the
+   * DHIS2 user is not flagged for external authentication, or the account is disabled or expired.
+   *
+   * @param userRequest the OIDC user request produced after the code-for-token exchange
+   * @return a {@link DhisOidcUser} bound to the resolved DHIS2 user
+   * @throws OAuth2AuthenticationException if the claim cannot be mapped to a valid DHIS2 user
+   */
   @Override
   public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
     OidcUser oidcUser = super.loadUser(userRequest);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
@@ -78,8 +78,20 @@ import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.security.oidc.provider.GenericOidcProviderBuilder;
 
 /**
- * Parses the DHIS.conf file for valid generic OIDC provider configurations. See the DHIS2 manual
- * for how to configure a OIDC provider correctly.
+ * Parses {@code dhis.conf} for generic OIDC provider configurations under the {@code
+ * oidc.provider.<id>.*} namespace and turns each valid group of keys into a {@link
+ * DhisOidcClientRegistration} suitable for any OIDC-compliant Identity Provider.
+ *
+ * <p>Reserved provider ids ({@code google}, {@code azure}, {@code wso2}, {@code dhis2}) are skipped
+ * here; they are handled by their dedicated provider classes ({@code GoogleProvider}, {@code
+ * AzureAdProvider}, {@code Wso2Provider}, {@code Dhis2InternalOidcProvider}).
+ *
+ * <p>Validation rejects unknown configuration keys and, for each rejected key, logs the closest
+ * valid key name by Levenshtein distance as a "did you mean" hint. URI-valued keys are also
+ * validated with {@link UrlValidator}. Providers whose configuration fails any required-key, name,
+ * or URI check are skipped without aborting startup.
+ *
+ * <p>See the DHIS2 manual for the canonical list of supported configuration keys.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/KeyStoreUtil.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/KeyStoreUtil.java
@@ -41,6 +41,18 @@ import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 
 /**
+ * Utility for loading RSA keys from a PKCS12 or JKS keystore on disk. Used on two sides of DHIS2's
+ * OAuth2/OIDC stack:
+ *
+ * <ul>
+ *   <li>On the Relying Party side, to load the per-provider signing key used to build {@code
+ *       private_key_jwt} client assertions when authenticating to an external IdP's token endpoint
+ *       ({@code oidc.provider.<id>.keystore_path}, {@code keystore_password}, {@code key_alias},
+ *       {@code key_password}).
+ *   <li>On the authorization-server side, to load the signing key DHIS2 uses to mint its own tokens
+ *       ({@code oauth2.server.jwt.keystore.*}).
+ * </ul>
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class KeyStoreUtil {
@@ -48,6 +60,17 @@ public class KeyStoreUtil {
     throw new IllegalArgumentException("This class should not be instantiated");
   }
 
+  /**
+   * Loads a keystore from disk using the JVM's default keystore type.
+   *
+   * @param keystorePath filesystem path to the keystore file
+   * @param keystorePassword password used to open the keystore
+   * @return the loaded {@link KeyStore}
+   * @throws KeyStoreException if the keystore type is not available
+   * @throws IOException if the file cannot be read
+   * @throws NoSuchAlgorithmException if the integrity algorithm is unavailable
+   * @throws CertificateException if any certificate in the keystore cannot be loaded
+   */
   public static KeyStore readKeyStore(String keystorePath, String keystorePassword)
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
     KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -58,6 +81,17 @@ public class KeyStoreUtil {
     return keyStore;
   }
 
+  /**
+   * Loads an RSA public key (and its key pair) from the given alias in a keystore as a Nimbus
+   * {@link RSAKey}.
+   *
+   * @param keyStore the keystore to read from
+   * @param alias the entry alias
+   * @param pin the password protecting the private key entry
+   * @return the loaded {@link RSAKey}
+   * @throws KeyStoreException if the entry cannot be read
+   * @throws JOSEException if the stored public key is not an RSA key
+   */
   public static RSAKey loadRSAPublicKey(
       final KeyStore keyStore, final String alias, final char[] pin)
       throws KeyStoreException, JOSEException {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/OidcLoginEnabledCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/OidcLoginEnabledCondition.java
@@ -35,6 +35,15 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
+ * Spring {@link org.springframework.context.annotation.Condition} that gates the external-IdP OIDC
+ * login filter chain on {@code oidc.oauth2.login.enabled=on} in {@code dhis.conf}. It returns
+ * {@code false} during test runs so integration tests do not accidentally enable OIDC login.
+ *
+ * <p>This condition governs the login buttons on the DHIS2 web login page driven by external
+ * providers ({@code google}, {@code azure.*}, {@code wso2}, generic {@code oidc.provider.*}). It
+ * does NOT gate the internal DHIS2 OIDC provider ({@code dhis2-internal}), which is activated by
+ * its own condition tied to {@code oauth2.server.enabled}.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class OidcLoginEnabledCondition extends PropertiesAwareConfigurationCondition {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AbstractOidcProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AbstractOidcProvider.java
@@ -30,14 +30,42 @@
 package org.hisp.dhis.security.oidc.provider;
 
 /**
+ * Abstract base for all built-in DHIS2 OIDC provider builders. Shared constants and configuration
+ * keys declared here are consumed by the concrete built-in providers, {@link GoogleProvider},
+ * {@link AzureAdProvider}, {@link Wso2Provider} and {@link Dhis2InternalOidcProvider}. Providers
+ * declared with an arbitrary, non-reserved id (for example {@code oidc.provider.keycloak.*}) are
+ * handled by {@link GenericOidcProviderBuilder} instead, which also extends this class to reuse the
+ * same config-key vocabulary.
+ *
+ * <p>Every configured OIDC provider whose registration is visible on the login page renders as a
+ * sign-in button on the DHIS2 web login page when {@code oidc.oauth2.login.enabled=on}. The
+ * internal DHIS2-as-IdP provider ({@link Dhis2InternalOidcProvider}) is registered when the
+ * embedded authorization server is enabled and is deliberately not shown on the login page.
+ *
+ * <p>The public string constants below fall into two groups: defaults used when a given
+ * configuration value is absent, and the canonical property-key suffixes used to look up values
+ * inside {@code oidc.provider.<id>.*} blocks. The keystore related constants carry the values used
+ * by providers that authenticate with {@code private_key_jwt}.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public abstract class AbstractOidcProvider {
+  /**
+   * Default Spring Security redirect URI template applied to every provider when no explicit {@code
+   * redirect_url} is configured. The {@code baseUrl} and {@code registrationId} placeholders are
+   * resolved by Spring Security at runtime.
+   */
   public static final String DEFAULT_REDIRECT_TEMPLATE_URL =
       "{baseUrl}/oauth2/code/{registrationId}";
 
+  /**
+   * Default ID-token / user-info claim used to look up the local DHIS2 user when no explicit {@code
+   * mapping_claim} is configured. The internal DHIS2-as-IdP provider overrides this with {@code
+   * username}.
+   */
   public static final String DEFAULT_MAPPING_CLAIM = "email";
 
+  /** Default OAuth2 / OIDC scope requested by every built-in provider. */
   public static final String DEFAULT_SCOPE = "openid";
 
   public static final String PROVIDER_ID = "provider_id";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/AzureAdProvider.java
@@ -45,9 +45,26 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 /**
+ * Builds one {@link DhisOidcClientRegistration} per configured Microsoft Entra ID (Azure AD) tenant
+ * from {@code oidc.provider.azure.<n>.*} configuration keys in {@code dhis.conf}, where {@code <n>}
+ * is a small integer index (up to {@link #MAX_AZURE_TENANTS}). Multiple tenants are supported; each
+ * {@code azure.<n>} block becomes its own login-page button on the DHIS2 web login page when {@code
+ * oidc.oauth2.login.enabled=on}. Note: "Azure AD" is the legacy name for Microsoft Entra ID and is
+ * retained only for backwards compatibility in the configuration key.
+ *
+ * <p>The key {@code tenant} holds the Azure directory / tenant ID; it is used both as the Spring
+ * Security registration id and as the base for all endpoint URIs. Endpoints are built against the
+ * modern Microsoft identity platform (v2.0): {@code /oauth2/v2.0/authorize}, {@code
+ * /oauth2/v2.0/token}, {@code /discovery/v2.0/keys}, issuer {@code /v2.0}, and {@code
+ * https://graph.microsoft.com/oidc/userinfo}. The corresponding well-known discovery document lives
+ * at {@code https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration}.
+ *
+ * <p>Per-tenant keys read: {@code tenant}, {@code client_id}, {@code client_secret}, {@code
+ * redirect_url}, {@code mapping_claim}, {@code display_alias}, {@code enable_logout}. {@code
+ * enable_logout} defaults to {@code TRUE}; when enabled, the {@code end_session_endpoint} is wired
+ * to {@code /oauth2/v2.0/logout} on the tenant host.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
- *     <p>Well known url for reference. In a perfect world we would dynamically parse this.
- *     https://login.microsoftonline.com/"+tenant+"/v2.0/.well-known/openid-configuration
  */
 public class AzureAdProvider extends AbstractOidcProvider {
   public static final int MAX_AZURE_TENANTS = 10;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProvider.java
@@ -48,8 +48,23 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 /**
- * Internal only OIDC provider, used when authorization server is enabled in dhis.conf with
- * (OAUTH2_SERVER_ENABLED).
+ * Builds the internal DHIS2-as-IdP {@link DhisOidcClientRegistration} with registration id {@code
+ * dhis2-internal}. This provider is built-in and is auto-registered when {@code
+ * oauth2.server.enabled=on} in {@code dhis.conf}; the {@code oidc.oauth2.login.enabled} flag does
+ * NOT gate it.
+ *
+ * <p>All endpoint URIs ({@code /oauth2/authorize}, {@code /oauth2/token}, {@code /oauth2/jwks},
+ * {@code /oauth2/userinfo}, issuer) are derived from {@code server.base.url} (or the explicit
+ * {@code oidc.provider.dhis2.server_url} override), so the DHIS2 instance itself acts as both
+ * authorization server and resource server.
+ *
+ * <p>The registration is intentionally hidden from the web login page ({@code
+ * visibleOnLoginPage=false}); it is consumed only by the DHIS2 Android Capture app's {@code
+ * authorization_code} flow against this DHIS2 instance as authorization server, and for
+ * resource-server JWT validation of tokens it issues.
+ *
+ * <p>Defaults: {@code client_id=dhis2-internal}, {@code client_secret=secret}, {@code
+ * mapping_claim=username}.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GenericOidcProviderBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GenericOidcProviderBuilder.java
@@ -56,6 +56,38 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 /**
+ * Builds a {@link DhisOidcClientRegistration} from a generic {@code oidc.provider.<id>.*} config
+ * block, where {@code <id>} is any alphanumeric identifier NOT in the reserved set {@code {google,
+ * azure, wso2, dhis2}}. Reserved ids are handled by the corresponding built-in providers ({@link
+ * GoogleProvider}, {@link AzureAdProvider}, {@link Wso2Provider}, {@link
+ * Dhis2InternalOidcProvider}).
+ *
+ * <p>Every successfully built registration renders as a sign-in button on the DHIS2 web login page
+ * when {@code oidc.oauth2.login.enabled=on}.
+ *
+ * <p>Supported per-provider keys (all suffixes declared as constants on {@link
+ * AbstractOidcProvider}):
+ *
+ * <ul>
+ *   <li>{@code client_id}, {@code client_secret} (required)
+ *   <li>{@code authorization_uri}, {@code token_uri}, {@code user_info_uri}, {@code jwk_uri},
+ *       {@code issuer_uri}
+ *   <li>{@code mapping_claim} (defaults to {@link AbstractOidcProvider#DEFAULT_MAPPING_CLAIM})
+ *   <li>{@code redirect_url} (defaults to {@link
+ *       AbstractOidcProvider#DEFAULT_REDIRECT_TEMPLATE_URL})
+ *   <li>{@code scopes} (space-separated, {@code openid} is always added)
+ *   <li>{@code display_alias}, {@code login_image}, {@code login_image_padding}
+ *   <li>{@code enable_logout} with {@code end_session_endpoint}
+ *   <li>{@code enable_pkce}
+ *   <li>{@code authorization_grant_type}, {@code client_authentication_method}
+ *   <li>{@code extra_request_parameters}
+ *   <li>Keys for {@code private_key_jwt} client authentication: {@code keystore_path}, {@code
+ *       keystore_password}, {@code key_alias}, {@code key_password}, {@code jwk_set_url}
+ * </ul>
+ *
+ * <p>Unknown keys inside a provider block are logged at startup, together with the closest
+ * known-key suggestion, so that typos in {@code dhis.conf} are surfaced to administrators.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class GenericOidcProviderBuilder extends AbstractOidcProvider {
@@ -63,6 +95,17 @@ public class GenericOidcProviderBuilder extends AbstractOidcProvider {
     throw new IllegalStateException("Utility class");
   }
 
+  /**
+   * Builds a {@link DhisOidcClientRegistration} for a single generic provider block.
+   *
+   * @param config per-provider key/value map extracted from {@code dhis.conf} (keys are the
+   *     canonical suffixes, e.g. {@code client_id}, not the full {@code oidc.provider.<id>.*} form)
+   * @param externalClients optional map of external clients that may call back into DHIS2 with
+   *     tokens issued by this provider, keyed by external client id
+   * @return the built registration, or {@code null} when the block is effectively empty (missing
+   *     {@code provider_id} or {@code client_id})
+   * @throws IllegalArgumentException if {@code client_secret} is missing
+   */
   public static DhisOidcClientRegistration build(
       Map<String, String> config, Map<String, Map<String, String>> externalClients) {
     Objects.requireNonNull(config, "DhisConfigurationProvider is missing!");
@@ -203,11 +246,13 @@ public class GenericOidcProviderBuilder extends AbstractOidcProvider {
   }
 
   /**
-   * Extra request parameters has to be in this form: acr_value 4, test_param five (trailing
-   * (PARAM1_NAME VALUE1,PARAM2_NAME VALUE2...)
+   * Parses the {@code extra_request_parameters} value into a name/value map. The expected format is
+   * a comma-separated list of whitespace-separated name/value pairs, for example {@code acr_value
+   * 4, test_param five}. Entries that are not exactly two whitespace-separated tokens are silently
+   * skipped. These parameters are added to every authorization request made to the provider.
    *
-   * @param config
-   * @return
+   * @param config per-provider key/value map
+   * @return a map of extra request parameter names to values, never {@code null}
    */
   public static Map<String, String> getExtraRequestParameters(Map<String, String> config) {
     String params = StringUtils.defaultIfEmpty(config.get(EXTRA_REQUEST_PARAMETERS), "");

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GoogleProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/GoogleProvider.java
@@ -45,6 +45,15 @@ import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 /**
+ * Builds the Google-specific {@link DhisOidcClientRegistration} from {@code oidc.provider.google.*}
+ * configuration keys in {@code dhis.conf}. Reads {@code client_id}, {@code client_secret}, {@code
+ * redirect_uri} and {@code mapping_claim}; the mapping claim defaults to {@code email}.
+ *
+ * <p>All OAuth2 / OIDC endpoints (authorization URI, token URI, JWK set URI, user-info URI) are
+ * taken from Spring Security's {@code CommonOAuth2Provider.GOOGLE} preset, which matches Google's
+ * well-known configuration. When {@code oidc.oauth2.login.enabled=on} and the Google block is
+ * present, Google renders as a sign-in button on the DHIS2 web login page.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class GoogleProvider extends AbstractOidcProvider {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Wso2Provider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Wso2Provider.java
@@ -51,6 +51,17 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 /**
+ * Builds the WSO2 Identity Server {@link DhisOidcClientRegistration} from {@code
+ * oidc.provider.wso2.*} configuration keys in {@code dhis.conf}. Reads {@code client_id}, {@code
+ * client_secret}, {@code server_url}, {@code mapping_claim}, {@code display_alias} and {@code
+ * enable_logout}.
+ *
+ * <p>The OAuth2 / OIDC endpoints are derived from the configured {@code server_url}: {@code
+ * /oauth2/authorize}, {@code /oauth2/token}, {@code /oauth2/jwks} and {@code /oauth2/userinfo}.
+ * When {@code enable_logout} is on, the {@code end_session_endpoint} is wired to {@code
+ * /oidc/logout} on the same host. When {@code oidc.oauth2.login.enabled=on} and the WSO2 block is
+ * present, WSO2 renders as a sign-in button on the DHIS2 web login page.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class Wso2Provider extends AbstractOidcProvider {


### PR DESCRIPTION
## Summary

Part 3 of 3 splitting #23734 into smaller PRs per reviewer request. This PR covers the existing OIDC **Relying Party** (external IdP login) code and the **JWT bearer** resource-server code. Both have been in DHIS2 since 2.41 and are the largest pre-existing block in the auth stack.

19 classes, Javadoc only, aligned with the user-facing OAuth2 / OIDC / JWT reference in [dhis2-docs#1739](https://github.com/dhis2/dhis2-docs/pull/1739).

- OIDC RP core (10): \`DhisOidcClientRegistration\`, \`DhisOidcProviderRepository\`, \`DhisOidcUserService\`, \`DhisOidcUser\`, \`DhisOidcLogoutSuccessHandler\`, \`DhisAuthorizationCodeTokenResponseClient\`, \`DhisCustomAuthorizationRequestResolver\`, \`GenericOidcProviderConfigParser\`, \`KeyStoreUtil\`, \`OidcLoginEnabledCondition\`.
- OIDC provider builders (6): \`AbstractOidcProvider\`, \`GenericOidcProviderBuilder\`, \`GoogleProvider\`, \`AzureAdProvider\` (Microsoft Entra ID), \`Wso2Provider\`, \`Dhis2InternalOidcProvider\`.
- JWT bearer (3): \`Dhis2JwtAuthenticationManagerResolver\`, \`DhisBearerJwtTokenAuthenticationEntryPoint\`, \`DhisJwtAuthenticationToken\`.

Companion PRs:
- SAS core: docs/javadocs-sas
- DCR: docs/javadocs-android-dcr



AI Assisted