### PR TITLE
fix: disable OAuth2 Authorization Server for 2.43.0

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
@@ -42,7 +42,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * exercise the feature locally, and the {@code oauth2.server.enabled} dhis.conf key is ignored for
  * this release.
  *
- * @author Ameen Mohamed
+ * @author Morten Svanæs
  */
 public class AuthorizationServerEnabledCondition extends PropertiesAwareConfigurationCondition {
   @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
@@ -31,25 +31,23 @@ package org.hisp.dhis.condition;
 
 import static org.hisp.dhis.commons.util.SystemUtils.isOAuth2AuthorizationServerTest;
 
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
- * Condition that matches to true if redis.enabled property is set to true in dhis.conf.
+ * Gate for the Spring Authorization Server and its supporting beans.
+ *
+ * <p>The OAuth2 Authorization Server is disabled in 2.43.0. Re-enable is planned for 2.43.1. The
+ * {@code oauth2-authorization-server-test} profile is still honored so the existing test suite can
+ * exercise the feature locally, and the {@code oauth2.server.enabled} dhis.conf key is ignored for
+ * this release.
  *
  * @author Ameen Mohamed
  */
 public class AuthorizationServerEnabledCondition extends PropertiesAwareConfigurationCondition {
   @Override
   public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-    if (isOAuth2AuthorizationServerTest(context.getEnvironment().getActiveProfiles())) {
-      return true;
-    }
-    if (!isTestRun(context)) {
-      return getConfiguration().isEnabled(ConfigurationKey.OAUTH2_SERVER_ENABLED);
-    }
-    return false;
+    return isOAuth2AuthorizationServerTest(context.getEnvironment().getActiveProfiles());
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/condition/AuthorizationServerEnabledCondition.java
@@ -37,8 +37,8 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 /**
  * Gate for the Spring Authorization Server and its supporting beans.
  *
- * <p>The OAuth2 Authorization Server is disabled in 2.43.0. Re-enable is planned for 2.43.1. The
- * {@code oauth2-authorization-server-test} profile is still honored so the existing test suite can
+ * <p>The OAuth2 Authorization Server is disabled in 2.43.0. The {@code
+ * oauth2-authorization-server-test} profile is still honored so the existing test suite can
  * exercise the feature locally, and the {@code oauth2.server.enabled} dhis.conf key is ignored for
  * this release.
  *

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.uitest.ConsentPage;
 import org.hisp.dhis.uitest.LoginPage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,7 @@ import org.springframework.http.ResponseEntity;
 
 @Tag("oauth2tests")
 @Slf4j
+@Disabled("OAuth2 Authorization Server is disabled in 2.43.0; re-enable scheduled for 2.43.1")
 class OAuth2Test extends BaseE2ETest {
 
   private static WebDriver driver;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -68,7 +68,7 @@ import org.springframework.http.ResponseEntity;
 
 @Tag("oauth2tests")
 @Slf4j
-@Disabled("OAuth2 Authorization Server is disabled in 2.43.0; re-enable scheduled for 2.43.1")
+@Disabled("OAuth2 Authorization Server is disabled in 2.43.0")
 class OAuth2Test extends BaseE2ETest {
 
   private static WebDriver driver;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Confirms the OAuth2 Authorization Server surface is disabled on 2.43.0.
+ *
+ * <p>The three OAuth2 controllers and the DCR enrollment endpoint are gated by {@code
+ * AuthorizationServerEnabledCondition}, which returns {@code false} outside the {@code
+ * oauth2-authorization-server-test} profile. This test runs in the default profile, so the beans
+ * never load and every path returns 404. Scheduled re-enable in 2.43.1.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Transactional
+class OAuth2AuthorizationServerDisabledTest extends H2ControllerIntegrationTestBase {
+
+  @Test
+  void oauth2Clients_get_returns404() {
+    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2Clients").status());
+  }
+
+  @Test
+  void oauth2Clients_post_returns404() {
+    assertEquals(
+        HttpStatus.NOT_FOUND,
+        POST("/oAuth2Clients", "{'clientId':'any','clientSecret':'any'}").status());
+  }
+
+  @Test
+  void oauth2Authorizations_get_returns404() {
+    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2Authorizations").status());
+  }
+
+  @Test
+  void oauth2AuthorizationConsents_get_returns404() {
+    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2AuthorizationConsents").status());
+  }
+
+  @Test
+  void dcrEnrollDevice_returns404() {
+    assertEquals(HttpStatus.NOT_FOUND, GET("/enrollDevice?client_id=x").status());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
@@ -37,7 +37,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Confirms the OAuth2 Authorization Server surface is disabled on 2.43.0.
+ * Confirms the OAuth2 Authorization Server surface is disabled on 2.43.0. The DCR enrollment
+ * endpoint is unreachable (404) because it is gated by {@code AuthorizationServerEnabledCondition}.
+ * The three CRUD/list controllers are superuser-only — non-admins get 403.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -45,29 +47,25 @@ import org.springframework.transaction.annotation.Transactional;
 class OAuth2AuthorizationServerDisabledTest extends H2ControllerIntegrationTestBase {
 
   @Test
-  void oauth2Clients_get_returns404() {
-    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2Clients").status());
-  }
-
-  @Test
-  void oauth2Clients_post_returns404() {
-    assertEquals(
-        HttpStatus.NOT_FOUND,
-        POST("/oAuth2Clients", "{'clientId':'any','clientSecret':'any'}").status());
-  }
-
-  @Test
-  void oauth2Authorizations_get_returns404() {
-    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2Authorizations").status());
-  }
-
-  @Test
-  void oauth2AuthorizationConsents_get_returns404() {
-    assertEquals(HttpStatus.NOT_FOUND, GET("/oAuth2AuthorizationConsents").status());
-  }
-
-  @Test
   void dcrEnrollDevice_returns404() {
     assertEquals(HttpStatus.NOT_FOUND, GET("/enrollDevice?client_id=x").status());
+  }
+
+  @Test
+  void oauth2Clients_nonAdmin_returns403() {
+    switchToNewUser("guest-clients");
+    assertEquals(HttpStatus.FORBIDDEN, GET("/oAuth2Clients").status());
+  }
+
+  @Test
+  void oauth2Authorizations_nonAdmin_returns403() {
+    switchToNewUser("guest-auth");
+    assertEquals(HttpStatus.FORBIDDEN, GET("/oAuth2Authorizations").status());
+  }
+
+  @Test
+  void oauth2AuthorizationConsents_nonAdmin_returns403() {
+    switchToNewUser("guest-consent");
+    assertEquals(HttpStatus.FORBIDDEN, GET("/oAuth2AuthorizationConsents").status());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2AuthorizationServerDisabledTest.java
@@ -39,11 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Confirms the OAuth2 Authorization Server surface is disabled on 2.43.0.
  *
- * <p>The three OAuth2 controllers and the DCR enrollment endpoint are gated by {@code
- * AuthorizationServerEnabledCondition}, which returns {@code false} outside the {@code
- * oauth2-authorization-server-test} profile. This test runs in the default profile, so the beans
- * never load and every path returns 404. Scheduled re-enable in 2.43.1.
- *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Transactional

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
@@ -44,8 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Controller for managing OAuth2 authorization consents for the DHIS2 OAuth2 authorization server.
  *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
- * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
@@ -32,26 +32,23 @@ package org.hisp.dhis.webapi.controller.security.oauth;
 import static org.hisp.dhis.security.Authorities.ALL;
 
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.consent.Dhis2OAuth2AuthorizationConsent;
 import org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * Controller for managing OAuth2 authorization consents for the DHIS2 OAuth2 authorization server.
- *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
+ * Superuser-only for 2.43.0; no new consents can be granted because the authorization server itself
+ * is disabled.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2AuthorizationConsents"})
 @RequiredArgsConstructor
-@Conditional(AuthorizationServerEnabledCondition.class)
 @RequiresAuthority(anyOf = ALL)
 public class OAuth2AuthorizationConsentController
     extends AbstractFullReadOnlyController<Dhis2OAuth2AuthorizationConsent, GetObjectListParams> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationConsentController.java
@@ -29,20 +29,30 @@
  */
 package org.hisp.dhis.webapi.controller.security.oauth;
 
+import static org.hisp.dhis.security.Authorities.ALL;
+
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.query.GetObjectListParams;
+import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.consent.Dhis2OAuth2AuthorizationConsent;
 import org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * Controller for managing OAuth2 authorization consents for the DHIS2 OAuth2 authorization server.
  *
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
+ * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2AuthorizationConsents"})
 @RequiredArgsConstructor
+@Conditional(AuthorizationServerEnabledCondition.class)
+@RequiresAuthority(anyOf = ALL)
 public class OAuth2AuthorizationConsentController
     extends AbstractFullReadOnlyController<Dhis2OAuth2AuthorizationConsent, GetObjectListParams> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
@@ -29,20 +29,30 @@
  */
 package org.hisp.dhis.webapi.controller.security.oauth;
 
+import static org.hisp.dhis.security.Authorities.ALL;
+
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.query.GetObjectListParams;
+import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.authorization.Dhis2OAuth2Authorization;
 import org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * Controller for managing OAuth2 authorizations for the DHIS2 OAuth2 authorization server.
  *
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
+ * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2Authorizations"})
 @RequiredArgsConstructor
+@Conditional(AuthorizationServerEnabledCondition.class)
+@RequiresAuthority(anyOf = ALL)
 public class OAuth2AuthorizationController
     extends AbstractFullReadOnlyController<Dhis2OAuth2Authorization, GetObjectListParams> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
@@ -44,8 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Controller for managing OAuth2 authorizations for the DHIS2 OAuth2 authorization server.
  *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
- * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2AuthorizationController.java
@@ -32,26 +32,23 @@ package org.hisp.dhis.webapi.controller.security.oauth;
 import static org.hisp.dhis.security.Authorities.ALL;
 
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.authorization.Dhis2OAuth2Authorization;
 import org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * Controller for managing OAuth2 authorizations for the DHIS2 OAuth2 authorization server.
- *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
+ * Superuser-only for 2.43.0; no new authorizations can be issued because the authorization server
+ * itself is disabled.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2Authorizations"})
 @RequiredArgsConstructor
-@Conditional(AuthorizationServerEnabledCondition.class)
 @RequiresAuthority(anyOf = ALL)
 public class OAuth2AuthorizationController
     extends AbstractFullReadOnlyController<Dhis2OAuth2Authorization, GetObjectListParams> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
@@ -29,12 +29,17 @@
  */
 package org.hisp.dhis.webapi.controller.security.oauth;
 
+import static org.hisp.dhis.security.Authorities.ALL;
+
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.query.GetObjectListParams;
+import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2Client;
 import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2ClientService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
@@ -44,11 +49,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Controller for managing OAuth2 clients for the DHIS2 OAuth2 authorization server.
  *
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
+ * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2Clients"})
 @RequiredArgsConstructor
+@Conditional(AuthorizationServerEnabledCondition.class)
+@RequiresAuthority(anyOf = ALL)
 public class OAuth2ClientController
     extends AbstractCrudController<Dhis2OAuth2Client, GetObjectListParams> {
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
@@ -49,8 +49,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Controller for managing OAuth2 clients for the DHIS2 OAuth2 authorization server.
  *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition}; superuser-only as a
- * defense-in-depth gate when the condition is flipped back on. Scheduled re-enable in 2.43.1.
+ * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/oauth/OAuth2ClientController.java
@@ -32,14 +32,12 @@ package org.hisp.dhis.webapi.controller.security.oauth;
 import static org.hisp.dhis.security.Authorities.ALL;
 
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.condition.AuthorizationServerEnabledCondition;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2Client;
 import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2ClientService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
@@ -47,16 +45,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- * Controller for managing OAuth2 clients for the DHIS2 OAuth2 authorization server.
- *
- * <p>Disabled in 2.43.0 via {@link AuthorizationServerEnabledCondition};
+ * Controller for managing OAuth2 clients for the DHIS2 OAuth2 authorization server. Superuser-only
+ * for 2.43.0; the persisted clients are inert because the authorization server itself is disabled.
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Controller
 @RequestMapping({"/api/oAuth2Clients"})
 @RequiredArgsConstructor
-@Conditional(AuthorizationServerEnabledCondition.class)
 @RequiresAuthority(anyOf = ALL)
 public class OAuth2ClientController
     extends AbstractCrudController<Dhis2OAuth2Client, GetObjectListParams> {


### PR DESCRIPTION
## Summary

Jira: [DHIS2-21367](https://dhis2.atlassian.net/browse/DHIS2-21367)

Disables the OAuth2 Authorization Server surface for 2.43.0. 

AI Assisted

[DHIS2-21367]: https://dhis2.atlassian.net/browse/DHIS2-21367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ