### PR TITLE
fix: Strip 'WebMessageResponse' from web response [DHIS2-21364]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webmessage/WebMessageResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webmessage/WebMessageResponse.java
@@ -46,6 +46,6 @@ public interface WebMessageResponse {
 
   @JsonProperty
   default String getResponseType() {
-    return getResponseClassType().getSimpleName();
+    return getResponseClassType().getSimpleName().replaceFirst("WebMessageResponse", "");
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
@@ -38,9 +38,11 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -142,5 +144,26 @@ class DataSetControllerTest extends H2ControllerIntegrationTestBase {
     dataSet = manager.get(DataSet.class, dataSetId);
 
     assertEquals(0, dataSet.getCompulsoryDataElementOperands().size());
+  }
+
+  @Test
+  @DisplayName("Response responseType should be 'ObjectReport'")
+  void responseTypeTest() {
+    // given a dataset exists
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/dataSets/",
+            "{'name':'data set test', 'shortName':'DST', 'periodType':'Monthly', 'id': 'DsUid090901'}"));
+
+    // when patching the dataset
+    JsonMixed content =
+        PATCH(
+                "/dataSets/DsUid090901",
+                "[{'op': 'replace', 'path': '/name', 'value': 'DS name update'}]")
+            .content();
+
+    // then the response type should be 'ObjectReport'
+    assertEquals("ObjectReport", content.getString("response.responseType").string());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -35,7 +35,6 @@ import static org.hisp.dhis.test.webapi.Assertions.assertNoDiff;
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.dxf2.webmessage.responses.TrackerJobWebMessageResponse;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -88,9 +87,7 @@ class TrackerImportControllerTest extends PostgresControllerIntegrationTestBase 
     assertContains("/tracker/jobs/", location);
     String jobId = location.substring(location.lastIndexOf('/') + 1);
     assertEquals(jobId, response.getString("id").string());
-    assertEquals(
-        TrackerJobWebMessageResponse.class.getSimpleName(),
-        response.getString("responseType").string());
+    assertEquals("TrackerJob", response.getString("responseType").string());
   }
 
   @Test


### PR DESCRIPTION
## Issue
When patching a `DataSet`, the `response.responseType` value is `ObjectReportWebMessageResponse` (see below). Previous behaviour (<42) has the value `ObjectReport`.
```json
{
    "httpStatus": "OK",
    "httpStatusCode": 200,
    "status": "OK",
    "response": {
        "uid": "lyLU2wR22tC",
        "klass": "org.hisp.dhis.dataset.DataSet",
        "errorReports": [],
        "responseType": "ObjectReportWebMessageResponse"
    }
}
```

This is not just confined to patching a `DataSet`. It impacts any web message response type ending in `WebMessageResponse` e.g. `ObjectReportWebMessageResponse`, `TrackerJobWebMessageResponse`.

## Cause
Accidentally removed in this PR: https://github.com/dhis2/dhis2-core/pull/18858/changes#diff-90de3dbd7fc100289651ac5854af5c9c2c002ea9f12dcaab8d386eb4f69acde0L47 

## Fix
Revert to stripping `WebMessageResponse` when present.
Approximately half of the 15 implementations of `WebResponse` have `WebMessageResponse` in their name.
- all of these will now have `WebMessageResponse` stripped
- it's a system wide change, not just restricted to patching a `DataSet`

## Testing
- Added web test to confirm expected response value of `ObjectReport`
- Updated existing Tracker test to expect new value `TrackerJob` instead of `TrackerJobWebMessageResponse`