### PR TITLE
feat: migrate CORS whitelist from Configuration to SystemSettings

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -110,7 +110,5 @@ public interface CacheProvider {
 
   <V> Cache<V> createQueryAliasCache();
 
-  <V> Cache<V> createCorsWhitelistCache();
-
   <V> Cache<V> createNotificationTemplateCache();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
@@ -67,6 +67,5 @@ public enum Region {
   dataIntegritySummaryCache,
   dataIntegrityDetailsCache,
   queryAliasCache,
-  corsWhitelistCache,
   notificationTemplateCache
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/Configuration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/Configuration.java
@@ -95,6 +95,18 @@ public class Configuration implements Serializable {
 
   private OrganisationUnitLevel facilityOrgUnitLevel;
 
+  /**
+   * API-compatibility only: the CORS whitelist is no longer persisted via Hibernate (the {@code
+   * configuration_corswhitelist} mapping was removed in 2.44). The authoritative source is {@link
+   * org.hisp.dhis.setting.SystemSettings#getCorsWhitelist()}; {@code
+   * ConfigurationController#getConfiguration} overlays the live value at read time so the {@code
+   * /api/configuration} JSON shape stays unchanged.
+   *
+   * @deprecated Read or write via {@link org.hisp.dhis.setting.SystemSettingsService} or the
+   *     dedicated {@code GET}/{@code POST /api/configuration/corsWhitelist} endpoints. This field
+   *     and its accessors are scheduled for removal in a future major release.
+   */
+  @Deprecated(since = "2.44", forRemoval = true)
   private Set<String> corsWhitelist = new HashSet<>();
 
   /** Set of periods used in data output (analytics). */
@@ -269,19 +281,33 @@ public class Configuration implements Serializable {
     this.facilityOrgUnitLevel = facilityOrgUnitLevel;
   }
 
+  /**
+   * @deprecated See {@link #corsWhitelist}.
+   */
+  @Deprecated(since = "2.44", forRemoval = true)
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Set<String> getCorsWhitelist() {
     return corsWhitelist;
   }
 
+  /**
+   * @deprecated See {@link #corsWhitelist}.
+   */
+  @Deprecated(since = "2.44", forRemoval = true)
   public void setCorsWhitelist(Set<String> corsWhitelist) {
     this.corsWhitelist = corsWhitelist;
   }
 
+  /**
+   * Alias for {@link #getCorsWhitelist()} kept for API compatibility.
+   *
+   * @deprecated See {@link #corsWhitelist}.
+   */
+  @Deprecated(since = "2.44", forRemoval = true)
   @JsonProperty
   public Set<String> getCorsAllowlist() {
-    return getCorsWhitelist(); // just an alias
+    return getCorsWhitelist();
   }
 
   @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/ConfigurationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/ConfigurationService.java
@@ -51,14 +51,6 @@ public interface ConfigurationService {
    */
   Configuration getConfiguration();
 
-  /**
-   * Indicates whether the given origin is CORS white listed.
-   *
-   * @param origin the origin.
-   * @return true if the given origin is CORS white listed.
-   */
-  boolean isCorsWhitelisted(String origin);
-
   /** Indicates whether the current user is part of the feedback Recipients group */
   boolean isUserInFeedbackRecipientUserGroup(UserDetails userDetails);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -33,10 +33,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.analytics.AnalyticsCacheTtlMode;
 import org.hisp.dhis.analytics.AnalyticsFinancialYearStartKey;
@@ -281,6 +284,15 @@ public non-sealed interface SystemSettings extends Settings {
 
   default boolean getSelfRegistrationNoRecaptcha() {
     return asBoolean("keySelfRegistrationNoRecaptcha", false);
+  }
+
+  /**
+   * Returns the CORS whitelist parsed from the {@code corsWhitelist} system setting. The stored
+   * value is comma- or newline-separated; see {@link #parseCorsWhitelist(String)} for the parsing
+   * rules.
+   */
+  default Set<String> getCorsWhitelist() {
+    return parseCorsWhitelist(asString("corsWhitelist", ""));
   }
 
   @Confidential
@@ -854,5 +866,40 @@ public non-sealed interface SystemSettings extends Settings {
    */
   default Boolean getCustomTranslationsEnabled() {
     return asBoolean("keyCustomTranslationsEnabled", false);
+  }
+
+  /**
+   * Parses a CORS whitelist stored as a single string. Accepts comma-separated, newline-separated,
+   * or both; trims each entry, drops empty entries, and preserves insertion order via {@link
+   * LinkedHashSet}. Returns an empty set for {@code null} or blank input.
+   */
+  static Set<String> parseCorsWhitelist(String value) {
+    if (value == null || value.isBlank()) {
+      return Set.of();
+    }
+
+    return value
+        .lines()
+        .flatMap(line -> Arrays.stream(line.split(",")))
+        .map(String::trim)
+        .filter(entry -> !entry.isEmpty())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  /**
+   * Encodes a CORS whitelist to the canonical storage form: trimmed, empty entries removed, sorted
+   * alphabetically (deterministic), comma-joined with no spaces. Returns an empty string for {@code
+   * null} or empty input.
+   */
+  static String encodeCorsWhitelist(Set<String> corsWhitelist) {
+    if (corsWhitelist == null || corsWhitelist.isEmpty()) {
+      return "";
+    }
+
+    return corsWhitelist.stream()
+        .map(String::trim)
+        .filter(entry -> !entry.isEmpty())
+        .sorted()
+        .collect(Collectors.joining(","));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/DefaultConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/DefaultConfigurationService.java
@@ -30,10 +30,8 @@
 package org.hisp.dhis.configuration;
 
 import java.util.Iterator;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.GenericStore;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -72,22 +70,6 @@ public class DefaultConfigurationService implements ConfigurationService {
     Iterator<Configuration> iterator = configurationStore.getAll().iterator();
 
     return iterator.hasNext() ? iterator.next() : new Configuration();
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public boolean isCorsWhitelisted(String origin) {
-    Set<String> corsWhitelist = getConfiguration().getCorsWhitelist();
-
-    for (String cors : corsWhitelist) {
-      String regex = TextUtils.createRegexFromGlob(cors);
-
-      if (origin.matches(regex)) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/configuration/hibernate/Configuration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/configuration/hibernate/Configuration.hbm.xml
@@ -44,12 +44,6 @@
     <many-to-one name="facilityOrgUnitLevel" class="org.hisp.dhis.organisationunit.OrganisationUnitLevel"
         column="facilityorgunitlevel" foreign-key="fk_configuration_facilityorgunitlevel" />
 
-    <set name="corsWhitelist" table="configuration_corswhitelist" lazy="false">
-      <cache usage="read-write" />
-      <key column="configurationid" foreign-key="fk_configuration_corswhitelist" />
-      <element type="string" column="corswhitelist" />
-    </set>
-
     <set name="dataOutputPeriodTypes" table="configuration_dataoutputperiodtype">
       <cache usage="read-write" />
       <key column="configurationid" foreign-key="fk_configuration_dataoutputperiodtype_configurationid" not-null="true" />

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -102,7 +102,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(148, keys.size());
+    assertEquals(149, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));
@@ -110,6 +110,25 @@ class SystemSettingsTest {
     assertTrue(keys.contains("keyCustomTranslationsEnabled"));
     assertTrue(keys.contains(("keyCustomColor")));
     assertTrue(keys.contains(("keyCustomColorMobile")));
+    assertTrue(keys.contains("corsWhitelist"));
+  }
+
+  @Test
+  void testCorsWhitelist() {
+    SystemSettings settings =
+        SystemSettings.of(
+            Map.of(
+                "corsWhitelist",
+                "https://alpha.example.org, https://beta.example.org\nhttps://gamma.example.org"));
+
+    assertEquals(
+        Set.of(
+            "https://alpha.example.org", "https://beta.example.org", "https://gamma.example.org"),
+        settings.getCorsWhitelist());
+    assertEquals(
+        "https://alpha.example.org,https://beta.example.org",
+        SystemSettings.encodeCorsWhitelist(
+            Set.of(" https://beta.example.org ", "https://alpha.example.org")));
   }
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_5__move_cors_whitelist_to_system_setting.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_5__move_cors_whitelist_to_system_setting.sql
@@ -1,0 +1,30 @@
+-- Move CORS whitelist persistence from the legacy singleton Configuration entity
+-- to the in-memory system settings snapshot, then remove the legacy table.
+-- Idempotent: the to_regclass guard skips work on a replay where the legacy table
+-- has already been dropped, and the not-exists check skips re-insertion when
+-- 'corsWhitelist' is already present in systemsetting.
+do $$
+begin
+  if to_regclass('configuration_corswhitelist') is not null then
+    with migrated_cors_whitelist as (
+      select string_agg(cors_entry, ',' order by cors_entry) as value
+      from (
+        select distinct trim(corswhitelist) as cors_entry
+        from configuration_corswhitelist
+        where corswhitelist is not null
+          and trim(corswhitelist) <> ''
+      ) entries
+    )
+    insert into systemsetting(systemsettingid, name, value)
+    select nextval('hibernate_sequence'), 'corsWhitelist', value
+    from migrated_cors_whitelist
+    where value is not null
+      and not exists (
+        select 1
+        from systemsetting
+        where name = 'corsWhitelist'
+      );
+  end if;
+end $$;
+
+drop table if exists configuration_corswhitelist cascade;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -442,21 +442,6 @@ public class DefaultCacheProvider implements CacheProvider {
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
   }
 
-  /**
-   * Cache for CORS whitelist to avoid database lookups on every HTTP request. Expires after 5
-   * minutes to pick up configuration changes.
-   */
-  @Override
-  public <V> Cache<V> createCorsWhitelistCache() {
-    return registerCache(
-        this.<V>newBuilder()
-            .forRegion(Region.corsWhitelistCache.name())
-            .expireAfterWrite(5, MINUTES)
-            .withInitialCapacity((int) getActualSize(SIZE_1))
-            .forceInMemory()
-            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_1))));
-  }
-
   @Override
   public <V> Cache<V> createNotificationTemplateCache() {
     return registerCache(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/configuration/ConfigurationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/configuration/ConfigurationServiceTest.java
@@ -30,13 +30,9 @@
 package org.hisp.dhis.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashSet;
-import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
@@ -85,22 +81,5 @@ class ConfigurationServiceTest extends PostgresIntegrationTestBase {
     assertNotNull(config.getFacilityOrgUnitGroupSet());
     assertEquals(group, config.getFeedbackRecipients());
     assertEquals(groupSet, config.getFacilityOrgUnitGroupSet());
-  }
-
-  @Test
-  void testCorsWhitelist() {
-    Configuration config = configurationService.getConfiguration();
-    Set<String> cors = new HashSet<>();
-    cors.add("http://localhost:3000/");
-    cors.add("http://*.local.tld:3000/");
-    cors.add("*.remote.tld/");
-    config.setCorsWhitelist(cors);
-    configurationService.setConfiguration(config);
-    assertTrue(configurationService.isCorsWhitelisted("http://localhost:3000/"));
-    assertTrue(configurationService.isCorsWhitelisted("http://foobar.local.tld:3000/"));
-    assertTrue(configurationService.isCorsWhitelisted("http://magic.remote.tld/"));
-    assertFalse(configurationService.isCorsWhitelisted("http://localhost:9000/"));
-    assertFalse(configurationService.isCorsWhitelisted("http://another.local.tld/"));
-    assertFalse(configurationService.isCorsWhitelisted("http://some.other.tld/"));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ConfigurationControllerTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
@@ -204,6 +205,29 @@ class ConfigurationControllerTest extends PostgresControllerIntegrationTestBase 
         GET("/configuration/infrastructuralIndicators").content(HttpStatus.OK).as(JsonObject.class);
     assertEquals(indicatorGroupId, indicatorGroup.getString("id").string());
     assertEquals("Test Infrastructure Group", indicatorGroup.getString("name").string());
+  }
+
+  @Test
+  @DisplayName("POST /configuration/corsWhitelist should store CORS whitelist as system setting")
+  void testSetCorsWhitelistUsesSystemSettings() {
+    String payload =
+        """
+            [
+              "https://beta.example.org",
+              "https://alpha.example.org"
+            ]
+            """;
+
+    assertStatus(HttpStatus.NO_CONTENT, POST("/configuration/corsWhitelist", payload));
+
+    String corsWhitelist = GET("/configuration/corsWhitelist").content(HttpStatus.OK).toString();
+    assertTrue(corsWhitelist.contains("https://alpha.example.org"));
+    assertTrue(corsWhitelist.contains("https://beta.example.org"));
+
+    JsonObject configuration = GET("/configuration").content(HttpStatus.OK).as(JsonObject.class);
+    String configurationCorsWhitelist = configuration.getArray("corsWhitelist").toString();
+    assertTrue(configurationCorsWhitelist.contains("https://alpha.example.org"));
+    assertTrue(configurationCorsWhitelist.contains("https://beta.example.org"));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.util.ObjectUtils;
@@ -95,6 +96,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class ConfigurationController {
   @Autowired private ConfigurationService configurationService;
 
+  @Autowired private SystemSettingsService settingsService;
+
   @Autowired private DhisConfigurationProvider config;
 
   @Autowired private IdentifiableObjectManager identifiableObjectManager;
@@ -113,7 +116,11 @@ public class ConfigurationController {
 
   @GetMapping
   public @ResponseBody Configuration getConfiguration(Model model, HttpServletRequest request) {
-    return configurationService.getConfiguration();
+    Configuration configuration = configurationService.getConfiguration();
+    // Overlay corsWhitelist from system settings; the field on Configuration is API-compat only
+    // (see Configuration#corsWhitelist) and is no longer Hibernate-mapped.
+    configuration.setCorsWhitelist(settingsService.getCurrentSettings().getCorsWhitelist());
+    return configuration;
   }
 
   @ResponseStatus(value = HttpStatus.OK)
@@ -459,7 +466,7 @@ public class ConfigurationController {
       value = {"/corsWhitelist", "/corsAllowlist"},
       produces = APPLICATION_JSON_VALUE)
   public @ResponseBody Set<String> getCorsWhitelist(Model model, HttpServletRequest request) {
-    return configurationService.getConfiguration().getCorsWhitelist();
+    return settingsService.getCurrentSettings().getCorsWhitelist();
   }
 
   @SuppressWarnings("unchecked")
@@ -471,11 +478,7 @@ public class ConfigurationController {
   public void setCorsWhitelist(@RequestBody String input) throws IOException {
     Set<String> corsWhitelist = renderService.fromJson(input, Set.class);
 
-    Configuration configuration = configurationService.getConfiguration();
-
-    configuration.setCorsWhitelist(corsWhitelist);
-
-    configurationService.setConfiguration(configuration);
+    settingsService.put("corsWhitelist", SystemSettings.encodeCorsWhitelist(corsWhitelist));
   }
 
   @GetMapping(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/CspFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/CspFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,10 +40,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -55,18 +53,11 @@ public class CspFilter extends OncePerRequestFilter {
 
   private final boolean enabled;
 
-  private final ConfigurationService configurationService;
+  private final SystemSettingsProvider settingsProvider;
 
-  /** Cache for CORS whitelist to avoid DB lookups on every request. Expires after 5 minutes. */
-  private final Cache<Set<String>> corsWhitelistCache;
-
-  public CspFilter(
-      DhisConfigurationProvider dhisConfig,
-      ConfigurationService configurationService,
-      CacheProvider cacheProvider) {
+  public CspFilter(DhisConfigurationProvider dhisConfig, SystemSettingsProvider settingsProvider) {
     this.enabled = dhisConfig.isEnabled(CSP_ENABLED);
-    this.configurationService = configurationService;
-    this.corsWhitelistCache = cacheProvider.createCorsWhitelistCache();
+    this.settingsProvider = settingsProvider;
   }
 
   @Override
@@ -103,14 +94,11 @@ public class CspFilter extends OncePerRequestFilter {
   }
 
   /**
-   * Returns the cached CORS whitelist, refreshing from the database if the cache has expired (older
-   * than 5 minutes) or is not yet initialized.
-   *
-   * @return the CORS whitelist Set
+   * Returns the CORS whitelist from the in-memory {@link org.hisp.dhis.setting.SystemSettings}
+   * snapshot. No database round-trip on the request path.
    */
   private Set<String> getCorsWhitelist() {
-    return corsWhitelistCache.get(
-        "CORS_WHITELIST", key -> configurationService.getConfiguration().getCorsWhitelist());
+    return settingsProvider.getCurrentSettings().getCorsWhitelist();
   }
 
   private boolean isUploadedContentInsideApi(String requestURI) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/DhisCorsProcessor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/DhisCorsProcessor.java
@@ -37,7 +37,8 @@ import java.net.URLEncoder;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.cors.CorsConfiguration;
@@ -45,6 +46,14 @@ import org.springframework.web.cors.CorsProcessor;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
+/**
+ * Spring {@link CorsProcessor} that decides whether to accept a CORS request based on the CORS
+ * whitelist stored in {@link org.hisp.dhis.setting.SystemSettings}. Whitelist entries support glob
+ * patterns (resolved via {@link TextUtils#createRegexFromGlob}). Reads come from the in-memory
+ * settings snapshot, so the request path does not open a Hibernate session.
+ *
+ * @author Morten Svanaes
+ */
 @Slf4j
 @Component
 public class DhisCorsProcessor implements CorsProcessor {
@@ -70,10 +79,10 @@ public class DhisCorsProcessor implements CorsProcessor {
 
   private static final Integer MAX_AGE = 60 * 60; // 1hr max-age
 
-  private final ConfigurationService configurationService;
+  private final SystemSettingsProvider settingsProvider;
 
-  public DhisCorsProcessor(ConfigurationService configurationService) {
-    this.configurationService = configurationService;
+  public DhisCorsProcessor(SystemSettingsProvider settingsProvider) {
+    this.settingsProvider = settingsProvider;
   }
 
   @Override
@@ -84,14 +93,13 @@ public class DhisCorsProcessor implements CorsProcessor {
 
     String origin = request.getHeader(CORS_ORIGIN);
 
-    // Origin header is required for CORS requests
-
+    // Origin header is required for CORS requests; pass through if absent.
     if (StringUtils.isEmpty(origin)) {
       return true;
     }
 
     if (!isOriginWhitelisted(request, origin)) {
-      log.debug("CORS request with origin " + origin + " is not whitelisted");
+      log.debug("CORS request with origin {} is not whitelisted", origin);
       return false;
     }
 
@@ -100,6 +108,7 @@ public class DhisCorsProcessor implements CorsProcessor {
     response.addHeader("Vary", CORS_ORIGIN);
 
     if (isPreflight(request)) {
+      // CORS preflight requires a 2xx status code, so short-circuit the filter chain with 204.
       String requestHeaders = request.getHeader(CORS_REQUEST_HEADERS);
       String requestMethod = request.getHeader(CORS_REQUEST_METHOD);
 
@@ -108,10 +117,6 @@ public class DhisCorsProcessor implements CorsProcessor {
       response.addHeader(CORS_MAX_AGE, String.valueOf(MAX_AGE));
 
       response.setStatus(HttpServletResponse.SC_NO_CONTENT);
-
-      // CORS preflight requires a 2xx status code, so short-circuit the
-      // filter chain
-
     } else {
       response.addHeader(CORS_EXPOSE_HEADERS, EXPOSED_HEADERS);
     }
@@ -139,12 +144,19 @@ public class DhisCorsProcessor implements CorsProcessor {
     String localUrl = uriBuilder.build().toString();
 
     return !StringUtils.isEmpty(origin)
-        && (localUrl.equals(origin) || configurationService.isCorsWhitelisted(origin));
+        && (localUrl.equals(origin) || matchesCorsWhitelist(origin));
+  }
+
+  private boolean matchesCorsWhitelist(String origin) {
+    return settingsProvider.getCurrentSettings().getCorsWhitelist().stream()
+        .filter(StringUtils::isNotBlank)
+        .map(TextUtils::createRegexFromGlob)
+        .anyMatch(origin::matches);
   }
 
   /**
-   * Simple HttpServletRequestWrapper implementation that makes sure that the query string is
-   * properly encoded.
+   * Simple {@link HttpServletRequestWrapper} that ensures the query string is properly URL-encoded
+   * before {@link ServletUriComponentsBuilder} parses it.
    */
   static class HttpServletRequestEncodingWrapper extends HttpServletRequestWrapper {
     public HttpServletRequestEncodingWrapper(HttpServletRequest request) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
-import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -58,6 +57,7 @@ import org.hisp.dhis.security.oidc.DhisOidcLogoutSuccessHandler;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
+import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.DhisCorsProcessor;
 import org.hisp.dhis.webapi.filter.SessionTimeoutHeaderFilter;
@@ -143,7 +143,7 @@ public class DhisWebApiWebSecurityConfig {
 
   @Autowired private ConfigurationService configurationService;
 
-  @Autowired private CacheProvider cacheProvider;
+  @Autowired private SystemSettingsProvider settingsProvider;
 
   @Autowired private ApiTokenAuthManager apiTokenAuthManager;
 
@@ -263,7 +263,7 @@ public class DhisWebApiWebSecurityConfig {
     }
 
     configureMatchers(http);
-    configureCspFilter(http, dhisConfig, configurationService, cacheProvider);
+    configureCspFilter(http, dhisConfig, settingsProvider);
     configureApiTokenAuthorizationFilter(http);
     configureOAuthTokenFilters(http);
 
@@ -468,19 +468,17 @@ public class DhisWebApiWebSecurityConfig {
   }
 
   @Bean
-  public CorsFilter corsFilter(ConfigurationService configurationService) {
+  public CorsFilter corsFilter(DhisCorsProcessor dhisCorsProcessor) {
     CorsFilter corsFilter = new CorsFilter(new UrlBasedCorsConfigurationSource());
-    corsFilter.setCorsProcessor(new DhisCorsProcessor(configurationService));
+    corsFilter.setCorsProcessor(dhisCorsProcessor);
     return corsFilter;
   }
 
   private void configureCspFilter(
       HttpSecurity http,
       DhisConfigurationProvider dhisConfig,
-      ConfigurationService configurationService,
-      CacheProvider cacheProvider) {
-    http.addFilterBefore(
-        new CspFilter(dhisConfig, configurationService, cacheProvider), HeaderWriterFilter.class);
+      SystemSettingsProvider settingsProvider) {
+    http.addFilterBefore(new CspFilter(dhisConfig, settingsProvider), HeaderWriterFilter.class);
   }
 
   private void configureApiTokenAuthorizationFilter(HttpSecurity http) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/CspFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/CspFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,20 +32,19 @@ package org.hisp.dhis.webapi.filter;
 import static org.hisp.dhis.external.conf.ConfigurationKey.CSP_ENABLED;
 import static org.hisp.dhis.webapi.filter.CspFilter.CONTENT_SECURITY_POLICY_HEADER_NAME;
 import static org.hisp.dhis.webapi.filter.CspFilter.FRAME_ANCESTORS_DEFAULT_CSP;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Set;
-import java.util.function.Function;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.configuration.Configuration;
-import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,54 +61,43 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @ExtendWith(MockitoExtension.class)
 class CspFilterTest {
 
-  @Mock private DhisConfigurationProvider dhisConfigurationProvider;
+  @Mock(lenient = true)
+  private DhisConfigurationProvider dhisConfigurationProvider;
 
-  @Mock private ConfigurationService configurationService;
+  @Mock(lenient = true)
+  private SystemSettingsProvider settingsProvider;
 
-  @Mock private Configuration configuration;
-
-  @Mock private CacheProvider cacheProvider;
-
-  @Mock private Cache<Set<String>> cache;
+  @Mock private SystemSettings settings;
 
   private CspFilter filter;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     when(dhisConfigurationProvider.isEnabled(CSP_ENABLED)).thenReturn(true);
-    when(cacheProvider.<Set<String>>createCorsWhitelistCache()).thenReturn(cache);
+    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
 
-    filter = new CspFilter(dhisConfigurationProvider, configurationService, cacheProvider);
+    filter = new CspFilter(dhisConfigurationProvider, settingsProvider);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
-  void shouldCacheCorsWhitelistAndNotCallServiceOnEveryRequest() throws Exception {
-    // Given: A CORS whitelist configured via cache
-    Set<String> corsWhitelist = Set.of("https://example.com");
-    when(cache.get(anyString(), any(Function.class))).thenReturn(corsWhitelist);
+  void shouldReadCorsWhitelistFromSystemSettingsOnEachRequest() throws Exception {
+    when(settings.getCorsWhitelist()).thenReturn(Set.of("https://example.com"));
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     FilterChain filterChain = mockFilterChain();
 
-    // When: Multiple requests are processed
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+    for (int i = 0; i < 5; i++) {
+      filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+    }
 
-    // Then: Cache.get() should be called for each request (cache handles expiration internally)
-    verify(cache, times(5)).get(anyString(), any(Function.class));
+    // SystemSettingsProvider snapshot is in-memory; the filter reads it on every request
+    verify(settingsProvider, times(5)).getCurrentSettings();
   }
 
-  @SuppressWarnings("unchecked")
   @Test
-  void shouldUseCacheForCorsWhitelistLookup() throws Exception {
-    // Given: Cache returns the CORS whitelist (simulates cache behavior)
-    when(cache.get(anyString(), any(Function.class)))
+  void shouldReflectUpdatedWhitelistAcrossRequests() throws Exception {
+    when(settings.getCorsWhitelist())
         .thenReturn(Set.of("https://example.com"))
         .thenReturn(Set.of("https://updated.com"));
 
@@ -117,28 +105,21 @@ class CspFilterTest {
     request.setServerName("localhost");
     FilterChain filterChain = mockFilterChain();
 
-    // When: Two requests are processed
     MockHttpServletResponse response1 = new MockHttpServletResponse();
     filter.doFilter(request, response1, filterChain);
 
     MockHttpServletResponse response2 = new MockHttpServletResponse();
     filter.doFilter(request, response2, filterChain);
 
-    // Then: Cache.get() is invoked for each request
-    verify(cache, times(2)).get(anyString(), any(Function.class));
-
-    // And responses contain the appropriate CORS origins
     assertTrue(
         response1.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME).contains("https://example.com"));
     assertTrue(
         response2.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME).contains("https://updated.com"));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetFrameAncestorsCspWithCorsWhitelist() throws Exception {
-    // Given: A CORS whitelist configured via cache
-    when(cache.get(anyString(), any(Function.class)))
+    when(settings.getCorsWhitelist())
         .thenReturn(Set.of("https://example.com", "https://other.com"));
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
@@ -146,10 +127,8 @@ class CspFilterTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain filterChain = mockFilterChain();
 
-    // When
     filter.doFilter(request, response, filterChain);
 
-    // Then: CSP header should include frame-ancestors with CORS origins
     String cspHeader = response.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME);
     assertNotNull(cspHeader);
     assertTrue(cspHeader.startsWith(FRAME_ANCESTORS_DEFAULT_CSP));
@@ -158,45 +137,34 @@ class CspFilterTest {
     assertTrue(cspHeader.endsWith(";"));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetDefaultFrameAncestorsCspWhenCorsWhitelistEmpty() throws Exception {
-    // Given: Empty CORS whitelist from cache
-    when(cache.get(anyString(), any(Function.class))).thenReturn(Set.of());
+    when(settings.getCorsWhitelist()).thenReturn(Set.of());
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain filterChain = mockFilterChain();
 
-    // When
     filter.doFilter(request, response, filterChain);
 
-    // Then: CSP header should only have default frame-ancestors
     String cspHeader = response.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME);
     assertEquals(FRAME_ANCESTORS_DEFAULT_CSP + ";", cspHeader);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetXFrameOptionsWhenCspDisabled() throws Exception {
-    // Given: CSP is disabled
     when(dhisConfigurationProvider.isEnabled(CSP_ENABLED)).thenReturn(false);
-    CspFilter disabledFilter =
-        new CspFilter(dhisConfigurationProvider, configurationService, cacheProvider);
+    CspFilter disabledFilter = new CspFilter(dhisConfigurationProvider, settingsProvider);
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain filterChain = mockFilterChain();
 
-    // When
     disabledFilter.doFilter(request, response, filterChain);
 
-    // Then: X-Frame-Options should be set, not CSP
     assertEquals("SAMEORIGIN", response.getHeader("X-Frame-Options"));
-    // Cache should not be accessed when CSP is disabled
-    verify(cache, never()).get(anyString(), any(Function.class));
   }
 
   private FilterChain mockFilterChain() {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/DhisCorsProcessorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/DhisCorsProcessorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.setting.SystemSettings;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class DhisCorsProcessorTest {
+
+  @Test
+  void processRequest_allowsOriginFromSystemSettingsCorsWhitelist() {
+    DhisCorsProcessor processor = processor(Set.of("https://allowed.example.org"));
+    MockHttpServletRequest request = request("https://allowed.example.org");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertTrue(processor.processRequest(null, request, response));
+
+    assertEquals("https://allowed.example.org", response.getHeader("Access-Control-Allow-Origin"));
+  }
+
+  @Test
+  void processRequest_rejectsOriginMissingFromSystemSettingsCorsWhitelist() {
+    DhisCorsProcessor processor = processor(Set.of("https://allowed.example.org"));
+    MockHttpServletRequest request = request("https://denied.example.org");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertFalse(processor.processRequest(null, request, response));
+  }
+
+  private static DhisCorsProcessor processor(Set<String> corsWhitelist) {
+    SystemSettings settings =
+        SystemSettings.of(
+            Map.of("corsWhitelist", SystemSettings.encodeCorsWhitelist(corsWhitelist)));
+    return new DhisCorsProcessor(() -> settings);
+  }
+
+  private static MockHttpServletRequest request(String origin) {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/me");
+    request.setScheme("https");
+    request.setServerName("dhis.example.org");
+    request.setServerPort(443);
+    request.addHeader(DhisCorsProcessor.CORS_ORIGIN, origin);
+    return request;
+  }
+}


### PR DESCRIPTION
## Summary

- Move the CORS whitelist out of the legacy singleton `Configuration` Hibernate entity and into `SystemSettings` so request-time reads come from the in-memory snapshot, not a Hibernate session.
- Mark `Configuration.corsWhitelist` (field + getter + setter + `getCorsAllowlist` alias) as `@Deprecated(since = "2.44", forRemoval = true)`. The field stays for `/api/configuration` JSON wire-format compatibility but is no longer Hibernate-mapped; clients should read/write via `SystemSettingsService` or `GET`/`POST /api/configuration/corsWhitelist`.
- Idempotent Flyway migration (`V2_44_5`) aggregates rows from `configuration_corswhitelist` into `systemsetting` and drops the legacy table.
- `configuration_corswhitelist` table is dropped by `V2_44_5`. Existing values preserved by aggregating into a single `systemsetting` row with key `corsWhitelist`.

AI Assisted
