### PR TITLE
fix: stabilize flaky UserGroupServiceTest.testGetAllUserGroups

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserGroupServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserGroupServiceTest.java
@@ -29,13 +29,13 @@
  */
 package org.hisp.dhis.user;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -134,20 +134,17 @@ class UserGroupServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetAllUserGroups() {
-    List<UserGroup> userGroups = new ArrayList<>();
     Set<User> members = new HashSet<>();
     members.add(user1);
     members.add(user3);
     UserGroup userGroupA = createUserGroup('A', members);
-    userGroups.add(userGroupA);
     userGroupService.addUserGroup(userGroupA);
     members = new HashSet<>();
     members.add(user1);
     members.add(user2);
     UserGroup userGroupB = createUserGroup('B', members);
-    userGroups.add(userGroupB);
     userGroupService.addUserGroup(userGroupB);
-    assertEquals(userGroupService.getAllUserGroups(), userGroups);
+    assertContainsOnly(List.of(userGroupA, userGroupB), userGroupService.getAllUserGroups());
   }
 
   @Test


### PR DESCRIPTION
## Summary

`UserGroupServiceTest.testGetAllUserGroups` is flaky on PostgreSQL CI: it asserts that `getAllUserGroups()` returns the two groups it inserted in **insertion order** (`[A, B]`), but the underlying SELECT has no `ORDER BY` so PostgreSQL is free to return rows in any order. Recently observed:

```
expected: [UserGroupB, UserGroupA]
but was:  [UserGroupA, UserGroupB]
```

(see e.g. https://github.com/dhis2/dhis2-core/actions/runs/25114246090/job/73596601636)

The test's actual intent is "those are the only two user groups present" — set semantics — so switch to `assertContainsOnly`. Also drops the now-unused intermediate `List<UserGroup>` and `ArrayList` import.


🤖 Generated with [Claude Code](https://claude.com/claude-code)