### PR TITLE
feat: cache CORS whitelist inside ConfigurationService

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/ConfigurationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/ConfigurationService.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.configuration;
 
+import java.util.Set;
 import org.hisp.dhis.user.UserDetails;
 
 /**
@@ -50,6 +51,23 @@ public interface ConfigurationService {
    * @return the configuration.
    */
   Configuration getConfiguration();
+
+  /**
+   * Returns the configured CORS whitelist. The result is cached for fast read access on hot paths
+   * (CORS preflight checks, CSP {@code frame-ancestors} composition); the cache is invalidated by
+   * {@link #setCorsWhitelist(Set)}.
+   *
+   * @return the whitelist (never {@code null}).
+   */
+  Set<String> getCorsWhitelist();
+
+  /**
+   * Replaces the CORS whitelist and invalidates the read cache populated by {@link
+   * #getCorsWhitelist()}.
+   *
+   * @param corsWhitelist the new whitelist (may be empty, must not be {@code null}).
+   */
+  void setCorsWhitelist(Set<String> corsWhitelist);
 
   /**
    * Indicates whether the given origin is CORS white listed.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/DefaultConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/DefaultConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,8 @@ package org.hisp.dhis.configuration;
 
 import java.util.Iterator;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.GenericStore;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.user.UserDetails;
@@ -43,11 +44,21 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @author Lars Helge Overland
  */
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.configuration.ConfigurationService")
 public class DefaultConfigurationService implements ConfigurationService {
-  @Qualifier("org.hisp.dhis.configuration.ConfigurationStore")
+  private static final String CORS_WHITELIST_CACHE_KEY = "CORS_WHITELIST";
+
   private final GenericStore<Configuration> configurationStore;
+
+  private final Cache<Set<String>> corsWhitelistCache;
+
+  public DefaultConfigurationService(
+      @Qualifier("org.hisp.dhis.configuration.ConfigurationStore")
+          GenericStore<Configuration> configurationStore,
+      CacheProvider cacheProvider) {
+    this.configurationStore = configurationStore;
+    this.corsWhitelistCache = cacheProvider.createCorsWhitelistCache();
+  }
 
   // -------------------------------------------------------------------------
   // ConfigurationService implementation
@@ -76,10 +87,27 @@ public class DefaultConfigurationService implements ConfigurationService {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean isCorsWhitelisted(String origin) {
-    Set<String> corsWhitelist = getConfiguration().getCorsWhitelist();
+  public Set<String> getCorsWhitelist() {
+    return corsWhitelistCache.get(
+        CORS_WHITELIST_CACHE_KEY, key -> Set.copyOf(getConfiguration().getCorsWhitelist()));
+  }
 
-    for (String cors : corsWhitelist) {
+  @Override
+  @Transactional
+  public void setCorsWhitelist(Set<String> corsWhitelist) {
+    if (corsWhitelist == null) {
+      throw new IllegalArgumentException("corsWhitelist must not be null");
+    }
+    Configuration configuration = getConfiguration();
+    configuration.setCorsWhitelist(corsWhitelist);
+    setConfiguration(configuration);
+    corsWhitelistCache.invalidate(CORS_WHITELIST_CACHE_KEY);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean isCorsWhitelisted(String origin) {
+    for (String cors : getCorsWhitelist()) {
       String regex = TextUtils.createRegexFromGlob(cors);
 
       if (origin.matches(regex)) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/configuration/ConfigurationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/configuration/ConfigurationServiceTest.java
@@ -89,18 +89,26 @@ class ConfigurationServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testCorsWhitelist() {
-    Configuration config = configurationService.getConfiguration();
     Set<String> cors = new HashSet<>();
     cors.add("http://localhost:3000/");
     cors.add("http://*.local.tld:3000/");
     cors.add("*.remote.tld/");
-    config.setCorsWhitelist(cors);
-    configurationService.setConfiguration(config);
+    configurationService.setCorsWhitelist(cors);
+
     assertTrue(configurationService.isCorsWhitelisted("http://localhost:3000/"));
     assertTrue(configurationService.isCorsWhitelisted("http://foobar.local.tld:3000/"));
     assertTrue(configurationService.isCorsWhitelisted("http://magic.remote.tld/"));
     assertFalse(configurationService.isCorsWhitelisted("http://localhost:9000/"));
     assertFalse(configurationService.isCorsWhitelisted("http://another.local.tld/"));
     assertFalse(configurationService.isCorsWhitelisted("http://some.other.tld/"));
+  }
+
+  @Test
+  void testSetCorsWhitelistInvalidatesCachedRead() {
+    configurationService.setCorsWhitelist(Set.of("http://first.example/"));
+    assertEquals(Set.of("http://first.example/"), configurationService.getCorsWhitelist());
+
+    configurationService.setCorsWhitelist(Set.of("http://second.example/"));
+    assertEquals(Set.of("http://second.example/"), configurationService.getCorsWhitelist());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -459,7 +459,7 @@ public class ConfigurationController {
       value = {"/corsWhitelist", "/corsAllowlist"},
       produces = APPLICATION_JSON_VALUE)
   public @ResponseBody Set<String> getCorsWhitelist(Model model, HttpServletRequest request) {
-    return configurationService.getConfiguration().getCorsWhitelist();
+    return configurationService.getCorsWhitelist();
   }
 
   @SuppressWarnings("unchecked")
@@ -471,11 +471,7 @@ public class ConfigurationController {
   public void setCorsWhitelist(@RequestBody String input) throws IOException {
     Set<String> corsWhitelist = renderService.fromJson(input, Set.class);
 
-    Configuration configuration = configurationService.getConfiguration();
-
-    configuration.setCorsWhitelist(corsWhitelist);
-
-    configurationService.setConfiguration(configuration);
+    configurationService.setCorsWhitelist(corsWhitelist);
   }
 
   @GetMapping(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/CspFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/CspFilter.java
@@ -40,8 +40,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -57,16 +55,10 @@ public class CspFilter extends OncePerRequestFilter {
 
   private final ConfigurationService configurationService;
 
-  /** Cache for CORS whitelist to avoid DB lookups on every request. Expires after 5 minutes. */
-  private final Cache<Set<String>> corsWhitelistCache;
-
   public CspFilter(
-      DhisConfigurationProvider dhisConfig,
-      ConfigurationService configurationService,
-      CacheProvider cacheProvider) {
+      DhisConfigurationProvider dhisConfig, ConfigurationService configurationService) {
     this.enabled = dhisConfig.isEnabled(CSP_ENABLED);
     this.configurationService = configurationService;
-    this.corsWhitelistCache = cacheProvider.createCorsWhitelistCache();
   }
 
   @Override
@@ -91,7 +83,7 @@ public class CspFilter extends OncePerRequestFilter {
   }
 
   private void setFrameAncestorsCspRule(HttpServletResponse res) {
-    Set<String> corsWhitelist = getCorsWhitelist();
+    Set<String> corsWhitelist = configurationService.getCorsWhitelist();
     if (!corsWhitelist.isEmpty()) {
       String corsAllowedOrigins = String.join(" ", corsWhitelist);
       res.addHeader(
@@ -100,17 +92,6 @@ public class CspFilter extends OncePerRequestFilter {
     } else {
       res.addHeader(CONTENT_SECURITY_POLICY_HEADER_NAME, FRAME_ANCESTORS_DEFAULT_CSP + ";");
     }
-  }
-
-  /**
-   * Returns the cached CORS whitelist, refreshing from the database if the cache has expired (older
-   * than 5 minutes) or is not yet initialized.
-   *
-   * @return the CORS whitelist Set
-   */
-  private Set<String> getCorsWhitelist() {
-    return corsWhitelistCache.get(
-        "CORS_WHITELIST", key -> configurationService.getConfiguration().getCorsWhitelist());
   }
 
   private boolean isUploadedContentInsideApi(String requestURI) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
-import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -142,8 +141,6 @@ public class DhisWebApiWebSecurityConfig {
   private HttpBasicWebAuthenticationDetailsSource httpBasicWebAuthenticationDetailsSource;
 
   @Autowired private ConfigurationService configurationService;
-
-  @Autowired private CacheProvider cacheProvider;
 
   @Autowired private ApiTokenAuthManager apiTokenAuthManager;
 
@@ -263,7 +260,7 @@ public class DhisWebApiWebSecurityConfig {
     }
 
     configureMatchers(http);
-    configureCspFilter(http, dhisConfig, configurationService, cacheProvider);
+    configureCspFilter(http, dhisConfig, configurationService);
     configureApiTokenAuthorizationFilter(http);
     configureOAuthTokenFilters(http);
 
@@ -477,10 +474,8 @@ public class DhisWebApiWebSecurityConfig {
   private void configureCspFilter(
       HttpSecurity http,
       DhisConfigurationProvider dhisConfig,
-      ConfigurationService configurationService,
-      CacheProvider cacheProvider) {
-    http.addFilterBefore(
-        new CspFilter(dhisConfig, configurationService, cacheProvider), HeaderWriterFilter.class);
+      ConfigurationService configurationService) {
+    http.addFilterBefore(new CspFilter(dhisConfig, configurationService), HeaderWriterFilter.class);
   }
 
   private void configureApiTokenAuthorizationFilter(HttpSecurity http) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/CspFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/CspFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,18 +32,15 @@ package org.hisp.dhis.webapi.filter;
 import static org.hisp.dhis.external.conf.ConfigurationKey.CSP_ENABLED;
 import static org.hisp.dhis.webapi.filter.CspFilter.CONTENT_SECURITY_POLICY_HEADER_NAME;
 import static org.hisp.dhis.webapi.filter.CspFilter.FRAME_ANCESTORS_DEFAULT_CSP;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.Set;
-import java.util.function.Function;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +52,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
- * Unit tests for {@link CspFilter}.
+ * Unit tests for {@link CspFilter}. CORS-whitelist caching is owned by {@link
+ * ConfigurationService#getCorsWhitelist()} and is exercised by {@code ConfigurationServiceTest};
+ * here we just verify the filter renders the right headers given whatever the service returns.
  *
  * @author Morten Svanæs
  */
@@ -66,90 +65,25 @@ class CspFilterTest {
 
   @Mock private ConfigurationService configurationService;
 
-  @Mock private Configuration configuration;
-
-  @Mock private CacheProvider cacheProvider;
-
-  @Mock private Cache<Set<String>> cache;
-
   private CspFilter filter;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     when(dhisConfigurationProvider.isEnabled(CSP_ENABLED)).thenReturn(true);
-    when(cacheProvider.<Set<String>>createCorsWhitelistCache()).thenReturn(cache);
-
-    filter = new CspFilter(dhisConfigurationProvider, configurationService, cacheProvider);
+    filter = new CspFilter(dhisConfigurationProvider, configurationService);
   }
 
-  @SuppressWarnings("unchecked")
-  @Test
-  void shouldCacheCorsWhitelistAndNotCallServiceOnEveryRequest() throws Exception {
-    // Given: A CORS whitelist configured via cache
-    Set<String> corsWhitelist = Set.of("https://example.com");
-    when(cache.get(anyString(), any(Function.class))).thenReturn(corsWhitelist);
-
-    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
-    request.setServerName("localhost");
-    FilterChain filterChain = mockFilterChain();
-
-    // When: Multiple requests are processed
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
-
-    // Then: Cache.get() should be called for each request (cache handles expiration internally)
-    verify(cache, times(5)).get(anyString(), any(Function.class));
-  }
-
-  @SuppressWarnings("unchecked")
-  @Test
-  void shouldUseCacheForCorsWhitelistLookup() throws Exception {
-    // Given: Cache returns the CORS whitelist (simulates cache behavior)
-    when(cache.get(anyString(), any(Function.class)))
-        .thenReturn(Set.of("https://example.com"))
-        .thenReturn(Set.of("https://updated.com"));
-
-    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
-    request.setServerName("localhost");
-    FilterChain filterChain = mockFilterChain();
-
-    // When: Two requests are processed
-    MockHttpServletResponse response1 = new MockHttpServletResponse();
-    filter.doFilter(request, response1, filterChain);
-
-    MockHttpServletResponse response2 = new MockHttpServletResponse();
-    filter.doFilter(request, response2, filterChain);
-
-    // Then: Cache.get() is invoked for each request
-    verify(cache, times(2)).get(anyString(), any(Function.class));
-
-    // And responses contain the appropriate CORS origins
-    assertTrue(
-        response1.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME).contains("https://example.com"));
-    assertTrue(
-        response2.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME).contains("https://updated.com"));
-  }
-
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetFrameAncestorsCspWithCorsWhitelist() throws Exception {
-    // Given: A CORS whitelist configured via cache
-    when(cache.get(anyString(), any(Function.class)))
+    when(configurationService.getCorsWhitelist())
         .thenReturn(Set.of("https://example.com", "https://other.com"));
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     MockHttpServletResponse response = new MockHttpServletResponse();
-    FilterChain filterChain = mockFilterChain();
 
-    // When
-    filter.doFilter(request, response, filterChain);
+    filter.doFilter(request, response, mockFilterChain());
 
-    // Then: CSP header should include frame-ancestors with CORS origins
     String cspHeader = response.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME);
     assertNotNull(cspHeader);
     assertTrue(cspHeader.startsWith(FRAME_ANCESTORS_DEFAULT_CSP));
@@ -158,50 +92,38 @@ class CspFilterTest {
     assertTrue(cspHeader.endsWith(";"));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetDefaultFrameAncestorsCspWhenCorsWhitelistEmpty() throws Exception {
-    // Given: Empty CORS whitelist from cache
-    when(cache.get(anyString(), any(Function.class))).thenReturn(Set.of());
+    when(configurationService.getCorsWhitelist()).thenReturn(Set.of());
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     MockHttpServletResponse response = new MockHttpServletResponse();
-    FilterChain filterChain = mockFilterChain();
 
-    // When
-    filter.doFilter(request, response, filterChain);
+    filter.doFilter(request, response, mockFilterChain());
 
-    // Then: CSP header should only have default frame-ancestors
-    String cspHeader = response.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME);
-    assertEquals(FRAME_ANCESTORS_DEFAULT_CSP + ";", cspHeader);
+    assertEquals(
+        FRAME_ANCESTORS_DEFAULT_CSP + ";", response.getHeader(CONTENT_SECURITY_POLICY_HEADER_NAME));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void shouldSetXFrameOptionsWhenCspDisabled() throws Exception {
-    // Given: CSP is disabled
     when(dhisConfigurationProvider.isEnabled(CSP_ENABLED)).thenReturn(false);
-    CspFilter disabledFilter =
-        new CspFilter(dhisConfigurationProvider, configurationService, cacheProvider);
+    CspFilter disabledFilter = new CspFilter(dhisConfigurationProvider, configurationService);
 
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
     request.setServerName("localhost");
     MockHttpServletResponse response = new MockHttpServletResponse();
-    FilterChain filterChain = mockFilterChain();
 
-    // When
-    disabledFilter.doFilter(request, response, filterChain);
+    disabledFilter.doFilter(request, response, mockFilterChain());
 
-    // Then: X-Frame-Options should be set, not CSP
     assertEquals("SAMEORIGIN", response.getHeader("X-Frame-Options"));
-    // Cache should not be accessed when CSP is disabled
-    verify(cache, never()).get(anyString(), any(Function.class));
+    verify(configurationService, never()).getCorsWhitelist();
   }
 
-  private FilterChain mockFilterChain() {
-    return (filterRequest, filterResponse) -> {
-      ((HttpServletResponse) filterResponse).setStatus(HttpServletResponse.SC_OK);
+  private static FilterChain mockFilterChain() {
+    return (req, res) -> {
+      // No-op chain.
     };
   }
 }


### PR DESCRIPTION
## Summary

- Move the CORS-whitelist cache out of `CspFilter` and into `ConfigurationService`, so every reader (CSP filter, `DhisCorsProcessor` via `isCorsWhitelisted`, the admin GET endpoint) shares one source of truth.
- Add `Set<String> getCorsWhitelist()` and `void setCorsWhitelist(Set<String>)` to `ConfigurationService`. The setter is the single mutation entry point and invalidates the cache immediately.
- `ConfigurationController.POST /configuration/corsWhitelist` now calls the new setter — invalidation happens automatically;
- `CspFilter` drops its private 5-minute cache and just calls the service; `DhisCorsProcessor` benefits transparently because `isCorsWhitelisted` now reads through the service cache.
- All read access is through a `@Transactional` service, so we don't need to think about OSIV.

## Why

`DhisCorsProcessor` runs on every CORS preflight and was hitting Hibernate every time. `CspFilter` and the (incoming) `CspPolicyService` each kept their own cache of the same set. One cache, owned by the data service, removes that duplication and closes the no-cache gap on the preflight path.

## Invalidation

- The settings app POST to `/api/configuration/corsWhitelist`, invalidates after a successful persist.
- Metadata import is the only other write path; 5-minute staleness is acceptable.


AI Assisted
