### PR TITLE
refactor: extract aggregated enrollment query assembler [DHIS2-21381]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssembler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssembler.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event.data;
+
+import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
+import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManager.COLUMN_ENROLLMENT_GEOMETRY_GEOJSON;
+import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManager.COL_VALUE;
+import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.isAggregateEnrollment;
+import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getOrgUnitLevelColumns;
+import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getPeriodColumns;
+import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.analytics.common.CteContext;
+import org.hisp.dhis.analytics.common.CteDefinition;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam.StaticDimension;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentDateHeaderResolver;
+import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentHeaderColumnResolver;
+import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier;
+import org.hisp.dhis.analytics.util.sql.SelectBuilder;
+import org.hisp.dhis.analytics.util.sql.SqlColumnParser;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
+import org.hisp.dhis.period.PeriodDimension;
+import org.hisp.dhis.program.AnalyticsType;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assembles SELECT-clause columns for enrollment analytics queries — both the aggregated path
+ * (count + org unit + period + header columns) and the standard list path (enrollment standard
+ * columns with optional shadow-CTE alias rewriting).
+ */
+@Component
+@RequiredArgsConstructor
+public class AggregatedEnrollmentQueryAssembler {
+
+  private static final AnalyticsType ANALYTICS_TYPE = AnalyticsType.ENROLLMENT;
+
+  private static final String AX_ALIAS = "ax";
+
+  private static final String ENROLLMENT_AGGR_BASE_ALIAS = "eb";
+
+  private final AnalyticsSqlBuilder sqlBuilder;
+
+  private final DateFieldPeriodBucketColumnResolver dateFieldPeriodBucketColumnResolver;
+
+  private final StageHeaderClassifier stageHeaderClassifier = new StageHeaderClassifier();
+
+  private final AggregatedEnrollmentDateHeaderResolver dateHeaderResolver =
+      new AggregatedEnrollmentDateHeaderResolver();
+
+  private final AggregatedEnrollmentHeaderColumnResolver headerColumnResolver =
+      new AggregatedEnrollmentHeaderColumnResolver(stageHeaderClassifier);
+
+  /** A response key paired with the optional bucketed expression that produces it. */
+  public record PeriodProjection(
+      String responseKey,
+      Optional<DateFieldPeriodBucketColumnResolver.ResolvedExpression> expression) {}
+
+  /** Adds the single aggregated enrollment count column. */
+  public void addAggregatedColumns(SelectBuilder sb) {
+    sb.addColumn("count(eb.enrollment) as value");
+  }
+
+  /**
+   * Adds standard enrollment columns. The shadow-CTE branch rewrites formula columns to their
+   * {@link #getFormulaColumnAliases() alias}; otherwise formula columns are emitted verbatim.
+   */
+  public void addStandardColumns(
+      SelectBuilder sb, CteContext cteContext, List<String> standardColumns) {
+    boolean useShadowCte = cteContext.containsCte("top_enrollments");
+
+    if (useShadowCte) {
+      addStandardColumnsWithShadowCte(sb, standardColumns);
+    } else {
+      addStandardColumnsWithoutShadowCte(sb, standardColumns);
+    }
+  }
+
+  private void addStandardColumnsWithShadowCte(SelectBuilder sb, List<String> standardColumns) {
+    Map<String, String> formulaAliases = getFormulaColumnAliases();
+
+    for (String column : standardColumns) {
+      if (columnIsInFormula(column)) {
+        String alias = formulaAliases.getOrDefault(column, createDefaultAlias(column));
+        sb.addColumn(alias, AX_ALIAS);
+      } else {
+        sb.addColumn(column, AX_ALIAS);
+      }
+    }
+  }
+
+  private void addStandardColumnsWithoutShadowCte(SelectBuilder sb, List<String> standardColumns) {
+    standardColumns.forEach(
+        column -> {
+          if (columnIsInFormula(column)) {
+            sb.addColumn(column);
+          } else {
+            sb.addColumn(column, AX_ALIAS);
+          }
+        });
+  }
+
+  /**
+   * Adds organisation-unit columns. When level columns are configured they replace the default
+   * {@code ou} column; otherwise the default is added unless the params describe an aggregate
+   * enrollment without dimensions.
+   */
+  public void addOrgUnitAggregateColumns(SelectBuilder sb, EventQueryParams params) {
+    Set<String> orgColumns = getOrgUnitLevelColumns(params);
+
+    if (orgColumns.isEmpty() && !isAggregateEnrollment(params)) {
+      sb.addColumn(ORGUNIT_DIM_ID);
+      sb.groupBy(ORGUNIT_DIM_ID);
+      return;
+    }
+
+    for (String col : orgColumns) {
+      String trimmed = col.trim();
+      sb.addColumn(trimmed);
+      sb.groupBy(trimmed);
+    }
+  }
+
+  /**
+   * Adds period columns. When date-field period projections are present they take precedence over
+   * the default {@code pe} column and bring along their resolved expressions.
+   */
+  public void addPeriodAggregateColumns(
+      EventQueryParams params, SelectBuilder sb, List<PeriodProjection> projections) {
+    if (projections.isEmpty()) {
+      Set<String> periodColumns = getPeriodColumns(params);
+      for (String periodColumn : periodColumns) {
+        var col = SqlColumnParser.removeTableAlias(periodColumn.trim());
+        sb.addColumn(col);
+        sb.groupBy(col);
+      }
+      return;
+    }
+
+    for (PeriodProjection projection : projections) {
+      if (projection.expression().isPresent()) {
+        DateFieldPeriodBucketColumnResolver.ResolvedExpression expr = projection.expression().get();
+        sb.addColumn(expr.selectExpression());
+        sb.groupBy(expr.groupByExpression());
+      } else {
+        String column = quote(projection.responseKey());
+        sb.addColumn(column);
+        sb.groupBy(column);
+      }
+    }
+  }
+
+  /**
+   * Adds the columns specified in the headers to the SelectBuilder. The columns are added in the
+   * order specified in the headers and are based on existing CTE definitions. Stage-specific
+   * prefixes (e.g. "stageUid.eventdate") are preserved so the resolver can look up the correct
+   * per-stage filter CTE.
+   */
+  public void addHeaderAggregateColumns(
+      List<GridHeader> headers,
+      EventQueryParams params,
+      CteContext cteContext,
+      SelectBuilder sb,
+      List<PeriodProjection> projections) {
+    Set<String> periodKeys =
+        projections.stream().map(PeriodProjection::responseKey).collect(Collectors.toSet());
+
+    // Also skip headers that match the date field key of a period projection source column
+    // (e.g. "eventdate" when EVENT_DATE is the date field for the period dimension)
+    periodKeys.addAll(collectPeriodDateFieldKeys(params));
+
+    Set<String> headerColumns = new LinkedHashSet<>();
+
+    for (GridHeader header : headers) {
+      String name = dateHeaderResolver.normalizeHeaderKey(header.getName());
+
+      if (isInfrastructureHeader(name)) {
+        continue;
+      }
+      if (periodKeys.stream().anyMatch(name::equalsIgnoreCase)) {
+        continue;
+      }
+      headerColumns.add(resolveHeaderColumn(name));
+    }
+
+    Map<String, CteDefinition> cteDefinitionMap = collectCteDefinitions(cteContext);
+    headerColumnResolver.addHeaderColumns(
+        headerColumns, cteContext, sb, cteDefinitionMap, this::quote);
+  }
+
+  /**
+   * Returns the per-period date-field projections derived from the {@code pe} dimension. Empty when
+   * the dimension is absent.
+   */
+  public List<PeriodProjection> resolveAggregatePeriodProjections(EventQueryParams params) {
+    DimensionalObject periodDimension = params.getDimension(PERIOD_DIM_ID);
+    if (periodDimension == null) {
+      return List.of();
+    }
+
+    return PeriodDimensionSplitter.splitPeriodDimension(periodDimension).stream()
+        .map(
+            dim ->
+                new PeriodProjection(
+                    dim.getDimensionName(),
+                    dateFieldPeriodBucketColumnResolver.resolve(
+                        ANALYTICS_TYPE, dim, ENROLLMENT_AGGR_BASE_ALIAS)))
+        .toList();
+  }
+
+  /** Returns true for headers whose columns are added by dedicated sibling methods. */
+  public boolean isInfrastructureHeader(String name) {
+    return name.equalsIgnoreCase(COL_VALUE)
+        || name.equalsIgnoreCase(PERIOD_DIM_ID)
+        || name.equalsIgnoreCase(ORGUNIT_DIM_ID);
+  }
+
+  /**
+   * Collects the date field keys from all period dimension items that have a non-default date
+   * field. For example, period items with date field EVENT_DATE produce "eventdate".
+   */
+  public Set<String> collectPeriodDateFieldKeys(EventQueryParams params) {
+    DimensionalObject periodDimension = params.getDimension(PERIOD_DIM_ID);
+    if (periodDimension == null) {
+      return Set.of();
+    }
+    return periodDimension.getItems().stream()
+        .filter(PeriodDimension.class::isInstance)
+        .map(PeriodDimension.class::cast)
+        .map(PeriodDimension::getDateField)
+        .filter(Objects::nonNull)
+        .map(PeriodDimensionSplitter::toDateFieldKey)
+        .collect(Collectors.toSet());
+  }
+
+  /** Maps header name to the corresponding database column name. */
+  public String resolveHeaderColumn(String name) {
+    if (name.equalsIgnoreCase(StaticDimension.PROGRAM_STATUS.getHeaderName())) {
+      return StaticDimension.PROGRAM_STATUS.getColumnName();
+    }
+    return quote(name);
+  }
+
+  /**
+   * Indexes program-stage and program-indicator CTE definitions by their quoted header key so the
+   * header-column resolver can look up which CTE supplies a given column.
+   */
+  public Map<String, CteDefinition> collectCteDefinitions(CteContext cteContext) {
+    Map<String, CteDefinition> cteDefinitionMap = new HashMap<>();
+
+    Set<String> cteKeys = cteContext.getCteKeysExcluding(ENROLLMENT_AGGR_BASE);
+
+    for (String key : cteKeys) {
+      CteDefinition def = cteContext.getDefinitionByItemUid(key);
+
+      if (def.isProgramStage() || def.isProgramIndicator()) {
+        String mapKey =
+            quote(
+                def.isProgramIndicator()
+                    ? def.getProgramIndicatorUid()
+                    : def.getProgramStageUid() + "." + def.getItemId());
+
+        cteDefinitionMap.put(mapKey, def);
+      }
+    }
+    return cteDefinitionMap;
+  }
+
+  private String quote(String relation) {
+    return sqlBuilder.quote(relation);
+  }
+
+  private Map<String, String> getFormulaColumnAliases() {
+    Map<String, String> aliases = new HashMap<>();
+    aliases.put(COLUMN_ENROLLMENT_GEOMETRY_GEOJSON, "enrollmentgeometry_geojson");
+    return aliases;
+  }
+
+  private boolean columnIsInFormula(String col) {
+    return col.contains("(") && col.contains(")");
+  }
+
+  private String createDefaultAlias(String formula) {
+    return "formula_" + (formula.hashCode() & Integer.MAX_VALUE);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -34,11 +34,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
-import static org.hisp.dhis.analytics.common.params.dimension.DimensionParam.StaticDimension.PROGRAM_STATUS;
-import static org.hisp.dhis.analytics.event.data.EnrollmentOrgUnitFilterHandler.isAggregateEnrollment;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getHeaderColumns;
-import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getOrgUnitLevelColumns;
-import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getPeriodColumns;
 import static org.hisp.dhis.analytics.event.data.OrgUnitTableJoiner.joinOrgUnitTables;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
 import static org.hisp.dhis.analytics.util.EventQueryParamsUtils.getProgramIndicators;
@@ -60,7 +56,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -78,7 +73,6 @@ import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentDateHeaderResolver;
-import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentHeaderColumnResolver;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagInfoInitializer;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagQueryGenerator;
 import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier;
@@ -131,11 +125,10 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     implements EnrollmentAnalyticsManager {
   private final EnrollmentTimeFieldSqlRenderer timeFieldSqlRenderer;
   private final EnrollmentEventSubqueryBuilder eventSubqueryBuilder;
+  private final AggregatedEnrollmentQueryAssembler aggregatedAssembler;
   private final StageHeaderClassifier stageHeaderClassifier = new StageHeaderClassifier();
   private final AggregatedEnrollmentDateHeaderResolver dateHeaderResolver =
       new AggregatedEnrollmentDateHeaderResolver();
-  private final AggregatedEnrollmentHeaderColumnResolver headerColumnResolver =
-      new AggregatedEnrollmentHeaderColumnResolver(stageHeaderClassifier);
 
   private static final String IS_NOT_NULL = " is not null ";
 
@@ -161,7 +154,8 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
       QueryItemFilterBuilder filterBuilder,
       StageQuerySqlFacade stageQuerySqlFacade,
       DateFieldPeriodBucketColumnResolver dateFieldPeriodBucketColumnResolver,
-      EnrollmentEventSubqueryBuilder eventSubqueryBuilder) {
+      EnrollmentEventSubqueryBuilder eventSubqueryBuilder,
+      AggregatedEnrollmentQueryAssembler aggregatedAssembler) {
     super(
         jdbcTemplate,
         programIndicatorService,
@@ -179,6 +173,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
         dateFieldPeriodBucketColumnResolver);
     this.timeFieldSqlRenderer = timeFieldSqlRenderer;
     this.eventSubqueryBuilder = eventSubqueryBuilder;
+    this.aggregatedAssembler = aggregatedAssembler;
   }
 
   @Override
@@ -1040,7 +1035,8 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
     // 3. Build up the final SQL using dedicated sub-steps
     SelectBuilder sb = new SelectBuilder();
-    List<PeriodProjection> periodProjections = resolveAggregatePeriodProjections(params);
+    List<AggregatedEnrollmentQueryAssembler.PeriodProjection> periodProjections =
+        aggregatedAssembler.resolveAggregatePeriodProjections(params);
 
     // 3.1: Append the WITH clause if needed
     addCteClause(sb, cteContext);
@@ -1050,10 +1046,11 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     //    2) org unit columns (orgColumns)
     //    3) period columns (periodColumns)
     //    4) header columns (headerColumns)
-    sb.addColumn("count(eb.enrollment) as value");
-    addOrgUnitAggregateColumns(sb, params);
-    addPeriodAggregateColumns(params, sb, periodProjections);
-    addHeaderAggregateColumns(headers, params, cteContext, sb, periodProjections);
+    aggregatedAssembler.addAggregatedColumns(sb);
+    aggregatedAssembler.addOrgUnitAggregateColumns(sb, params);
+    aggregatedAssembler.addPeriodAggregateColumns(params, sb, periodProjections);
+    aggregatedAssembler.addHeaderAggregateColumns(
+        headers, params, cteContext, sb, periodProjections);
 
     // 3.3: Append the FROM clause (the main enrollment analytics table)
     sb.from(ENROLLMENT_AGGR_BASE, ENROLLMENT_AGGR_BASE_ALIAS);
@@ -1078,120 +1075,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
         || cteDefinition.getCteType() == CteDefinition.CteType.FILTER;
   }
 
-  /**
-   * Add the columns specified in the headers to the SelectBuilder. The columns are added in the
-   * order specified in the headers and are based on existing CTE definitions. Stage-specific
-   * prefixes (e.g. "stageUid.eventdate") are preserved so the resolver can look up the correct
-   * per-stage filter CTE.
-   */
-  private void addHeaderAggregateColumns(
-      List<GridHeader> headers,
-      EventQueryParams params,
-      CteContext cteContext,
-      SelectBuilder sb,
-      List<PeriodProjection> projections) {
-    Set<String> periodKeys =
-        projections.stream().map(PeriodProjection::responseKey).collect(Collectors.toSet());
-
-    // Also skip headers that match the date field key of a period projection source column
-    // (e.g. "eventdate" when EVENT_DATE is the date field for the period dimension)
-    collectPeriodDateFieldKeys(params).forEach(periodKeys::add);
-
-    Set<String> headerColumns = new LinkedHashSet<>();
-
-    for (GridHeader header : headers) {
-      String name = dateHeaderResolver.normalizeHeaderKey(header.getName());
-
-      if (isInfrastructureHeader(name)) {
-        continue;
-      }
-      if (periodKeys.stream().anyMatch(name::equalsIgnoreCase)) {
-        continue;
-      }
-      headerColumns.add(resolveHeaderColumn(name));
-    }
-
-    Map<String, CteDefinition> cteDefinitionMap = collectCteDefinitions(cteContext);
-    headerColumnResolver.addHeaderColumns(
-        headerColumns, cteContext, sb, cteDefinitionMap, this::quote);
-  }
-
-  /** Returns true for headers whose columns are added by dedicated sibling methods. */
-  private boolean isInfrastructureHeader(String name) {
-    return name.equalsIgnoreCase(COL_VALUE)
-        || name.equalsIgnoreCase(PERIOD_DIM_ID)
-        || name.equalsIgnoreCase(ORGUNIT_DIM_ID);
-  }
-
-  /**
-   * Collects the date field keys from all period dimension items that have a non-default date
-   * field. For example, period items with date field EVENT_DATE produce "eventdate".
-   */
-  private Set<String> collectPeriodDateFieldKeys(EventQueryParams params) {
-    DimensionalObject periodDimension = params.getDimension(PERIOD_DIM_ID);
-    if (periodDimension == null) {
-      return Set.of();
-    }
-    return periodDimension.getItems().stream()
-        .filter(PeriodDimension.class::isInstance)
-        .map(PeriodDimension.class::cast)
-        .map(PeriodDimension::getDateField)
-        .filter(Objects::nonNull)
-        .map(PeriodDimensionSplitter::toDateFieldKey)
-        .collect(Collectors.toSet());
-  }
-
-  /** Maps header name to the corresponding database column name. */
-  private String resolveHeaderColumn(String name) {
-    if (name.equalsIgnoreCase(PROGRAM_STATUS.getHeaderName())) {
-      return PROGRAM_STATUS.getColumnName();
-    }
-    return quote(name);
-  }
-
-  private record PeriodProjection(
-      String responseKey,
-      Optional<DateFieldPeriodBucketColumnResolver.ResolvedExpression> expression) {}
-
-  private List<PeriodProjection> resolveAggregatePeriodProjections(EventQueryParams params) {
-    DimensionalObject periodDimension = params.getDimension(PERIOD_DIM_ID);
-    if (periodDimension == null) {
-      return List.of();
-    }
-
-    return PeriodDimensionSplitter.splitPeriodDimension(periodDimension).stream()
-        .map(
-            dim ->
-                new PeriodProjection(
-                    dim.getDimensionName(),
-                    resolveDateFieldPeriodBucket(dim, ENROLLMENT_AGGR_BASE_ALIAS)))
-        .toList();
-  }
-
-  private Map<String, CteDefinition> collectCteDefinitions(CteContext cteContext) {
-
-    Map<String, CteDefinition> cteDefinitionMap = new HashMap<>();
-
-    // Get all CTE keys excluding ENROLLMENT_AGGR_BASE
-    Set<String> cteKeys = cteContext.getCteKeysExcluding(ENROLLMENT_AGGR_BASE);
-
-    for (String key : cteKeys) {
-      CteDefinition def = cteContext.getDefinitionByItemUid(key);
-
-      // Only process if it's a program stage or program indicator
-      if (def.isProgramStage() || def.isProgramIndicator()) {
-        String mapKey =
-            quote(
-                def.isProgramIndicator()
-                    ? def.getProgramIndicatorUid()
-                    : def.getProgramStageUid() + "." + def.getItemId());
-
-        cteDefinitionMap.put(mapKey, def);
-      }
-    }
-    return cteDefinitionMap;
-  }
-
   @Override
   protected String getSortClause(EventQueryParams params) {
     if (params.isSorting()) {
@@ -1200,50 +1083,10 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     return "";
   }
 
-  private void addOrgUnitAggregateColumns(SelectBuilder sb, EventQueryParams params) {
-    Set<String> orgColumns = getOrgUnitLevelColumns(params);
-
-    if (orgColumns.isEmpty() && !isAggregateEnrollment(params)) {
-      sb.addColumn(ORGUNIT_DIM_ID);
-      sb.groupBy(ORGUNIT_DIM_ID);
-      return;
-    }
-
-    for (String col : orgColumns) {
-      String trimmed = col.trim();
-      sb.addColumn(trimmed);
-      sb.groupBy(trimmed);
-    }
-  }
-
-  private void addPeriodAggregateColumns(
-      EventQueryParams params, SelectBuilder sb, List<PeriodProjection> projections) {
-    if (projections.isEmpty()) {
-      Set<String> periodColumns = getPeriodColumns(params);
-      for (String periodColumn : periodColumns) {
-        var col = SqlColumnParser.removeTableAlias(periodColumn.trim());
-        sb.addColumn(col);
-        sb.groupBy(col);
-      }
-      return;
-    }
-
-    for (PeriodProjection projection : projections) {
-      if (projection.expression().isPresent()) {
-        DateFieldPeriodBucketColumnResolver.ResolvedExpression expr = projection.expression().get();
-        sb.addColumn(expr.selectExpression());
-        sb.groupBy(expr.groupByExpression());
-      } else {
-        String column = quote(projection.responseKey());
-        sb.addColumn(column);
-        sb.groupBy(column);
-      }
-    }
-  }
-
-  private void appendPeriodBucketJoins(SelectBuilder sb, List<PeriodProjection> projections) {
+  private void appendPeriodBucketJoins(
+      SelectBuilder sb, List<AggregatedEnrollmentQueryAssembler.PeriodProjection> projections) {
     projections.stream()
-        .map(PeriodProjection::expression)
+        .map(AggregatedEnrollmentQueryAssembler.PeriodProjection::expression)
         .flatMap(Optional::stream)
         .map(DateFieldPeriodBucketColumnResolver.ResolvedExpression::joinClause)
         .flatMap(Optional::stream)
@@ -1272,57 +1115,13 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   @Override
   void addSelectClause(SelectBuilder sb, EventQueryParams params, CteContext cteContext) {
     if (params.isAggregatedEnrollments()) {
-      addAggregatedColumns(sb);
+      aggregatedAssembler.addAggregatedColumns(sb);
     } else {
-      addStandardColumns(sb, params, cteContext);
+      aggregatedAssembler.addStandardColumns(sb, cteContext, getStandardColumns(params));
     }
 
     // Append columns from CTE definitions
     getSelectColumnsWithCTE(params, cteContext).forEach(sb::addColumn);
-  }
-
-  /** Adds aggregated enrollment count column. */
-  private void addAggregatedColumns(SelectBuilder sb) {
-    sb.addColumn("count(eb.enrollment) as value");
-  }
-
-  /** Adds standard columns based on whether shadow CTE is used. */
-  private void addStandardColumns(
-      SelectBuilder sb, EventQueryParams params, CteContext cteContext) {
-    boolean useShadowCte = cteContext.containsCte("top_enrollments");
-
-    if (useShadowCte) {
-      addStandardColumnsWithShadowCte(sb, params);
-    } else {
-      addStandardColumnsWithoutShadowCte(sb, params);
-    }
-  }
-
-  /** Adds standard columns when using shadow CTE with formula aliases. */
-  private void addStandardColumnsWithShadowCte(SelectBuilder sb, EventQueryParams params) {
-    Map<String, String> formulaAliases = getFormulaColumnAliases();
-
-    for (String column : getStandardColumns(params)) {
-      if (columnIsInFormula(column)) {
-        String alias = formulaAliases.getOrDefault(column, createDefaultAlias(column));
-        sb.addColumn(alias, "ax");
-      } else {
-        sb.addColumn(column, "ax");
-      }
-    }
-  }
-
-  /** Adds standard columns without shadow CTE using original logic. */
-  private void addStandardColumnsWithoutShadowCte(SelectBuilder sb, EventQueryParams params) {
-    getStandardColumns(params)
-        .forEach(
-            column -> {
-              if (columnIsInFormula(column)) {
-                sb.addColumn(column);
-              } else {
-                sb.addColumn(column, "ax");
-              }
-            });
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
@@ -130,7 +130,6 @@ class AggregatedEnrollmentQueryAssemblerTest {
   void addStandardColumnsFormulaColumnInPlainPathIsAddedVerbatim() {
     SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
     CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
-    EventQueryParams params = mock(EventQueryParams.class);
     String formula = "ST_AsGeoJSON(enrollmentgeometry)";
 
     assembler.addStandardColumns(sb, cteContext, List.of(formula));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.analytics.common.CteContext;
+import org.hisp.dhis.analytics.common.CteDefinition;
+import org.hisp.dhis.analytics.common.EndpointItem;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.util.sql.SelectBuilder;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for {@link AggregatedEnrollmentQueryAssembler}. Pin the SQL fragments produced
+ * by the column-building helpers extracted from {@code JdbcEnrollmentAnalyticsManager} so the move
+ * preserves byte-identical output. End-to-end coverage of the orchestrator path is left to {@code
+ * EnrollmentAnalyticsManagerCteTest}.
+ */
+class AggregatedEnrollmentQueryAssemblerTest {
+
+  private final PostgreSqlAnalyticsSqlBuilder sqlBuilder = new PostgreSqlAnalyticsSqlBuilder();
+
+  private final AggregatedEnrollmentQueryAssembler assembler =
+      new AggregatedEnrollmentQueryAssembler(
+          sqlBuilder, new DateFieldPeriodBucketColumnResolver(sqlBuilder));
+
+  @Test
+  void addAggregatedColumnsEmitsCountValue() {
+    SelectBuilder sb = new SelectBuilder().from("eb_table", "eb");
+
+    assembler.addAggregatedColumns(sb);
+
+    assertThat(sb.build(), containsString("count(eb.enrollment) as value"));
+  }
+
+  @Test
+  void isInfrastructureHeaderRecognisesValuePeriodAndOrgUnit() {
+    assertTrue(assembler.isInfrastructureHeader("value"));
+    assertTrue(assembler.isInfrastructureHeader("VALUE"));
+    assertTrue(assembler.isInfrastructureHeader("pe"));
+    assertTrue(assembler.isInfrastructureHeader("ou"));
+  }
+
+  @Test
+  void isInfrastructureHeaderRejectsOtherHeaders() {
+    assertFalse(assembler.isInfrastructureHeader("enrollmentdate"));
+    assertFalse(assembler.isInfrastructureHeader("eventdate"));
+    assertFalse(assembler.isInfrastructureHeader("oucode"));
+  }
+
+  @Test
+  void resolveHeaderColumnQuotesPlainNames() {
+    assertEquals("\"created\"", assembler.resolveHeaderColumn("created"));
+  }
+
+  @Test
+  void resolveHeaderColumnMapsProgramStatusToEnrollmentStatus() {
+    // PROGRAM_STATUS is an alias for ENROLLMENT_STATUS — the resolver collapses to the actual
+    // physical column "enrollmentstatus".
+    String resolved = assembler.resolveHeaderColumn("programstatus");
+
+    assertThat(resolved, containsString("enrollmentstatus"));
+  }
+
+  @Test
+  void addStandardColumnsWithoutShadowCteEmitsAxAlias() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    assembler.addStandardColumns(sb, cteContext, List.of("enrollment", "trackedentity"));
+
+    String sql = sb.build();
+    assertThat(sql, containsString("ax.enrollment"));
+    assertThat(sql, containsString("ax.trackedentity"));
+  }
+
+  @Test
+  void addStandardColumnsFormulaColumnInPlainPathIsAddedVerbatim() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    EventQueryParams params = mock(EventQueryParams.class);
+    String formula = "ST_AsGeoJSON(enrollmentgeometry)";
+
+    assembler.addStandardColumns(sb, cteContext, List.of(formula));
+
+    String sql = sb.build();
+    // Formula columns are emitted verbatim (no ax. prefix) in the plain path.
+    assertThat(sql, containsString(formula));
+    assertThat(sql, not(containsString("ax." + formula)));
+  }
+
+  @Test
+  void addStandardColumnsWithShadowCtePrefixesPlainColumnsWithAx() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    CteContext cteContext = shadowCteContext();
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    assembler.addStandardColumns(sb, cteContext, List.of("enrollment", "trackedentity"));
+
+    String sql = sb.build();
+    assertThat(sql, containsString("ax.enrollment"));
+    assertThat(sql, containsString("ax.trackedentity"));
+  }
+
+  @Test
+  void addStandardColumnsWithShadowCteRewritesGeometryFormulaToAlias() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    CteContext cteContext = shadowCteContext();
+    EventQueryParams params = mock(EventQueryParams.class);
+    String formula = "ST_AsGeoJSON(enrollmentgeometry)";
+
+    assembler.addStandardColumns(sb, cteContext, List.of(formula));
+
+    String sql = sb.build();
+    // Shadow path swaps the formula for the registered alias and ax-prefixes it.
+    assertThat(sql, containsString("ax.enrollmentgeometry_geojson"));
+    assertThat(sql, not(containsString(formula)));
+  }
+
+  @Test
+  void addOrgUnitAggregateColumnsEmitsDefaultOuWhenNoLevelColumnsAndNotAggregateEnrollment() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    assembler.addOrgUnitAggregateColumns(sb, params);
+
+    String sql = sb.build();
+    assertThat(sql, containsString("ou"));
+    assertThat(sql, containsString("group by"));
+  }
+
+  @Test
+  void resolveAggregatePeriodProjectionsReturnsEmptyWhenNoPeriodDimension() {
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    List<AggregatedEnrollmentQueryAssembler.PeriodProjection> projections =
+        assembler.resolveAggregatePeriodProjections(params);
+
+    assertTrue(projections.isEmpty());
+  }
+
+  @Test
+  void collectPeriodDateFieldKeysReturnsEmptyWhenNoPeriodDimension() {
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    assertTrue(assembler.collectPeriodDateFieldKeys(params).isEmpty());
+  }
+
+  @Test
+  void collectCteDefinitionsReturnsEmptyForEmptyContext() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+
+    assertTrue(assembler.collectCteDefinitions(cteContext).isEmpty());
+  }
+
+  @Test
+  void collectCteDefinitionsKeysProgramStageByStageUidAndItemId() {
+    CteContext cteContext = mock(CteContext.class);
+    CteDefinition stageDef = mock(CteDefinition.class);
+    when(cteContext.getCteKeysExcluding(CteDefinition.ENROLLMENT_AGGR_BASE))
+        .thenReturn(Set.of("stagecte"));
+    when(cteContext.getDefinitionByItemUid("stagecte")).thenReturn(stageDef);
+    when(stageDef.isProgramStage()).thenReturn(true);
+    when(stageDef.isProgramIndicator()).thenReturn(false);
+    when(stageDef.getProgramStageUid()).thenReturn("PStageUid");
+    when(stageDef.getItemId()).thenReturn("itemA");
+
+    Map<String, CteDefinition> result = assembler.collectCteDefinitions(cteContext);
+
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("\"PStageUid.itemA\""));
+    assertEquals(stageDef, result.get("\"PStageUid.itemA\""));
+  }
+
+  @Test
+  void collectCteDefinitionsKeysProgramIndicatorByIndicatorUid() {
+    CteContext cteContext = mock(CteContext.class);
+    CteDefinition piDef = mock(CteDefinition.class);
+    when(cteContext.getCteKeysExcluding(CteDefinition.ENROLLMENT_AGGR_BASE))
+        .thenReturn(Set.of("picte"));
+    when(cteContext.getDefinitionByItemUid("picte")).thenReturn(piDef);
+    when(piDef.isProgramStage()).thenReturn(false);
+    when(piDef.isProgramIndicator()).thenReturn(true);
+    when(piDef.getProgramIndicatorUid()).thenReturn("PiUid");
+
+    Map<String, CteDefinition> result = assembler.collectCteDefinitions(cteContext);
+
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("\"PiUid\""));
+    assertEquals(piDef, result.get("\"PiUid\""));
+  }
+
+  @Test
+  void collectCteDefinitionsSkipsDefinitionsThatAreNeitherStageNorIndicator() {
+    CteContext cteContext = mock(CteContext.class);
+    CteDefinition otherDef = mock(CteDefinition.class);
+    when(cteContext.getCteKeysExcluding(CteDefinition.ENROLLMENT_AGGR_BASE))
+        .thenReturn(Set.of("otherCte"));
+    when(cteContext.getDefinitionByItemUid("otherCte")).thenReturn(otherDef);
+    when(otherDef.isProgramStage()).thenReturn(false);
+    when(otherDef.isProgramIndicator()).thenReturn(false);
+
+    assertTrue(assembler.collectCteDefinitions(cteContext).isEmpty());
+  }
+
+  private static CteContext shadowCteContext() {
+    CteContext context = new CteContext(EndpointItem.ENROLLMENT);
+    context.addShadowCte("top_enrollments", "select 1", CteDefinition.CteType.TOP_ENROLLMENTS);
+    return context;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
@@ -118,7 +118,6 @@ class AggregatedEnrollmentQueryAssemblerTest {
   void addStandardColumnsWithoutShadowCteEmitsAxAlias() {
     SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
     CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
-    EventQueryParams params = mock(EventQueryParams.class);
 
     assembler.addStandardColumns(sb, cteContext, List.of("enrollment", "trackedentity"));
 
@@ -146,7 +145,6 @@ class AggregatedEnrollmentQueryAssemblerTest {
   void addStandardColumnsWithShadowCtePrefixesPlainColumnsWithAx() {
     SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
     CteContext cteContext = shadowCteContext();
-    EventQueryParams params = mock(EventQueryParams.class);
 
     assembler.addStandardColumns(sb, cteContext, List.of("enrollment", "trackedentity"));
 
@@ -159,7 +157,6 @@ class AggregatedEnrollmentQueryAssemblerTest {
   void addStandardColumnsWithShadowCteRewritesGeometryFormulaToAlias() {
     SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
     CteContext cteContext = shadowCteContext();
-    EventQueryParams params = mock(EventQueryParams.class);
     String formula = "ST_AsGeoJSON(enrollmentgeometry)";
 
     assembler.addStandardColumns(sb, cteContext, List.of(formula));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
@@ -32,6 +32,12 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.DimensionType.PERIOD;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,13 +46,20 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.CteDefinition;
 import org.hisp.dhis.analytics.common.EndpointItem;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.PeriodDimension;
+import org.hisp.dhis.period.PeriodType;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -158,6 +171,20 @@ class AggregatedEnrollmentQueryAssemblerTest {
   }
 
   @Test
+  void addStandardColumnsWithShadowCteRewritesUnknownFormulaToStableDefaultAlias() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    CteContext cteContext = shadowCteContext();
+    String formula = "coalesce(enrollmentdate, created)";
+
+    assembler.addStandardColumns(sb, cteContext, List.of(formula));
+
+    String sql = sb.build();
+    String expectedAlias = "formula_" + (formula.hashCode() & Integer.MAX_VALUE);
+    assertThat(sql, containsString("ax." + expectedAlias));
+    assertThat(sql, not(containsString(formula)));
+  }
+
+  @Test
   void addOrgUnitAggregateColumnsEmitsDefaultOuWhenNoLevelColumnsAndNotAggregateEnrollment() {
     SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
     EventQueryParams params = mock(EventQueryParams.class);
@@ -167,6 +194,196 @@ class AggregatedEnrollmentQueryAssemblerTest {
     String sql = sb.build();
     assertThat(sql, containsString("ou"));
     assertThat(sql, containsString("group by"));
+  }
+
+  @Test
+  void addOrgUnitAggregateColumnsEmitsLevelColumnsWhenOuModeRequiresThem() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    OrganisationUnit organisationUnit = new OrganisationUnit("OrgTest");
+    organisationUnit.setPath("/Level1/OrgTest");
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withOrganisationUnitMode(CAPTURE)
+            .addDimension(
+                new BaseDimensionalObject(
+                    ORGUNIT_DIM_ID, ORGANISATION_UNIT, List.of(organisationUnit)))
+            .build();
+
+    assembler.addOrgUnitAggregateColumns(sb, params);
+
+    String sql = sb.build();
+    assertThat(sql, containsString("uidlevel2"));
+    assertThat(sql, containsString("group by uidlevel2"));
+    assertThat(sql, not(containsString("group by ou")));
+  }
+
+  @Test
+  void addOrgUnitAggregateColumnsSkipsDefaultOuForAggregateEnrollmentWithoutOuDimensions() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withEndpointAction(AGGREGATE)
+            .withEndpointItem(org.hisp.dhis.common.RequestTypeAware.EndpointItem.ENROLLMENT)
+            .build();
+
+    assembler.addOrgUnitAggregateColumns(sb, params);
+
+    String sql = sb.build();
+    assertThat(sql, not(containsString("ou")));
+    assertThat(sql, not(containsString("group by")));
+  }
+
+  @Test
+  void addPeriodAggregateColumnsUsesPeriodColumnsWhenNoProjectionExists() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject(PERIOD_DIM_ID, PERIOD, List.of(month("202301"))))
+            .build();
+
+    assembler.addPeriodAggregateColumns(params, sb, List.of());
+
+    String sql = sb.build();
+    assertThat(sql, containsString("Monthly"));
+    assertThat(sql, containsString("group by Monthly"));
+    assertThat(sql, not(containsString("t1.Monthly")));
+  }
+
+  @Test
+  void addPeriodAggregateColumnsAddsResolvedExpressions() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    EventQueryParams params = mock(EventQueryParams.class);
+    DateFieldPeriodBucketColumnResolver.ResolvedExpression expression =
+        new DateFieldPeriodBucketColumnResolver.ResolvedExpression(
+            "date_trunc('month', eb.\"enrollmentdate\") as \"enrollmentdate\"",
+            "date_trunc('month', eb.\"enrollmentdate\")",
+            "enrollmentdate",
+            Optional.empty());
+
+    assembler.addPeriodAggregateColumns(
+        params,
+        sb,
+        List.of(
+            new AggregatedEnrollmentQueryAssembler.PeriodProjection(
+                "enrollmentdate", Optional.of(expression))));
+
+    String sql = sb.build();
+    assertThat(
+        sql, containsString("date_trunc('month', eb.\"enrollmentdate\") as \"enrollmentdate\""));
+    assertThat(sql, containsString("group by date_trunc('month', eb.\"enrollmentdate\")"));
+  }
+
+  @Test
+  void addPeriodAggregateColumnsQuotesProjectionKeysWithoutResolvedExpressions() {
+    SelectBuilder sb = new SelectBuilder().from("ax_table", "ax");
+    EventQueryParams params = mock(EventQueryParams.class);
+
+    assembler.addPeriodAggregateColumns(
+        params,
+        sb,
+        List.of(
+            new AggregatedEnrollmentQueryAssembler.PeriodProjection(
+                "scheduleddate", Optional.empty())));
+
+    String sql = sb.build();
+    assertThat(sql, containsString("\"scheduleddate\""));
+    assertThat(sql, containsString("group by \"scheduleddate\""));
+  }
+
+  @Test
+  void addHeaderAggregateColumnsSkipsInfrastructureAndPeriodHeaders() {
+    SelectBuilder sb = new SelectBuilder().from("enrollment_aggr_base", "eb");
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject(
+                    PERIOD_DIM_ID,
+                    PERIOD,
+                    "monthly",
+                    "Period",
+                    List.of(month("202301").setDateField(TimeField.ENROLLMENT_DATE.name()))))
+            .build();
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+
+    assembler.addHeaderAggregateColumns(
+        List.of(
+            new GridHeader("value"),
+            new GridHeader("ou"),
+            new GridHeader("pe"),
+            new GridHeader("enrollmentdate"),
+            new GridHeader("plain")),
+        params,
+        cteContext,
+        sb,
+        List.of(
+            new AggregatedEnrollmentQueryAssembler.PeriodProjection("monthly", Optional.empty())));
+
+    String sql = sb.build();
+    assertThat(sql, containsString("\"plain\""));
+    assertThat(sql, not(containsString("\"enrollmentdate\"")));
+    assertThat(sql, not(containsString("\"value\"")));
+    assertThat(sql, not(containsString("\"ou\"")));
+    assertThat(sql, not(containsString("\"pe\"")));
+  }
+
+  @Test
+  void addHeaderAggregateColumnsUsesStageFilterCteWhenPresent() {
+    SelectBuilder sb = new SelectBuilder().from("enrollment_aggr_base", "eb");
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+
+    assembler.addHeaderAggregateColumns(
+        List.of(new GridHeader("stage1.eventdate")),
+        mock(EventQueryParams.class),
+        cteContext,
+        sb,
+        List.of());
+
+    String sql = sb.build();
+    assertThat(sql, containsString("ev_occurreddate as \"stage1.eventdate\""));
+    assertThat(sql, containsString("group by"));
+    assertThat(sql, containsString("ev_occurreddate"));
+  }
+
+  @Test
+  void addHeaderAggregateColumnsSkipsPeriodProjectionHeadersCaseInsensitively() {
+    SelectBuilder sb = new SelectBuilder().from("enrollment_aggr_base", "eb");
+
+    assembler.addHeaderAggregateColumns(
+        List.of(new GridHeader("ScheduledDate"), new GridHeader("plain")),
+        mock(EventQueryParams.class),
+        new CteContext(EndpointItem.ENROLLMENT),
+        sb,
+        List.of(
+            new AggregatedEnrollmentQueryAssembler.PeriodProjection(
+                "scheduleddate", Optional.empty())));
+
+    String sql = sb.build();
+    assertThat(sql, containsString("\"plain\""));
+    assertThat(sql, not(containsString("\"ScheduledDate\"")));
+    assertThat(sql, not(containsString("\"scheduleddate\"")));
+  }
+
+  @Test
+  void addHeaderAggregateColumnsUsesProgramIndicatorCteWhenHeaderMatchesIndicatorUid() {
+    SelectBuilder sb = new SelectBuilder().from("enrollment_aggr_base", "eb");
+    CteContext cteContext = mock(CteContext.class);
+    CteDefinition piDef = mock(CteDefinition.class);
+    when(cteContext.getCteKeysExcluding(CteDefinition.ENROLLMENT_AGGR_BASE))
+        .thenReturn(Set.of("PiUid"));
+    when(cteContext.getDefinitionByItemUid("PiUid")).thenReturn(piDef);
+    when(piDef.isProgramStage()).thenReturn(false);
+    when(piDef.isProgramIndicator()).thenReturn(true);
+    when(piDef.getProgramIndicatorUid()).thenReturn("PiUid");
+    when(piDef.getAlias()).thenReturn("pi_cte");
+
+    assembler.addHeaderAggregateColumns(
+        List.of(new GridHeader("PiUid")), mock(EventQueryParams.class), cteContext, sb, List.of());
+
+    String sql = sb.build();
+    assertThat(sql, containsString("pi_cte.value as \"PiUid\""));
+    assertThat(sql, containsString("group by \"PiUid\""));
   }
 
   @Test
@@ -180,10 +397,96 @@ class AggregatedEnrollmentQueryAssemblerTest {
   }
 
   @Test
+  void resolveAggregatePeriodProjectionsSplitsMixedDateFieldPeriods() {
+    PeriodDimension enrollmentDate = month("202301").setDateField(TimeField.ENROLLMENT_DATE.name());
+    PeriodDimension lastUpdated = month("202302").setDateField(TimeField.LAST_UPDATED.name());
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject(
+                    PERIOD_DIM_ID,
+                    PERIOD,
+                    "monthly",
+                    "Period",
+                    List.of(enrollmentDate, lastUpdated)))
+            .build();
+
+    List<AggregatedEnrollmentQueryAssembler.PeriodProjection> projections =
+        assembler.resolveAggregatePeriodProjections(params);
+
+    assertEquals(2, projections.size());
+    assertTrue(
+        projections.stream()
+            .anyMatch(
+                projection ->
+                    "enrollmentdate".equals(projection.responseKey())
+                        && projection.expression().isPresent()));
+    assertTrue(
+        projections.stream()
+            .anyMatch(
+                projection ->
+                    "lastupdated".equals(projection.responseKey())
+                        && projection.expression().isPresent()));
+  }
+
+  @Test
+  void resolveAggregatePeriodProjectionsKeepsDefaultGroupWhenMixedWithNonDefaultDateField() {
+    PeriodDimension defaultPeriod = month("202301");
+    PeriodDimension enrollmentDate = month("202302").setDateField(TimeField.ENROLLMENT_DATE.name());
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject(
+                    PERIOD_DIM_ID,
+                    PERIOD,
+                    "monthly",
+                    "Period",
+                    List.of(defaultPeriod, enrollmentDate)))
+            .build();
+
+    List<AggregatedEnrollmentQueryAssembler.PeriodProjection> projections =
+        assembler.resolveAggregatePeriodProjections(params);
+
+    assertEquals(2, projections.size());
+    assertTrue(
+        projections.stream()
+            .anyMatch(
+                projection ->
+                    "monthly".equals(projection.responseKey())
+                        && projection.expression().isEmpty()));
+    assertTrue(
+        projections.stream()
+            .anyMatch(
+                projection ->
+                    "enrollmentdate".equals(projection.responseKey())
+                        && projection.expression().isPresent()));
+  }
+
+  @Test
   void collectPeriodDateFieldKeysReturnsEmptyWhenNoPeriodDimension() {
     EventQueryParams params = mock(EventQueryParams.class);
 
     assertTrue(assembler.collectPeriodDateFieldKeys(params).isEmpty());
+  }
+
+  @Test
+  void collectPeriodDateFieldKeysReturnsNormalizedNonNullDateFields() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject(
+                    PERIOD_DIM_ID,
+                    PERIOD,
+                    "monthly",
+                    "Period",
+                    List.of(
+                        month("202301").setDateField(TimeField.ENROLLMENT_DATE.name()),
+                        month("202302"),
+                        month("202303").setDateField(TimeField.LAST_UPDATED.name()))))
+            .build();
+
+    assertEquals(
+        Set.of("enrollmentdate", "lastupdated"), assembler.collectPeriodDateFieldKeys(params));
   }
 
   @Test
@@ -247,5 +550,11 @@ class AggregatedEnrollmentQueryAssemblerTest {
     CteContext context = new CteContext(EndpointItem.ENROLLMENT);
     context.addShadowCte("top_enrollments", "select 1", CteDefinition.CteType.TOP_ENROLLMENTS);
     return context;
+  }
+
+  private static PeriodDimension month(String isoPeriod) {
+    PeriodDimension period = PeriodDimension.of(isoPeriod);
+    period.getPeriod().setPeriodType(PeriodType.getPeriodTypeFromIsoString(isoPeriod));
+    return period;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -732,6 +732,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
             new DefaultStageDatePeriodBucketSqlRenderer(builder),
             new DefaultStageOrgUnitSqlService(organisationUnitResolver, builder));
 
+    DateFieldPeriodBucketColumnResolver bucketResolver =
+        new DateFieldPeriodBucketColumnResolver(builder);
     return new JdbcEnrollmentAnalyticsManager(
         jdbcTemplate,
         programIndicatorService,
@@ -747,8 +749,9 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
         columnMapper,
         filterBuilder,
         stageQuerySqlFacade,
-        new DateFieldPeriodBucketColumnResolver(builder),
-        new EnrollmentEventSubqueryBuilder(builder, new ProgramStageOffsetSqlBuilder(builder)));
+        bucketResolver,
+        new EnrollmentEventSubqueryBuilder(builder, new ProgramStageOffsetSqlBuilder(builder)),
+        new AggregatedEnrollmentQueryAssembler(builder, bucketResolver));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -145,6 +145,9 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             new DefaultStageDatePeriodBucketSqlRenderer(sqlBuilder),
             new DefaultStageOrgUnitSqlService(organisationUnitResolver, sqlBuilder));
 
+    DateFieldPeriodBucketColumnResolver bucketResolver =
+        new DateFieldPeriodBucketColumnResolver(new PostgreSqlAnalyticsSqlBuilder());
+
     subject =
         new JdbcEnrollmentAnalyticsManager(
             jdbcTemplate,
@@ -161,9 +164,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             columnMapper,
             filterBuilder,
             stageQuerySqlFacade,
-            new DateFieldPeriodBucketColumnResolver(new PostgreSqlAnalyticsSqlBuilder()),
+            bucketResolver,
             new EnrollmentEventSubqueryBuilder(
-                sqlBuilder, new ProgramStageOffsetSqlBuilder(sqlBuilder)));
+                sqlBuilder, new ProgramStageOffsetSqlBuilder(sqlBuilder)),
+            new AggregatedEnrollmentQueryAssembler(sqlBuilder, bucketResolver));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR refactors enrollment analytics SQL building logic by extracting the aggregated and standard enrollment SELECT-column logic from `JdbcEnrollmentAnalyticsManager` into a dedicated `AggregatedEnrollmentQueryAssembler` component.

The extracted assembler now owns:
- aggregated enrollment count, org unit, period, and header column assembly
- date-field period projection handling
- CTE-backed header column resolution
- standard enrollment column selection, including shadow CTE formula alias handling

`JdbcEnrollmentAnalyticsManager` now delegates this responsibility while keeping the surrounding query orchestration unchanged.

ref: [DHIS2-21381](https://dhis2.atlassian.net/browse/DHIS2-21381)


[DHIS2-21381]: https://dhis2.atlassian.net/browse/DHIS2-21381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ