### PR TITLE
fix: Metadata sync fails when snapshot version over 20MB [DHIS2-21252](2.42)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/metadata/version/MetadataVersionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/metadata/version/MetadataVersionService.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.metadata.version;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 
@@ -128,12 +130,27 @@ public interface MetadataVersionService {
   boolean saveVersion(VersionType versionType);
 
   /**
-   * Gets the Version data - the actual JSON snapshot given the version name.
+   * Streams the metadata snapshot for the given version name directly to the output stream.
    *
-   * @param versionName
-   * @return JSON data for the version snapshot
+   * <p>Scans the stored JSONB wrapper directly without materialising a full Java String copy of the
+   * metadata field, which is a more memory-efficient path for large snapshots.
+   *
+   * @param versionName the version name
+   * @param out the output stream to write the snapshot to
+   * @return true if the snapshot was found and written, false if no snapshot exists
+   * @throws IOException if writing to the output stream fails
    */
-  String getVersionData(String versionName);
+  boolean streamVersionData(String versionName, OutputStream out) throws IOException;
+
+  /**
+   * Returns whether a metadata snapshot exists for the given version name. Cheap pre-flight check
+   * intended to be called before opening any response output stream — see {@link
+   * MetadataVersionStore#metadataVersionSnapshotExists} for the rationale.
+   *
+   * @param versionName the version name
+   * @return true if a snapshot is stored for that version
+   */
+  boolean snapshotExists(String versionName);
 
   /**
    * Creates an entry in the DataStore given the MetadataVersion details.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/metadata/version/MetadataVersionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/metadata/version/MetadataVersionStore.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.metadata.version;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.common.GenericStore;
@@ -75,4 +77,29 @@ public interface MetadataVersionStore extends GenericStore<MetadataVersion> {
    * @return Initial/First MetadataVersion of the system
    */
   MetadataVersion getInitialVersion();
+
+  /**
+   * Streams the metadata snapshot for the given version name directly from the underlying datastore
+   * row to the output stream. Avoids materialising the snapshot as a Java String, which is
+   * memory-prohibitive for large snapshots and would also trip Jackson's default 20MB string-token
+   * limit during deserialisation of the wrapper object.
+   *
+   * @param versionName the version name
+   * @param out the output stream to write the snapshot to
+   * @return true if the snapshot was found and written, false if no snapshot exists
+   * @throws IOException if writing to the output stream fails
+   */
+  boolean streamMetadataVersionData(String versionName, OutputStream out) throws IOException;
+
+  /**
+   * Returns whether a metadata snapshot exists for the given version name. Intended as a cheap
+   * pre-flight check before opening a response output stream — once {@link
+   * #streamMetadataVersionData} starts writing, response headers are committed and an error status
+   * can no longer be returned to the client (especially relevant for the gzipped variant where
+   * {@code GZIPOutputStream} writes its magic header on construction).
+   *
+   * @param versionName the version name
+   * @return true if a snapshot row exists in the metadata datastore namespace
+   */
+  boolean metadataVersionSnapshotExists(String versionName);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/metadata/version/hibernate/HibernateMetadataVersionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/metadata/version/hibernate/HibernateMetadataVersionStore.java
@@ -31,9 +31,15 @@ package org.hisp.dhis.metadata.version.hibernate;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.sql.ResultSet;
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.datastore.MetadataDatastoreService;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionStore;
 import org.hisp.dhis.security.acl.AclService;
@@ -106,5 +112,45 @@ public class HibernateMetadataVersionStore extends HibernateIdentifiableObjectSt
             .addOrder(root -> builder.asc(root.get("created")))
             .setMaxResults(1)
             .setCacheable(false));
+  }
+
+  @Override
+  public boolean metadataVersionSnapshotExists(String versionName) {
+    return Boolean.TRUE.equals(
+        jdbcTemplate.query(
+            "SELECT 1 FROM keyjsonvalue WHERE namespace = ? AND namespacekey = ? LIMIT 1",
+            ResultSet::next,
+            MetadataDatastoreService.METADATA_STORE_NS,
+            versionName));
+  }
+
+  @Override
+  public boolean streamMetadataVersionData(String versionName, OutputStream out)
+      throws IOException {
+    // The 'metadata' JSON key must match MetadataWrapper#getMetadata(); renaming the wrapper
+    // field would silently break this query (no row found, snapshot reported missing).
+    String sql =
+        "SELECT jbvalue->>'metadata' FROM keyjsonvalue"
+            + " WHERE namespace = ? AND namespacekey = ?";
+    try {
+      Boolean found =
+          jdbcTemplate.query(
+              sql,
+              rs -> {
+                if (!rs.next()) return false;
+                try (InputStream in = rs.getBinaryStream(1)) {
+                  if (in == null) return false;
+                  in.transferTo(out);
+                } catch (IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+                return true;
+              },
+              MetadataDatastoreService.METADATA_STORE_NS,
+              versionName);
+      return Boolean.TRUE.equals(found);
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncService.java
@@ -29,8 +29,13 @@
  */
 package org.hisp.dhis.dxf2.metadata.sync;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.CheckForNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -101,16 +106,21 @@ public class DefaultMetadataSyncService implements MetadataSyncService {
     MetadataVersion version = getMetadataVersion(syncParams);
 
     setMetadataImportMode(syncParams, version);
-    String metadataVersionSnapshot = getMetadataVersionSnapshot(version);
 
-    if (metadataSyncDelegate.shouldStopSync(metadataVersionSnapshot)) {
+    // Obtain the snapshot as a byte[] buffer. Coming from the local datastore it is streamed
+    // (without MetadataWrapper deserialisation); coming from remote it is downloaded and
+    // integrity-checked. Holding it once as UTF-8 bytes is substantially cheaper than keeping
+    // a Java String alive for the whole import, which the previous String-based flow required.
+    byte[] snapshotBytes = getOrFetchSnapshotBytes(version);
+
+    if (metadataSyncDelegate.shouldStopSync(new ByteArrayInputStream(snapshotBytes))) {
       throw new DhisVersionMismatchException(
           "Metadata sync failed because your version of DHIS does not match the master version");
     }
 
-    saveMetadataVersionSnapshotLocally(version, metadataVersionSnapshot);
     MetadataSyncSummary metadataSyncSummary =
-        metadataSyncImportHandler.importMetadata(syncParams, metadataVersionSnapshot);
+        metadataSyncImportHandler.importMetadata(
+            syncParams, new ByteArrayInputStream(snapshotBytes));
 
     log.info("Metadata Sync Summary: " + metadataSyncSummary);
 
@@ -123,32 +133,49 @@ public class DefaultMetadataSyncService implements MetadataSyncService {
     return (metadataVersionService.getVersionByName(version.getName()) == null);
   }
 
-  private void saveMetadataVersionSnapshotLocally(
-      MetadataVersion version, String metadataVersionSnapshot) {
-    if (getLocalVersionSnapshot(version) == null) {
-      metadataVersionService.createMetadataVersionInDataStore(
-          version.getName(), metadataVersionSnapshot);
-      log.info(
-          "Downloaded the metadata snapshot from remote and saved in Data Store for the version: "
-              + version);
-    }
-  }
-
-  private String getMetadataVersionSnapshot(MetadataVersion version) {
-    String metadataVersionSnapshot = getLocalVersionSnapshot(version);
-
-    if (metadataVersionSnapshot != null) {
-      return metadataVersionSnapshot;
+  /**
+   * Returns the metadata snapshot bytes for the given version. If the snapshot is already stored
+   * locally it is streamed directly from the datastore; otherwise it is downloaded from the remote
+   * server, integrity-checked, and saved locally before returning.
+   */
+  private byte[] getOrFetchSnapshotBytes(MetadataVersion version) {
+    byte[] local = readLocalSnapshotBytes(version);
+    if (local != null) {
+      log.info("Rendering the MetadataVersion from local DataStore");
+      return local;
     }
 
-    metadataVersionSnapshot = getMetadataVersionSnapshotFromRemote(version);
+    String remoteSnapshot = getMetadataVersionSnapshotFromRemote(version);
 
-    if (!(metadataVersionService.isMetadataPassingIntegrity(version, metadataVersionSnapshot))) {
+    if (!metadataVersionService.isMetadataPassingIntegrity(version, remoteSnapshot)) {
       throw new MetadataSyncServiceException(
           "Metadata snapshot is corrupted. Not saving it locally");
     }
 
-    return metadataVersionSnapshot;
+    metadataVersionService.createMetadataVersionInDataStore(version.getName(), remoteSnapshot);
+    log.info(
+        "Downloaded the metadata snapshot from remote and saved in Data Store for the version: "
+            + version);
+
+    return remoteSnapshot.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /** Returns the locally stored snapshot bytes, or {@code null} if none are stored. */
+  @CheckForNull
+  private byte[] readLocalSnapshotBytes(MetadataVersion version) {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try {
+      if (!metadataVersionService.streamVersionData(version.getName(), buffer)
+          || buffer.size() == 0) {
+        return null;
+      }
+    } catch (IOException e) {
+      throw new MetadataSyncServiceException(
+          "Exception occurred while reading local metadata snapshot for version "
+              + version.getName(),
+          e);
+    }
+    return buffer.toByteArray();
   }
 
   private String getMetadataVersionSnapshotFromRemote(MetadataVersion version) {
@@ -176,17 +203,6 @@ public class DefaultMetadataSyncService implements MetadataSyncService {
   // ----------------------------------------------------------------------------------------
   // Private Methods
   // ----------------------------------------------------------------------------------------
-
-  private String getLocalVersionSnapshot(MetadataVersion version) {
-    String metadataVersionSnapshot = metadataVersionService.getVersionData(version.getName());
-
-    if (StringUtils.isNotEmpty(metadataVersionSnapshot)) {
-      log.info("Rendering the MetadataVersion from local DataStore");
-      return metadataVersionSnapshot;
-    }
-
-    return null;
-  }
 
   private List<String> getVersionsFromParams(Map<String, List<String>> parameters) {
     if (parameters == null) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegate.java
@@ -30,9 +30,8 @@
 package org.hisp.dhis.dxf2.metadata.sync;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.InputStream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -59,20 +58,18 @@ public class MetadataSyncDelegate {
 
   private final SystemService systemService;
 
-  public boolean shouldStopSync(String metadataVersionSnapshot) {
+  public boolean shouldStopSync(InputStream metadataVersionSnapshot) {
     String systemVersion = systemService.getSystemInfoVersion();
     if (StringUtils.isEmpty(systemVersion)
         || !metadataSystemSettingService.getStopMetadataSyncSetting()) {
       return false;
     }
 
-    ByteArrayInputStream byteArrayInputStream =
-        new ByteArrayInputStream(metadataVersionSnapshot.getBytes(StandardCharsets.UTF_8));
     String remoteVersion = "";
 
     try {
       JsonNode systemObject =
-          renderService.getSystemObject(byteArrayInputStream, RenderFormat.JSON);
+          renderService.getSystemObject(metadataVersionSnapshot, RenderFormat.JSON);
 
       if (systemObject == null) {
         return false;
@@ -84,7 +81,7 @@ public class MetadataSyncDelegate {
         return false;
       }
     } catch (IOException e) {
-      log.error("Exception occurred when parsing the metadata snapshot" + e.getMessage());
+      log.error("Exception occurred when parsing the metadata snapshot", e);
     }
 
     return !systemVersion.trim().equals(remoteVersion.trim());

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandler.java
@@ -29,9 +29,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.sync;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +69,8 @@ public class MetadataSyncImportHandler {
 
   private final MetadataImportService metadataImportService;
 
-  public MetadataSyncSummary importMetadata(MetadataSyncParams syncParams, String versionSnapShot) {
+  public MetadataSyncSummary importMetadata(
+      MetadataSyncParams syncParams, InputStream versionSnapshot) {
     MetadataVersion version = getMetadataVersion(syncParams);
     MetadataImportParams importParams = syncParams.getImportParams();
     MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
@@ -80,7 +80,7 @@ public class MetadataSyncImportHandler {
     }
 
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> classListMap =
-        parseClassListMap(versionSnapShot);
+        parseClassListMap(versionSnapshot);
 
     if (classListMap == null) {
       throw new MetadataSyncServiceException("ClassListMap can't be null");
@@ -136,12 +136,9 @@ public class MetadataSyncImportHandler {
   }
 
   private Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> parseClassListMap(
-      String metadataVersionSnapshot) {
-    ByteArrayInputStream byteArrayInputStream =
-        new ByteArrayInputStream(metadataVersionSnapshot.getBytes(StandardCharsets.UTF_8));
-
+      InputStream metadataVersionSnapshot) {
     try {
-      return renderService.fromMetadata(byteArrayInputStream, RenderFormat.JSON);
+      return renderService.fromMetadata(metadataVersionSnapshot, RenderFormat.JSON);
     } catch (IOException ex) {
       String message =
           "Exception occurred while trying to do JSON conversion while parsing class list map";

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -225,18 +226,14 @@ public class DefaultMetadataVersionService implements MetadataVersionService {
 
   @Override
   @Transactional(readOnly = true)
-  public String getVersionData(String versionName) {
-    DatastoreEntry entry = metaDataDatastoreService.getMetaDataVersion(versionName);
+  public boolean streamVersionData(String versionName, OutputStream out) throws IOException {
+    return versionStore.streamMetadataVersionData(versionName, out);
+  }
 
-    if (entry != null) {
-      try {
-        return renderService.fromJson(entry.getValue(), MetadataWrapper.class).getMetadata();
-      } catch (IOException e) {
-        log.error("Exception occurred while deserializing metadata.", e);
-      }
-    }
-
-    return null;
+  @Override
+  @Transactional(readOnly = true)
+  public boolean snapshotExists(String versionName) {
+    return versionStore.metadataVersionSnapshotExists(versionName);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.dxf2.metadata.sync;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -39,6 +40,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -212,7 +217,7 @@ class DefaultMetadataSyncServiceTest {
     when(syncParams.getVersion()).thenReturn(metadataVersion);
     when(metadataVersionDelegate.downloadMetadataVersionSnapshot(metadataVersion))
         .thenReturn(expectedMetadataSnapshot);
-    when(metadataSyncDelegate.shouldStopSync(expectedMetadataSnapshot)).thenReturn(true);
+    when(metadataSyncDelegate.shouldStopSync(any(InputStream.class))).thenReturn(true);
     when(metadataVersionService.isMetadataPassingIntegrity(
             metadataVersion, expectedMetadataSnapshot))
         .thenReturn(true);
@@ -233,7 +238,7 @@ class DefaultMetadataSyncServiceTest {
     when(syncParams.getVersion()).thenReturn(metadataVersion);
     when(metadataVersionDelegate.downloadMetadataVersionSnapshot(metadataVersion))
         .thenReturn(expectedMetadataSnapshot);
-    when(metadataSyncDelegate.shouldStopSync(expectedMetadataSnapshot)).thenReturn(false);
+    when(metadataSyncDelegate.shouldStopSync(any(InputStream.class))).thenReturn(false);
     when(metadataVersionService.isMetadataPassingIntegrity(
             metadataVersion, expectedMetadataSnapshot))
         .thenReturn(true);
@@ -261,7 +266,8 @@ class DefaultMetadataSyncServiceTest {
   }
 
   @Test
-  void testShouldStoreMetadataSnapshotInDataStoreAndImport() throws DhisVersionMismatchException {
+  void testShouldStoreMetadataSnapshotInDataStoreAndImport()
+      throws DhisVersionMismatchException, IOException {
     MetadataSyncParams syncParams = Mockito.mock(MetadataSyncParams.class);
     MetadataVersion metadataVersion = new MetadataVersion("testVersion", VersionType.ATOMIC);
     MetadataSyncSummary metadataSyncSummary = new MetadataSyncSummary();
@@ -269,13 +275,14 @@ class DefaultMetadataSyncServiceTest {
     String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
     when(syncParams.getVersion()).thenReturn(metadataVersion);
-    when(metadataVersionService.getVersionData("testVersion")).thenReturn(null);
+    when(metadataVersionService.streamVersionData(eq("testVersion"), any(OutputStream.class)))
+        .thenReturn(false);
     when(metadataVersionDelegate.downloadMetadataVersionSnapshot(metadataVersion))
         .thenReturn(expectedMetadataSnapshot);
     when(metadataVersionService.isMetadataPassingIntegrity(
             metadataVersion, expectedMetadataSnapshot))
         .thenReturn(true);
-    when(metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot))
+    when(metadataSyncImportHandler.importMetadata(eq(syncParams), any(InputStream.class)))
         .thenReturn(metadataSyncSummary);
 
     MetadataSyncSummary actualSummary = metadataSyncService.doMetadataSync(syncParams);
@@ -289,7 +296,7 @@ class DefaultMetadataSyncServiceTest {
 
   @Test
   void testShouldNotStoreMetadataSnapshotInDataStoreWhenAlreadyExistsInLocalStore()
-      throws DhisVersionMismatchException {
+      throws DhisVersionMismatchException, IOException {
     MetadataSyncParams syncParams = Mockito.mock(MetadataSyncParams.class);
 
     MetadataVersion metadataVersion = new MetadataVersion("testVersion", VersionType.ATOMIC);
@@ -300,9 +307,15 @@ class DefaultMetadataSyncServiceTest {
     String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
     when(syncParams.getVersion()).thenReturn(metadataVersion);
-    when(metadataVersionService.getVersionData("testVersion")).thenReturn(expectedMetadataSnapshot);
+    when(metadataVersionService.streamVersionData(eq("testVersion"), any(OutputStream.class)))
+        .thenAnswer(
+            invocation -> {
+              OutputStream out = invocation.getArgument(1);
+              out.write(expectedMetadataSnapshot.getBytes(StandardCharsets.UTF_8));
+              return true;
+            });
 
-    when(metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot))
+    when(metadataSyncImportHandler.importMetadata(eq(syncParams), any(InputStream.class)))
         .thenReturn(metadataSyncSummary);
 
     MetadataSyncSummary actualSummary = metadataSyncService.doMetadataSync(syncParams);
@@ -317,7 +330,7 @@ class DefaultMetadataSyncServiceTest {
 
   @Test
   void testShouldVerifyImportParamsAtomicTypeForTheGivenBestEffortVersion()
-      throws DhisVersionMismatchException {
+      throws DhisVersionMismatchException, IOException {
     MetadataSyncParams syncParams = new MetadataSyncParams();
 
     MetadataVersion metadataVersion = new MetadataVersion("testVersion", VersionType.BEST_EFFORT);
@@ -330,16 +343,22 @@ class DefaultMetadataSyncServiceTest {
     metadataSyncSummary.setMetadataVersion(metadataVersion);
     String expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
 
-    when(metadataVersionService.getVersionData("testVersion")).thenReturn(expectedMetadataSnapshot);
+    when(metadataVersionService.streamVersionData(eq("testVersion"), any(OutputStream.class)))
+        .thenAnswer(
+            invocation -> {
+              OutputStream out = invocation.getArgument(1);
+              out.write(expectedMetadataSnapshot.getBytes(StandardCharsets.UTF_8));
+              return true;
+            });
 
     metadataSyncService.doMetadataSync(syncParams);
 
     verify(metadataSyncImportHandler, times(1))
         .importMetadata(
-            (argThat(
+            argThat(
                 metadataSyncParams ->
-                    syncParams.getImportParams().getAtomicMode().equals(AtomicMode.NONE))),
-            eq(expectedMetadataSnapshot));
+                    syncParams.getImportParams().getAtomicMode().equals(AtomicMode.NONE)),
+            any(InputStream.class));
 
     verify(metadataVersionService, never())
         .createMetadataVersionInDataStore(metadataVersion.getName(), expectedMetadataSnapshot);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.hisp.dhis.dxf2.metadata.systemsettings.DefaultMetadataSystemSettingService;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
@@ -68,7 +70,7 @@ class MetadataSyncDelegateTest {
     String versionSnapshot =
         "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
     when(systemService.getSystemInfoVersion()).thenReturn(null);
-    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(versionSnapshot);
+    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(toStream(versionSnapshot));
     assertFalse(shouldStopSync);
   }
 
@@ -77,7 +79,7 @@ class MetadataSyncDelegateTest {
     String versionSnapshot =
         "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
     when(systemService.getSystemInfoVersion()).thenReturn("2.26");
-    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(versionSnapshot);
+    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(toStream(versionSnapshot));
     assertFalse(shouldStopSync);
   }
 
@@ -91,10 +93,10 @@ class MetadataSyncDelegateTest {
     when(metadataSystemSettingService.getStopMetadataSyncSetting()).thenReturn(true);
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.readTree(systemNodeString);
-    when(renderService.getSystemObject(any(ByteArrayInputStream.class), eq(RenderFormat.JSON)))
+    when(renderService.getSystemObject(any(InputStream.class), eq(RenderFormat.JSON)))
         .thenReturn(jsonNode);
 
-    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(versionSnapshot);
+    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(toStream(versionSnapshot));
     assertTrue(shouldStopSync);
   }
 
@@ -107,10 +109,10 @@ class MetadataSyncDelegateTest {
     when(metadataSystemSettingService.getStopMetadataSyncSetting()).thenReturn(true);
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.readTree(systemNodeString);
-    when(renderService.getSystemObject(any(ByteArrayInputStream.class), eq(RenderFormat.JSON)))
+    when(renderService.getSystemObject(any(InputStream.class), eq(RenderFormat.JSON)))
         .thenReturn(jsonNode);
 
-    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(versionSnapshot);
+    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(toStream(versionSnapshot));
     assertFalse(shouldStopSync);
   }
 
@@ -120,7 +122,11 @@ class MetadataSyncDelegateTest {
         "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
     when(systemService.getSystemInfoVersion()).thenReturn("2.26");
     when(metadataSystemSettingService.getStopMetadataSyncSetting()).thenReturn(false);
-    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(versionSnapshot);
+    boolean shouldStopSync = metadataSyncDelegate.shouldStopSync(toStream(versionSnapshot));
     assertFalse(shouldStopSync);
+  }
+
+  private static InputStream toStream(String s) {
+    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
@@ -38,8 +38,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
@@ -51,6 +53,7 @@ import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.VersionType;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,12 +82,20 @@ class MetadataSyncImportHandlerTest {
 
   private ImportReport importReport;
 
+  private InputStream snapshot;
+
   @BeforeEach
-  public void setup() {
+  void setup() {
     metadataVersion = new MetadataVersion("testVersion", VersionType.ATOMIC);
     expectedMetadataSnapshot = "{\"date\":\"2016-05-24T05:27:25.128+0000\"}";
     syncParams = new MetadataSyncParams();
     importReport = new ImportReport();
+    snapshot = new ByteArrayInputStream(expectedMetadataSnapshot.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    snapshot.close();
   }
 
   @Test
@@ -92,7 +103,7 @@ class MetadataSyncImportHandlerTest {
     syncParams.setImportParams(null);
     assertThrows(
         MetadataSyncServiceException.class,
-        () -> metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot),
+        () -> metadataSyncImportHandler.importMetadata(syncParams, snapshot),
         "MetadataImportParams for the Sync cant be null.");
   }
 
@@ -103,7 +114,7 @@ class MetadataSyncImportHandlerTest {
 
     assertThrows(
         MetadataSyncServiceException.class,
-        () -> metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot),
+        () -> metadataSyncImportHandler.importMetadata(syncParams, snapshot),
         "MetadataImportParams for the Sync cant be null.");
   }
 
@@ -114,9 +125,10 @@ class MetadataSyncImportHandlerTest {
 
     when(metadataImportService.importMetadata(eq(syncParams.getImportParams()), any()))
         .thenThrow(new MetadataSyncServiceException(""));
+
     assertThrows(
         MetadataSyncImportException.class,
-        () -> metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot));
+        () -> metadataSyncImportHandler.importMetadata(syncParams, snapshot));
     verify(metadataVersionDelegate, never()).addNewMetadataVersion(metadataVersion);
   }
 
@@ -136,7 +148,7 @@ class MetadataSyncImportHandlerTest {
     doNothing().when(metadataVersionDelegate).addNewMetadataVersion(metadataVersion);
 
     MetadataSyncSummary actualMetadataSyncSummary =
-        metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot);
+        metadataSyncImportHandler.importMetadata(syncParams, snapshot);
 
     verify(metadataVersionDelegate).addNewMetadataVersion(metadataVersion);
     assertEquals(
@@ -170,7 +182,7 @@ class MetadataSyncImportHandlerTest {
     doNothing().when(metadataVersionDelegate).addNewMetadataVersion(metadataVersion);
 
     MetadataSyncSummary actualMetadataSyncSummary =
-        metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot);
+        metadataSyncImportHandler.importMetadata(syncParams, snapshot);
     verify(metadataVersionDelegate).addNewMetadataVersion(metadataVersion);
     assertEquals(
         metadataSyncSummary.getImportReport(), actualMetadataSyncSummary.getImportReport());
@@ -197,7 +209,7 @@ class MetadataSyncImportHandlerTest {
 
     assertThrows(
         MetadataSyncServiceException.class,
-        () -> metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot),
+        () -> metadataSyncImportHandler.importMetadata(syncParams, snapshot),
         "ClassListMap can't be null");
 
     verify(metadataImportService, never()).importMetadata(eq(syncParams.getImportParams()), any());
@@ -216,7 +228,7 @@ class MetadataSyncImportHandlerTest {
 
     assertThrows(
         MetadataSyncServiceException.class,
-        () -> metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot),
+        () -> metadataSyncImportHandler.importMetadata(syncParams, snapshot),
         "Exception occurred while trying to do JSON conversion while parsing class list map");
 
     verify(metadataImportService, never()).importMetadata(eq(syncParams.getImportParams()), any());
@@ -239,7 +251,7 @@ class MetadataSyncImportHandlerTest {
         .thenReturn(importReport);
 
     MetadataSyncSummary actualMetadataSyncSummary =
-        metadataSyncImportHandler.importMetadata(syncParams, expectedMetadataSnapshot);
+        metadataSyncImportHandler.importMetadata(syncParams, snapshot);
 
     verify(metadataVersionDelegate, never()).addNewMetadataVersion(metadataVersion);
     assertEquals(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -38,6 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.time.DateUtils;
@@ -236,24 +239,24 @@ class DefaultMetadataVersionServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testShouldGiveValidVersionDataIfExists() {
-    versionService.createMetadataVersionInDataStore("myVersion", "myJson");
-
-    assertEquals("myJson", versionService.getVersionData("myVersion"));
+  void testShouldReturnFalseWhenAVersionDoesNotExist() throws IOException {
+    assertFalse(
+        versionService.streamVersionData("myNonExistingVersion", new ByteArrayOutputStream()));
   }
 
   @Test
-  void testShouldReturnNullWhenAVersionDoesNotExist() {
-    assertNull(versionService.getVersionData("myNonExistingVersion"));
-  }
-
-  @Test
-  void testShouldStoreSnapshotInMetadataStore() {
+  void testShouldStoreSnapshotInMetadataStore() throws IOException {
     versionService.createMetadataVersionInDataStore("myVersion", "mySnapshot");
 
     dbmsManager.flushSession();
 
-    assertEquals("mySnapshot", versionService.getVersionData("myVersion"));
+    assertEquals("mySnapshot", streamToString("myVersion"));
+  }
+
+  private String streamToString(String versionName) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertTrue(versionService.streamVersionData(versionName, out));
+    return out.toString(StandardCharsets.UTF_8);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataVersionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataVersionControllerTest.java
@@ -30,13 +30,14 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonMetadataVersion;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-class MetadataVersionControllerTest extends H2ControllerIntegrationTestBase {
+class MetadataVersionControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   @DisplayName("A valid metadata version should be returned from the versions endpoint")
@@ -177,5 +178,32 @@ class MetadataVersionControllerTest extends H2ControllerIntegrationTestBase {
     // then
     assertTrue(response.success(), "response is successful");
     assertEquals("application/gzip", response.header("Content-Type"));
+  }
+
+  @Test
+  @DisplayName("Missing version on data endpoint returns an error, not a 2xx empty body")
+  void getMissingMetadataVersionDataReturnsError() {
+    POST("/systemSettings/keyVersionEnabled?value=true").success();
+
+    HttpResponse response = GET("/metadata/version/DoesNotExist/data");
+
+    assertFalse(response.success(), "response should not be 2xx for a missing snapshot");
+    assertTrue(
+        response.error().getMessage().contains("DoesNotExist"),
+        "error message should reference the missing version name");
+  }
+
+  @Test
+  @DisplayName(
+      "Missing version on data.gz endpoint returns an error, not a 2xx empty gzip (GZIPOutputStream commits the response on construction)")
+  void getMissingMetadataVersionDataGzReturnsError() {
+    POST("/systemSettings/keyVersionEnabled?value=true").success();
+
+    HttpResponse response = GET("/metadata/version/DoesNotExist/data.gz");
+
+    assertFalse(response.success(), "response should not be 2xx for a missing snapshot");
+    assertTrue(
+        response.error().getMessage().contains("DoesNotExist"),
+        "error message should reference the missing version name");
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -34,7 +34,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -236,22 +235,17 @@ public class MetadataVersionController {
   // endpoint to download metadata
   @RequiresAuthority(anyOf = F_METADATA_MANAGE)
   @GetMapping(value = "/version/{versionName}/data", produces = APPLICATION_JSON_VALUE)
-  public @ResponseBody String downloadVersion(@PathVariable("versionName") String versionName)
-      throws MetadataVersionException, BadRequestException {
-    boolean enabled = isMetadataVersioningEnabled();
+  public void downloadVersion(
+      @PathVariable("versionName") String versionName, HttpServletResponse response)
+      throws MetadataVersionException, BadRequestException, IOException {
+    requireVersioningEnabledAndSnapshotExists(versionName);
 
     try {
-      if (!enabled) {
-        throw new BadRequestException("Metadata versioning is not enabled for this instance.");
-      }
-
-      String versionData = versionService.getVersionData(versionName);
-
-      if (versionData == null) {
-        throw new MetadataVersionException(
-            "No metadata version snapshot found for the given version " + versionName);
-      }
-      return versionData;
+      response.setContentType(APPLICATION_JSON_VALUE);
+      // Snapshots are downloaded once per remote sync client and never re-requested.
+      // Tell intermediaries not to spend cache space on a body nobody will ask for again.
+      response.setHeader(ContextUtils.HEADER_CACHE_CONTROL, "no-store");
+      versionService.streamVersionData(versionName, response.getOutputStream());
     } catch (MetadataVersionServiceException ex) {
       throw new MetadataVersionException(
           "Unable to download version from system: " + versionName + ex.getMessage());
@@ -264,13 +258,9 @@ public class MetadataVersionController {
   public void downloadGZipVersion(
       @PathVariable("versionName") String versionName, HttpServletResponse response)
       throws MetadataVersionException, IOException, BadRequestException {
-    boolean enabled = isMetadataVersioningEnabled();
+    requireVersioningEnabledAndSnapshotExists(versionName);
 
     try {
-      if (!enabled) {
-        throw new BadRequestException("Metadata versioning is not enabled for this instance.");
-      }
-
       contextUtils.configureResponse(
           response,
           ContextUtils.CONTENT_TYPE_GZIP,
@@ -278,19 +268,33 @@ public class MetadataVersionController {
           "metadata.json.gz",
           true);
       response.addHeader(ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary");
-      String versionData = versionService.getVersionData(versionName);
+      // CacheStrategy.NO_CACHE maps to Cache-Control: no-cache (revalidate, may store).
+      // Override with no-store: snapshots are fetched once per remote, so caching wastes space.
+      response.setHeader(ContextUtils.HEADER_CACHE_CONTROL, "no-store");
 
-      if (versionData == null) {
-        throw new MetadataVersionException(
-            "No metadata version snapshot found for the given version " + versionName);
+      try (GZIPOutputStream gos = new GZIPOutputStream(response.getOutputStream())) {
+        versionService.streamVersionData(versionName, gos);
       }
-
-      GZIPOutputStream gos = new GZIPOutputStream(response.getOutputStream());
-      gos.write(versionData.getBytes(StandardCharsets.UTF_8));
-      gos.close();
     } catch (MetadataVersionServiceException ex) {
       throw new MetadataVersionException(
           "Unable to download version from system: " + versionName + ex.getMessage());
+    }
+  }
+
+  /**
+   * Pre-flight check before opening any response output stream. Once {@code GZIPOutputStream} is
+   * constructed it writes the gzip magic header to the response, committing it — at which point a
+   * thrown error can no longer reach the client (Spring's exception handler can't rewrite a
+   * committed response). This method must run before any byte is written.
+   */
+  private void requireVersioningEnabledAndSnapshotExists(String versionName)
+      throws BadRequestException, MetadataVersionException {
+    if (!isMetadataVersioningEnabled()) {
+      throw new BadRequestException("Metadata versioning is not enabled for this instance.");
+    }
+    if (!versionService.snapshotExists(versionName)) {
+      throw new MetadataVersionException(
+          "No metadata version snapshot found for the given version " + versionName);
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ConditionalOpenEntityManagerInViewFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ConditionalOpenEntityManagerInViewFilter.java
@@ -81,7 +81,13 @@ public class ConditionalOpenEntityManagerInViewFilter extends OpenEntityManagerI
               "/api/ping",
               "/api/metrics",
               "/api/system/ping",
-              "/api/potentialDuplicates")
+              "/api/potentialDuplicates",
+              // Metadata version snapshots are streamed directly via JDBC; no Hibernate
+              // session is needed for either the plain or gzipped variant.
+              "/api/metadata/version/*/data",
+              "/api/metadata/version/*/data.gz",
+              "/api/*/metadata/version/*/data",
+              "/api/*/metadata/version/*/data.gz")
           .map(PARSER::parse)
           .toList();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
@@ -92,7 +92,10 @@ public class ExcludableShallowEtagHeaderFilter extends ShallowEtagHeaderFilter {
           + UID_REGEXP
           + "/attributes/"
           + UID_REGEXP
-          + "/(file|image)";
+          + "/(file|image)|"
+          // Metadata version snapshots are not suitable for ETag buffering.
+          // Ideally, versions are only requested once per remote client.
+          + "/api/(\\d{2}/)?metadata/version/.+/data(\\.gz)?";
 
   private Pattern pattern = null;
 


### PR DESCRIPTION
port of #23739 
- excludes changes in `SchemaToDataFetcher` as it is not required on `<= 2.42` due to https://github.com/dhis2/dhis2-core/pull/23108 which only currently exists on `>= 2.43`