### PR TITLE
chore: remove unused spring-security-jwt dependency

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -100,7 +100,6 @@
 
     <!-- Security -->
     <spring-security.version>6.5.10</spring-security.version>
-    <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
     <spring-authorization-server.version>1.5.2</spring-authorization-server.version>
     <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
     <jasypt.version>1.9.3</jasypt.version>
@@ -574,11 +573,6 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-resource-server</artifactId>
         <version>${spring-security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-jwt</artifactId>
-        <version>${spring-security-jwt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
## Summary

- Removes `org.springframework.security:spring-security-jwt:1.1.1.RELEASE` and its version property from `dhis-2/pom.xml`.
- The dependency only existed in `<dependencyManagement>` and was never declared by any module; no Java source imports `org.springframework.security.jwt.*`.
- Library is from the EOL Spring Security OAuth project (last release May 2020). Modern JWT handling is already in place via `spring-security-oauth2-resource-server` + Nimbus JOSE.


AI Assisted