### PR TITLE
feat: remove EntityManager from TrackerPersister [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -108,16 +108,11 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
       return new CommitResult(PersistenceReport.emptyReport(), List.of());
     }
 
-    PersistResult trackedEntities =
-        commitService.getTrackerPersister().persist(entityManager, bundle);
-    PersistResult enrollments =
-        commitService.getEnrollmentPersister().persist(entityManager, bundle);
-    PersistResult trackerEvents =
-        commitService.getTrackerEventPersister().persist(entityManager, bundle);
-    PersistResult singleEvents =
-        commitService.getSingleEventPersister().persist(entityManager, bundle);
-    PersistResult relationships =
-        commitService.getRelationshipPersister().persist(entityManager, bundle);
+    PersistResult trackedEntities = commitService.getTrackerPersister().persist(bundle);
+    PersistResult enrollments = commitService.getEnrollmentPersister().persist(bundle);
+    PersistResult trackerEvents = commitService.getTrackerEventPersister().persist(bundle);
+    PersistResult singleEvents = commitService.getSingleEventPersister().persist(bundle);
+    PersistResult relationships = commitService.getRelationshipPersister().persist(bundle);
 
     PersistenceReport report =
         new PersistenceReport(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -36,7 +36,7 @@ import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
@@ -87,7 +87,7 @@ import org.hisp.dhis.user.UserDetails;
 public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends IdentifiableObject>
     implements TrackerPersister<T, V> {
   private static final DateTimeFormatter DATE_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
   @PersistenceContext private EntityManager entityManager;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -35,6 +35,9 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
@@ -83,18 +86,22 @@ import org.hisp.dhis.user.UserDetails;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends IdentifiableObject>
     implements TrackerPersister<T, V> {
+  private static final DateTimeFormatter DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
+
+  @PersistenceContext private EntityManager entityManager;
+
   protected final ReservedValueService reservedValueService;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
    * flow of Tracker entities
    *
-   * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
    * @return a {@link TrackerTypeReport}
    */
   @Override
-  public PersistResult persist(EntityManager entityManager, TrackerBundle bundle) {
+  public PersistResult persist(TrackerBundle bundle) {
     //
     // Init the report that will hold the results of the persist operation
     //
@@ -136,7 +143,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
         if (isNew(bundle, trackerDto)) {
           entityManager.persist(convertedDto);
           updateDataValues(
-              entityManager,
               bundle.getPreheat(),
               trackerDto,
               convertedDto,
@@ -146,12 +152,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           typeReport.getStats().incCreated();
           typeReport.addEntity(objectReport);
           updateAttributes(
-              entityManager,
-              bundle.getPreheat(),
-              trackerDto,
-              convertedDto,
-              bundle.getUser(),
-              changeLogs);
+              bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
           bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
         } else {
           if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -159,7 +160,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             // Relationships are not updated. A warning was already added to the report
           } else {
             updateDataValues(
-                entityManager,
                 bundle.getPreheat(),
                 trackerDto,
                 convertedDto,
@@ -167,12 +167,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 bundle.getUser(),
                 changeLogs);
             updateAttributes(
-                entityManager,
-                bundle.getPreheat(),
-                trackerDto,
-                convertedDto,
-                bundle.getUser(),
-                changeLogs);
+                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
             entityManager.merge(convertedDto);
             typeReport.getStats().incUpdated();
             typeReport.addEntity(objectReport);
@@ -256,7 +251,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       T trackerDto,
       V payloadEntity,
@@ -266,7 +260,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /** Execute the persistence of Attribute values linked to the entity being processed */
   protected abstract void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       T trackerDto,
       V hibernateEntity,
@@ -336,22 +329,16 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   // // // // // // // //
   // // // // // // // //
 
-  protected void assignFileResource(
-      EntityManager entityManager, TrackerPreheat preheat, String fileResourceOwner, String fr) {
-    assignFileResource(entityManager, preheat, fileResourceOwner, fr, true);
+  protected void assignFileResource(TrackerPreheat preheat, String fileResourceOwner, String fr) {
+    assignFileResource(preheat, fileResourceOwner, fr, true);
   }
 
-  protected void unassignFileResource(
-      EntityManager entityManager, TrackerPreheat preheat, String fileResourceOwner, String fr) {
-    assignFileResource(entityManager, preheat, fileResourceOwner, fr, false);
+  protected void unassignFileResource(TrackerPreheat preheat, String fileResourceOwner, String fr) {
+    assignFileResource(preheat, fileResourceOwner, fr, false);
   }
 
   private void assignFileResource(
-      EntityManager entityManager,
-      TrackerPreheat preheat,
-      String fileResourceOwner,
-      String fr,
-      boolean isAssign) {
+      TrackerPreheat preheat, String fileResourceOwner, String fr, boolean isAssign) {
     FileResource fileResource = preheat.get(FileResource.class, fr);
 
     if (fileResource == null) {
@@ -364,7 +351,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected void handleTrackedEntityAttributeValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
@@ -396,10 +382,9 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
           if (isDelete && !isNew) {
-            delete(entityManager, preheat, currentValue, trackedEntity, user, changeLogs);
+            delete(preheat, currentValue, trackedEntity, user, changeLogs);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
-                entityManager,
                 preheat,
                 trackedEntity,
                 attribute,
@@ -413,7 +398,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   private void saveOrUpdateAttributeValue(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntity trackedEntity,
       Attribute attribute,
@@ -435,28 +419,19 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             .setLastUpdated(new Date());
 
     saveOrUpdate(
-        entityManager,
-        preheat,
-        isNew,
-        trackedEntity,
-        attributeToPersist,
-        previousValue,
-        user,
-        changeLogs);
+        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs);
 
     handleReservedValue(attributeToPersist);
   }
 
   private void delete(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       TrackedEntity trackedEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
-      unassignFileResource(
-          entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
+      unassignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     entityManager.remove(
@@ -474,7 +449,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   private void saveOrUpdate(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       boolean isNew,
       TrackedEntity trackedEntity,
@@ -483,8 +457,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
-      assignFileResource(
-          entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
+      assignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     ChangeLogType changeLogType;
@@ -534,9 +507,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected static String formatDate(Date date) {
-    java.text.SimpleDateFormat formatter =
-        new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    return date != null ? formatter.format(date) : null;
+    return date != null ? DATE_FORMATTER.format(date.toInstant()) : null;
   }
 
   protected static String formatGeometry(org.locationtech.jts.geom.Geometry geometry) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -66,14 +65,12 @@ public class EnrollmentPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     handleTrackedEntityAttributeValues(
-        entityManager,
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
@@ -160,7 +157,6 @@ public class EnrollmentPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
       Enrollment payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
@@ -66,7 +65,6 @@ public class RelationshipPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,
@@ -102,7 +100,6 @@ public class RelationshipPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -149,7 +148,6 @@ public class SingleEventPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,
@@ -160,20 +158,17 @@ public class SingleEventPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent payloadEntity,
       SingleEvent currentEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleDataValues(
-        entityManager, preheat, event.getDataValues(), payloadEntity, user, changeLogs);
+    handleDataValues(preheat, event.getDataValues(), payloadEntity, user, changeLogs);
     logFieldChanges(currentEntity, payloadEntity, user.getUsername(), changeLogs);
   }
 
   private void handleDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
       SingleEvent event,
@@ -192,7 +187,7 @@ public class SingleEventPersister
           if (isNewDataValue(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event, dataElement, program, null, dataValue.getValue(), CREATE, username);
-            saveDataValue(dataValue, event, dataElement, user, entityManager, preheat);
+            saveDataValue(dataValue, event, dataElement, user, preheat);
           } else if (isUpdate(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event,
@@ -202,12 +197,11 @@ public class SingleEventPersister
                 dataValue.getValue(),
                 UPDATE,
                 username);
-            updateDataValue(
-                dbDataValue, dataValue, event, dataElement, user, entityManager, preheat);
+            updateDataValue(dbDataValue, dataValue, event, dataElement, user, preheat);
           } else if (isDeletion(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event, dataElement, program, dbDataValue.getValue(), null, DELETE, username);
-            deleteDataValue(dbDataValue, event, dataElement, entityManager, preheat);
+            deleteDataValue(dbDataValue, event, dataElement, preheat);
           }
         });
   }
@@ -217,7 +211,6 @@ public class SingleEventPersister
       SingleEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     EventDataValue eventDataValue = new EventDataValue();
     eventDataValue.setDataElement(dataElement.getUid());
@@ -232,7 +225,7 @@ public class SingleEventPersister
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
 
     if (dataElement.isFileType()) {
-      assignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().add(eventDataValue);
@@ -244,14 +237,13 @@ public class SingleEventPersister
       SingleEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     eventDataValue.setLastUpdated(new Date());
     eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
-      assignFileResource(entityManager, preheat, event.getUid(), dv.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), dv.getValue());
     }
 
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
@@ -262,10 +254,9 @@ public class SingleEventPersister
       EventDataValue eventDataValue,
       SingleEvent event,
       DataElement dataElement,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().remove(eventDataValue);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -57,14 +56,12 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleTrackedEntityAttributeValues(
-        entityManager, preheat, trackerDto.getAttributes(), te, user, changeLogs);
+    handleTrackedEntityAttributeValues(preheat, trackerDto.getAttributes(), te, user, changeLogs);
   }
 
   @Override
@@ -100,7 +97,6 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -152,7 +151,6 @@ public class TrackerEventPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,
@@ -163,20 +161,17 @@ public class TrackerEventPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent payloadEntity,
       TrackerEvent currentEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleDataValues(
-        entityManager, preheat, event.getDataValues(), payloadEntity, user, changeLogs);
+    handleDataValues(preheat, event.getDataValues(), payloadEntity, user, changeLogs);
     logFieldChanges(currentEntity, payloadEntity, user.getUsername(), changeLogs);
   }
 
   private void handleDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
       TrackerEvent event,
@@ -195,7 +190,7 @@ public class TrackerEventPersister
           if (isNewDataValue(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event, dataElement, program, null, dataValue.getValue(), CREATE, username);
-            saveDataValue(dataValue, event, dataElement, user, entityManager, preheat);
+            saveDataValue(dataValue, event, dataElement, user, preheat);
           } else if (isUpdate(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event,
@@ -205,12 +200,11 @@ public class TrackerEventPersister
                 dataValue.getValue(),
                 UPDATE,
                 username);
-            updateDataValue(
-                dbDataValue, dataValue, event, dataElement, user, entityManager, preheat);
+            updateDataValue(dbDataValue, dataValue, event, dataElement, user, preheat);
           } else if (isDeletion(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event, dataElement, program, dbDataValue.getValue(), null, DELETE, username);
-            deleteDataValue(dbDataValue, event, dataElement, entityManager, preheat);
+            deleteDataValue(dbDataValue, event, dataElement, preheat);
           }
         });
   }
@@ -275,7 +269,6 @@ public class TrackerEventPersister
       TrackerEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     EventDataValue eventDataValue = new EventDataValue();
     eventDataValue.setDataElement(dataElement.getUid());
@@ -290,7 +283,7 @@ public class TrackerEventPersister
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
 
     if (dataElement.isFileType()) {
-      assignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().add(eventDataValue);
@@ -302,14 +295,13 @@ public class TrackerEventPersister
       TrackerEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     eventDataValue.setLastUpdated(new Date());
     eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
-      assignFileResource(entityManager, preheat, event.getUid(), dv.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), dv.getValue());
     }
 
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
@@ -320,10 +312,9 @@ public class TrackerEventPersister
       EventDataValue eventDataValue,
       TrackerEvent event,
       DataElement dataElement,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().remove(eventDataValue);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
@@ -49,9 +48,8 @@ public interface TrackerPersister<T extends TrackerDto, V> {
    * Persist one of the collections in the provided Tracker Bundle. Each class implementing this
    * method should be responsible to persist one collection of the TrackerBundle (e.g. Enrollments)
    *
-   * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
    * @return a {@link PersistResult} containing the report and any notifications
    */
-  PersistResult persist(EntityManager entityManager, TrackerBundle bundle);
+  PersistResult persist(TrackerBundle bundle);
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                             
  `EntityManager` was a parameter on `TrackerPersister.persist()` and threaded through every                                                                                                                                                                                   
  method signature in the persister stack — interface, abstract class, five concrete                                                                                                                                                                                           
  persisters, and a dozen private helpers — even though no concrete persister ever called                                                                                                                                                                                      
  `entityManager.*` directly. They only passed it down to shared methods                                                                                                                                                                                                       
  (`assignFileResource`, `handleTrackedEntityAttributeValues`, etc.) defined in                                                                                                                                                                                                
  `AbstractTrackerPersister` itself.                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                               
  The fix is purely structural: inject `EntityManager` once into `AbstractTrackerPersister`                                                                                                                                                                                    
  via `@PersistenceContext` and remove it from every method signature. No behaviour changes.

**Quick fix**

  `AbstractTrackerPersister.formatDate()` was allocating a new `SimpleDateFormat` instance                                                                                                                                                                                     
  on every call. `SimpleDateFormat` is not thread-safe, and its constructor is expensive                                                                                                                                                                                        
  (`initialize` + `compile` of the pattern). The method showed up in the JFR CPU profile                                                                                                                                                                                       
  at ~1% of total samples across all import requests.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                           
  Replace it with a single `static final DateTimeFormatter`, which is immutable,                                                                                                                                                                                               
  thread-safe, and allocated once at class load time.                                                                                                                                                                                    

  ## Performance

Four compare runs of a load test only on the tracker importer

### Median Response Time (p50) — candidate vs. co-run baseline                                                                                                                                
                                                     
  | Endpoint | [25317120504](https://github.com/dhis2/dhis2-core/actions/runs/25317120504) | [25318959103](https://github.com/dhis2/dhis2-core/actions/runs/25318959103) | [25323941141](https://github.com/dhis2/dhis2-core/actions/runs/25323941141) | [25346146027](https://github.com/dhis2/dhis2-core/actions/runs/25346146027) |
  |:---|---:|---:|---:|---:|                                                                                                                                                                    
  | Login | 118 ms (+3, **+2.6%**) | 116 ms (+4, **+3.6%**) | 116 ms (−4, **−2.9%**) | 131 ms (+1, **+0.8%**) |                                                                                 
  | MNCH import | 1,066 ms (+2, **+0.1%**) | 1,052 ms (−6, **−0.6%**) | 1,038 ms (±0, **0.0%**) | 1,051 ms (+6, **+0.5%**) |                                                                    
  | Child Programme import | 496 ms (−8, **−1.5%**) | 494 ms (−31, **−5.9%**) | 489 ms (+2, **+0.3%**) | 500 ms (−10, **−1.9%**) |                                                              
  | ANC import | 407 ms (+8, **+2.0%**) | 404 ms (−9, **−2.2%**) | 383 ms (−9, **−2.3%**) | 398 ms (+3, **+0.8%**) |                                                                            
                                                                                                                                                                                                
  ### 95th Percentile Response Time (p95) — candidate vs. co-run baseline                                                                                                                       
                                                                                                                                                                                                
  | Endpoint | [25317120504](https://github.com/dhis2/dhis2-core/actions/runs/25317120504) | [25318959103](https://github.com/dhis2/dhis2-core/actions/runs/25318959103) | [25323941141](https://github.com/dhis2/dhis2-core/actions/runs/25323941141) | [25346146027](https://github.com/dhis2/dhis2-core/actions/runs/25346146027) |
  |:---|---:|---:|---:|---:|                                                                                                                                                                    
  | Login | 234 ms (+35, **+17.6%**) | 145 ms (−1, **−0.9%**) | 122 ms (−27, **−18.0%**) | 157 ms (+16, **+11.3%**) |
  | MNCH import | 1,190 ms (+5, **+0.4%**) | 1,175 ms (−1, **0.0%**) | 1,128 ms (−22, **−1.9%**) | 1,186 ms (+28, **+2.4%**) |                                                                  
  | Child Programme import | 554 ms (−6, **−1.0%**) | 538 ms (−49, **−8.3%**) | 534 ms (−17, **−3.1%**) | 556 ms (−185, **−24.9%**) |                                                           
  | ANC import | 742 ms (+51, **+7.4%**) | 475 ms (−416, **−46.7%**) | 440 ms (−362, **−45.1%**) | 681 ms (+107, **+18.6%**) |                                                                  
                                                                                                                                                                                                
  _↓ negative = candidate faster than its co-run baseline; ↑ positive = slower._ 

### Impact on allocations attributed to AbstractTrackerPersister.formatDate

| | Baseline | Candidate | Delta | Delta % |
|---|---:|---:|---:|---:|
| **Total** | 13.16 GB | 12.31 GB | -0.86 GB | -6.5% |
| **DefaultTrackerImportService.importTracker** | 12.56 GB | 11.75 GB | -0.82 GB | -6.5% |
| **AbstractTrackerPersister** | 4.98 GB | 4.25 GB | -0.73 GB | -14.7% |
                                                                                                                                                                                                                
  ## Next steps                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                               
  This is Phase 0 of the tracker import Hibernate → JDBC migration (~37% CPU overhead                                                                                                                                                                                          
  directly eliminated once completed).                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                               
  - **Quick fix** ✅ `formatDate`: `SimpleDateFormat` → `static final DateTimeFormatter`                                                                                                                                                                                       ─
  - **Phase 0** ✅ Remove `EntityManager` from `TrackerPersister` interface and all method parameters                                                                                                                                                                           
  - **Phase 1** — Decouple `ChangeLogAccumulator` from Hibernate `Session`; obtain the                                                                                                                                                                                         
    transaction-bound `Connection` via `DataSourceUtils` instead of `session.doWork()`                                                                                                                                                                                         
  - **Phase 2** — Extract `FileResource` assignment update out of `AbstractTrackerPersister`                                                                                                                                                                                   
    into `FileResourceStore`                                                                                                                                                                                                                                                   
  - **Phase 3** — Introduce `EntityWriteBatch`; accumulate and batch-flush TEAV writes                                                                                                                                                                                         
    (multi-row INSERT / unnest UPDATE / tuple DELETE)                                                                                                                                                                                                                          
  - **Phase 4** — Pre-allocate IDs from PostgreSQL sequences; stage top-level entity                                                                                                                                                                                           
    inserts and updates in `EntityWriteBatch`; remove all `entityManager.flush()` calls                                                                                                                                                                                        
  - **Phase 5** — Replace `updateTrackedEntitiesLastUpdated` named query with                                                                                                                                                                                                  
    `NamedParameterJdbcTemplate`; remove last Hibernate dependency from                                                                                                                                                                                                        
    `DefaultTrackerBundleService`                                                                                                                                                                                                                                              
  - **Phase 6** — Implement JDBC flush methods one entity type at a time                                                                                                                                                                                                       
    (`TrackedEntity` → `Enrollment` → `TrackerEvent`/`SingleEvent` → `Relationship`)   