### PR TITLE
fix: add @Transactional to maintenance soft-delete methods TECH-1517

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
@@ -91,6 +91,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   // -------------------------------------------------------------------------
 
   @Override
+  @Transactional
   public int deleteZeroDataValues() {
     int result = maintenanceStore.deleteZeroDataValues();
 
@@ -100,6 +101,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   }
 
   @Override
+  @Transactional
   public int deleteSoftDeletedDataValues() {
     int result = maintenanceStore.deleteSoftDeletedDataValues();
 
@@ -109,6 +111,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   }
 
   @Override
+  @Transactional
   public int deleteSoftDeletedEvents() {
     int result = maintenanceStore.deleteSoftDeletedEvents();
 
@@ -118,6 +121,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   }
 
   @Override
+  @Transactional
   public int deleteSoftDeletedRelationships() {
     int result = maintenanceStore.deleteSoftDeletedRelationships();
 
@@ -127,6 +131,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   }
 
   @Override
+  @Transactional
   public int deleteSoftDeletedEnrollments() {
     int result = maintenanceStore.deleteSoftDeletedEnrollments();
 
@@ -136,6 +141,7 @@ public class DefaultMaintenanceService implements MaintenanceService {
   }
 
   @Override
+  @Transactional
   public int deleteSoftDeletedTrackedEntities() {
     int result = maintenanceStore.deleteSoftDeletedTrackedEntities();
 


### PR DESCRIPTION
Follow-up to #22578.

`DefaultMaintenanceService.deleteZeroDataValues` and the five `deleteSoftDeleted*` methods delegate JDBC writes to `JdbcMaintenanceStore` but were missing `@Transactional`. Previously masked by `hibernate.allow_update_outside_transaction=true`, which #22578 removed. The JDBC `DELETE` now hits the connection's default state and fails with `ERROR: cannot execute DELETE in a read-only transaction`, poisoning the session for the rest of the request.

Surfaced by the post-merge api-test e2e run ([25366622199](https://github.com/dhis2/dhis2-core/actions/runs/25366622199/job/74379013752)). Not sure why this was not caught on the original PR build.

Fix: add `@Transactional` to the six write methods. The other write methods in the class (`prunePeriods`, `pruneData`) were already annotated.
