### PR TITLE
fix: emergency disable file resource cleanup until trim SQL is fixed [DHIS2-21427]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -58,61 +58,21 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
 
   @Override
   public int updateFileResourcesNotAssignedToAnyDataValue() {
-    // using with to do this in a single pass on the datavalue table
-    // abort if we cannot get the locks quickly
-    String sql =
-        """
-        WITH candidates AS (
-            SELECT uid
-            FROM fileresource
-            WHERE domain = 'DATA_VALUE' AND isassigned = true
-        ),
-        fr_datavalues AS (
-            SELECT dv.value
-            FROM datavalue dv
-            JOIN dataelement de ON de.dataelementid = dv.dataelementid
-            WHERE de.valuetype = 'FILE_RESOURCE'
-        )
-        UPDATE fileresource fr
-        SET isassigned = false, lastupdated = now()
-        FROM candidates c
-        LEFT JOIN fr_datavalues frdv ON frdv.value = c.uid
-        WHERE fr.isassigned = true
-          AND fr.uid = c.uid
-          AND frdv.value IS NULL""";
-    return getSession()
-        .createNativeQuery(sql)
-        .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
-        .executeUpdate();
+    // HOTFIX [DHIS2-21427]: disabled. The original SQL only scanned the
+    // aggregate `datavalue` table, missing file resources referenced from
+    // trackerevent.eventdatavalues and TEAVs, so it wrongly flipped
+    // isassigned=false on still-referenced FRs. Restore once the SQL is
+    // widened to UNION all four sources (datavalue, trackerevent JSONB,
+    // singleevent JSONB, trackedentityattributevalue).
+    return 0;
   }
 
   @Override
   public int updateFileResourcesAssignedToAnyDataValue() {
-    // using with to do this in a single pass on the datavalue table
-    // abort if we cannot get the locks quickly
-    String sql =
-        """
-        WITH candidates AS (
-            SELECT uid
-            FROM fileresource
-            WHERE domain = 'DATA_VALUE' AND isassigned = false
-        ),
-        fr_datavalues AS (
-            SELECT DISTINCT dv.value
-            FROM datavalue dv
-            JOIN dataelement de ON de.dataelementid = dv.dataelementid
-            WHERE de.valuetype = 'FILE_RESOURCE'
-        )
-        UPDATE fileresource fr
-        SET isassigned = true
-        FROM candidates c
-        JOIN fr_datavalues frdv ON frdv.value = c.uid
-        WHERE fr.isassigned = false
-          AND fr.uid = c.uid""";
-    return getSession()
-        .createNativeQuery(sql)
-        .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
-        .executeUpdate();
+    // HOTFIX [DHIS2-21427]: disabled symmetrically. The inverse query had the
+    // same blind spot, so it could not repair what the other one broke.
+    // Restore alongside the symmetric SQL widening.
+    return 0;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -118,16 +118,12 @@ public class FileResourceCleanUpJob implements Job {
 
     List<UnassignedFileResource> deletedFileResources = new ArrayList<>();
 
-    // DV FRs
-    if (!FileResourceRetentionStrategy.FOREVER.equals(retentionStrategy)) {
-      List<FileResource> dvUnassigned =
-          fileResourceService.getExpiredDataValueFileResources(retentionStrategy);
-      deleteFrs(
-          progress,
-          "Deleting unassigned DataValue file resources",
-          dvUnassigned,
-          deletedFileResources);
-    }
+    // HOTFIX [DHIS2-21427]: DATA_VALUE-domain cleanup is disabled. The
+    // DATA_VALUE_TRIM job's SQL in HibernateDataValueTrimStore only scans the
+    // aggregate `datavalue` table, so file resources referenced from
+    // trackerevent.eventdatavalues / TEAVs are wrongly flipped to
+    // isassigned=false and would be deleted here. Restore once the trim SQL
+    // is widened to scan event JSONB and TEAVs.
 
     // Job Data FRs
     List<FileResource> jobDataUnassigned =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -91,13 +91,12 @@ class FileResourceCleanUpJobTest extends PostgresIntegrationTestBase {
       // when the cleanup job runs
       cleanUpJob.execute(null, JobProgress.noop());
 
-      // then unassigned file resources are deleted
+      // then unassigned file resources are deleted (DATA_VALUE excluded — see below)
       assertNull(fileResourceStore.getByUid(fr1.getUid()));
       assertNull(fileResourceStore.getByUid(fr3.getUid()));
       assertNull(fileResourceStore.getByUid(fr5.getUid()));
       assertNull(fileResourceStore.getByUid(fr7.getUid()));
       assertNull(fileResourceStore.getByUid(fr13.getUid()));
-      assertNull(fileResourceStore.getByUid(fr15.getUid()));
 
       // and assigned file resources still exist
       assertNotNull(fileResourceStore.getByUid(fr2.getUid()));
@@ -106,6 +105,11 @@ class FileResourceCleanUpJobTest extends PostgresIntegrationTestBase {
       assertNotNull(fileResourceStore.getByUid(fr8.getUid()));
       assertNotNull(fileResourceStore.getByUid(fr14.getUid()));
       assertNotNull(fileResourceStore.getByUid(fr16.getUid()));
+
+      // HOTFIX [DHIS2-21427]: DATA_VALUE-domain unassigned FRs are NOT deleted
+      // until the trim SQL is widened. fr15 (DATA_VALUE, unassigned) must
+      // therefore still exist after the cleanup job runs.
+      assertNotNull(fileResourceStore.getByUid(fr15.getUid()));
 
       // and domains not to be deleted (MESSAGE_ATTACHMENT) still exist whether assigned or not
       assertNotNull(fileResourceStore.getByUid(fr9.getUid()));


### PR DESCRIPTION
## Summary

JIRA: [DHIS2-21427](https://dhis2.atlassian.net/browse/DHIS2-21427)
Emergency patch to stop file loss caused by a bug in `DATA_VALUE_TRIM`.

The trim job's SQL in `HibernateDataValueTrimStore` only scans the aggregate `datavalue` table. File resources referenced from `trackerevent.eventdatavalues` JSONB or `trackedentityattributevalue.value` are wrongly flipped to `isassigned=false` every night, and `FileResourceCleanUpJob` then deletes those FRs (and the underlying files) within ~3 days unless `keyFileResourceRetentionStrategy=FOREVER`.

Implementations have reported file loss starting March 2026, after upgrading to 2.41.7+ / 2.42.4 / 2.43-pre.

## Changes

- `FileResourceCleanUpJob.execute()` — DV-domain cleanup block removed (only path that auto-deletes DV-domain FRs based on `isassigned=false`)
- `HibernateDataValueTrimStore.updateFileResources*ToAnyDataValue()` — both methods return 0 (no-op). Stops the wrongly-stamped flag at the source so other code that reads `isassigned` is not misled.
- `FileResourceCleanUpJobTest` — `fr15` (DATA_VALUE, unassigned) assertion moved from `assertNull` to `assertNotNull` to reflect the new behavior.

## Affected versions

Verified via separate verification PR: master, `2.43`, `2.42.4`, `2.41.7`, `2.41.8`. Backports will follow after this lands on master.

`2.40` and earlier do not have the trim job and are unaffected.

## Known regressions while this patch is in effect

- **No automatic cleanup of legitimately-orphaned DV-domain FRs.** Disk usage grows slowly. Restored when the proper SQL fix lands.
- **Wrongly-unassigned FRs from prior runs are not repaired by this patch.** They are auto-repaired on the next nightly `DATA_VALUE_TRIM` run after the proper SQL fix lands (via the symmetric `updateFileResourcesAssignedToAnyDataValue` once it learns about events and TEAVs).

## Followups

- Proper SQL fix (widen both `update*` methods to UNION-ALL aggregate + trackerevent JSONB + singleevent JSONB + TEAVs) ships in a separate PR.
- Backports for 2.41 / 2.42 / 2.43 will be applied once this lands.

AI Assisted


[DHIS2-21427]: https://dhis2.atlassian.net/browse/DHIS2-21427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ