### PR TITLE
fix: disable file resource cleanup until trim SQL is fixed [DHIS2-21427](2.41.8.1)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -55,61 +55,21 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
 
   @Override
   public int updateFileResourcesNotAssignedToAnyDataValue() {
-    // using with to do this in a single pass on the datavalue table
-    // abort if we cannot get the locks quickly
-    String sql =
-        """
-                WITH candidates AS (
-                    SELECT uid
-                    FROM fileresource
-                    WHERE domain = 'DATA_VALUE' AND isassigned = true
-                ),
-                fr_datavalues AS (
-                    SELECT dv.value
-                    FROM datavalue dv
-                    JOIN dataelement de ON de.dataelementid = dv.dataelementid
-                    WHERE de.valuetype = 'FILE_RESOURCE'
-                )
-                UPDATE fileresource fr
-                SET isassigned = false, lastupdated = now()
-                FROM candidates c
-                LEFT JOIN fr_datavalues frdv ON frdv.value = c.uid
-                WHERE fr.isassigned = true
-                  AND fr.uid = c.uid
-                  AND frdv.value IS NULL""";
-    return getSession()
-        .createNativeQuery(sql)
-        .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
-        .executeUpdate();
+    // HOTFIX [DHIS2-21427]: disabled. The original SQL only scanned the
+    // aggregate `datavalue` table, missing file resources referenced from
+    // trackerevent.eventdatavalues and TEAVs, so it wrongly flipped
+    // isassigned=false on still-referenced FRs. Restore once the SQL is
+    // widened to UNION all four sources (datavalue, trackerevent JSONB,
+    // singleevent JSONB, trackedentityattributevalue).
+    return 0;
   }
 
   @Override
   public int updateFileResourcesAssignedToAnyDataValue() {
-    // using with to do this in a single pass on the datavalue table
-    // abort if we cannot get the locks quickly
-    String sql =
-        """
-                WITH candidates AS (
-                    SELECT uid
-                    FROM fileresource
-                    WHERE domain = 'DATA_VALUE' AND isassigned = false
-                ),
-                fr_datavalues AS (
-                    SELECT DISTINCT dv.value
-                    FROM datavalue dv
-                    JOIN dataelement de ON de.dataelementid = dv.dataelementid
-                    WHERE de.valuetype = 'FILE_RESOURCE'
-                )
-                UPDATE fileresource fr
-                SET isassigned = true, lastupdated = now()
-                FROM candidates c
-                JOIN fr_datavalues frdv ON frdv.value = c.uid
-                WHERE fr.isassigned = false
-                  AND fr.uid = c.uid""";
-    return getSession()
-        .createNativeQuery(sql)
-        .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
-        .executeUpdate();
+    // HOTFIX [DHIS2-21427]: disabled symmetrically. The inverse query had the
+    // same blind spot, so it could not repair what the other one broke.
+    // Restore alongside the symmetric SQL widening.
+    return 0;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -116,16 +116,12 @@ public class FileResourceCleanUpJob implements Job {
 
     List<UnassignedFileResource> deletedFileResources = new ArrayList<>();
 
-    // DV FRs
-    if (!FileResourceRetentionStrategy.FOREVER.equals(retentionStrategy)) {
-      List<FileResource> dvUnassigned =
-          fileResourceService.getExpiredDataValueFileResources(retentionStrategy);
-      deleteFrs(
-          progress,
-          "Deleting unassigned DataValue file resources",
-          dvUnassigned,
-          deletedFileResources);
-    }
+    // HOTFIX [DHIS2-21427]: DATA_VALUE-domain cleanup is disabled. The
+    // DATA_VALUE_TRIM job's SQL in HibernateDataValueTrimStore only scans the
+    // aggregate `datavalue` table, so file resources referenced from
+    // trackerevent.eventdatavalues / TEAVs are wrongly flipped to
+    // isassigned=false and would be deleted here. Restore once the trim SQL
+    // is widened to scan event JSONB and TEAVs.
 
     // Job Data FRs
     List<FileResource> jobDataUnassigned =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -91,13 +91,12 @@ class FileResourceCleanUpJobTest extends TransactionalIntegrationTest {
       // when the cleanup job runs
       cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
 
-      // then unassigned file resources are deleted
+      // then unassigned file resources are deleted (DATA_VALUE excluded — see below)
       assertNull(fileResourceStore.getByUid(fr1.getUid()));
       assertNull(fileResourceStore.getByUid(fr3.getUid()));
       assertNull(fileResourceStore.getByUid(fr5.getUid()));
       assertNull(fileResourceStore.getByUid(fr7.getUid()));
       assertNull(fileResourceStore.getByUid(fr13.getUid()));
-      assertNull(fileResourceStore.getByUid(fr15.getUid()));
 
       // and assigned file resources still exist
       assertNotNull(fileResourceStore.getByUid(fr2.getUid()));
@@ -106,6 +105,11 @@ class FileResourceCleanUpJobTest extends TransactionalIntegrationTest {
       assertNotNull(fileResourceStore.getByUid(fr8.getUid()));
       assertNotNull(fileResourceStore.getByUid(fr14.getUid()));
       assertNotNull(fileResourceStore.getByUid(fr16.getUid()));
+
+      // HOTFIX [DHIS2-21427]: DATA_VALUE-domain unassigned FRs are NOT deleted
+      // until the trim SQL is widened. fr15 (DATA_VALUE, unassigned) must
+      // therefore still exist after the cleanup job runs.
+      assertNotNull(fileResourceStore.getByUid(fr15.getUid()));
 
       // and domains not to be deleted (MESSAGE_ATTACHMENT, PUSH_ANALYSIS) still exist whether
       // assigned or not


### PR DESCRIPTION
Backport of #23803 to patch/2.41.8.1.

Conflict resolution: same as the 2.41 dev backport (#23806) — PUSH_ANALYSIS domain still present in test, both update* methods had `SET ... lastupdated = now()` upstream. Both differences fall away because the methods are no-ops in this PR.

JIRA: https://jira.dhis2.org/browse/DHIS2-21427

AI Assisted