### PR TITLE
feat: enhance internal DHIS2 oidc provider (#23032) [2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcClientRegistration.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcClientRegistration.java
@@ -67,6 +67,8 @@ public class DhisOidcClientRegistration {
 
   private final String jwkSetUrl;
 
+  @Builder.Default private final boolean visibleOnLoginPage = true;
+
   @Builder.Default private final Map<String, Map<String, String>> externalClients = new HashMap<>();
 
   public Collection<String> getClientIds() {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcProviderRepository.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcProviderRepository.java
@@ -100,12 +100,22 @@ public class DhisOidcProviderRepository implements ClientRegistrationRepository 
   }
 
   public DhisOidcClientRegistration findByIssuerUri(String issuerUri) {
+    String normalizedInput =
+        issuerUri == null
+            ? ""
+            : issuerUri.endsWith("/") ? issuerUri.substring(0, issuerUri.length() - 1) : issuerUri;
     return registrationHashMap.values().stream()
         .filter(
-            c ->
-                MoreObjects.firstNonNull(
-                        c.getClientRegistration().getProviderDetails().getIssuerUri(), "")
-                    .equals(issuerUri))
+            c -> {
+              String providerIssuer =
+                  MoreObjects.firstNonNull(
+                      c.getClientRegistration().getProviderDetails().getIssuerUri(), "");
+              String normalizedProviderIssuer =
+                  providerIssuer.endsWith("/") && providerIssuer.length() > 1
+                      ? providerIssuer.substring(0, providerIssuer.length() - 1)
+                      : providerIssuer;
+              return normalizedProviderIssuer.equals(normalizedInput);
+            })
         .findAny()
         .orElse(null);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
@@ -91,7 +91,8 @@ public final class GenericOidcProviderConfigParser {
    * OIDC provider config properties lines starting with these client names will be ignored by this
    * parser, these clients/providers have their own respective provider classes and config parsers.
    */
-  private static final Set<String> RESERVED_PROVIDER_IDS = Set.of("azure", "google", "wso2");
+  private static final Set<String> RESERVED_PROVIDER_IDS =
+      Set.of("azure", "google", "wso2", "dhis2");
 
   private static final ImmutableMap<String, Boolean> KEY_REQUIRED_MAP;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProvider.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_DHIS2_INTERNAL_C
 import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET;
 import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM;
 import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL;
+import static org.hisp.dhis.external.conf.ConfigurationKey.SERVER_BASE_URL;
 import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.DEFAULT_MAPPING_CLAIM;
 import static org.hisp.dhis.security.oidc.provider.AbstractOidcProvider.DEFAULT_REDIRECT_TEMPLATE_URL;
 
@@ -73,9 +74,16 @@ public class Dhis2InternalOidcProvider {
       throw new IllegalArgumentException("DHIS2 internal client secret is missing!");
     }
 
+    String serverUrl = config.getProperty(OIDC_DHIS2_INTERNAL_SERVER_URL);
+    if (Strings.isNullOrEmpty(serverUrl)) {
+      serverUrl = config.getProperty(SERVER_BASE_URL);
+    }
+    if (serverUrl.endsWith("/")) {
+      serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
+    }
+
     ClientRegistration clientRegistration =
-        buildClientRegistration(
-            dhis2ClientId, dhis2ClientSecret, config.getProperty(OIDC_DHIS2_INTERNAL_SERVER_URL));
+        buildClientRegistration(dhis2ClientId, dhis2ClientSecret, serverUrl);
 
     return DhisOidcClientRegistration.builder()
         .clientRegistration(clientRegistration)
@@ -83,6 +91,7 @@ public class Dhis2InternalOidcProvider {
         .loginIcon("")
         .loginIconPadding("")
         .loginText("not visible")
+        .visibleOnLoginPage(false)
         .build();
   }
 
@@ -100,7 +109,7 @@ public class Dhis2InternalOidcProvider {
     builder.tokenUri(providerBaseUrl + "/oauth2/token");
     builder.jwkSetUri(providerBaseUrl + "/oauth2/jwks");
     builder.userInfoUri(providerBaseUrl + "/oauth2/userinfo");
-    builder.issuerUri(providerBaseUrl);
+    builder.issuerUri(providerBaseUrl + "/");
     builder.redirectUri(DEFAULT_REDIRECT_TEMPLATE_URL);
     builder.userInfoAuthenticationMethod(AuthenticationMethod.HEADER);
     builder.userNameAttributeName(IdTokenClaimNames.SUB);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/GenericOidcProviderBuilderConfigParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/GenericOidcProviderBuilderConfigParserTest.java
@@ -42,6 +42,53 @@ import org.junit.jupiter.api.Test;
 class GenericOidcProviderBuilderConfigParserTest {
 
   @Test
+  void parseDhis2ProviderIsReservedAndSkipped() {
+    Properties p = new Properties();
+    p.put("oidc.provider.dhis2.client_id", "dhis2-client");
+    p.put("oidc.provider.dhis2.client_secret", "secret");
+    p.put("oidc.provider.dhis2.authorization_uri", "http://localhost:8080/oauth2/authorize");
+    p.put("oidc.provider.dhis2.token_uri", "http://localhost:8080/oauth2/token");
+    p.put("oidc.provider.dhis2.user_info_uri", "http://localhost:8080/userinfo");
+    p.put("oidc.provider.dhis2.jwk_uri", "http://localhost:8080/oauth2/jwks");
+    List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse(p);
+    assertThat(parse, hasSize(0));
+  }
+
+  @Test
+  void parseDhis2ProviderSkippedButOthersStillParsed() {
+    Properties p = new Properties();
+    p.put("oidc.provider.dhis2.client_id", "dhis2-client");
+    p.put("oidc.provider.dhis2.client_secret", "secret");
+    p.put("oidc.provider.dhis2.authorization_uri", "http://localhost:8080/oauth2/authorize");
+    p.put("oidc.provider.dhis2.token_uri", "http://localhost:8080/oauth2/token");
+    p.put("oidc.provider.dhis2.user_info_uri", "http://localhost:8080/userinfo");
+    p.put("oidc.provider.dhis2.jwk_uri", "http://localhost:8080/oauth2/jwks");
+
+    p.put("oidc.provider.idporten.client_id", "testClientId");
+    p.put("oidc.provider.idporten.client_secret", "testClientSecret");
+    p.put("oidc.provider.idporten.authorization_uri", "https://oidc-ver2.difi.no/authorize");
+    p.put("oidc.provider.idporten.token_uri", "https://oidc-ver2.difi.no/token");
+    p.put("oidc.provider.idporten.user_info_uri", "https://oidc-ver2.difi.no/userinfo");
+    p.put("oidc.provider.idporten.jwk_uri", "https://oidc-ver2.difi.no/jwk");
+
+    List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse(p);
+    assertThat(parse, hasSize(1));
+  }
+
+  @Test
+  void parseSkipsAllReservedProviderIds() {
+    Properties p = new Properties();
+    p.put("oidc.provider.dhis2.client_id", "dhis2-client");
+    p.put("oidc.provider.google.client_id", "google-client");
+    p.put("oidc.provider.azure.client_id", "azure-client");
+    p.put("oidc.provider.wso2.client_id", "wso2-client");
+    p.put("oidc.provider.custom.client_id", "custom-client");
+
+    List<DhisOidcClientRegistration> parse = GenericOidcProviderConfigParser.parse(p);
+    assertThat(parse, hasSize(0));
+  }
+
+  @Test
   void parseConfigAllValidParameters() {
     Properties p = new Properties();
     p.put("oidc.provider.idporten.client_id", "testClientId");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/security/oidc/provider/Dhis2InternalOidcProviderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oidc.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+@ExtendWith(MockitoExtension.class)
+class Dhis2InternalOidcProviderTest {
+
+  @Mock private DhisConfigurationProvider config;
+
+  @Test
+  void parseReturnsNullWhenClientIdIsEmpty() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID)).thenReturn("");
+    assertNull(Dhis2InternalOidcProvider.parse(config));
+  }
+
+  @Test
+  void parseFallsBackToServerBaseUrlWhenServerUrlIsEmpty() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID))
+        .thenReturn("dhis2-internal");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET))
+        .thenReturn("secret");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL)).thenReturn("");
+    when(config.getProperty(ConfigurationKey.SERVER_BASE_URL))
+        .thenReturn("http://example.com:8080");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM))
+        .thenReturn("username");
+
+    DhisOidcClientRegistration registration = Dhis2InternalOidcProvider.parse(config);
+
+    assertNotNull(registration);
+    ClientRegistration cr = registration.getClientRegistration();
+    assertEquals(
+        "http://example.com:8080/oauth2/authorize", cr.getProviderDetails().getAuthorizationUri());
+    assertEquals("http://example.com:8080/oauth2/token", cr.getProviderDetails().getTokenUri());
+    assertEquals("http://example.com:8080/oauth2/jwks", cr.getProviderDetails().getJwkSetUri());
+    assertEquals("http://example.com:8080/", cr.getProviderDetails().getIssuerUri());
+  }
+
+  @Test
+  void parseUsesExplicitServerUrlWhenProvided() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID))
+        .thenReturn("dhis2-internal");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET))
+        .thenReturn("secret");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL))
+        .thenReturn("http://custom-server:9090");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM))
+        .thenReturn("username");
+
+    DhisOidcClientRegistration registration = Dhis2InternalOidcProvider.parse(config);
+
+    assertNotNull(registration);
+    ClientRegistration cr = registration.getClientRegistration();
+    assertEquals(
+        "http://custom-server:9090/oauth2/authorize",
+        cr.getProviderDetails().getAuthorizationUri());
+    assertEquals("http://custom-server:9090/", cr.getProviderDetails().getIssuerUri());
+  }
+
+  @Test
+  void parseStripsTrailingSlashFromServerBaseUrl() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID))
+        .thenReturn("dhis2-internal");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET))
+        .thenReturn("secret");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL)).thenReturn("");
+    when(config.getProperty(ConfigurationKey.SERVER_BASE_URL))
+        .thenReturn("http://example.com:8080/");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM))
+        .thenReturn("username");
+
+    DhisOidcClientRegistration registration = Dhis2InternalOidcProvider.parse(config);
+
+    assertNotNull(registration);
+    ClientRegistration cr = registration.getClientRegistration();
+    assertEquals(
+        "http://example.com:8080/oauth2/authorize", cr.getProviderDetails().getAuthorizationUri());
+    assertEquals("http://example.com:8080/", cr.getProviderDetails().getIssuerUri());
+  }
+
+  @Test
+  void parseSetVisibleOnLoginPageToFalse() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID))
+        .thenReturn("dhis2-internal");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET))
+        .thenReturn("secret");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL))
+        .thenReturn("http://localhost:8080");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM))
+        .thenReturn("username");
+
+    DhisOidcClientRegistration registration = Dhis2InternalOidcProvider.parse(config);
+
+    assertNotNull(registration);
+    assertFalse(registration.isVisibleOnLoginPage());
+  }
+
+  @Test
+  void parseRegistrationIdIsDhis2Internal() {
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_ID))
+        .thenReturn("dhis2-internal");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_CLIENT_SECRET))
+        .thenReturn("secret");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_SERVER_URL))
+        .thenReturn("http://localhost:8080");
+    when(config.getProperty(ConfigurationKey.OIDC_DHIS2_INTERNAL_MAPPING_CLAIM))
+        .thenReturn("username");
+
+    DhisOidcClientRegistration registration = Dhis2InternalOidcProvider.parse(config);
+
+    assertNotNull(registration);
+    assertEquals("dhis2-internal", registration.getClientRegistration().getRegistrationId());
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -758,7 +758,7 @@ public enum ConfigurationKey {
   OIDC_DHIS2_INTERNAL_CLIENT_ID("oidc.provider.dhis2.client_id", "dhis2-internal", false),
   OIDC_DHIS2_INTERNAL_CLIENT_SECRET("oidc.provider.dhis2.client_secret", "secret", false),
   OIDC_DHIS2_INTERNAL_MAPPING_CLAIM("oidc.provider.dhis2.mapping_claim", "username", false),
-  OIDC_DHIS2_INTERNAL_SERVER_URL("oidc.provider.dhis2.server_url", "http://localhost:8080", false);
+  OIDC_DHIS2_INTERNAL_SERVER_URL("oidc.provider.dhis2.server_url", "", false);
 
   private final String key;
 

--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -25,11 +25,11 @@ login.security.totp_2fa.enabled = on
 login.security.email_2fa.enabled = on
 
 oauth2.server.enabled = on
-server.base.url = http://web:8080
+server.base.url = http://web:8080/
 oidc.jwt.token.authentication.enabled = on
 
 oidc.oauth2.login.enabled = on
-oidc.logout.redirect_url = http://web:8080
+oidc.logout.redirect_url = http://web:8080/
 oidc.provider.dhis2.client_id = dhis2-client
 oidc.provider.dhis2.client_secret = secret
 oidc.provider.dhis2.mapping_claim = email
@@ -38,7 +38,7 @@ oidc.provider.dhis2.enable_logout = on
 oidc.provider.dhis2.scopes = email
 oidc.provider.dhis2.authorization_uri = http://web:8080/oauth2/authorize
 oidc.provider.dhis2.token_uri = http://web:8080/oauth2/token
-oidc.provider.dhis2.issuer_uri = http://web:8080
+oidc.provider.dhis2.issuer_uri = http://web:8080/
 oidc.provider.dhis2.jwk_uri = http://web:8080/oauth2/jwks
 oidc.provider.dhis2.user_info_uri = http://web:8080/userinfo
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -195,7 +195,7 @@ class OAuth2Test extends BaseE2ETest {
     String accessToken = getAccessToken(code);
 
     String actualIssuerUri = null;
-    String expectedIssuerUri = "http://web:8080";
+    String expectedIssuerUri = "http://web:8080/";
 
     // 6. Decode the access_token
     try {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -230,7 +230,7 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
     assertNotNull(claims);
     assertEquals("admin", claims.get("sub"));
     assertEquals("client.create", claims.get("scope"));
-    assertEquals("http://localhost:8080", claims.get("iss"));
+    assertEquals("http://localhost:8080/", claims.get("iss"));
     assertTrue(
         ((Instant) claims.get("exp")).getEpochSecond()
             > Instant.now().plus(30, ChronoUnit.SECONDS).getEpochSecond());
@@ -306,7 +306,8 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
   }
 
   private String callTokenEndpoint(KeyPair keyPair, String clientId) throws Exception {
-    String tokenEndpoint = authorizationServerSettings.getIssuer() + "/oauth2/token";
+    // This is the server base URL with trailing slash!!!
+    String serverBaseUrlWithTrailingSlash = authorizationServerSettings.getIssuer();
 
     JwsHeader assertionHeader =
         JwsHeader.with(SignatureAlgorithm.RS256).keyId(keyPair.rsaKey().getKeyID()).build();
@@ -318,7 +319,7 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
         JwtClaimsSet.builder()
             .issuer(clientId)
             .subject(clientId)
-            .audience(List.of(tokenEndpoint))
+            .audience(List.of(serverBaseUrlWithTrailingSlash))
             .issuedAt(Instant.now())
             .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
             .build();

--- a/dhis-2/dhis-test-web-api/src/test/resources/dhisControllerWithJwtTokenAuthTestDhis.conf
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dhisControllerWithJwtTokenAuthTestDhis.conf
@@ -12,7 +12,7 @@ hibernate.cache.use_query_cache=false
 hibernate.cache.use_second_level_cache=false
 
 
-server.base.url = http://localhost:8080
+server.base.url = http://localhost:8080/
 oauth2.server.enabled = on
 oidc.jwt.token.authentication.enabled = on
 # Enables OIDC login

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -113,6 +113,10 @@ public class LoginConfigController {
       DhisOidcClientRegistration clientRegistration =
           oidcProviderRepository.getDhisOidcClientRegistration(registrationId);
 
+      if (!clientRegistration.isVisibleOnLoginPage()) {
+        continue;
+      }
+
       providers.add(
           LoginOidcProvider.builder()
               .id(registrationId)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
@@ -127,9 +127,15 @@ public class AuthorizationServerConfig {
    */
   @Bean
   public AuthorizationServerSettings authorizationServerSettings(DhisConfigurationProvider config) {
-    return AuthorizationServerSettings.builder()
-        .issuer(config.getProperty(ConfigurationKey.SERVER_BASE_URL))
-        .build();
+    String baseUrl = config.getProperty(ConfigurationKey.SERVER_BASE_URL);
+    if (baseUrl.isEmpty()) {
+      throw new IllegalStateException(
+          "The server base URL is not configured. Please set the 'server.base.url' property in dhis.conf.");
+    }
+    if (!baseUrl.endsWith("/")) {
+      baseUrl = baseUrl + "/";
+    }
+    return AuthorizationServerSettings.builder().issuer(baseUrl).build();
   }
 
   /**
@@ -339,8 +345,8 @@ public class AuthorizationServerConfig {
     } else {
       if (!generateIfMissing) {
         String errorMsg =
-            "Keystore configuration is missing and generation of keys is disabled. "
-                + "Configure oauth2.jwt.keystore.path or enable oauth2.jwt.keystore.generate-if-missing.";
+            "Keystore configuration is missing and generation of keys is disabled. Configure"
+                + " oauth2.jwt.keystore.path or enable oauth2.jwt.keystore.generate-if-missing.";
         log.error(errorMsg);
         throw new IllegalStateException(errorMsg);
       }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -510,7 +510,8 @@ public class DhisWebApiWebSecurityConfig {
    * @param http HttpSecurity config
    */
   private void configureOAuthTokenFilters(HttpSecurity http) {
-    if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)) {
+    if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)
+        || dhisConfig.isEnabled(ConfigurationKey.OAUTH2_SERVER_ENABLED)) {
       http.addFilterAfter(getJwtBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class);
     }
   }


### PR DESCRIPTION
## Summary

Backport of #23032 to 2.42, plus #22531 (trailing-slash normalization) which is a prerequisite on 2.42.

#23032 enhances the internal DHIS2 OIDC provider — simplifies Android OAuth2 config and hides the internal provider from the login page while preserving JWT validation against the internal issuer.

## Backport notes

- **Now also includes #22531** ("fix: always add trailing slash to the base url for the auth server"). On master, #22531 landed Nov 2025 and #23032 then relied on the normalized issuer-URI lookup; backporting #23032 alone leaves bearer-token auth at /api/users returning 401 because the registration's \`issuerUri\` ends in / while 2.42's AS issuer config doesn't.
- Test config \`dhisControllerWithJwtTokenAuthTestDhis.conf\` updated to \`server.base.url = http://localhost:8080/` to match.


AI Assisted