### PR TITLE
fix: disable OAuth2 consent prompt for DCR-registered clients (#23215) [2.42]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -145,6 +145,8 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
     ClientSettings clientSettings = client.getClientSettings();
     assertNotNull(clientSettings.getSetting("client.inline.jwks"));
     assertNull(client.getClientSecret());
+    // DCR-registered clients are first-party (Android) and must not require consent
+    assertEquals(false, clientSettings.isRequireAuthorizationConsent());
 
     // When calling token endpoint with private_key_jwt authentication
     String tokenResponse = callTokenEndpoint(keyPair, clientId);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
@@ -69,8 +69,12 @@ final class InlineJwksClientMetadataConfig {
       // Let SAS map standard fields first
       RegisteredClient rc = delegate.convert(reg);
 
-      // Copy current client settings so we can add our own
+      // Copy current client settings so we can add our own.
+      // Override the SAS default of requireAuthorizationConsent(true) — DCR-registered clients
+      // are first-party (e.g. Android app) authenticating with their own DHIS2 server,
+      // so no end-user consent prompt is needed.
       ClientSettings.Builder cs = ClientSettings.withSettings(rc.getClientSettings().getSettings());
+      cs.requireAuthorizationConsent(false);
       Map<String, Object> claims = reg.getClaims();
 
       // Accept optional "token_endpoint_auth_signing_alg": "RS256"


### PR DESCRIPTION
## Summary

Backport of #23215 to 2.42.

DCR-registered Android clients should not get an OAuth2 consent prompt.

AI Assisted