### PR TITLE
fix: LazyInitializationException in JWT bearer token authentication for non-OSIV endpoints (#23611) [2.42]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -509,6 +509,26 @@ public interface UserService {
   UserDetails createUserDetailsSafe(@Nonnull String userUid);
 
   /**
+   * Creates {@link UserDetails} for the user with the given username. The user lookup and details
+   * creation happen within a single transaction, ensuring lazy collections are accessible.
+   *
+   * @param username the username to look up
+   * @return the {@link UserDetails} or {@code null} if no user with the given username exists
+   */
+  @CheckForNull
+  UserDetails createUserDetailsByUsername(@Nonnull String username);
+
+  /**
+   * Creates {@link UserDetails} for the user with the given OpenID. The user lookup and details
+   * creation happen within a single transaction, ensuring lazy collections are accessible.
+   *
+   * @param openId the OpenID to look up
+   * @return the {@link UserDetails} or {@code null} if no user with the given OpenID exists
+   */
+  @CheckForNull
+  UserDetails createUserDetailsByOpenId(@Nonnull String openId);
+
+  /**
    * It creates a CurrentUserDetailsImpl object from a User object. It also fetches the users locked
    * and credentials expired status.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -42,10 +42,8 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2ClientService;
 import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.user.UserStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -86,7 +84,6 @@ public class Dhis2JwtAuthenticationManagerResolver
     implements AuthenticationManagerResolver<HttpServletRequest> {
 
   @Autowired private DhisConfigurationProvider config;
-  @Autowired private UserStore userStore;
   @Autowired private DhisOidcProviderRepository clientRegistrationRepository;
   @Autowired private Dhis2OAuth2ClientService oAuth2ClientService;
   @Autowired private UserService userService;
@@ -180,22 +177,22 @@ public class Dhis2JwtAuthenticationManagerResolver
 
       String mappingClaimKey = clientRegistration.getMappingClaimKey();
       String mappingValue = jwt.getClaim(mappingClaimKey);
-      User user;
-      switch (mappingClaimKey) {
-        case "username" -> user = userStore.getUserByUsername(mappingValue);
-        case "email" -> user = userStore.getUserByOpenId(mappingValue);
-        default -> throw new InvalidBearerTokenException("Invalid mapping claim");
-      }
+      UserDetails currentUserDetails =
+          switch (mappingClaimKey) {
+            case "username" -> userService.createUserDetailsByUsername(mappingValue);
+            case "email" -> userService.createUserDetailsByOpenId(mappingValue);
+            default -> throw new InvalidBearerTokenException("Invalid mapping claim");
+          };
 
-      if (user == null) {
+      if (currentUserDetails == null) {
         throw new InvalidBearerTokenException(
             String.format(
                 "Found no matching DHIS2 user for the mapping claim: '%s' with the value: '%s'",
                 mappingClaimKey, mappingValue));
       }
 
-      UserDetails currentUserDetails = userService.createUserDetails(user);
-      Collection<GrantedAuthority> grantedAuthorities = user.getAuthorities();
+      Collection<GrantedAuthority> grantedAuthorities =
+          List.copyOf(currentUserDetails.getAuthorities());
 
       return new DhisJwtAuthenticationToken(
           jwt, grantedAuthorities, mappingValue, currentUserDetails);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -912,6 +912,28 @@ public class DefaultUserService implements UserService {
 
   @Override
   @Transactional(readOnly = true)
+  @CheckForNull
+  public UserDetails createUserDetailsByUsername(@Nonnull String username) {
+    User user = userStore.getUserByUsername(username);
+    if (user == null) {
+      return null;
+    }
+    return createUserDetails(user);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  @CheckForNull
+  public UserDetails createUserDetailsByOpenId(@Nonnull String openId) {
+    User user = userStore.getUserByOpenId(openId);
+    if (user == null) {
+      return null;
+    }
+    return createUserDetails(user);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public UserDetails createUserDetails(User user) {
     if (user == null) {
       return null;


### PR DESCRIPTION
## Summary

Backport of #23611 to 2.42.

JWT bearer auth can fail on tracker/non-OSIV endpoints with LazyInitializationException. This patch creates UserDetails directly via username/openId resolution and copies authorities eagerly.



AI Assisted