### PR TITLE
feat: add warn on missing server.base.url (#23628) [2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.user.CurrentUserUtil.injectUserInSecurityContext;
 
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.configuration.Configuration;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.encryption.EncryptionStatus;
@@ -68,6 +69,7 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
     }
 
     checkSecurityConfiguration();
+    checkServerBaseUrl();
 
     Configuration config = configurationService.getConfiguration();
 
@@ -88,6 +90,32 @@ public class ConfigurationPopulator extends TransactionContextStartupRoutine {
       log.warn("Encryption not configured: " + status.getKey());
     } else {
       log.info("Encryption is available");
+    }
+  }
+
+  private static final String BASE_URL_HINT =
+      " Expected an absolute URL without a trailing slash,"
+          + " for example: 'https://dhis2.example.org/dhis'."
+          + " This value is important: features including password recovery, OIDC/OAuth2"
+          + " redirects, notification emails, and interpretation sharing will not work"
+          + " correctly without it. See the 'Server base URL' section in the dhis.conf"
+          + " reference documentation.";
+
+  private void checkServerBaseUrl() {
+    String baseUrl = dhisConfigurationProvider.getServerBaseUrl();
+    if (baseUrl == null) {
+      log.warn("'server.base.url' is not set in dhis.conf." + BASE_URL_HINT);
+      return;
+    }
+
+    String[] schemes = new String[] {"http", "https"};
+    UrlValidator urlValidator = new UrlValidator(schemes);
+    if (!urlValidator.isValid(baseUrl)) {
+      log.warn("'server.base.url' is not a valid URL: '{}'." + BASE_URL_HINT, baseUrl);
+
+    } else if (baseUrl.endsWith("/")) {
+      log.warn(
+          "'server.base.url' must not end with a trailing slash: '{}'." + BASE_URL_HINT, baseUrl);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/startup/ConfigurationPopulatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.startup;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.hisp.dhis.configuration.Configuration;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.encryption.EncryptionStatus;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link ConfigurationPopulator}.
+ *
+ * <p>The startup routine only logs warnings for misconfigured properties. These tests verify that
+ * each validation path completes without error and does not modify the existing configuration.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfigurationPopulatorTest {
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private DhisConfigurationProvider dhisConfigurationProvider;
+
+  private ConfigurationPopulator populator;
+
+  @BeforeEach
+  void setUp() {
+    populator = new ConfigurationPopulator(configurationService, dhisConfigurationProvider);
+
+    // Stubs required by executeInTransaction() regardless of the test scenario
+    when(dhisConfigurationProvider.getEncryptionStatus()).thenReturn(EncryptionStatus.OK);
+    Configuration config = new Configuration();
+    config.setSystemId("existing-id");
+    when(configurationService.getConfiguration()).thenReturn(config);
+  }
+
+  static Stream<Arguments> baseUrlScenarios() {
+    return Stream.of(
+        Arguments.of("valid URL", "https://dhis2.example.org"),
+        Arguments.of("valid URL with path", "https://dhis2.example.org/dhis"),
+        Arguments.of("missing URL", null),
+        Arguments.of("invalid URL", "not-a-url"),
+        Arguments.of("URL with trailing slash", "https://dhis2.example.org/dhis/"));
+  }
+
+  @ParameterizedTest(name = "{0}: {1}")
+  @MethodSource("baseUrlScenarios")
+  void testBaseUrlValidation(String scenario, String baseUrl) {
+    when(dhisConfigurationProvider.getServerBaseUrl()).thenReturn(baseUrl);
+
+    populator.executeInTransaction();
+
+    verify(dhisConfigurationProvider).getServerBaseUrl();
+    verify(configurationService, never()).setConfiguration(org.mockito.ArgumentMatchers.any());
+  }
+}


### PR DESCRIPTION
## Summary

Backport of #23628 to 2.42.

Adds a startup warning when \`server.base.url\` is not configured. 

AI Assisted