### PR TITLE
feat: decouple ChangeLogAccumulator from Hibernate Session [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -36,6 +36,8 @@ import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,6 +81,7 @@ import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 /**
  * @author Luciano Fiandesio
@@ -92,6 +96,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   @PersistenceContext private EntityManager entityManager;
 
   protected final ReservedValueService reservedValueService;
+
+  protected final DataSource dataSource;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
@@ -115,50 +121,35 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     //
     List<T> dtos = getByType(bundle);
 
-    for (T trackerDto : dtos) {
+    Connection conn = DataSourceUtils.getConnection(dataSource);
+    try {
+      for (T trackerDto : dtos) {
 
-      Entity objectReport = new Entity(getType(), trackerDto.getUID());
-      boolean isNewEntity = isNew(bundle, trackerDto);
-      // Capture before convert() which mutates the preheat entity's status
-      boolean completedInThisImport =
-          !bundle.isSkipSideEffects()
-              && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
-      ChangeLogAccumulator.Mark mark = changeLogs.mark();
-      try {
-        V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
+        Entity objectReport = new Entity(getType(), trackerDto.getUID());
+        boolean isNewEntity = isNew(bundle, trackerDto);
+        // Capture before convert() which mutates the preheat entity's status
+        boolean completedInThisImport =
+            !bundle.isSkipSideEffects()
+                && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
+        ChangeLogAccumulator.Mark mark = changeLogs.mark();
+        try {
+          V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
 
-        //
-        // Convert the TrackerDto into an Hibernate-managed entity
-        //
-        V convertedDto = convert(bundle, trackerDto);
+          //
+          // Convert the TrackerDto into an Hibernate-managed entity
+          //
+          V convertedDto = convert(bundle, trackerDto);
 
-        //
-        // Handle ownership records, if required
-        //
-        persistOwnership(bundle, trackerDto, convertedDto);
+          //
+          // Handle ownership records, if required
+          //
+          persistOwnership(bundle, trackerDto, convertedDto);
 
-        //
-        // Save or update the entity
-        //
-        if (isNew(bundle, trackerDto)) {
-          entityManager.persist(convertedDto);
-          updateDataValues(
-              bundle.getPreheat(),
-              trackerDto,
-              convertedDto,
-              originalEntity,
-              bundle.getUser(),
-              changeLogs);
-          typeReport.getStats().incCreated();
-          typeReport.addEntity(objectReport);
-          updateAttributes(
-              bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
-          bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
-        } else {
-          if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
-            typeReport.getStats().incIgnored();
-            // Relationships are not updated. A warning was already added to the report
-          } else {
+          //
+          // Save or update the entity
+          //
+          if (isNew(bundle, trackerDto)) {
+            entityManager.persist(convertedDto);
             updateDataValues(
                 bundle.getPreheat(),
                 trackerDto,
@@ -166,62 +157,91 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 originalEntity,
                 bundle.getUser(),
                 changeLogs);
+            typeReport.getStats().incCreated();
+            typeReport.addEntity(objectReport);
             updateAttributes(
                 bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
-            entityManager.merge(convertedDto);
-            typeReport.getStats().incUpdated();
-            typeReport.addEntity(objectReport);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
+          } else {
+            if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
+              typeReport.getStats().incIgnored();
+              // Relationships are not updated. A warning was already added to the report
+            } else {
+              updateDataValues(
+                  bundle.getPreheat(),
+                  trackerDto,
+                  convertedDto,
+                  originalEntity,
+                  bundle.getUser(),
+                  changeLogs);
+              updateAttributes(
+                  bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+              entityManager.merge(convertedDto);
+              typeReport.getStats().incUpdated();
+              typeReport.addEntity(objectReport);
+              bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
+            }
           }
-        }
 
-        if (!bundle.isSkipSideEffects()) {
-          EntityNotifications entityNotifications =
-              collectNotifications(bundle, convertedDto, isNewEntity, completedInThisImport);
-          if (entityNotifications != null) {
-            notifications.add(entityNotifications);
+          if (!bundle.isSkipSideEffects()) {
+            EntityNotifications entityNotifications =
+                collectNotifications(bundle, convertedDto, isNewEntity, completedInThisImport);
+            if (entityNotifications != null) {
+              notifications.add(entityNotifications);
+            }
           }
-        }
 
-        //
-        // Add the entity to the Preheat
-        //
-        updatePreheat(bundle.getPreheat(), convertedDto);
+          //
+          // Add the entity to the Preheat
+          //
+          updatePreheat(bundle.getPreheat(), convertedDto);
 
-        if (FlushMode.OBJECT == bundle.getFlushMode()) {
-          // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
-          // (trackedentityid, eventid) exist before changelog rows reference them.
-          entityManager.flush();
-          changeLogs.flushAll(entityManager);
-        }
-      } catch (Exception e) {
-        changeLogs.rollbackTo(mark);
+          if (FlushMode.OBJECT == bundle.getFlushMode()) {
+            // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+            // (trackedentityid, eventid) exist before changelog rows reference them.
+            entityManager.flush();
+            changeLogs.flushAll(conn);
+          }
+        } catch (Exception e) {
+          changeLogs.rollbackTo(mark);
 
-        final String msg =
-            "A Tracker Entity of type '"
-                + getType().getName()
-                + "' ("
-                + trackerDto.getUID()
-                + ") failed to persist.";
+          final String msg =
+              "A Tracker Entity of type '"
+                  + getType().getName()
+                  + "' ("
+                  + trackerDto.getUID()
+                  + ") failed to persist.";
 
-        if (AtomicMode.ALL.equals(bundle.getAtomicMode())) {
-          throw new PersistenceException(msg, e);
-        } else {
-          // TODO currently we do not keep track of the failed entity
-          // in the TrackerObjectReport
+          if (AtomicMode.ALL.equals(bundle.getAtomicMode())) {
+            throw new PersistenceException(msg, e);
+          } else {
+            // TODO currently we do not keep track of the failed entity
+            // in the TrackerObjectReport
 
-          log.warn(msg + "\nThe Import process will process remaining entities.", e);
+            // TODO: if the failure originated from a JDBC flush (changeLogs.flushAll or, from
+            // Phase 3 onward, EntityWriteBatch.flush), the underlying PostgreSQL connection is
+            // now in an aborted-transaction state. Any subsequent SQL on the same connection
+            // will fail with "current transaction is aborted". This means a single JDBC flush
+            // failure in non-atomic mode silently cascades and causes all remaining entities to
+            // be ignored as well. Consider wrapping each entity's JDBC flush in a savepoint so
+            // that a failure can be rolled back to the savepoint and the connection stays usable.
+            log.warn(msg + "\nThe Import process will process remaining entities.", e);
 
-          typeReport.getStats().incIgnored();
+            typeReport.getStats().incIgnored();
+          }
         }
       }
-    }
 
-    if (FlushMode.AUTO == bundle.getFlushMode()) {
-      // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
-      // (trackedentityid, eventid) exist before changelog rows reference them.
-      entityManager.flush();
-      changeLogs.flushAll(entityManager);
+      if (FlushMode.AUTO == bundle.getFlushMode()) {
+        // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+        // (trackedentityid, eventid) exist before changelog rows reference them.
+        entityManager.flush();
+        changeLogs.flushAll(conn);
+      }
+    } catch (SQLException e) {
+      throw new PersistenceException(e);
+    } finally {
+      DataSourceUtils.releaseConnection(conn, dataSource);
     }
     return new PersistResult(typeReport, notifications);
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -40,7 +39,6 @@ import java.util.Date;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import org.hibernate.Session;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
@@ -185,15 +183,15 @@ class ChangeLogAccumulator {
     truncate(singleEventChangeLogs, mark.singleEventSize);
   }
 
-  void flushAll(EntityManager entityManager) {
+  void flushAll(Connection connection) throws SQLException {
     if (teChangeLogs.isEmpty()
         && trackerEventChangeLogs.isEmpty()
         && singleEventChangeLogs.isEmpty()) {
       return;
     }
 
-    Session session = entityManager.unwrap(Session.class);
-    session.doWork(this::insertAll);
+    insertAll(connection);
+
     teChangeLogs.clear();
     trackerEventChangeLogs.clear();
     singleEventChangeLogs.clear();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.notification.NotificationTrigger;
@@ -58,8 +59,9 @@ public class EnrollmentPersister
 
   public EnrollmentPersister(
       ReservedValueService reservedValueService,
+      DataSource dataSource,
       TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
-    super(reservedValueService);
+    super(reservedValueService, dataSource);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
@@ -49,8 +50,8 @@ import org.springframework.stereotype.Component;
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.tracker.model.Relationship> {
 
-  public RelationshipPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public RelationshipPersister(ReservedValueService reservedValueService, DataSource dataSource) {
+    super(reservedValueService, dataSource);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
@@ -73,8 +74,8 @@ import org.springframework.stereotype.Component;
 public class SingleEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.SingleEvent, SingleEvent> {
-  public SingleEventPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public SingleEventPersister(ReservedValueService reservedValueService, DataSource dataSource) {
+    super(reservedValueService, dataSource);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.tracker.TrackerType;
@@ -50,8 +51,8 @@ public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
 
-  public TrackedEntityPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public TrackedEntityPersister(ReservedValueService reservedValueService, DataSource dataSource) {
+    super(reservedValueService, dataSource);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
@@ -74,8 +75,8 @@ import org.springframework.stereotype.Component;
 public class TrackerEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackerEvent, TrackerEvent> {
-  public TrackerEventPersister(ReservedValueService reservedValueService) {
-    super(reservedValueService);
+  public TrackerEventPersister(ReservedValueService reservedValueService, DataSource dataSource) {
+    super(reservedValueService, dataSource);
   }
 
   @Override


### PR DESCRIPTION
### What changes                                                                                                                                                                              
                                                            
  **`ChangeLogAccumulator`**                                                                                                                                                                    
   
  - `flushAll(EntityManager)` → `flushAll(Connection)`.                                                                                                                                         
    The class was already pure JDBC internally; it only used Hibernate to unwrap a `Connection` via `session.doWork()`. That indirection is removed.                                                                                                                           
    `EntityManager` and `org.hibernate.Session` imports are gone. The class now has zero Hibernate dependencies.                                                                                                                                                                
                                                                                                                                                                                                
  **`AbstractTrackerPersister`**                                                                                                                                                                
                                                            
  - Injects `DataSource` as a constructor field (via `@RequiredArgsConstructor`).                                                                                                               
  - At the start of `persist()`, obtains the connection once with `DataSourceUtils.getConnection(dataSource)` and releases it in a `finally` block via `DataSourceUtils.releaseConnection(conn, dataSource)`.                                                                                                                                  
    Within the active `@Transactional` context in `DefaultTrackerBundleService.commit()`, `DataSourceUtils` returns the connection already bound to the Spring-managed transaction — the same connection Hibernate's `doWork` was providing — so transaction integrity is maintained.                                                                                                                                                        
  - Passes `conn` to `changeLogs.flushAll(conn)` at both flush points (`FlushMode.OBJECT` inside the entity loop, `FlushMode.AUTO` after it).                                                                                                                     
  - `SQLException` from the `FlushMode.AUTO` flush path is caught at the outer level and wrapped in `PersistenceException` (unchecked), triggering Spring's transactional rollback. `SQLException` from the `FlushMode.OBJECT` path is caught by the per-entity inner catch, consistent with the existing atomic/non-atomic branching.                                                                                                           
                                                                                                                                                                                                
  **Concrete persisters** (`TrackedEntityPersister`, `EnrollmentPersister`, `TrackerEventPersister`, `SingleEventPersister`, `RelationshipPersister`)                                                                                                                     
                                                                                                                                                                                                
  - Each constructor gains a `DataSource` parameter forwarded to `super(...)`.                                                                                                                  

#### Performance

Four compare runs of a load test only on the tracker importer

[25659662711](https://github.com/dhis2/dhis2-core/actions/runs/25659662711)
[25659660683](https://github.com/dhis2/dhis2-core/actions/runs/25659660683)
[25656873606](https://github.com/dhis2/dhis2-core/actions/runs/25656873606)
[25656346626](https://github.com/dhis2/dhis2-core/actions/runs/25656346626)

#### Median Response Time (p50) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Login | 122 | 0.38 | 117 | 0.38 | -5 | :arrow_down: -4.1% |
| MNCH import | 1,071 | 1.91 | 1,054 | 1.92 | -18 | :arrow_down: -1.6% |
| Child Programme import | 497 | 1.91 | 506 | 1.92 | +10 | :arrow_up: +1.9% |
| ANC import | 384 | 1.91 | 380 | 1.92 | -4 | :arrow_down: -1.2% |

### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Login | 230 | 0.38 | 247 | 0.38 | +17 | :arrow_up: +7.3% |
| MNCH import | 1,271 | 1.91 | 1,330 | 1.92 | +59 | :arrow_up: +4.7% |
| Child Programme import | 552 | 1.91 | 555 | 1.92 | +3 | :arrow_up: +0.6% |
| ANC import | 457 | 1.91 | 441 | 1.92 | -15 | :arrow_down: -3.3% |

_:arrow_down: = faster, :arrow_up: = slower_
                                                                                                                                                                                                
  ### Open question

In non-atomic mode with `FlushMode.OBJECT`, a `SQLException` from `changeLogs.flushAll(conn)` leaves the PostgreSQL connection in an aborted-transaction state. Subsequent SQL on the same connection fails with "current transaction is aborted", so a single flush failure silently cascades to all remaining entities in the batch. This becomes more significant in Phase 3 when `EntityWriteBatch.flush(conn)` is added alongside `changeLogs.flushAll(conn)`.
When a `SQLException` is thrown, does it mean that there is a bug in the query? Should we just return 500?

  ### What does not change

- No behaviour change for callers.
- `DefaultTrackerBundleService` and the `@Transactional` boundary are unchanged.

## Next steps                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                

  - **Quick fix** ✅ `formatDate`: `SimpleDateFormat` → `static final DateTimeFormatter`                                                                                                                                                                                       ─
  - **Phase 0** ✅ Remove `EntityManager` from `TrackerPersister` interface and all method parameters - https://github.com/dhis2/dhis2-core/pull/23836                                                                                                                                                                       
  - **Phase 1** ✅ Decouple `ChangeLogAccumulator` from Hibernate `Session`; obtain the                                                                                                                                                                                         
    transaction-bound `Connection` via `DataSourceUtils` instead of `session.doWork()`                                                                                                                                                                                         
  - **Phase 2** — Extract `FileResource` assignment update out of `AbstractTrackerPersister`                                                                                                                                                                                   
    into `FileResourceStore`                                                                                                                                                                                                                                                   
  - **Phase 3** — Introduce `EntityWriteBatch`; accumulate and batch-flush TEAV writes                                                                                                                                                                                         
    (multi-row INSERT / unnest UPDATE / tuple DELETE)                                                                                                                                                                                                                          
  - **Phase 4** — Pre-allocate IDs from PostgreSQL sequences; stage top-level entity                                                                                                                                                                                           
    inserts and updates in `EntityWriteBatch`; remove all `entityManager.flush()` calls                                                                                                                                                                                        
  - **Phase 5** — Replace `updateTrackedEntitiesLastUpdated` named query with                                                                                                                                                                                                  
    `NamedParameterJdbcTemplate`; remove last Hibernate dependency from                                                                                                                                                                                                        
    `DefaultTrackerBundleService`                                                                                                                                                                                                                                              
  - **Phase 6** — Implement JDBC flush methods one entity type at a time                                                                                                                                                                                                       
    (`TrackedEntity` → `Enrollment` → `TrackerEvent`/`SingleEvent` → `Relationship`)   
 