### PR TITLE
test: Add optional DB_DIR arg for platform perf DBs [DHIS2-21329]

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -185,6 +185,7 @@ jobs:
         PROF_ARGS_VALUE=$(grep "^PROF_ARGS=" "$RUN_ENV" | cut -d= -f2-)
         CAPTURE_DHIS2_LOGS_VALUE=$(grep "^CAPTURE_DHIS2_LOGS=" "$RUN_ENV" | cut -d= -f2-)
         CAPTURE_SQL_LOGS_VALUE=$(grep "^CAPTURE_SQL_LOGS=" "$RUN_ENV" | cut -d= -f2-)
+        DB_DIR=$(grep "^DB_DIR=" "$RUN_ENV" | cut -d= -f2-)
         DB_TYPE=$(grep "^DB_TYPE=" "$RUN_ENV" | cut -d= -f2-)
         DB_VERSION=$(grep "^DB_VERSION=" "$RUN_ENV" | cut -d= -f2-)
 
@@ -199,7 +200,11 @@ jobs:
         echo "* **Simulation**: \`$SIM_CLASS\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Performance tests git ref**: \`$PERF_GIT_BRANCH\` (\`$PERF_GIT_COMMIT\`)" >> $GITHUB_STEP_SUMMARY
         echo "* **Warmup iterations**: $WARMUP_COUNT" >> $GITHUB_STEP_SUMMARY
-        echo "* **Database**: \`$DB_TYPE\` / \`$DB_VERSION\`" >> $GITHUB_STEP_SUMMARY
+        if [ -n "$DB_DIR" ]; then
+          echo "* **Database**: \`$DB_DIR\` / \`$DB_TYPE\` / \`$DB_VERSION\`" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "* **Database**: \`$DB_TYPE\` / \`$DB_VERSION\`" >> $GITHUB_STEP_SUMMARY
+        fi
         if [ -n "$MVN_ARGS_VALUE" ]; then
           echo "* **Maven arguments**: \`$MVN_ARGS_VALUE\`" >> $GITHUB_STEP_SUMMARY
         fi

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -46,9 +46,10 @@ services:
       dockerfile: Dockerfile.postgres
       args:
         POSTGRES_BASE_IMAGE: ghcr.io/baosystems/postgis:14-3.5
+        DB_DIR: "${DB_DIR:-}"
         DB_TYPE: "${DB_TYPE:-sierra-leone}"
         DB_VERSION: "${DB_VERSION:-dev}"
-    image: localhost/dhis2-postgres:14-3.5-${DB_TYPE:-sierra-leone}-${DB_VERSION:-dev}
+    image: localhost/dhis2-postgres:14-3.5-${DB_IMAGE_TAG:-sierra-leone-dev}
     cpus: 4
     mem_limit: 16gb
     shm_size: 6gb

--- a/dhis-2/dhis-test-performance/docker-compose.yml
+++ b/dhis-2/dhis-test-performance/docker-compose.yml
@@ -49,7 +49,7 @@ services:
         DB_DIR: "${DB_DIR:-}"
         DB_TYPE: "${DB_TYPE:-sierra-leone}"
         DB_VERSION: "${DB_VERSION:-dev}"
-    image: localhost/dhis2-postgres:14-3.5-${DB_IMAGE_TAG:-sierra-leone-dev}
+    image: localhost/dhis2-postgres:14-3.5-${DB_TYPE:-sierra-leone}-${DB_VERSION:-dev}
     cpus: 4
     mem_limit: 16gb
     shm_size: 6gb

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -1,21 +1,28 @@
 # syntax=docker/dockerfile:1
 # Dockerfile to build and restore the DB dump at build time (not runtime)
 # This significantly speeds up container startup for performance tests.
+ARG DB_DIR
 ARG DB_TYPE
 ARG DB_VERSION
 
 FROM amazon/aws-cli:latest AS downloader
+ARG DB_DIR
 ARG DB_TYPE
 ARG DB_VERSION
 WORKDIR /tmp
 
-RUN S3_PATH="s3://databases.dhis2.org/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz" && \
+RUN if [ -n "$DB_DIR" ]; then \
+      S3_PATH="s3://databases.dhis2.org/${DB_DIR}/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
+    else \
+      S3_PATH="s3://databases.dhis2.org/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
+    fi && \
     echo "Downloading from: $S3_PATH" && \
     aws s3 cp --no-sign-request "$S3_PATH" dump.sql.gz
 
 FROM ghcr.io/baosystems/postgis:14-3.5 AS builder
 
-# Ensure build cache is invalidated when DB_TYPE or DB_VERSION changes so dump is restored
+# Ensure build cache is invalidated when DB_DIR, DB_TYPE or DB_VERSION changes so dump is restored
+ARG DB_DIR
 ARG DB_TYPE
 ARG DB_VERSION
 

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -17,11 +17,15 @@ show_usage() {
   echo "  SIMULATION_CLASS      Fully qualified Gatling Simulation class name"
   echo ""
   echo "OPTIONS:"
+  echo "  DB_DIR                Optional top-level S3 directory (default: not set)"
+  echo "                        When set, DB_TYPE can be any valid identifier"
+  echo "                        Pattern: s3://databases.dhis2.org/<dir>/<type>/<version>/dhis2-db-<type>.sql.gz"
   echo "  DB_TYPE               Database type (default: sierra-leone)"
-  echo "                        Valid values: sierra-leone, hmis"
+  echo "                        Valid values without DB_DIR: sierra-leone, hmis"
+  echo "                        Any valid identifier when DB_DIR is set"
   echo "  DB_VERSION            Database version (default: dev)"
   echo "                        Must be alphanumeric, dots, hyphens, underscores only"
-  echo "                        Pattern: s3://databases.dhis2.org/<type>/<version>/dhis2-db-<type>.sql.gz"
+  echo "                        Pattern (no DB_DIR): s3://databases.dhis2.org/<type>/<version>/dhis2-db-<type>.sql.gz"
   echo "  DHIS2_USERNAME        DHIS2 username for API authentication (default: admin)"
   echo "  DHIS2_PASSWORD        DHIS2 password for API authentication (default: district)"
   echo "  ANALYTICS_GENERATE    Generate analytics tables before running tests (default: false)"
@@ -89,6 +93,7 @@ fi
 # ENVIRONMENT SETUP
 ################################################################################
 
+DB_DIR=${DB_DIR:-""}
 DB_TYPE=${DB_TYPE:-"sierra-leone"}
 DB_VERSION=${DB_VERSION:-"dev"}
 DHIS2_USERNAME=${DHIS2_USERNAME:-"admin"}
@@ -106,17 +111,37 @@ MVN_ARGS=${MVN_ARGS:-""}
 # Track last non-warmup run directory for output summary
 LAST_RUN_DIR=""
 
-# Validate DB_TYPE (only allow sierra-leone or hmis)
-case "$DB_TYPE" in
-  sierra-leone|hmis)
-    # Valid
-    ;;
-  *)
-    echo "Error: DB_TYPE must be 'sierra-leone' or 'hmis', got: $DB_TYPE" >&2
+# Validate DB_DIR (no slashes, no special characters that could be malicious)
+# Allow only alphanumeric, dots, hyphens, and underscores
+if [ -n "$DB_DIR" ] && ! echo "$DB_DIR" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+  echo "Error: DB_DIR contains invalid characters: $DB_DIR" >&2
+  echo "DB_DIR must contain only alphanumeric characters, dots, hyphens, and underscores" >&2
+  echo "Run '$0' without arguments to see usage" >&2
+  exit 1
+fi
+
+# Validate DB_TYPE: when DB_DIR is not set, only allow the standard databases
+if [ -z "$DB_DIR" ]; then
+  case "$DB_TYPE" in
+    sierra-leone|hmis)
+      # Valid
+      ;;
+    *)
+      echo "Error: DB_TYPE must be 'sierra-leone' or 'hmis' when DB_DIR is not set, got: $DB_TYPE" >&2
+      echo "Set DB_DIR to use a custom database type" >&2
+      echo "Run '$0' without arguments to see usage" >&2
+      exit 1
+      ;;
+  esac
+else
+  # When DB_DIR is set, DB_TYPE can be any valid identifier
+  if ! echo "$DB_TYPE" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+    echo "Error: DB_TYPE contains invalid characters: $DB_TYPE" >&2
+    echo "DB_TYPE must contain only alphanumeric characters, dots, hyphens, and underscores" >&2
     echo "Run '$0' without arguments to see usage" >&2
     exit 1
-    ;;
-esac
+  fi
+fi
 
 # Validate DB_VERSION (no slashes, no special characters that could be malicious)
 # Allow only alphanumeric, dots, hyphens, and underscores
@@ -126,6 +151,14 @@ if ! echo "$DB_VERSION" | grep -qE '^[a-zA-Z0-9._-]+$'; then
   echo "Run '$0' without arguments to see usage" >&2
   exit 1
 fi
+
+# Compute the Docker image tag for the postgres container, incorporating DB_DIR when set
+if [ -n "$DB_DIR" ]; then
+  DB_IMAGE_TAG="${DB_DIR}-${DB_TYPE}-${DB_VERSION}"
+else
+  DB_IMAGE_TAG="${DB_TYPE}-${DB_VERSION}"
+fi
+export DB_IMAGE_TAG
 
 parse_prof_args() {
   if [ -z "$PROF_ARGS" ]; then
@@ -631,6 +664,7 @@ generate_metadata() {
     echo "# Args"
     echo "DHIS2_IMAGE=$DHIS2_IMAGE"
     echo "SIMULATION_CLASS=$SIMULATION_CLASS"
+    echo "DB_DIR=$DB_DIR"
     echo "DB_TYPE=$DB_TYPE"
     echo "DB_VERSION=$DB_VERSION"
     echo "DHIS2_USERNAME=$DHIS2_USERNAME"

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -18,11 +18,11 @@ show_usage() {
   echo ""
   echo "OPTIONS:"
   echo "  DB_DIR                Optional top-level S3 directory (default: not set)"
-  echo "                        When set, DB_TYPE can be any valid identifier"
+  echo "                        Valid values: dev"
   echo "                        Pattern: s3://databases.dhis2.org/<dir>/<type>/<version>/dhis2-db-<type>.sql.gz"
   echo "  DB_TYPE               Database type (default: sierra-leone)"
   echo "                        Valid values without DB_DIR: sierra-leone, hmis"
-  echo "                        Any valid identifier when DB_DIR is set"
+  echo "                        Valid values with DB_DIR: platform-perf"
   echo "  DB_VERSION            Database version (default: dev)"
   echo "                        Must be alphanumeric, dots, hyphens, underscores only"
   echo "                        Pattern (no DB_DIR): s3://databases.dhis2.org/<type>/<version>/dhis2-db-<type>.sql.gz"
@@ -111,17 +111,16 @@ MVN_ARGS=${MVN_ARGS:-""}
 # Track last non-warmup run directory for output summary
 LAST_RUN_DIR=""
 
-# Validate DB_DIR (no slashes, no special characters that could be malicious)
-# Allow only alphanumeric, dots, hyphens, and underscores
-if [ -n "$DB_DIR" ] && ! echo "$DB_DIR" | grep -qE '^[a-zA-Z0-9._-]+$'; then
-  echo "Error: DB_DIR contains invalid characters: $DB_DIR" >&2
-  echo "DB_DIR must contain only alphanumeric characters, dots, hyphens, and underscores" >&2
+# Validate DB_DIR: currently only 'dev' is supported
+if [ -n "$DB_DIR" ] && [ "$DB_DIR" != "dev" ]; then
+  echo "Error: DB_DIR must be 'dev', got: $DB_DIR" >&2
   echo "Run '$0' without arguments to see usage" >&2
   exit 1
 fi
 
-# Validate DB_TYPE: when DB_DIR is not set, only allow the standard databases
+# Validate DB_TYPE
 if [ -z "$DB_DIR" ]; then
+  # No DB_DIR: only standard public databases are allowed
   case "$DB_TYPE" in
     sierra-leone|hmis)
       # Valid
@@ -134,10 +133,9 @@ if [ -z "$DB_DIR" ]; then
       ;;
   esac
 else
-  # When DB_DIR is set, DB_TYPE can be any valid identifier
-  if ! echo "$DB_TYPE" | grep -qE '^[a-zA-Z0-9._-]+$'; then
-    echo "Error: DB_TYPE contains invalid characters: $DB_TYPE" >&2
-    echo "DB_TYPE must contain only alphanumeric characters, dots, hyphens, and underscores" >&2
+  # DB_DIR is set: only 'platform-perf' is supported for now
+  if [ "$DB_TYPE" != "platform-perf" ]; then
+    echo "Error: DB_TYPE must be 'platform-perf' when DB_DIR is set, got: $DB_TYPE" >&2
     echo "Run '$0' without arguments to see usage" >&2
     exit 1
   fi

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -150,14 +150,6 @@ if ! echo "$DB_VERSION" | grep -qE '^[a-zA-Z0-9._-]+$'; then
   exit 1
 fi
 
-# Compute the Docker image tag for the postgres container, incorporating DB_DIR when set
-if [ -n "$DB_DIR" ]; then
-  DB_IMAGE_TAG="${DB_DIR}-${DB_TYPE}-${DB_VERSION}"
-else
-  DB_IMAGE_TAG="${DB_TYPE}-${DB_VERSION}"
-fi
-export DB_IMAGE_TAG
-
 parse_prof_args() {
   if [ -z "$PROF_ARGS" ]; then
     EVENT_FLAG=""


### PR DESCRIPTION
## Summary

Adds an optional arg`DB_DIR` to choose a platform performance DB for the performance test pipeline.

### DB selection
When `DB_DIR` not provided -> existing behaviour prevails.
Example, no DB args provided results in:
- `DB_DIR=`, `DB_TYPE=sierra-leone`, `DB_VERSION=dev`
- `s3://databases.dhis2.org/sierra-leone/dev/dhis2-db-sierra-leone.sql.gz`

When `DB_DIR` provided -> DB will be retrieved through chosen directory
Example, DB args provided `DB_DIR=dev`, `DB_TYPE=platform-perf`, `DB_VERSION=43` results in:
- `s3://databases.dhis2.org/dev/platform-perf/43/dhis2-db-platform-perf.sql.gz`

### Validation
- When `DB_DIR` not provided -> existing validation prevails
- When `DB_DIR` provided
  - `DB_DIR` can only be `dev`
  - `DB_TYPE` can only be `platform-perf`

Validation kept tight for now. Any future requirements can relax the validation if necessary

## Testing Summary

| #  | Scenario                                            | Expected                              | Result |
  | -- | --------------------------------------------------- | ------------------------------------- |  ------ |
  | 1  | No `DB_DIR`, invalid `DB_TYPE`                      | Rejected with guidance                |  PASS   |
  | 2  | `DB_DIR` set unlocks `platform-perf` `DB_TYPE`               | Passes validation, fails on Docker    |  PASS   |
  | 3  | `DB_DIR` not `dev                           | Rejected with guidance      |  PASS   |
  | 4  | `DB_TYPE` not `platform-perf`               | Rejected with guidance       |  PASS   |
  | 5  | Local run, no new params                            | Tests run, HTML report produced       |  PASS   |
  | 6  | Local run with new params + valid DB                | Tests run, HTML report produced       |  PASS   |
  | 7  | Local run with new params + invalid DB version      | S3 DB not found                       |  PASS   |
  | 8  | Existing Tracker test, no DB env vars               | Runs against default DB               |  PASS   |

  ---

## Testing Details
### Test 1 — Existing restriction still works (no `DB_DIR`, bad `DB_TYPE`)

  ```bash
  DHIS2_IMAGE=dummy SIMULATION_CLASS=dummy DB_TYPE=custom \
    ./run-simulation.sh 2>&1
  ```

  **Expected:** `Error: DB_TYPE must be 'sierra-leone' or 'hmis' when DB_DIR is not set...`

  **Actual:**
  ```
  Error: DB_TYPE must be 'sierra-leone' or 'hmis' when DB_DIR is not set, got: custom
  Set DB_DIR to use a custom database type
  Run './run-simulation.sh' without arguments to see usage
  ```

  **Result:** PASS

  ---

  ### Test 2 — `DB_DIR` unlocks `platform-perf` `DB_TYPE`

  ```bash
  DHIS2_IMAGE=dummy SIMULATION_CLASS=dummy DB_DIR=dev DB_TYPE=platform-perf \
    ./run-simulation.sh 2>&1
  ```

  **Expected:** Passes `DB_TYPE` validation, then fails on Docker (not validation).

  **Actual:**
  ```
  ========================================
  PHASE: Container Startup
  ========================================
  Testing with image: dummy
  Waiting for containers to be ready...
  [+] Running 2/2
   ! db Warning                                          2.6s
   x web Error                                           4.2s
  Error response from daemon: pull access denied for dummy, repository does not exist...
  Error: Failed to start containers
  ```

  **Result:** PASS

  ---

  ### Test 3 — Invalid `DB_DIR` characters (slash)

  ```bash
  DHIS2_IMAGE=dummy SIMULATION_CLASS=dummy DB_DIR=dev/bad DB_TYPE=platform-perf \
    ./run-simulation.sh 2>&1
  ```

  **Expected:** `DB_DIR must be 'dev'`

  **Actual:**
  ```
  Error: DB_DIR must be 'dev', got: dev/bad
  Run './run-simulation.sh' without arguments to see usage
  ```

  **Result:** PASS

  ---

  ### Test 4 — Invalid `DB_TYPE` characters (when `DB_DIR` is set)

  ```bash
  DHIS2_IMAGE=dummy SIMULATION_CLASS=dummy DB_DIR=dev DB_TYPE="bad type" \
    ./run-simulation.sh 2>&1
  ```

  **Expected:** `Error: DB_TYPE must be 'platform-perf'...`

  **Actual:**
  ```
  Error: DB_TYPE must be 'platform-perf' when DB_DIR is set, got: bad type
  Run './run-simulation.sh' without arguments to see usage
  ```

  **Result:** PASS

  ---

  ### Test 5 — Local test run without new params

  ```bash
  DHIS2_IMAGE=dhis2/core-dev:latest \
  SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest \
  WARMUP=1 MVN_ARGS=-Diterations=1 \
    ./run-simulation.sh
  ```

  **Expected:** Tests run with results.

  **Actual:** Tests run with default DB config and HTML report produced.

  **Result:** PASS

  ---

  ### Test 6 — Local test run with new params (valid DB)

  ```bash
  DHIS2_IMAGE=dhis2/core-dev:latest \
  SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest \
  WARMUP=2 MVN_ARGS=-Diterations=3 \
  DB_DIR=dev DB_TYPE=platform-perf DB_VERSION=43-2026-03-10 \
    ./run-simulation.sh
  ```

  **Expected:** Tests run with results.

  **Actual:** Tests run and HTML report produced. Env vars from `run-simulation.env`:
  ```
  DB_DIR=dev
  DB_TYPE=platform-perf
  DB_VERSION=43-2026-03-10
  ```

  S3 path resolved: `s3://databases.dhis2.org/dev/platform-perf/43/dhis2-db-platform-perf.sql.gz`

  **Result:** PASS

  ---

  ### Test 7 — Local test run with new params (invalid DB version)

  ```bash
  DHIS2_IMAGE=dhis2/core-dev:latest \
  SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest \
  WARMUP=2 MVN_ARGS=-Diterations=3 \
  DB_DIR=dev DB_TYPE=platform-perf DB_VERSION=43 \
    ./run-simulation.sh
  ```

  **Expected:** S3 DB not found.

  **Actual:**
  ```
  Downloading from: s3://databases.dhis2.org/dev/platform-perf/43/dhis2-db-platform-perf.sql.gz
  fatal error: An error occurred (404) when calling the HeadObject operation:
  Key "dev/platform-perf/43/dhis2-db-platform-perf.sql.gz" does not exist
  ```

  **Result:** PASS

  ---

  ### Test 8 — Existing Tracker test (no DB env vars supplied)

  ```bash
  DHIS2_IMAGE=dhis2/core-dev:latest \
  SIMULATION_CLASS=org.hisp.dhis.test.tracker.TrackerTest \
  WARMUP=2 MVN_ARGS=-Diterations=1 \
    ./run-simulation.sh
  ```

  **Expected:** Tests run against default DB with HTML results.

  **Actual:** Runs against default DB. Env vars from `run-simulation.env`:
  ```
  DB_DIR=
  DB_TYPE=sierra-leone
  DB_VERSION=dev
  ```

  **Result:** PASS