### PR TITLE
perf: reset database state between warmup and measured run

### DIFF
--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -576,12 +576,11 @@ prepare_database() {
   fi
 }
 
-reset_database_state() {
+prepare_database_for_measurement() {
   # Drains warmup-induced WAL and reclaims dead tuples so the measured run starts
-  # from a clean state. Without this the warmup leaves WAL ~half full and a
-  # wal-triggered checkpoint can fire mid-measurement, producing tail-latency spikes.
+  # from a clean state.
   echo ""
-  echo "Resetting database state (vacuum analyze + checkpoint)..."
+  echo "Preparing database for measurement (vacuum analyze + checkpoint)..."
   docker compose exec db psql --username=dhis --quiet --command='vacuum analyze;' --command='checkpoint;' > /dev/null
 }
 
@@ -816,7 +815,7 @@ if [ "$WARMUP" -gt 0 ]; then
     run_simulation "$i"
   done
   echo "Warmup complete."
-  reset_database_state
+  prepare_database_for_measurement
 fi
 
 echo ""

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -576,6 +576,15 @@ prepare_database() {
   fi
 }
 
+reset_database_state() {
+  # Drains warmup-induced WAL and reclaims dead tuples so the measured run starts
+  # from a clean state. Without this the warmup leaves WAL ~half full and a
+  # wal-triggered checkpoint can fire mid-measurement, producing tail-latency spikes.
+  echo ""
+  echo "Resetting database state (vacuum analyze + checkpoint)..."
+  docker compose exec db psql --username=dhis --quiet --command='vacuum analyze;' --command='checkpoint;' > /dev/null
+}
+
 start_profiler() {
   if [ -n "$PROF_ARGS" ]; then
     # shellcheck disable=SC2086
@@ -807,6 +816,7 @@ if [ "$WARMUP" -gt 0 ]; then
     run_simulation "$i"
   done
   echo "Warmup complete."
+  reset_database_state
 fi
 
 echo ""


### PR DESCRIPTION
**Title:** perf: reset database state between warmup and measured run                                                                                                                         
                                                                                                                                                                                                
  ## Summary                                                                                                                                                                                    
   
  Adds a `reset_database_state` step (`VACUUM ANALYZE; CHECKPOINT;`) between the warmup loop and the measured run in `run-simulation.sh`, so the measured run starts from a known-clean WAL/heap
   state.         
                                                                                                                                                                                                
  ## Why          

  The warmup loop generates a substantial amount of WAL and dead tuples. Without a reset, the measured run inherits a near-trigger WAL state, and a WAL-triggered `checkpoint starting` can fire
   partway into the measurement window. When that happens, a cluster of slow-query outliers appears on tracker insert/update statements, inflating ~p99 tail latency and adding variance between
   candidate and baseline runs.                                                                                                                                                                 
                  
  Forcing a checkpoint after warmup drains the WAL and resets the trigger distance, removing this source of tail-latency variance.

  Note: this only affects the ~p99 tail. The dominant body of request latency (DB-wait time from one-row-at-a-time JDBC round-trips and insert-then-update patterns on tracker tables) is       
  unchanged — that's a separate workstream.
                                                                                                                                                                                                
  ## Changes      

  - New `reset_database_state` function in `dhis-test-performance/run-simulation.sh` running `vacuum analyze; checkpoint;` against the `db` container.                                          
  - Invoked after the warmup loop completes, only when `WARMUP > 0`.
 
## Performance

### 4 combined runs on master

[25542406971](https://github.com/dhis2/dhis2-core/actions/runs/25542406971)
[25542408928](https://github.com/dhis2/dhis2-core/actions/runs/25542408928)
[25542410682](https://github.com/dhis2/dhis2-core/actions/runs/25542410682)
[25542412424](https://github.com/dhis2/dhis2-core/actions/runs/25542412424)
request_name | count | req/s | min | 50th | 75th | 95th | 99th | max |
|:---|---:|---:|---:|---:|---:|---:|---:|---:|
| Login | 48 | 0.34 | 102 | 118 | 129 | 178 | 182 | 183 |
| MNCH import | 240 | 1.69 | 803 | 1107 | 1231 | 1696 | 2215 | 2455 |
| Child Programme import | 240 | 1.69 | 358 | 513 | 562 | 836 | 935 | 1025 |
| ANC import | 240 | 1.69 | 281 | 392 | 652 | 1002 | 1549 | 1558 |

### 4 combined runs on current PR

[25543336449](https://github.com/dhis2/dhis2-core/actions/runs/25543336449)
[25543334858](https://github.com/dhis2/dhis2-core/actions/runs/25543334858)
[25543330266](https://github.com/dhis2/dhis2-core/actions/runs/25543330266)
[25543328236](https://github.com/dhis2/dhis2-core/actions/runs/25543328236)
| request_name | count | req/s | min | 50th | 75th | 95th | 99th | max |
|:---|---:|---:|---:|---:|---:|---:|---:|---:|
| Login | 48 | 0.37 | 97 | 114 | 125 | 152 | 160 | 161 |
| MNCH import | 240 | 1.84 | 790 | 1074 | 1265 | 1738 | 2044 | 2212 |
| Child Programme import | 240 | 1.84 | 415 | 469 | 490 | 520 | 536 | 545 |
| ANC import | 240 | 1.84 | 314 | 371 | 386 | 747 | 911 | 933 |

This fix addressed the random mid-run checkpoint spike. What remains is structural to the workload schedule, not a maintenance-task interference. The schedule has 3 sequential waves: MNCH (sec 0-16) → Child Programme (17-24) → ANC (25-32). MNCH and ANC both spike on the very first batch of their wave, every single time.

#### Most likely causes of the remaining spikes

  - MNCH first batch (sec 0): hits the DB right after the harness vacuum analyze; checkpoint. Checkpoint flushed dirty buffers; query plans may have been invalidated by analyze. Classic cold-cache / first-touch on the largest payload.
  - ANC first batch (sec 26): ANC touches different programs/tables than MNCH and Child Programme — first time those tables/indexes are read into shared buffers in the measured run.