### PR TITLE
test: qualify Docker image with version so that client version and server version match (#23838) [2.40]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
@@ -123,7 +123,7 @@ class RouteControllerTest extends DhisControllerIntegrationTest {
   @BeforeAll
   public static void beforeAll() {
     upstreamMockServerContainer =
-        new GenericContainer<>("mockserver/mockserver")
+        new GenericContainer<>("mockserver/mockserver:5.15.0")
             .waitingFor(new HttpWaitStrategy().forStatusCode(404))
             .withExposedPorts(1080);
     upstreamMockServerContainer.start();


### PR DESCRIPTION
Backport of #23838 to 2.40.

Pins the `mockserver/mockserver` Testcontainers image to `5.15.0` so the client and server versions match. Without the tag, Testcontainers pulled `:latest`, which caused a client/server version mismatch and broke CI.

Note: 2.40 only has the upstream mock server in `RouteControllerTest` (1 occurrence) — `EventHookControllerTest` does not exist on this branch, and the token mock server in `RouteControllerTest` was added in a later refactor.

AI Assisted.