### PR TITLE
fix: PI disag date between functions [DHIS2-21440] (#23828)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -38,7 +38,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.hisp.dhis.analytics.AggregationType.CUSTOM;
 import static org.hisp.dhis.analytics.AggregationType.NONE;
 import static org.hisp.dhis.analytics.AnalyticsConstants.DATE_PERIOD_STRUCT_ALIAS;
@@ -77,6 +76,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -141,6 +141,8 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   private static final Collector<CharSequence, ?, String> OR_JOINER = joining(OR, "(", ")");
 
   private static final Collector<CharSequence, ?, String> AND_JOINER = joining(AND);
+
+  private static final Pattern TRAILING_ALIAS_PATTERN = Pattern.compile("\\s+as\\s+\"?(\\w+)\"?+$");
 
   @Qualifier("analyticsReadOnlyJdbcTemplate")
   protected final JdbcTemplate jdbcTemplate;
@@ -295,7 +297,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    * @return the columns without aliases.
    */
   List<String> removeAliases(List<String> columns) {
-    return columns.stream().map(c -> substringBefore(c, " as ")).toList();
+    return columns.stream().map(c -> TRAILING_ALIAS_PATTERN.matcher(c).replaceAll("")).toList();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -910,7 +910,14 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void testRemoveAliases() {
     // Given
-    List<String> columnsWithAliases = List.of("columnA as cA", "columnB", "columnC as cC", "");
+    List<String> columnsWithAliases =
+        List.of(
+            "columnA as cA",
+            "columnB",
+            "columnC as cC",
+            "cast(columnD as date)",
+            "cast(columnE as date) as cE",
+            "");
 
     // When
     List<String> columnsWithNoAliases = eventSubject.removeAliases(columnsWithAliases);
@@ -920,6 +927,8 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
     assertTrue(columnsWithNoAliases.contains("columnA"));
     assertTrue(columnsWithNoAliases.contains("columnB"));
     assertTrue(columnsWithNoAliases.contains("columnC"));
+    assertTrue(columnsWithNoAliases.contains("cast(columnD as date)"));
+    assertTrue(columnsWithNoAliases.contains("cast(columnE as date)"));
     assertTrue(columnsWithNoAliases.contains(""));
   }
 


### PR DESCRIPTION
* fix: PI disag date between functions [DHIS2-21440]

* fix: spotless [DHIS2-21440]

* fix: SonarQube [DHIS2-21440]

(cherry picked from commit 4f3d068b28093ec06a7550c060e8630113d7103d)

[DHIS2-21440]: https://dhis2.atlassian.net/browse/DHIS2-21440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21440]: https://dhis2.atlassian.net/browse/DHIS2-21440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21440]: https://dhis2.atlassian.net/browse/DHIS2-21440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ