### PR TITLE
fix: Fix continuous event analytics export (2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -194,10 +194,10 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
 
     List<Program> programs =
         params.isSkipPrograms()
-            ? idObjectManager.getAllNoAcl(Program.class)
-            : idObjectManager.getAllNoAcl(Program.class).stream()
+            ? idObjectManager.getAllNoAcl(Program.class).stream()
                 .filter(p -> !params.getSkipPrograms().contains(p.getUid()))
-                .collect(toList());
+                .collect(toList())
+            : idObjectManager.getAllNoAcl(Program.class);
 
     Integer firstDataYear = availableDataYears.get(0);
     Integer latestDataYear = availableDataYears.get(availableDataYears.size() - 1);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -31,8 +31,10 @@ import static java.time.LocalDate.now;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hisp.dhis.DhisConvenienceTest.createCategory;
 import static org.hisp.dhis.DhisConvenienceTest.createCategoryCombo;
@@ -1111,6 +1113,42 @@ class JdbcEventAnalyticsTableManagerTest {
 
     assertThat(sql.getValue(), containsString(String.format(ouQuery, "uid")));
     assertThat(sql.getValue(), containsString(String.format(ouQuery, "name")));
+  }
+
+  @Test
+  @DisplayName("getRegularAnalyticsTables excludes programs listed in skipPrograms")
+  void getRegularAnalyticsTablesExcludesSkippedPrograms() {
+    Program prA = createProgram('A');
+    Program prB = createProgram('B');
+    Program prC = createProgram('C');
+    Program prD = createProgram('D');
+
+    Set<String> skipPrograms = new HashSet<>();
+    skipPrograms.add(prC.getUid());
+    skipPrograms.add(prD.getUid());
+
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder()
+            .withLastYears(2)
+            .withStartTime(START_TIME)
+            .withToday(today)
+            .withSkipPrograms(skipPrograms)
+            .build();
+
+    when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(prA, prB, prC, prD));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
+    when(jdbcTemplate.queryForList(Mockito.anyString(), Mockito.eq(Integer.class)))
+        .thenReturn(List.of(2018, 2019));
+
+    List<AnalyticsTable> tables = subject.getAnalyticsTables(params);
+
+    assertThat(tables, hasSize(2));
+
+    List<String> programUids =
+        tables.stream().map(t -> t.getProgram().getUid()).collect(Collectors.toList());
+    assertThat(programUids, not(hasItem(prC.getUid())));
+    assertThat(programUids, not(hasItem(prD.getUid())));
   }
 
   private String toAlias(String template, String uid) {


### PR DESCRIPTION
**Fix:** Fix skipPrograms filter inversion in continuous event analytics export                                                           
                                                                                                                                        
Fixes a bug in getRegularAnalyticsTables where the skipPrograms ternary was inverted: when a skip-program list was provided, all programs were returned unfiltered; when no skip list was set, it attempted to filter against an empty set.                            
   
**Note: scope differs from the equivalent fix in 2.41+**                                                                                  
                                                            
The 2.41/2.42/2.43/master fix addressed two bugs:                                                                                     
1. The skipPrograms ternary inversion (this PR)           
2. removeUpdatedData deleting from the staging table instead of the live table                                                        
                                                                                
Bug 2 does not exist in 2.40. The 2.40 AnalyticsTable model has separate getTableName() (live) and getTempTableName() (staging) methods, and removeUpdatedData correctly used getTableName(). The staging/live name conflation was introduced when the table model was refactored in 2.41 and the bug has existed there ever since.                                                                                                                  
                                                                                                                                        
**Testing:** Added a unit test confirming that programs listed in skipPrograms are excluded from the regular analytics table build.  