### PR TITLE
fix: mapView should not be exported at root level

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -121,7 +121,6 @@ import org.hisp.dhis.schema.descriptors.LegendDefinitionsSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.LegendSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.LegendSetSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MapSchemaDescriptor;
-import org.hisp.dhis.schema.descriptors.MapViewSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MessageConversationSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MetadataVersionSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MinMaxDataElementSchemaDescriptor;
@@ -252,7 +251,6 @@ public class DefaultSchemaService implements SchemaService {
     register(new LegendSetSchemaDescriptor());
     register(new ExternalMapLayerSchemaDescriptor());
     register(new MapSchemaDescriptor());
-    register(new MapViewSchemaDescriptor());
     register(new MessageConversationSchemaDescriptor());
     register(new MetadataVersionSchemaDescriptor());
     register(new OptionSchemaDescriptor());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -30,19 +30,31 @@
 package org.hisp.dhis.metadata.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
+import org.hisp.dhis.dxf2.metadata.MetadataImportService;
+import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramSection;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.render.RenderFormat;
+import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +69,14 @@ import org.springframework.transaction.annotation.Transactional;
 class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
 
   @Autowired private MetadataExportService metadataExportService;
+
+  @Autowired private MetadataImportService metadataImportService;
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private RenderService renderService;
+
+  @Autowired private ObjectMapper jsonMapper;
 
   @Test
   void testExportProgramWithProgramSection() {
@@ -120,5 +140,29 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
     programStage.getProgramStageDataElements().add(programStageDataElement);
     entityManager.merge(programStage);
     return program;
+  }
+
+  @Test
+  @DisplayName("MapView should not be exported at root level when exporting Map with dependencies")
+  void exportMetadataShouldNotContainMapView() throws IOException {
+    MapView mapView = createMapView("A");
+    org.hisp.dhis.mapping.Map map = new org.hisp.dhis.mapping.Map();
+    map.setName("MapA");
+    map.setMapViews(List.of(mapView));
+    map.setAutoFields();
+    manager.save(map);
+
+    MetadataExportParams exportParams = new MetadataExportParams();
+    exportParams.addClass(org.hisp.dhis.mapping.Map.class);
+    exportParams.addClass(MapView.class);
+    ObjectNode exported = metadataExportService.getMetadataAsObjectNode(exportParams);
+
+    Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
+        renderService.fromMetadata(
+            new ByteArrayInputStream(jsonMapper.writeValueAsBytes(exported)), RenderFormat.JSON);
+    assertNull(metadata.get(org.hisp.dhis.mapping.MapView.class));
+    org.hisp.dhis.mapping.Map exportMap =
+        (org.hisp.dhis.mapping.Map) metadata.get(org.hisp.dhis.mapping.Map.class).get(0);
+    assertNotNull(exportMap.getMapViews());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -443,23 +443,29 @@ class ProgramControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testDeleteWithMapView() {
-    String mapViewJson =
+
+    String mapJson =
         """
         {
-          "name": "test mapview",
-          "id": "mVIVRd23Jm9",
-          "organisationUnitLevels": [],
-          "maps": [],
-          "layer": "event",
-          "program": {
-            "id": "PrZMWi7rBga"
-          },
-          "programStage": {
-            "id": "PSzMWi7rBga"
-          }
+          "name": "test map",
+          "id": "mAPVRd23Jm9",
+          "mapViews": [
+            {
+              "name": "test mapview",
+              "id": "mVIVRd23Jm9",
+              "organisationUnitLevels": [],
+              "layer": "event",
+              "program": {
+                "id": "PrZMWi7rBga"
+              },
+              "programStage": {
+                "id": "PSzMWi7rBga"
+              }
+            }
+          ]
         }
         """;
-    POST("/mapViews", mapViewJson).content(HttpStatus.CREATED);
+    POST("/maps", mapJson).content(HttpStatus.CREATED);
 
     assertStatus(HttpStatus.OK, DELETE("/programs/%s".formatted(PROGRAM_UID)));
     assertStatus(HttpStatus.NOT_FOUND, GET("/programs/%s".formatted(PROGRAM_UID)));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.mapping.MappingService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.query.GetObjectListParams;
-import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.AbstractFullReadOnlyController;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -59,7 +59,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @RequestMapping("/api/mapViews")
 @OpenApi.Document(classifiers = {"team:analytics", "purpose:metadata"})
-public class MapViewController extends AbstractCrudController<MapView, GetObjectListParams> {
+public class MapViewController
+    extends AbstractFullReadOnlyController<MapView, GetObjectListParams> {
   @Autowired private MappingService mappingService;
 
   @Autowired private OrganisationUnitService organisationUnitService;


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-20266

### Issue
- User reported that when export metadata with `Map` and `MapView`, then import again, server throw duplicate exception because `MapView` included at root level and also inside `Map` object.

### Fix
- The issue happens because `MapView` is both `embedded object` and `identifiable object`. 
- This PR fix the issue by remove the `MapViewSchemaDiscriptor`, this will exclude `MapView` from the root level of the metadata export. 
- This PR also remove the `AbstractCrudController` from `MapViewController` so this object can only be imported as a collection of `Map` object through `MapController`.

### Test
- Added test and existing test in `MapControllerTest` also passed.