### PR TITLE
fix: update datastore-app to point to master for CD (v42)

### DIFF
--- a/dhis-2/dhis-web-server/apps-to-bundle.json
+++ b/dhis-2/dhis-web-server/apps-to-bundle.json
@@ -8,7 +8,7 @@
   "https://github.com/d2-ci/data-administration-app#master",
   "https://github.com/d2-ci/data-visualizer-app#master",
   "https://github.com/d2-ci/data-quality-app#v42",
-  "https://github.com/d2-ci/datastore-app#v42",
+  "https://github.com/d2-ci/datastore-app#master",
   "https://github.com/d2-ci/event-reports-app#v42",
   "https://github.com/d2-ci/event-charts-app#v42",
   "https://github.com/d2-ci/import-export-app#master",


### PR DESCRIPTION
App is on CD now: https://dhis2.atlassian.net/browse/DHIS2-19318