### PR TITLE
fix: aggregate enrollment stage CTE projection

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -282,6 +282,8 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   static final String ANALYTICS_EVENT = "analytics_event_";
 
+  public static final String LATEST_EVENTS_CTE_PREFIX = "latest_events_";
+
   static final String COLUMN_ENROLLMENT_GEOMETRY_GEOJSON =
       String.format(
           "ST_AsGeoJSON(%s)", EnrollmentAnalyticsColumnName.ENROLLMENT_GEOMETRY_COLUMN_NAME);
@@ -2560,16 +2562,16 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   void generateFilterCTEs(
       EventQueryParams params, CteContext cteContext, boolean isAggregateQuery) {
 
+    if (isAggregateQuery) {
+      generateAggregateFilterCTEs(params, cteContext);
+      return;
+    }
+
     // Combine items and item filters and filter only those with an actual filter
     List<QueryItem> queryItems =
         Stream.concat(params.getItems().stream(), params.getItemFilters().stream())
             .filter(QueryItem::hasFilter)
             .toList();
-
-    if (isAggregateQuery) {
-      generateAggregateFilterCTEs(queryItems, params, cteContext);
-      return;
-    }
 
     // Group query items by repeatable and non-repeatable stages
     Map<RepeatableStateStatus, List<QueryItem>> itemsByRepeatableFlag =
@@ -2607,27 +2609,31 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   }
 
   /**
-   * Generates filter CTEs for aggregate enrollment queries. Items are grouped by program stage UID,
-   * producing one CTE per stage with all dimension columns and filter conditions combined.
+   * Generates filter CTEs for aggregate enrollment queries. Stage items (both dimensions and item
+   * filters) are grouped by program stage UID, producing one CTE per stage that projects eligible
+   * stage dimensions and applies the combined filter conditions.
    *
-   * @param queryItems filtered query items that have at least one filter
+   * <p>A {@code latest_events_<stage>} CTE is emitted only when at least one item for the stage
+   * carries a filter. Unfiltered stage items are still projected by the CTE when they can be read
+   * from the same "latest event" row without losing repeatable-stage offset semantics.
+   *
    * @param params the {@link EventQueryParams} object
    * @param cteContext the {@link CteContext} to register CTEs into
    */
-  private void generateAggregateFilterCTEs(
-      List<QueryItem> queryItems, EventQueryParams params, CteContext cteContext) {
-
-    // Collect all items that have a program stage and group by stage UID
+  private void generateAggregateFilterCTEs(EventQueryParams params, CteContext cteContext) {
     Map<String, List<QueryItem>> itemsByStage =
-        queryItems.stream()
+        Stream.concat(params.getItems().stream(), params.getItemFilters().stream())
             .filter(qi -> qi.hasProgram() && qi.hasProgramStage())
+            .filter(qi -> qi.hasFilter() || canProjectUnfilteredItemInAggregateFilterCte(qi))
             .collect(groupingBy(qi -> qi.getProgramStage().getUid(), LinkedHashMap::new, toList()));
 
-    // For each stage, build a single CTE with all dimension columns and filters
     itemsByStage.forEach(
         (stageUid, stageItems) -> {
+          if (stageItems.stream().noneMatch(QueryItem::hasFilter)) {
+            return;
+          }
           String cteSql = buildAggregateFilterCteSql(stageItems, params);
-          String cteKey = "latest_events_" + stageUid;
+          String cteKey = LATEST_EVENTS_CTE_PREFIX + stageUid;
           cteContext.addCteFilter(cteKey, stageItems.get(0), cteSql);
         });
   }
@@ -2791,6 +2797,14 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       if (item.hasFilter()) {
         return;
       }
+      // The per-stage filter CTE projects non-offset dimensions for that stage,
+      // so a redundant per-item CTE would only inflate the query without adding data.
+      if (canProjectUnfilteredItemInAggregateFilterCte(item)
+          && cteContext.getDefinitionByItemUid(
+                  LATEST_EVENTS_CTE_PREFIX + item.getProgramStage().getUid())
+              != null) {
+        return;
+      }
       handleAggregatedEnrollments(cteContext, item, eventTableName, colName, params);
       return;
     }
@@ -2838,6 +2852,10 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   protected boolean columnIsInFormula(String col) {
     return col.contains("(") && col.contains(")");
+  }
+
+  private boolean canProjectUnfilteredItemInAggregateFilterCte(QueryItem item) {
+    return !item.hasRepeatableStageParams() || item.getRepeatableStageParams().isDefaultObject();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolver.java
@@ -29,6 +29,9 @@
  */
 package org.hisp.dhis.analytics.event.data.aggregate;
 
+import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManager.LATEST_EVENTS_CTE_PREFIX;
+import static org.hisp.dhis.analytics.util.RepeatableStageParamsHelper.removeRepeatableStageParams;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -44,7 +47,6 @@ import org.hisp.dhis.analytics.util.sql.SqlColumnParser;
  * stage-specific dimensions via per-stage filter CTEs.
  */
 public final class AggregatedEnrollmentHeaderColumnResolver {
-  private static final String LATEST_EVENTS_CTE_PREFIX = "latest_events_";
 
   private final StageHeaderClassifier stageHeaderClassifier;
 
@@ -91,8 +93,8 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
 
       Map.Entry<String, CteDefinition> matchingEntry = findMatchingCte(cteDefinitionMap, colName);
       if (matchingEntry != null) {
-        sb.addColumn(matchingEntry.getValue().getAlias() + ".value", "", matchingEntry.getKey());
-        sb.groupBy(matchingEntry.getKey());
+        sb.addColumn(matchingEntry.getValue().getAlias() + ".value", "", quotedCol);
+        sb.groupBy(quotedCol);
       } else {
         sb.addColumn(quotedCol);
         sb.groupBy(quotedCol);
@@ -155,8 +157,12 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
 
   private Map.Entry<String, CteDefinition> findMatchingCte(
       Map<String, CteDefinition> cteDefinitionMap, String colName) {
+    String normalizedColName =
+        removeRepeatableStageParams(colName.replace("\"", "").replace("`", ""));
     for (Map.Entry<String, CteDefinition> entry : cteDefinitionMap.entrySet()) {
-      if (entry.getKey().contains(colName)) {
+      String normalizedKey =
+          removeRepeatableStageParams(entry.getKey().replace("\"", "").replace("`", ""));
+      if (normalizedKey.contains(normalizedColName)) {
         return entry;
       }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -30,10 +30,12 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
+import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.EVENT_STATUS_COLUMN_NAME;
 import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME;
 import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.OU_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionConstants.OPTION_SEP;
@@ -78,6 +80,7 @@ import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -90,6 +93,7 @@ import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -409,6 +413,134 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     assertThat(generatedSql, containsString("\"n1rtSHYf6O6\" in ('ImspTQPwCqd')"));
     assertThat(baseCteSql, containsString("inner join latest_events_" + programStage.getUid()));
     assertThat(baseCteSql, not(containsString("and \"n1rtSHYf6O6\" in ('ImspTQPwCqd')")));
+  }
+
+  @Test
+  void verifyAggregateEnrollmentUnfilteredEventStatusUsesLatestEventsCte() {
+    // When a stage-specific dimension without a filter (e.g. stage.EVENT_STATUS) is requested
+    // alongside a filtered stage dimension (stage.EVENT_DATE), the unfiltered dimension must
+    // also be projected by the latest_events_<stage> CTE so the outer SELECT can read it from
+    // the same "latest event" row. Without this, the resolver emits a reference to
+    // uiogg.ev_eventstatus while the CTE doesn't project the column, producing a SQL error.
+    String stageUid = programStage.getUid();
+
+    QueryItem dateItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(OCCURRED_DATE_COLUMN_NAME),
+            programA,
+            null,
+            ValueType.DATE,
+            null,
+            null);
+    dateItem.setProgram(programA);
+    dateItem.setProgramStage(programStage);
+    dateItem.addFilter(new QueryFilter(QueryOperator.GE, "2026-01-01"));
+    dateItem.addFilter(new QueryFilter(QueryOperator.LE, "2026-12-31"));
+
+    QueryItem statusItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(EVENT_STATUS_COLUMN_NAME),
+            programA,
+            null,
+            ValueType.TEXT,
+            null,
+            null);
+    statusItem.setProgram(programA);
+    statusItem.setProgramStage(programStage);
+
+    EventQueryParams.Builder params = createRequestParamsBuilder();
+    params.addItem(dateItem);
+    params.addItem(statusItem);
+    params.withEndpointAction(AGGREGATE);
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(new GridHeader("value", "Value", ValueType.NUMBER, false, false));
+    grid.addHeader(
+        new GridHeader(stageUid + ".eventdate", "Event date", ValueType.DATE, false, false));
+    grid.addHeader(
+        new GridHeader(stageUid + ".eventstatus", "Event status", ValueType.TEXT, false, false));
+
+    subject.getEnrollments(params.build(), grid, 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String latestEventsCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("latest_events_" + stageUid + " as ("),
+            generatedSql.indexOf("enrollment_aggr_base as ("));
+
+    // The latest_events CTE must project both the filtered (eventdate) and unfiltered
+    // (eventstatus) stage dimensions so the outer SELECT can read them from the same row.
+    assertThat(latestEventsCteSql, containsString("ev_occurreddate"));
+    assertThat(latestEventsCteSql, containsString("ev_eventstatus"));
+
+    // The redundant per-item CTE must not be created when a latest_events_<stage> already exists.
+    assertThat(generatedSql, not(containsString(stageUid + "_" + EVENT_STATUS_COLUMN_NAME + "_0")));
+  }
+
+  @Test
+  void verifyAggregateEnrollmentRepeatableOffsetItemKeepsPerItemCteWhenLatestEventsCteExists() {
+    String stageUid = repeatableProgramStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    QueryItem dateItem = createFilteredStageDateItem(repeatableProgramStage);
+    QueryItem offsetItem = createRepeatableOffsetDataElementItem(stageUid, -1);
+
+    EventQueryParams.Builder params = createRequestParamsBuilder();
+    params.addItem(dateItem);
+    params.addItem(offsetItem);
+    params.withEndpointAction(AGGREGATE);
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(new GridHeader("value", "Value", ValueType.NUMBER, false, false));
+    grid.addHeader(
+        new GridHeader(stageUid + ".eventdate", "Event date", ValueType.DATE, false, false));
+    grid.addHeader(
+        new GridHeader(stageUid + "[-1]." + deUid, "Offset value", ValueType.NUMBER, false, false));
+
+    subject.getEnrollments(params.build(), grid, 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String latestEventsCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("latest_events_" + stageUid + " as ("),
+            generatedSql.indexOf("enrollment_aggr_base as ("));
+
+    assertThat(latestEventsCteSql, containsString("ev_occurreddate"));
+    assertThat(latestEventsCteSql, not(containsString("ev_" + deUid)));
+    assertThat(generatedSql, containsString(stageUid + "_" + deUid + "_0 as ("));
+    assertThat(generatedSql, containsString("as \"" + stageUid + "[-1]." + deUid + "\""));
+  }
+
+  @Test
+  void verifyAggregateEnrollmentRepeatableOffsetsAreNotDuplicatedInLatestEventsCte() {
+    String stageUid = repeatableProgramStage.getUid();
+    String deUid = dataElementA.getUid();
+
+    EventQueryParams.Builder params = createRequestParamsBuilder();
+    params.addItem(createFilteredStageDateItem(repeatableProgramStage));
+    params.addItem(createRepeatableOffsetDataElementItem(stageUid, -1));
+    params.addItem(createRepeatableOffsetDataElementItem(stageUid, 1));
+    params.withEndpointAction(AGGREGATE);
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(new GridHeader("value", "Value", ValueType.NUMBER, false, false));
+    grid.addHeader(
+        new GridHeader(stageUid + ".eventdate", "Event date", ValueType.DATE, false, false));
+
+    subject.getEnrollments(params.build(), grid, 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String latestEventsCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("latest_events_" + stageUid + " as ("),
+            generatedSql.indexOf("enrollment_aggr_base as ("));
+
+    assertThat(countOccurrences(latestEventsCteSql, "ev_" + deUid), is(0));
+    assertThat(generatedSql, containsString(stageUid + "_" + deUid + "_0 as ("));
+    assertThat(generatedSql, containsString(stageUid + "_" + deUid + "_1 as ("));
   }
 
   @Test
@@ -1106,6 +1238,32 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     return params.build();
   }
 
+  private QueryItem createFilteredStageDateItem(ProgramStage stage) {
+    QueryItem dateItem =
+        new QueryItem(
+            new BaseDimensionalItemObject(OCCURRED_DATE_COLUMN_NAME),
+            programA,
+            null,
+            ValueType.DATE,
+            null,
+            null);
+    dateItem.setProgram(programA);
+    dateItem.setProgramStage(stage);
+    dateItem.addFilter(new QueryFilter(QueryOperator.GE, "2026-01-01"));
+    dateItem.addFilter(new QueryFilter(QueryOperator.LE, "2026-12-31"));
+    return dateItem;
+  }
+
+  private QueryItem createRepeatableOffsetDataElementItem(String stageUid, int offset) {
+    QueryItem item = new QueryItem(new BaseDimensionalItemObject(dataElementA.getUid()));
+    item.setProgram(programA);
+    item.setProgramStage(repeatableProgramStage);
+    item.setValueType(ValueType.NUMBER);
+    item.setRepeatableStageParams(
+        RepeatableStageParams.of(offset, stageUid + "[" + offset + "]." + dataElementA.getUid()));
+    return item;
+  }
+
   private EventQueryParams createAggregateEnrollmentWithEventDateParams() {
     BaseDimensionalItemObject dateItem = new BaseDimensionalItemObject(OCCURRED_DATE_COLUMN_NAME);
     QueryItem queryItem = new QueryItem(dateItem, programA, null, ValueType.DATE, null, null);
@@ -1199,5 +1357,15 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
 
   private String noEof(String sql) {
     return sql.replaceAll("\\s+", " ").trim();
+  }
+
+  private int countOccurrences(String value, String search) {
+    int count = 0;
+    int index = 0;
+    while ((index = value.indexOf(search, index)) >= 0) {
+      count++;
+      index += search.length();
+    }
+    return count;
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
@@ -741,6 +741,79 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
   }
 
   @Test
+  public void stageAndUnfilteredEventStatus() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=100")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("dimension=A03MvHHogjR.EVENT_STATUS,A03MvHHogjR.EVENT_DATE:202205,A03MvHHogjR.wQLfBvPrXqq,A03MvHHogjR.ou:USER_ORGUNIT")
+            ;
+
+    // When
+    ApiResponse response = actions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 62, 5, 5); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ww8JVblo4SI\":{\"uid\":\"ww8JVblo4SI\",\"code\":\"Others\",\"name\":\"Others\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"Cd0gtHGmlwS\":{\"uid\":\"Cd0gtHGmlwS\",\"code\":\"NVP only\",\"name\":\"NVP only\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"A03MvHHogjR.eventstatus\":{\"name\":\"Event status\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ou\":{\"name\":\"Organisation unit\"},\"A03MvHHogjR.wQLfBvPrXqq\":{\"uid\":\"wQLfBvPrXqq\",\"code\":\"DE_2008294\",\"name\":\"MCH ARV at birth\",\"description\":\"Onlu used for birth details.\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"202205\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[\"202205\"],\"A03MvHHogjR.eventstatus\":[],\"A03MvHHogjR.wQLfBvPrXqq\":[\"Cd0gtHGmlwS\",\"ww8JVblo4SI\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.eventstatus", "Event status", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.ou", "Organisation unit", "ORGANISATION_UNIT", "org.hisp.dhis.organisationunit.OrganisationUnit", false, true);
+    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.wQLfBvPrXqq", "MCH ARV at birth", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("value", "11", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-01 00:00:00.0"));
+
+    // Validate row exists with values from original row index 8
+    validateRowExists(response, actualHeaders, Map.of("value", "13", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-09 00:00:00.0"));
+
+    // Validate row exists with values from original row index 16
+    validateRowExists(response, actualHeaders, Map.of("value", "6", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-17 00:00:00.0"));
+
+    // Validate row exists with values from original row index 24
+    validateRowExists(response, actualHeaders, Map.of("value", "14", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-25 00:00:00.0"));
+
+    // Validate row exists with values from original row index 32
+    validateRowExists(response, actualHeaders, Map.of("value", "6", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-02 00:00:00.0"));
+
+    // Validate row exists with values from original row index 40
+    validateRowExists(response, actualHeaders, Map.of("value", "8", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-10 00:00:00.0"));
+
+    // Validate row exists with values from original row index 48
+    validateRowExists(response, actualHeaders, Map.of("value", "5", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-18 00:00:00.0"));
+
+    // Validate row exists with values from original row index 56
+    validateRowExists(response, actualHeaders, Map.of("value", "11", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-26 00:00:00.0"));
+
+    // Validate row exists with values from original row index 61
+    validateRowExists(response, actualHeaders, Map.of("value", "14", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-31 00:00:00.0"));
+  }
+
+  @Test
   public void stageAndMultipleStages() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
@@ -746,71 +746,229 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     boolean expectPostgis = isPostgres();
 
     // Given
-    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
             .add("displayProperty=NAME")
             .add("totalPages=false")
             .add("pageSize=100")
             .add("outputType=ENROLLMENT")
             .add("page=1")
-            .add("dimension=A03MvHHogjR.EVENT_STATUS,A03MvHHogjR.EVENT_DATE:202205,A03MvHHogjR.wQLfBvPrXqq,A03MvHHogjR.ou:USER_ORGUNIT")
-            ;
+            .add(
+                "dimension=A03MvHHogjR.EVENT_STATUS,A03MvHHogjR.EVENT_DATE:202205,A03MvHHogjR.wQLfBvPrXqq,A03MvHHogjR.ou:USER_ORGUNIT");
 
     // When
     ApiResponse response = actions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 62, 5, 5); // Pass runtime flag, row count, and expected header counts
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        62,
+        5,
+        5); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
             .map(obj -> (Map<String, Object>) obj) // Ensure correct type
             .collect(Collectors.toList());
 
-
     // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ww8JVblo4SI\":{\"uid\":\"ww8JVblo4SI\",\"code\":\"Others\",\"name\":\"Others\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"Cd0gtHGmlwS\":{\"uid\":\"Cd0gtHGmlwS\",\"code\":\"NVP only\",\"name\":\"NVP only\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"A03MvHHogjR.eventstatus\":{\"name\":\"Event status\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ou\":{\"name\":\"Organisation unit\"},\"A03MvHHogjR.wQLfBvPrXqq\":{\"uid\":\"wQLfBvPrXqq\",\"code\":\"DE_2008294\",\"name\":\"MCH ARV at birth\",\"description\":\"Onlu used for birth details.\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"202205\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[\"202205\"],\"A03MvHHogjR.eventstatus\":[],\"A03MvHHogjR.wQLfBvPrXqq\":[\"Cd0gtHGmlwS\",\"ww8JVblo4SI\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ww8JVblo4SI\":{\"uid\":\"ww8JVblo4SI\",\"code\":\"Others\",\"name\":\"Others\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"Cd0gtHGmlwS\":{\"uid\":\"Cd0gtHGmlwS\",\"code\":\"NVP only\",\"name\":\"NVP only\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"A03MvHHogjR.eventstatus\":{\"name\":\"Event status\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ou\":{\"name\":\"Organisation unit\"},\"A03MvHHogjR.wQLfBvPrXqq\":{\"uid\":\"wQLfBvPrXqq\",\"code\":\"DE_2008294\",\"name\":\"MCH ARV at birth\",\"description\":\"Onlu used for birth details.\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"202205\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[\"202205\"],\"A03MvHHogjR.eventstatus\":[],\"A03MvHHogjR.wQLfBvPrXqq\":[\"Cd0gtHGmlwS\",\"ww8JVblo4SI\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.eventstatus", "Event status", "TEXT", "java.lang.String", false, true);
-    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.ou", "Organisation unit", "ORGANISATION_UNIT", "org.hisp.dhis.organisationunit.OrganisationUnit", false, true);
-    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.wQLfBvPrXqq", "MCH ARV at birth", "TEXT", "java.lang.String", false, true);
-    validateHeaderPropertiesByName(response, actualHeaders,"A03MvHHogjR.eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
-
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventstatus",
+        "Event status",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "A03MvHHogjR.ou",
+        "Organisation unit",
+        "ORGANISATION_UNIT",
+        "org.hisp.dhis.organisationunit.OrganisationUnit",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "A03MvHHogjR.wQLfBvPrXqq",
+        "MCH ARV at birth",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "A03MvHHogjR.eventdate",
+        "Report date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
-    validateRowExists(response, actualHeaders, Map.of("value", "11", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-01 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "11",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "NVP only",
+            "A03MvHHogjR.eventdate",
+            "2022-05-01 00:00:00.0"));
 
     // Validate row exists with values from original row index 8
-    validateRowExists(response, actualHeaders, Map.of("value", "13", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-09 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "13",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "NVP only",
+            "A03MvHHogjR.eventdate",
+            "2022-05-09 00:00:00.0"));
 
     // Validate row exists with values from original row index 16
-    validateRowExists(response, actualHeaders, Map.of("value", "6", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-17 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "6",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "NVP only",
+            "A03MvHHogjR.eventdate",
+            "2022-05-17 00:00:00.0"));
 
     // Validate row exists with values from original row index 24
-    validateRowExists(response, actualHeaders, Map.of("value", "14", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "NVP only", "A03MvHHogjR.eventdate", "2022-05-25 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "14",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "NVP only",
+            "A03MvHHogjR.eventdate",
+            "2022-05-25 00:00:00.0"));
 
     // Validate row exists with values from original row index 32
-    validateRowExists(response, actualHeaders, Map.of("value", "6", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-02 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "6",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "Others",
+            "A03MvHHogjR.eventdate",
+            "2022-05-02 00:00:00.0"));
 
     // Validate row exists with values from original row index 40
-    validateRowExists(response, actualHeaders, Map.of("value", "8", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-10 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "8",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "Others",
+            "A03MvHHogjR.eventdate",
+            "2022-05-10 00:00:00.0"));
 
     // Validate row exists with values from original row index 48
-    validateRowExists(response, actualHeaders, Map.of("value", "5", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-18 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "5",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "Others",
+            "A03MvHHogjR.eventdate",
+            "2022-05-18 00:00:00.0"));
 
     // Validate row exists with values from original row index 56
-    validateRowExists(response, actualHeaders, Map.of("value", "11", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-26 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "11",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "Others",
+            "A03MvHHogjR.eventdate",
+            "2022-05-26 00:00:00.0"));
 
     // Validate row exists with values from original row index 61
-    validateRowExists(response, actualHeaders, Map.of("value", "14", "A03MvHHogjR.eventstatus", "ACTIVE", "A03MvHHogjR.ou", "ImspTQPwCqd", "A03MvHHogjR.wQLfBvPrXqq", "Others", "A03MvHHogjR.eventdate", "2022-05-31 00:00:00.0"));
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of(
+            "value",
+            "14",
+            "A03MvHHogjR.eventstatus",
+            "ACTIVE",
+            "A03MvHHogjR.ou",
+            "ImspTQPwCqd",
+            "A03MvHHogjR.wQLfBvPrXqq",
+            "Others",
+            "A03MvHHogjR.eventdate",
+            "2022-05-31 00:00:00.0"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-aggregated.json
@@ -153,6 +153,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "stageAndUnfilteredEventStatus",
+      "query": "/api/analytics/enrollments/aggregate/IpHINAT79UW.json?includeMetadataDetails=true&displayProperty=NAME&totalPages=false&pageSize=100&outputType=ENROLLMENT&page=1&dimension=A03MvHHogjR.EVENT_STATUS&dimension=A03MvHHogjR.EVENT_DATE:202205&dimension=A03MvHHogjR.wQLfBvPrXqq&dimension=A03MvHHogjR.ou:USER_ORGUNIT",
+      "version": {
+        "min": 43
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

When requesting an aggregated enrollment analytics query that combines a stage-specific dimension without a filter with other stage-specific dimensions that do have filters, the generated SQL was invalid.

Example:

API request (against `/api/analytics/enrollments/aggregate/<programUid>`):

```
dimension=A03MvHHogjR.EVENT_STATUS
dimension=A03MvHHogjR.EVENT_DATE:LAST_12_MONTHS
dimension=A03MvHHogjR.ou:USER_ORGUNIT
```

**Postgres response:**
```
SQL Error [42703]: ERROR: column uiogg.ev_eventstatus does not exist
```

The outer SELECT referenced `uiogg.ev_eventstatus` (where `uiogg` aliased the `latest_events_A03MvHHogjR` CTE), but that CTE did not project `ev_eventstatus`.

## Fix 
Make the per-stage filter CTE the "single source of truth" for every stage dimension requested in that stage's scope.
The aggregate branch no longer pre-filters items by `hasFilter()`. Instead it groups every stage item from both `params.getItems()` and `params.getItemFilters()` by program stage `UID`, then emits a `latest_events_<stage>` CTE only when at least
one item for that stage carries a filter. 
Unfiltered stage items belonging to a stage that does have a filter get projected into the same CTE, sharing the "latest event matching the filter" row.
