### PR TITLE
fix: data export - replace O(n²) org unit descendants cross-join with path index scan [DHIS2-21490]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
@@ -174,10 +174,9 @@ public class HibernateDataExportStore implements DataExportStore {
       ),
       ou_with_descendants_ids AS (
         SELECT DISTINCT ou.organisationunitid
-        FROM organisationunit ou
-        LEFT JOIN organisationunit parent_ou ON (ou.path LIKE parent_ou.path || '%')
-        WHERE ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
-             OR parent_ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
+        FROM ou_ids
+        JOIN organisationunit root USING (organisationunitid)
+        JOIN organisationunit ou ON ou.path LIKE root.path || '%'
       )
       SELECT
         de.uid AS deid,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/hibernate/DataExportQueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/hibernate/DataExportQueryBuilderTest.java
@@ -298,10 +298,9 @@ class DataExportQueryBuilderTest extends AbstractQueryBuilderTest {
         ),
         ou_with_descendants_ids AS (
           SELECT DISTINCT ou.organisationunitid
-          FROM organisationunit ou
-          LEFT JOIN organisationunit parent_ou ON (ou.path LIKE parent_ou.path || '%')
-          WHERE ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
-               OR parent_ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
+          FROM ou_ids
+          JOIN organisationunit root USING (organisationunitid)
+          JOIN organisationunit ou ON ou.path LIKE root.path || '%'
         )
         SELECT
           de.uid AS deid,
@@ -391,10 +390,9 @@ class DataExportQueryBuilderTest extends AbstractQueryBuilderTest {
         ),
         ou_with_descendants_ids AS (
           SELECT DISTINCT ou.organisationunitid
-          FROM organisationunit ou
-          LEFT JOIN organisationunit parent_ou ON (ou.path LIKE parent_ou.path || '%')
-          WHERE ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
-               OR parent_ou.organisationunitid IN (SELECT organisationunitid FROM ou_ids)
+          FROM ou_ids
+          JOIN organisationunit root USING (organisationunitid)
+          JOIN organisationunit ou ON ou.path LIKE root.path || '%'
         )
         SELECT
           de.uid AS deid,


### PR DESCRIPTION
### Summary
While testing I noticed that data export was unreasonably slow. I found that the SQL to expand direct OU matches to include all children was the cause. I ended up discussing this with Jason who came up with the SQL in this PR. The same query that took 2 minutes or so before now was instant. 

### Query plan
 before:
```
Nested Loop Left Join ... (actual time=2.156..681.690 rows=1333 loops=1)
  Join Filter: ((ou_1.path)::text ~~ ((parent_ou.path)::text || '%'::text))
  Rows Removed by Join Filter: 1,771,738
```
Query plan here: https://explain.depesz.com/s/eK52 (638 ms)

after:
```
Nested Loop (actual time=0.040..1.049 rows=1333 loops=1)
  Join Filter: ou_1.path ~~ root.path || '%'
  ->  Seq Scan on organisationunit ou_1  (1333 rows)
  ->  Materialize (rows=1 loops=1333)
```

Query plan here: https://explain.depesz.com/s/s5Voe (8 ms)