### PR TITLE
fix: Make Basemap serializable

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/Basemap.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/Basemap.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -40,7 +41,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode
-public class Basemap {
+public class Basemap implements Serializable {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)


### PR DESCRIPTION
Suddenly, Basemap started failing in master:

```
Caused by: java.io.NotSerializableException: org.hisp.dhis.mapping.Basemap
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1187)
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:350)
	at java.base/java.util.ArrayList.writeObject(ArrayList.java:866)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor390.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1070)
	at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1516)
	at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1438)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1181)
	at java.base/java.io.ObjectOutputStream.writeArray(ObjectOutputStream.java:1381)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
	at java.base/java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1572)
	at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1529)
	at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1438)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1181)
	at java.base/java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1572)
	at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1529)
	at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1438)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1181)
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:350)
	at org.ehcache.impl.serialization.PlainJavaSerializer.serialize(PlainJavaSerializer.java:50)
	... 240 more
* ERROR 2026-05-12T10:05:35,958 java.lang.IllegalArgumentException (CrudControllerAdvice [http-nio-8080-exec-10]) IDzelFCFL3Ph/fmowBJTQyc9uQ/nTAaACM/85G3tIWUjI= 
java.lang.IllegalArgumentException: java.io.NotSerializableException: org.hisp.dhis.mapping.Basemap (through reference chain: org.hisp.dhis.dashboard.Dashboard["dashboardItems"]->org.hibernate.collection.internal.PersistentList[4]->org.hisp.dhis.dashboard.DashboardItem["map"]->org.hisp.dhis.mapping.Map$HibernateProxy$jdBJthiA["displayName"])
	at com.fasterxml.jackson.databind.ObjectMapper.valueToTree(ObjectMapper.java:3686)
	at org.hisp.dhis.fieldfiltering.FieldFilterService.toObjectNodes(FieldFilterService.java:271)
	at org.hisp.dhis.fieldfiltering.FieldFilterService.toObjectNodesStream(FieldFilterService.java:348)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

I'm making it Serializable in order to prevent this issue.