### PR TITLE
fix: Use authenticated user to save note [DHIS2-20208]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -238,7 +238,7 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
   private Note note() {
     return Note.builder()
         .note(UID.generate())
-        .storedBy("This is the creator")
+        .storedBy(userDetails.getUsername())
         .value("This is a note")
         .build();
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -127,7 +127,7 @@ public class JdbcNoteStore {
 
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("text", note.getValue());
-    params.addValue("creator", note.getStoredBy());
+    params.addValue("creator", user.getUsername());
     params.addValue("lastUpdatedBy", user.getUid());
     params.addValue("uid", note.getNote().getValue());
     params.addValue("created", new Date());


### PR DESCRIPTION
I'm fixing the `storedBy` field in enrollment and events notes so we always store the authenticated user username for that field. Up until now we used the request payload to populate this field.