### PR TITLE
fix: categoryOption missing dimensionItemType and dimensionItem

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -343,6 +343,7 @@ public class CategoryOption extends BaseMetadataObject
   // -------------------------------------------------------------------------
 
   @Override
+  @JsonProperty
   public String getDimensionItem() {
     return getUid();
   }
@@ -353,11 +354,13 @@ public class CategoryOption extends BaseMetadataObject
   }
 
   @Override
+  @JsonProperty
   public DimensionItemType getDimensionItemType() {
     return DimensionItemType.CATEGORY_OPTION;
   }
 
   @Override
+  @JsonProperty
   public AggregationType getAggregationType() {
     return (queryMods != null && queryMods.getAggregationType() != null)
         ? queryMods.getAggregationType()
@@ -365,11 +368,13 @@ public class CategoryOption extends BaseMetadataObject
   }
 
   @Override
+  @JsonProperty
   public boolean hasAggregationType() {
     return false;
   }
 
   @Override
+  @JsonProperty
   public TotalAggregationType getTotalAggregationType() {
     return null;
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -40,6 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.http.HttpStatus;
@@ -420,5 +422,52 @@ class VisualizationControllerTest extends H2ControllerIntegrationTestBase {
     assertTrue(columnNode.get("dataDimension").booleanValue());
     assertEquals("PROGRAM_DATA_ELEMENT_OPTION", itemsNode.get("dimensionItemType").string());
     assertEquals("SUM", itemsNode.get("aggregationType").string());
+  }
+
+  @Test
+  void testPostAndGetCategoryOptionItemInColumn() {
+    // Given
+    CategoryOption categoryOption = createCategoryOption("Female", "qkPbeWaFsnU");
+    manager.save(categoryOption);
+
+    Category category = createCategory("Gender", "fMZEcRHuamy", categoryOption);
+    manager.save(category);
+
+    String categoryUid = category.getUid();
+    String optionUid = categoryOption.getUid();
+    String jsonBody =
+"""
+{
+    "type": "PIE",
+    "columns": [
+        {
+            "id": "${categoryUid}",
+            "items": [
+                {
+                    "id": "${optionUid}",
+                    "dimensionItemType": "CATEGORY_OPTION"
+                }
+            ]
+        }
+    ],
+    "name": "CategoryOption - Test"
+}
+"""
+            .replace("${categoryUid}", categoryUid)
+            .replace("${optionUid}", optionUid);
+
+    // When
+    String uid = assertStatus(CREATED, POST("/visualizations/", jsonBody));
+
+    // Then
+    String getParams = "?fields=columns[:all,items[:all]]";
+    JsonObject response = GET("/visualizations/" + uid + getParams).content();
+
+    JsonObject columnNode = response.getList("columns", JsonObject.class).get(0);
+    JsonObject itemsNode = columnNode.getList("items", JsonObject.class).get(0);
+
+    assertEquals(categoryUid, columnNode.get("id").string());
+    assertEquals("CATEGORY_OPTION", itemsNode.get("dimensionItemType").string());
+    assertEquals(optionUid, itemsNode.get("dimensionItem").string());
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-21424
This PR add missing `@JsonProperty` to `CategoryOption` class, which is causing issue `api/visualizations` endpoint return  empty properties like below

```
{
  "columns": [
    {
      "items": [
        { }
      ],
      "id": "fMZEcRHuamy"
    },
  ]
}
```
While correct response should be like in screenshot
<img width="891" height="528" alt="Screenshot 2026-05-14 at 12 38 47 AM" src="https://github.com/user-attachments/assets/f3bf6f83-5d0c-4ec8-b706-9f72b6ee92d1" />

