### PR TITLE
feat: Remove program enforcement [DHIS2-21520]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/hibernate/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/hibernate/EventChart.hbm.xml
@@ -115,7 +115,7 @@
         <property name="userOrganisationUnitGrandChildren"/>
 
         <many-to-one name="program" class="org.hisp.dhis.program.Program"
-                     column="programid" not-null="true" foreign-key="fk_evisualization_programid"/>
+                     column="programid" foreign-key="fk_evisualization_programid"/>
 
         <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
                      column="programstageid" foreign-key="fk_evisualization_programstageid"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/hibernate/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/hibernate/EventReport.hbm.xml
@@ -115,7 +115,7 @@
         <property name="userOrganisationUnitGrandChildren"/>
 
         <many-to-one name="program" class="org.hisp.dhis.program.Program"
-                     column="programid" not-null="true" foreign-key="fk_evisualization_programid"/>
+                     column="programid" foreign-key="fk_evisualization_programid"/>
 
         <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
                      column="programstageid" foreign-key="fk_evisualization_programstageid"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
@@ -114,7 +114,7 @@
         <property name="userOrganisationUnitGrandChildren"/>
 
         <many-to-one name="program" class="org.hisp.dhis.program.Program"
-                     column="programid" not-null="true" foreign-key="fk_evisualization_programid"/>
+                     column="programid" foreign-key="fk_evisualization_programid"/>
 
         <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
                      column="programstageid" foreign-key="fk_evisualization_programstageid"/>


### PR DESCRIPTION
The `program` does not need to be mandatory anymore in visualization objects. The front-end has some new features that require saving such objects without a program. It has no impact on existing features.