### PR TITLE
[2.43] fix: prevent NPE in event report table-layout download when dimensions/items metadata entries are missing

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
@@ -493,7 +493,7 @@ public class EventAggregateService {
           (List<String>)
               ((Map<String, Object>) grid.getMetaData().get(DIMENSIONS.getKey())).get(dimension);
 
-      if (legendOptions.isEmpty()) {
+      if (legendOptions == null || legendOptions.isEmpty()) {
         List<Legend> legends = eventDimensionalItemObject.getLegendSet().getSortedLegends();
         addLegends(dimensionalItems, parentUid, legends);
       } else {
@@ -604,7 +604,7 @@ public class EventAggregateService {
       MetadataItem metadataItem =
           (MetadataItem) ((Map<String, Object>) grid.getMetaData().get(ITEMS.getKey())).get(row);
 
-      String name = defaultIfEmpty(metadataItem.getName(), row);
+      String name = metadataItem == null ? row : defaultIfEmpty(metadataItem.getName(), row);
       String col = defaultIfEmpty(COLUMN_NAMES.get(row), row);
 
       outputGrid.addHeader(new GridHeader(name, col, TEXT, false, true));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
@@ -32,20 +32,32 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hisp.dhis.analytics.DataQueryParams.VALUE_ID;
 import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionType.PERIOD;
+import static org.hisp.dhis.test.TestBase.createDataElement;
+import static org.hisp.dhis.test.TestBase.createLegend;
+import static org.hisp.dhis.test.TestBase.createLegendSet;
 import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
+import org.hisp.dhis.analytics.EventAnalyticsDimensionalItem;
 import org.hisp.dhis.analytics.common.ColumnHeader;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.legend.Legend;
+import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -124,6 +136,39 @@ class EventAggregateServiceTest {
   }
 
   @Test
+  void shouldFallBackToAllLegendsWhenDimensionsMetadataOmitsLegendSetDataElement()
+      throws Exception {
+    Legend legendA = createLegend('A', 0.0, 2.0);
+    Legend legendB = createLegend('B', 2.0, 4.0);
+    LegendSet legendSet = createLegendSet('A', legendA, legendB);
+
+    DataElement dataElement = createDataElement('A');
+    dataElement.setValueType(ValueType.NUMBER);
+    dataElement.setLegendSets(List.of(legendSet));
+
+    Grid grid = new ListGrid();
+    grid.getMetaData().put(AnalyticsMetaDataKey.DIMENSIONS.getKey(), new HashMap<String, Object>());
+
+    List<EventAnalyticsDimensionalItem> dimensionalItems = new ArrayList<>();
+
+    invokeAddEventReportDimensionalItems(dataElement, dimensionalItems, grid, dataElement.getUid());
+
+    assertFalse(dimensionalItems.isEmpty());
+  }
+
+  @Test
+  void shouldNotNpeWhenItemsMetadataOmitsRowDimension() throws Exception {
+    String missingDimensionUid = "deUidAAAAA";
+
+    Grid grid = new ListGrid();
+    grid.getMetaData().put(AnalyticsMetaDataKey.ITEMS.getKey(), new HashMap<String, Object>());
+
+    EventQueryParams params = new EventQueryParams.Builder().build();
+
+    invokeGenerateOutputGrid(grid, params, List.of(), List.of(), List.of(missingDimensionUid));
+  }
+
+  @Test
   void shouldKeepValueAndEnrollmentOuHeadersUnchanged() throws Exception {
     EventQueryParams params =
         new EventQueryParams.Builder(defaultPeriodParams())
@@ -155,6 +200,43 @@ class EventAggregateServiceTest {
     Method method = EventAggregateService.class.getDeclaredMethod(methodName, arg0Type, arg1Type);
     method.setAccessible(true);
     method.invoke(service, arg0, arg1);
+  }
+
+  private void invokeAddEventReportDimensionalItems(
+      ValueTypedDimensionalItemObject item,
+      List<EventAnalyticsDimensionalItem> dimensionalItems,
+      Grid grid,
+      String dimension)
+      throws Exception {
+    Method method =
+        EventAggregateService.class.getDeclaredMethod(
+            "addEventReportDimensionalItems",
+            ValueTypedDimensionalItemObject.class,
+            List.class,
+            Grid.class,
+            String.class);
+    method.setAccessible(true);
+    method.invoke(service, item, dimensionalItems, grid, dimension);
+  }
+
+  private Grid invokeGenerateOutputGrid(
+      Grid grid,
+      EventQueryParams params,
+      List<Map<String, EventAnalyticsDimensionalItem>> rowPermutations,
+      List<Map<String, EventAnalyticsDimensionalItem>> columnPermutations,
+      List<String> rowDimensions)
+      throws Exception {
+    Method method =
+        EventAggregateService.class.getDeclaredMethod(
+            "generateOutputGrid",
+            Grid.class,
+            EventQueryParams.class,
+            List.class,
+            List.class,
+            List.class);
+    method.setAccessible(true);
+    return (Grid)
+        method.invoke(service, grid, params, rowPermutations, columnPermutations, rowDimensions);
   }
 
   private EventQueryParams singleDateFieldParams(String dateField, Program program) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
@@ -226,6 +226,7 @@ class EventAggregateServiceTest {
       List<Map<String, EventAnalyticsDimensionalItem>> columnPermutations,
       List<String> rowDimensions)
       throws Exception {
+
     Method method =
         EventAggregateService.class.getDeclaredMethod(
             "generateOutputGrid",


### PR DESCRIPTION
Backport from https://github.com/dhis2/dhis2-core/pull/23686