### PR TITLE
feat: support OU DE/TEA fallback coordinate fields

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
@@ -35,12 +35,10 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -83,25 +81,8 @@ public class DefaultEventCoordinateService implements EventCoordinateService {
       return false;
     }
 
-    if (COL_NAME_TRACKED_ENTITY_GEOMETRY.equals(coordinateField)) {
-      return isRegistration;
-    }
-
-    if (COL_NAME_PROGRAM_NO_REGISTRATION_GEOMETRY_LIST.contains(coordinateField)) {
-      return true;
-    }
-
-    DataElement dataElement = dataElementService.getDataElement(coordinateField);
-
-    TrackedEntityAttribute attribute = attributeService.getTrackedEntityAttribute(coordinateField);
-
-    if (dataElement != null || attribute != null) {
-      return true;
-    }
-
-    throwIllegalQueryEx(ErrorCode.E7232, coordinateField);
-
-    return false;
+    resolveAndValidateFallbackColumn(isRegistration, coordinateField);
+    return true;
   }
 
   @Override
@@ -112,11 +93,8 @@ public class DefaultEventCoordinateService implements EventCoordinateService {
     List<String> fallbackCoordinateFields = new ArrayList<>();
 
     if (fallbackCoordinateField != null) {
-      if (!isFallbackCoordinateFieldValid(pr.isRegistration(), fallbackCoordinateField)) {
-        throw new IllegalQueryException(new ErrorMessage(ErrorCode.E7232, fallbackCoordinateField));
-      }
-
-      fallbackCoordinateFields.add(fallbackCoordinateField);
+      fallbackCoordinateFields.add(
+          resolveAndValidateFallbackColumn(pr.isRegistration(), fallbackCoordinateField));
     } else if (defaultCoordinateFallback) {
       List<String> items =
           new ArrayList<>(
@@ -128,6 +106,54 @@ public class DefaultEventCoordinateService implements EventCoordinateService {
     }
 
     return fallbackCoordinateFields;
+  }
+
+  /**
+   * Validates a fallback coordinate field and resolves it to the analytics table column to use in
+   * SQL. Built-in geometry fields are returned unchanged, coordinate DE/TEA fields are returned
+   * unchanged, and organisation unit DE/TEA fields are resolved to their generated geometry column.
+   *
+   * @param isRegistration true when the program has registration.
+   * @param fallbackCoordinateField the requested fallback coordinate field.
+   * @return the analytics table column name to use for the fallback field, or {@code null} when the
+   *     fallback field is {@code null}.
+   * @throws org.hisp.dhis.common.IllegalQueryException if the field is unknown, is not valid for
+   *     the program type, or has an unsupported value type.
+   */
+  private String resolveAndValidateFallbackColumn(
+      boolean isRegistration, String fallbackCoordinateField) {
+    if (fallbackCoordinateField == null) {
+      return null;
+    }
+
+    if (COL_NAME_TRACKED_ENTITY_GEOMETRY.equals(fallbackCoordinateField)) {
+      if (!isRegistration) {
+        throwIllegalQueryEx(ErrorCode.E7232, fallbackCoordinateField);
+      }
+
+      return fallbackCoordinateField;
+    }
+
+    if (COL_NAME_PROGRAM_NO_REGISTRATION_GEOMETRY_LIST.contains(fallbackCoordinateField)) {
+      return fallbackCoordinateField;
+    }
+
+    DataElement dataElement = dataElementService.getDataElement(fallbackCoordinateField);
+    if (dataElement != null) {
+      return validateCoordinateField(
+          dataElement.getValueType(), fallbackCoordinateField, ErrorCode.E7219);
+    }
+
+    TrackedEntityAttribute attribute =
+        attributeService.getTrackedEntityAttribute(fallbackCoordinateField);
+    if (attribute != null) {
+      return validateCoordinateField(
+          attribute.getValueType(), fallbackCoordinateField, ErrorCode.E7220);
+    }
+
+    throwIllegalQueryEx(ErrorCode.E7232, fallbackCoordinateField);
+
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateServiceTest.java
@@ -39,9 +39,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,5 +113,84 @@ class DefaultEventCoordinateServiceTest {
 
     assertThrows(
         IllegalQueryException.class, () -> service.isFallbackCoordinateFieldValid(false, geometry));
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithDataElementOfTypeOrgUnitAppendsGeomSuffix() {
+    String uid = "deUid000001";
+    DataElement de = new DataElement();
+    de.setValueType(ValueType.ORGANISATION_UNIT);
+
+    when(programService.getProgram(any(String.class))).thenReturn(createProgram('A'));
+    when(dataElementService.getDataElement(uid)).thenReturn(de);
+
+    assertEquals(List.of(uid + "_geom"), service.getFallbackCoordinateFields("A", uid, false));
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithDataElementOfTypeCoordinateIsReturnedUnchanged() {
+    String uid = "deUid000002";
+    DataElement de = new DataElement();
+    de.setValueType(ValueType.COORDINATE);
+
+    when(programService.getProgram(any(String.class))).thenReturn(createProgram('A'));
+    when(dataElementService.getDataElement(uid)).thenReturn(de);
+
+    assertEquals(List.of(uid), service.getFallbackCoordinateFields("A", uid, false));
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithDataElementOfUnsupportedTypeThrows() {
+    String uid = "deUid000003";
+    DataElement de = new DataElement();
+    de.setValueType(ValueType.TEXT);
+
+    when(dataElementService.getDataElement(uid)).thenReturn(de);
+
+    IllegalQueryException ex =
+        assertThrows(
+            IllegalQueryException.class, () -> service.isFallbackCoordinateFieldValid(false, uid));
+    assertEquals(ErrorCode.E7219, ex.getErrorCode());
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithAttributeOfTypeOrgUnitAppendsGeomSuffix() {
+    String uid = "teaUid00001";
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setValueType(ValueType.ORGANISATION_UNIT);
+
+    when(programService.getProgram(any(String.class))).thenReturn(createProgram('A'));
+    when(dataElementService.getDataElement(uid)).thenReturn(null);
+    when(attributeService.getTrackedEntityAttribute(uid)).thenReturn(tea);
+
+    assertEquals(List.of(uid + "_geom"), service.getFallbackCoordinateFields("A", uid, false));
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithAttributeOfTypeCoordinateIsReturnedUnchanged() {
+    String uid = "teaUid00002";
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setValueType(ValueType.COORDINATE);
+
+    when(programService.getProgram(any(String.class))).thenReturn(createProgram('A'));
+    when(dataElementService.getDataElement(uid)).thenReturn(null);
+    when(attributeService.getTrackedEntityAttribute(uid)).thenReturn(tea);
+
+    assertEquals(List.of(uid), service.getFallbackCoordinateFields("A", uid, false));
+  }
+
+  @Test
+  void testFallbackCoordinateFieldWithAttributeOfUnsupportedTypeThrows() {
+    String uid = "teaUid00003";
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setValueType(ValueType.TEXT);
+
+    when(dataElementService.getDataElement(uid)).thenReturn(null);
+    when(attributeService.getTrackedEntityAttribute(uid)).thenReturn(tea);
+
+    IllegalQueryException ex =
+        assertThrows(
+            IllegalQueryException.class, () -> service.isFallbackCoordinateFieldValid(false, uid));
+    assertEquals(ErrorCode.E7220, ex.getErrorCode());
   }
 }


### PR DESCRIPTION
## Summary

Aligns the param `fallbackCoordinateField` with `coordinateField` on the `/api/analytics/events/query` endpoint:

- DataElements and Tracked Entity Attributes of value type `ORGANISATION_UNIT` are now accepted as a fallback geometry source.
The OU geometry column (`<uid>_geom`) is resolved automatically, matching how `coordinateField` already behaves.
- DE/TEA whose value type is neither `COORDINATE` nor `ORGANISATION_UNIT` are now rejected up front with `E7219` (DE) / `E7220` (TEA) instead of silently passing validation and failing later at SQL execution.