### PR TITLE
chore: delete getAllSorted (replaced with getAll)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -194,9 +194,6 @@ public interface IdentifiableObjectManager {
   <T extends IdentifiableObject> List<T> getDataReadAll(@Nonnull Class<T> type);
 
   @Nonnull
-  <T extends IdentifiableObject> List<T> getAllSorted(@Nonnull Class<T> type);
-
-  @Nonnull
   <T extends IdentifiableObject> List<T> getAllByAttributes(
       @Nonnull Class<T> type, @Nonnull Collection<UID> attributes);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryService.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.category;
 
+import static java.util.Comparator.comparing;
+
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -651,21 +653,24 @@ public class DefaultCategoryService implements CategoryService {
   @Transactional(readOnly = true)
   public List<DataElementOperand> getOperands(
       Collection<DataElement> dataElements, boolean includeTotals) {
-    List<DataElementOperand> operands = Lists.newArrayList();
+    List<DataElementOperand> operands = new ArrayList<>();
 
-    for (DataElement dataElement : dataElements) {
-      Set<CategoryCombo> categoryCombos = dataElement.getCategoryCombos();
+    dataElements.stream()
+        .sorted(comparing(DataElement::getName))
+        .forEach(
+            dataElement -> {
+              Set<CategoryCombo> categoryCombos = dataElement.getCategoryCombos();
 
-      boolean anyIsDefault = categoryCombos.stream().anyMatch(cc -> cc.isDefault());
+              boolean anyIsDefault = categoryCombos.stream().anyMatch(CategoryCombo::isDefault);
 
-      if (includeTotals && !anyIsDefault) {
-        operands.add(new DataElementOperand(dataElement));
-      }
+              if (includeTotals && !anyIsDefault) {
+                operands.add(new DataElementOperand(dataElement));
+              }
 
-      for (CategoryCombo categoryCombo : categoryCombos) {
-        operands.addAll(getOperands(dataElement, categoryCombo));
-      }
-    }
+              for (CategoryCombo categoryCombo : categoryCombos) {
+                operands.addAll(getOperands(dataElement, categoryCombo));
+              }
+            });
 
     return operands;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -447,19 +447,6 @@ public class DefaultIdentifiableObjectManager implements IdentifiableObjectManag
   @Nonnull
   @Override
   @Transactional(readOnly = true)
-  public <T extends IdentifiableObject> List<T> getAllSorted(@Nonnull Class<T> type) {
-    IdentifiableObjectStore<T> store = getIdentifiableObjectStore(type);
-
-    if (store == null) {
-      return List.of();
-    }
-
-    return store.getAllOrderedName();
-  }
-
-  @Nonnull
-  @Override
-  @Transactional(readOnly = true)
   public <T extends IdentifiableObject> List<T> getAllByAttributes(
       @Nonnull Class<T> type, @Nonnull Collection<UID> attributes) {
     if (!hasAttributeValues(type) || attributes.isEmpty()) return List.of();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -295,21 +295,6 @@ class IdentifiableObjectManagerTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void getAllOrderedName() {
-    idObjectManager.save(createDataElement('D'));
-    idObjectManager.save(createDataElement('B'));
-    idObjectManager.save(createDataElement('C'));
-    idObjectManager.save(createDataElement('A'));
-    List<DataElement> dataElements =
-        new ArrayList<>(idObjectManager.getAllSorted(DataElement.class));
-    assertEquals(4, dataElements.size());
-    assertEquals("DataElementA", dataElements.get(0).getName());
-    assertEquals("DataElementB", dataElements.get(1).getName());
-    assertEquals("DataElementC", dataElements.get(2).getName());
-    assertEquals("DataElementD", dataElements.get(3).getName());
-  }
-
-  @Test
   void userIsCurrentIfNoUserSet() {
     User user = createUserAndInjectSecurityContext(true);
     DataElement dataElement = createDataElement('A');

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.webapi.controller.dataelement;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -126,7 +125,7 @@ public class DataElementOperandController {
         DataSet dataSet = manager.get(DataSet.class, ds);
         dataElementOperands = dataElementCategoryService.getOperands(dataSet, totals);
       } else {
-        List<DataElement> dataElements = new ArrayList<>(manager.getAllSorted(DataElement.class));
+        List<DataElement> dataElements = manager.getAll(DataElement.class);
         dataElementOperands = dataElementCategoryService.getOperands(dataElements, totals);
       }
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -168,7 +168,7 @@ class DataElementOperandControllerTest {
     final List<DataElement> dataElements =
         rnd.objects(DataElement.class, 1).collect(Collectors.toList());
 
-    when(manager.getAllSorted(DataElement.class)).thenReturn(dataElements);
+    when(manager.getAll(DataElement.class)).thenReturn(dataElements);
 
     final List<DataElementOperand> dataElementOperands =
         rnd.objects(DataElementOperand.class, (int) totalSize).collect(Collectors.toList());
@@ -225,7 +225,7 @@ class DataElementOperandControllerTest {
     final List<DataElement> dataElements =
         rnd.objects(DataElement.class, 1).collect(Collectors.toList());
 
-    when(manager.getAllSorted(DataElement.class)).thenReturn(dataElements);
+    when(manager.getAll(DataElement.class)).thenReturn(dataElements);
 
     final List<DataElementOperand> dataElementOperands =
         rnd.objects(DataElementOperand.class, (int) totalSize).collect(Collectors.toList());


### PR DESCRIPTION
### Summary
With the goal of getting a handle on the risky "get all" this PR removes `getAllSorted` (and replaces it with `getAll`) to reduce the API surface area that needs attention in later PRs. 

Only 1 caller used the `getAllSorted`, I don't know if it was required to iterate the DE sorted by name for get the operands but I maintained that by sorting by name during the iteration of the for-each loop. 

### Automatic Testing
Existing tests were adjusted