### PR TITLE
chore: replace all non-test callers of getAll with more specific method

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -185,6 +185,7 @@ public interface IdentifiableObjectManager {
   <T extends IdentifiableObject> T search(@Nonnull Class<T> type, @Nonnull String query);
 
   @Nonnull
+  @UsageTestOnly
   <T extends IdentifiableObject> List<T> getAll(@Nonnull Class<T> type);
 
   @Nonnull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementService.java
@@ -224,4 +224,10 @@ public interface DataElementService {
   DataElementGroupSet getDataElementGroupSet(long id);
 
   DataElementGroupSet getDataElementGroupSet(String uid);
+
+  // -------------------------------------------------------------------------
+  // DataElementOperand
+  // -------------------------------------------------------------------------
+
+  List<DataElementOperand> getAllDataElementOperands();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
@@ -59,4 +59,6 @@ public interface ProgramNotificationTemplateService {
 
   List<ProgramNotificationTemplate> getProgramNotificationTemplates(
       ProgramNotificationTemplateOperationParams programNotificationTemplateParam);
+
+  List<ProgramNotificationTemplate> getScheduledTemplates();
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
@@ -50,13 +50,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.dataelement.DataElementService")
 public class DefaultDataElementService implements DataElementService {
+
   private final DataElementStore dataElementStore;
-
   private final IdentifiableObjectStore<OptionSet> optionSetStore;
-
   private final IdentifiableObjectStore<DataElementGroup> dataElementGroupStore;
-
   private final GenericDimensionalObjectStore<DataElementGroupSet> dataElementGroupSetStore;
+  private final DataElementOperandStore dataElementOperandStore;
 
   // -------------------------------------------------------------------------
   // DataElement
@@ -260,5 +259,11 @@ public class DefaultDataElementService implements DataElementService {
   @Transactional(readOnly = true)
   public DataElementGroupSet getDataElementGroupSet(String uid) {
     return dataElementGroupSetStore.getByUid(uid);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<DataElementOperand> getAllDataElementOperands() {
+    return dataElementOperandStore.getAll();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
@@ -133,4 +133,10 @@ public class DefaultProgramNotificationTemplateService
 
     return store.getProgramNotificationTemplates(queryParams);
   }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<ProgramNotificationTemplate> getScheduledTemplates() {
+    return store.getAll().stream().filter(n -> n.getNotificationTrigger().isScheduled()).toList();
+  }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
@@ -155,7 +155,7 @@ public class DefaultProgramNotificationService extends HibernateGenericStore<Tra
   public void sendScheduledNotificationsForDay(Date notificationDate, JobProgress progress) {
     progress.startingStage("Fetching and filtering scheduled templates ");
     List<ProgramNotificationTemplate> scheduledTemplates =
-        progress.runStage(List.of(), this::getScheduledTemplates);
+        progress.runStage(List.of(), notificationTemplateService::getScheduledTemplates);
 
     progress.startingStage(
         "Processing ProgramStageNotification messages",
@@ -471,12 +471,6 @@ public class DefaultProgramNotificationService extends HibernateGenericStore<Tra
     }
 
     return null;
-  }
-
-  private List<ProgramNotificationTemplate> getScheduledTemplates() {
-    return manager.getAll(ProgramNotificationTemplate.class).stream()
-        .filter(n -> n.getNotificationTrigger().isScheduled())
-        .collect(toList());
   }
 
   private void sendEnrollmentNotifications(Enrollment enrollment, NotificationTrigger trigger) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
@@ -71,14 +72,12 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/api/dataElementOperands")
 @RequiredArgsConstructor
 public class DataElementOperandController {
+
+  private final DataElementService dataElementService;
   private final IdentifiableObjectManager manager;
-
   private final QueryService queryService;
-
   private final FieldFilterService fieldFilterService;
-
   private final LinkService linkService;
-
   private final CategoryService dataElementCategoryService;
 
   @Data
@@ -104,7 +103,7 @@ public class DataElementOperandController {
     List<DataElementOperand> dataElementOperands = List.of();
 
     if (params.isPersisted()) {
-      dataElementOperands = Lists.newArrayList(manager.getAll(DataElementOperand.class));
+      dataElementOperands = Lists.newArrayList(dataElementService.getAllDataElementOperands());
     } else {
       boolean totals = params.isTotals();
 
@@ -125,7 +124,7 @@ public class DataElementOperandController {
         DataSet dataSet = manager.get(DataSet.class, ds);
         dataElementOperands = dataElementCategoryService.getOperands(dataSet, totals);
       } else {
-        List<DataElement> dataElements = manager.getAll(DataElement.class);
+        List<DataElement> dataElements = dataElementService.getAllDataElements();
         dataElementOperands = dataElementCategoryService.getOperands(dataElements, totals);
       }
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.node.DefaultNodeService;
@@ -101,6 +102,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class DataElementOperandControllerTest {
   private MockMvc mockMvc;
 
+  @Mock private DataElementService dataElementService;
+
   @Mock private IdentifiableObjectManager manager;
 
   @Mock private FieldFilterService fieldFilterService;
@@ -137,7 +140,12 @@ class DataElementOperandControllerTest {
     // Controller under test
     final DataElementOperandController controller =
         new DataElementOperandController(
-            manager, queryService, fieldFilterService, linkService, dataElementCategoryService);
+            dataElementService,
+            manager,
+            queryService,
+            fieldFilterService,
+            linkService,
+            dataElementCategoryService);
 
     // Set custom Node Message converter //
     Jackson2JsonNodeSerializer serializer = new Jackson2JsonNodeSerializer(staticJsonMapper());
@@ -168,7 +176,7 @@ class DataElementOperandControllerTest {
     final List<DataElement> dataElements =
         rnd.objects(DataElement.class, 1).collect(Collectors.toList());
 
-    when(manager.getAll(DataElement.class)).thenReturn(dataElements);
+    when(dataElementService.getAllDataElements()).thenReturn(dataElements);
 
     final List<DataElementOperand> dataElementOperands =
         rnd.objects(DataElementOperand.class, (int) totalSize).collect(Collectors.toList());
@@ -225,7 +233,7 @@ class DataElementOperandControllerTest {
     final List<DataElement> dataElements =
         rnd.objects(DataElement.class, 1).collect(Collectors.toList());
 
-    when(manager.getAll(DataElement.class)).thenReturn(dataElements);
+    when(dataElementService.getAllDataElements()).thenReturn(dataElements);
 
     final List<DataElementOperand> dataElementOperands =
         rnd.objects(DataElementOperand.class, (int) totalSize).collect(Collectors.toList());


### PR DESCRIPTION
The good news is that with this PR there are no more non-test callers of  `getAll(Class)`. The bad news is that I replaced them with `getAll()` on the store API. 

ATM I mostly try to narrow risky API surface. 