### PR TITLE
task: Remove storedBy from notes [DHIS2-21537]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/note/Note.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/note/Note.java
@@ -42,17 +42,14 @@ import org.hisp.dhis.common.DxfNamespaces;
 public class Note extends BaseIdentifiableObject {
   private String noteText;
 
-  private String creator;
-
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
 
   public Note() {}
 
-  public Note(String noteText, String creator) {
+  public Note(String noteText) {
     this.noteText = noteText;
-    this.creator = creator;
   }
 
   // -------------------------------------------------------------------------
@@ -67,15 +64,5 @@ public class Note extends BaseIdentifiableObject {
 
   public void setNoteText(String noteText) {
     this.noteText = noteText;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getCreator() {
-    return creator;
-  }
-
-  public void setCreator(String creator) {
-    this.creator = creator;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
@@ -21,7 +21,5 @@
 
     <property name="noteText" column="notetext" type="text" />
 
-    <property name="creator" column="creator" />
-
   </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_7__remove_tracker_stored_by.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_7__remove_tracker_stored_by.sql
@@ -1,0 +1,1 @@
+alter table note drop column if exists creator;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -782,7 +782,6 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   @Test
   void shouldNotDeleteNoteWhenDeletingEnrollment() {
     Note note = new Note();
-    note.setCreator(CodeGenerator.generateUid());
     note.setNoteText("text");
     manager.save(note);
     enrollmentA.getNotes().add(note);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -370,7 +370,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     eventA.setCompletedDate(parseDate("2021-02-27T11:05:00.000"));
     eventA.setCompletedBy("herb");
     eventA.setAssignedUser(user);
-    Note note = new Note("note1", "ant");
+    Note note = new Note("note1");
     note.setUid(generateUid());
     note.setCreated(new Date());
     note.setLastUpdated(new Date());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -227,7 +227,6 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
               .orElse(null);
       assertNotNull(dbNote);
       assertEquals(note.getValue(), dbNote.getNoteText());
-      assertEquals(note.getStoredBy(), dbNote.getCreator());
       assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
       assertEquals(updatedBy.getUsername(), dbNote.getLastUpdatedBy().getUsername());
       assertEquals(updatedBy.getFirstName(), dbNote.getLastUpdatedBy().getFirstName());
@@ -236,10 +235,6 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
   }
 
   private Note note() {
-    return Note.builder()
-        .note(UID.generate())
-        .storedBy("This is the creator")
-        .value("This is a note")
-        .build();
+    return Note.builder().note(UID.generate()).value("This is a note").build();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -42,7 +42,6 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1000;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1102;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -357,7 +356,6 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertNull(note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });
   }
@@ -380,7 +378,6 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertNull(note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -148,14 +148,11 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
   private TrackedEntityType trackedEntityType;
 
   private EventDataValue dv;
-  private EventDataValue dvMultiText;
 
   private DataElement de;
 
   private DataElement deMultiText;
 
-  private TrackerEvent eventRBG;
-  private TrackerEvent eventRWY;
   private TrackerEvent eventNoValue;
 
   @BeforeEach
@@ -212,8 +209,8 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     dv.setStoredBy("user");
     dv.setValue(DATA_ELEMENT_VALUE);
 
-    eventRBG = createEvent(createDataValue(MULTI_TEXT_DATA_ELEMENT_VALUE_RBG), orgUnit, EVENT_RBG);
-    eventRWY = createEvent(createDataValue(MULTI_TEXT_DATA_ELEMENT_VALUE_RWY), orgUnit, EVENT_RWY);
+    createEvent(createDataValue(MULTI_TEXT_DATA_ELEMENT_VALUE_RBG), orgUnit, EVENT_RBG);
+    createEvent(createDataValue(MULTI_TEXT_DATA_ELEMENT_VALUE_RWY), orgUnit, EVENT_RWY);
     eventNoValue =
         createEvent(
             createDataValue(MULTI_TEXT_DATA_ELEMENT_VALUE_NO_VALUE), orgUnit, EVENT_NO_VALUE);
@@ -223,7 +220,7 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
   void getEventByPathIsIdenticalToQueryParam() {
     TrackedEntity to = trackedEntity();
     TrackerEvent event = event(enrollment(to));
-    event.setNotes(List.of(note("oqXG28h988k", "my notes", owner.getUid())));
+    event.setNotes(List.of(note("oqXG28h988k", "my notes")));
     manager.update(event);
     relationship(event, to);
     switchContextToUser(user);
@@ -273,7 +270,7 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
   @Test
   void getEventByIdWithNotes() {
     TrackerEvent event = event(enrollment(trackedEntity()));
-    event.setNotes(List.of(note("oqXG28h988k", "my notes", owner.getUid())));
+    event.setNotes(List.of(note("oqXG28h988k", "my notes")));
     manager.update(event);
     switchContextToUser(user);
 
@@ -285,7 +282,6 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     JsonNote note = jsonEvent.getNotes().get(0);
     assertEquals("oqXG28h988k", note.getNote());
     assertEquals("my notes", note.value());
-    assertEquals(owner.getUid(), note.getStoredBy());
   }
 
   @Test
@@ -1228,8 +1224,8 @@ class EventsExportControllerTest extends PostgresControllerIntegrationTestBase {
     return event;
   }
 
-  private Note note(String uid, String value, String storedBy) {
-    Note note = new Note(value, storedBy);
+  private Note note(String uid, String value) {
+    Note note = new Note(value);
     note.setUid(uid);
     manager.save(note, false);
     return note;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -354,8 +354,7 @@ class RelationshipsExportControllerTest extends PostgresControllerIntegrationTes
             "expected to find relationship " + relationship1.getUID());
 
     JsonList<JsonNote> notes = jsonRelationship.getTo().getEvent().getNotes();
-    notes.forEach(
-        note -> assertHasOnlyMembers(note, "note", "value", "storedAt", "storedBy", "createdBy"));
+    notes.forEach(note -> assertHasOnlyMembers(note, "note", "value", "storedAt", "createdBy"));
   }
 
   @Test

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -292,7 +292,7 @@ class JdbcEnrollmentStore {
         """
       left join lateral (
         select json_agg(json_build_object('uid', n.uid, 'text', n.notetext,
-          'creator', n.creator, 'created', n.created, 'updatedByUid', u.uid,
+          'created', n.created, 'updatedByUid', u.uid,
           'updatedByUsername', u.username, 'updatedByFirstname', u.firstname,
           'updatedBySurname', u.surname, 'updatedByName', u.name)) as jsonnotes
           from enrollment_notes en
@@ -725,7 +725,6 @@ class JdbcEnrollmentStore {
         Note note = new Note();
         note.setUid(jdbcNote.getUid());
         note.setNoteText(jdbcNote.getText());
-        note.setCreator(jdbcNote.getCreator());
         note.setCreated(DateUtils.safeParseDate(jdbcNote.getCreated()));
         User user = new User();
         user.setUid(jdbcNote.getUpdatedByUid());
@@ -791,7 +790,6 @@ class JdbcEnrollmentStore {
   private static class JdbcNote {
     private String uid;
     private String text;
-    private String creator;
     private String created;
     private String updatedByUid;
     private String updatedByUsername;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipItemMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipItemMapper.java
@@ -363,6 +363,5 @@ public interface RelationshipItemMapper {
   @Mapping(target = "created")
   @Mapping(target = "noteText")
   @Mapping(target = "lastUpdatedBy")
-  @Mapping(target = "creator")
   Note map(Note note);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
@@ -102,7 +102,6 @@ class JdbcSingleEventStore {
        n.noteid as note_id,\
        n.notetext as note_text,\
        n.created as note_created,\
-       n.creator as note_creator,\
        n.uid as note_uid,\
        userinfo.userinfoid as note_user_id,\
        userinfo.code as note_user_code,\
@@ -340,7 +339,6 @@ class JdbcSingleEventStore {
               note.setUid(resultSet.getString("note_uid"));
               note.setNoteText(resultSet.getString("note_text"));
               note.setCreated(resultSet.getTimestamp("note_created"));
-              note.setCreator(resultSet.getString("note_creator"));
 
               if (resultSet.getObject("note_user_id") != null) {
                 User noteLastUpdatedBy = new User();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/JdbcTrackerEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/JdbcTrackerEventStore.java
@@ -108,7 +108,6 @@ class JdbcTrackerEventStore {
        n.noteid as note_id,\
        n.notetext as note_text,\
        n.created as note_created,\
-       n.creator as note_creator,\
        n.uid as note_uid,\
        userinfo.userinfoid as note_user_id,\
        userinfo.code as note_user_code,\
@@ -362,7 +361,6 @@ class JdbcTrackerEventStore {
               note.setUid(resultSet.getString("note_uid"));
               note.setNoteText(resultSet.getString("note_text"));
               note.setCreated(resultSet.getTimestamp("note_created"));
-              note.setCreator(resultSet.getString("note_creator"));
 
               if (resultSet.getObject("note_user_id") != null) {
                 User noteLastUpdatedBy = new User();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
@@ -398,7 +398,6 @@ public class TrackerObjectsMapper {
     dbNote.setUid(note.getNote().getValue());
     dbNote.setCreated(now);
     dbNote.setLastUpdatedBy(user);
-    dbNote.setCreator(note.getStoredBy());
     dbNote.setNoteText(note.getValue());
 
     return dbNote;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
@@ -52,6 +52,4 @@ public class Note implements Serializable {
   @Nonnull @JsonProperty private UID note;
 
   @JsonProperty private String value;
-
-  @JsonProperty private String storedBy;
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -115,10 +115,9 @@ public class JdbcNoteStore {
   private long saveNote(@Nonnull Note note, @Nonnull UserDetails user) {
     String sql =
         """
-            INSERT INTO public.note(noteid, notetext, creator, lastupdatedby, uid, created)
+            INSERT INTO public.note(noteid, notetext, lastupdatedby, uid, created)
             VALUES (nextVal('note_sequence'),
                     :text,
-                    :creator,
                     (select userinfoid from userinfo where uid = :lastUpdatedBy),
                     :uid,
                     :created)
@@ -127,7 +126,6 @@ public class JdbcNoteStore {
 
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("text", note.getValue());
-    params.addValue("creator", note.getStoredBy());
     params.addValue("lastUpdatedBy", user.getUid());
     params.addValue("uid", note.getNote().getValue());
     params.addValue("created", new Date());

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -332,11 +332,6 @@ public class Assertions {
                                       "noteText"),
                               () ->
                                   assertEquals(
-                                      expectedNote.getCreator(),
-                                      actualNote.getCreator(),
-                                      "creator"),
-                              () ->
-                                  assertEquals(
                                       expectedNote.getCreated(),
                                       actualNote.getCreated(),
                                       "created"));

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
@@ -209,7 +209,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .occurredAt(YESTERDAY.toInstant())
             .status(ACTIVE)
             .storedBy(creatingUser.getUsername())
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -235,7 +235,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
             .storedBy(creatingUser.getUsername())
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -263,7 +263,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.COMPLETED)
             .storedBy(creatingUser.getUsername())
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -291,7 +291,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.CANCELLED)
             .storedBy(creatingUser.getUsername())
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -319,7 +319,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
             .storedBy(creatingUser.getUsername())
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -367,7 +367,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .build();
 
     TrackerEvent result = TrackerObjectsMapper.map(preheat, event, updatingUser);
@@ -393,7 +393,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .build();
 
     TrackerEvent result = TrackerObjectsMapper.map(preheat, event, updatingUser);
@@ -424,7 +424,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .assignedUser(user)
             .build();
 
@@ -455,7 +455,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .assignedUser(user)
             .attributeOptionCombo(MetadataIdentifier.ofUid(COC_UID))
             .build();
@@ -635,7 +635,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
               .orElse(null);
       assertNotNull(dbNote);
       assertEquals(note.getValue(), dbNote.getNoteText());
-      assertEquals(note.getStoredBy(), dbNote.getCreator());
       assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
     }
   }
@@ -698,12 +697,11 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
     return dbEvent;
   }
 
-  private List<org.hisp.dhis.tracker.imports.domain.Note> notes(UserDetails user) {
+  private List<org.hisp.dhis.tracker.imports.domain.Note> notes() {
     return List.of(
         org.hisp.dhis.tracker.imports.domain.Note.builder()
             .note(NOTE_UID)
             .value("This is a note")
-            .storedBy(user.getUsername())
             .build());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
@@ -41,6 +41,5 @@ public interface NoteMapper {
   @Mapping(target = "storedAt", source = "created")
   @Mapping(target = "value", source = "noteText")
   @Mapping(target = "createdBy", source = "lastUpdatedBy")
-  @Mapping(target = "storedBy", source = "creator")
   Note map(org.hisp.dhis.note.Note note);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Note.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Note.java
@@ -61,6 +61,4 @@ public class Note {
   @JsonProperty private String value;
 
   @JsonProperty private User createdBy;
-
-  @JsonProperty private String storedBy;
 }


### PR DESCRIPTION
I'm removing `storedBy` since `lastUpdatedBy` already stores the user ID.
Because notes are immutable, `lastUpdatedBy` effectively represents the creator of the note.

In a follow-up PR, I'll also remove `storedBy` from tracked entities, enrollments, and events.