### PR TITLE
feat: stage TEAV writes through EntityWriteBatch [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -146,6 +146,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
+    manager.clear();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();
@@ -171,6 +172,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
+    manager.clear();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -118,6 +118,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
     List<EntityNotifications> notifications = new ArrayList<>();
     ChangeLogAccumulator changeLogs = new ChangeLogAccumulator();
+    EntityWriteBatch batch = new EntityWriteBatch();
 
     //
     // Extract the entities to persist from the Bundle
@@ -134,7 +135,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
         boolean completedInThisImport =
             !bundle.isSkipSideEffects()
                 && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
-        ChangeLogAccumulator.Mark mark = changeLogs.mark();
+        ChangeLogAccumulator.Mark changeLogMark = changeLogs.mark();
+        EntityWriteBatch.Mark batchMark = batch.mark();
         try {
           V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
 
@@ -163,7 +165,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             typeReport.getStats().incCreated();
             typeReport.addEntity(objectReport);
             updateAttributes(
-                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs, batch);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
           } else {
             if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -178,7 +180,12 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                   bundle.getUser(),
                   changeLogs);
               updateAttributes(
-                  bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+                  bundle.getPreheat(),
+                  trackerDto,
+                  convertedDto,
+                  bundle.getUser(),
+                  changeLogs,
+                  batch);
               entityManager.merge(convertedDto);
               typeReport.getStats().incUpdated();
               typeReport.addEntity(objectReport);
@@ -202,11 +209,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           if (FlushMode.OBJECT == bundle.getFlushMode()) {
             // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
             // (trackedentityid, eventid) exist before changelog rows reference them.
+            batch.flush(entityManager);
             entityManager.flush();
             changeLogs.flushAll(conn);
           }
         } catch (Exception e) {
-          changeLogs.rollbackTo(mark);
+          batch.rollbackTo(batchMark);
+          changeLogs.rollbackTo(changeLogMark);
 
           final String msg =
               "A Tracker Entity of type '"
@@ -238,6 +247,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       if (FlushMode.AUTO == bundle.getFlushMode()) {
         // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
         // (trackedentityid, eventid) exist before changelog rows reference them.
+        batch.flush(entityManager);
         entityManager.flush();
         changeLogs.flushAll(conn);
       }
@@ -287,7 +297,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       T trackerDto,
       V hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs);
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch);
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -376,18 +387,44 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
 
     TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
+    // TODO [Phase 6 / DHIS2-21378]: drop this JPQL query and the batch overlay below once
+    // EntityWriteBatch is shared across persisters and writes go through JDBC instead of the
+    // EntityManager. At that point the batch itself is the source of truth for "what has already
+    // been staged for this TE", and DB rows can be loaded eagerly by the preheat -- no per-call
+    // round-trip needed here. Until then: build the lookup from the EntityManager rather than
+    // the lazy TE collection. The collection is a Hibernate PersistentSet whose in-memory state
+    // diverges from the persistence context once a write to a TE attribute has been deferred
+    // (staged in EntityWriteBatch) and flushed by a prior persister -- the same logical TEAV
+    // (composite key trackedentityid + trackedentityattributeid) can appear on a TrackedEntity
+    // payload and on an Enrollment payload, and querying the EM here sees both DB rows and TEAVs
+    // already attached to the session, preventing a duplicate em.persist that would throw
+    // EntityExistsException. The batch overlay catches the within-persister case (e.g. two
+    // enrollments under the same TE both carrying the same attribute) where the second occurrence
+    // would otherwise produce a fresh instance with the same composite key.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
-        trackedEntity.getTrackedEntityAttributeValues().stream()
+        entityManager
+            .createQuery(
+                "select v from TrackedEntityAttributeValue v where v.trackedEntity = :te",
+                TrackedEntityAttributeValue.class)
+            .setParameter("te", trackedEntity)
+            .getResultList()
+            .stream()
             .collect(
                 Collectors.toMap(
                     teav -> idSchemes.toMetadataIdentifier(teav.getAttribute()),
                     Function.identity()));
+    batch
+        .stagedFor(trackedEntity)
+        .forEach(
+            teav ->
+                attributeValueById.put(idSchemes.toMetadataIdentifier(teav.getAttribute()), teav));
 
     payloadAttributes.forEach(
         attribute -> {
@@ -403,7 +440,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
           if (isDelete && !isNew) {
-            delete(preheat, currentValue, trackedEntity, user, changeLogs);
+            delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
                 preheat,
@@ -413,7 +450,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 isNew,
                 previousValue,
                 user,
-                changeLogs);
+                changeLogs,
+                batch);
           }
         });
   }
@@ -426,7 +464,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       boolean isNew,
       String previousValue,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     TrackedEntityAttributeValue attributeToPersist =
         Optional.ofNullable(currentValue)
             .orElseGet(
@@ -440,7 +479,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             .setLastUpdated(new Date());
 
     saveOrUpdate(
-        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs);
+        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs, batch);
 
     handleReservedValue(attributeToPersist);
   }
@@ -450,15 +489,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       TrackedEntity trackedEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (isFileResource(trackedEntityAttributeValue)) {
       unassignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
-    entityManager.remove(
-        entityManager.contains(trackedEntityAttributeValue)
-            ? trackedEntityAttributeValue
-            : entityManager.merge(trackedEntityAttributeValue));
+    batch.stageTeavDelete(trackedEntityAttributeValue);
 
     changeLogs.addTrackedEntityChangeLog(
         trackedEntity,
@@ -476,20 +513,18 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       String previousValue,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (isFileResource(trackedEntityAttributeValue)) {
       assignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     ChangeLogType changeLogType;
     if (isNew) {
-      entityManager.persist(trackedEntityAttributeValue);
-      // In case it's a newly created attribute we'll add it back to TE,
-      // so it can end up in preheat
-      trackedEntity.getTrackedEntityAttributeValues().add(trackedEntityAttributeValue);
+      batch.stageTeavInsert(trackedEntityAttributeValue);
       changeLogType = CREATE;
     } else {
-      entityManager.merge(trackedEntityAttributeValue);
+      batch.stageTeavUpdate(trackedEntityAttributeValue);
       changeLogType = UPDATE;
     }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -73,13 +73,15 @@ public class EnrollmentPersister
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     handleTrackedEntityAttributeValues(
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
         user,
-        changeLogs);
+        changeLogs,
+        batch);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+
+/**
+ * Accumulates entity-level writes staged during the persist loop and applies them at a single flush
+ * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
+ * per-entity error isolation in non-atomic mode.
+ *
+ * <p>Phase 3 scope: TEAV inserts/updates/deletes only. The flush implementation currently delegates
+ * back to {@link EntityManager} so that Hibernate continues to drive persistence while the staging
+ * shape is in place. Phase 6 replaces {@link #flush(EntityManager)} with a connection-based
+ * implementation that emits multi-row INSERT / unnest UPDATE / tuple DELETE statements. Top-level
+ * entities (TrackedEntity, Enrollment, events, relationships) are added by Phase 4.
+ */
+class EntityWriteBatch {
+
+  private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+
+  void stageTeavInsert(TrackedEntityAttributeValue value) {
+    teavInserts.add(value);
+  }
+
+  void stageTeavUpdate(TrackedEntityAttributeValue value) {
+    teavUpdates.add(value);
+  }
+
+  void stageTeavDelete(TrackedEntityAttributeValue value) {
+    teavDeletes.add(value);
+  }
+
+  /**
+   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
+   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
+   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
+   * each carrying the same attribute value -- so it can fold the second occurrence into the first
+   * staged instance instead of producing a duplicate {@code em.persist} that would throw {@code
+   * EntityExistsException}.
+   */
+  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
+    return Stream.concat(teavInserts.stream(), teavUpdates.stream())
+        .filter(v -> v.getTrackedEntity() == trackedEntity);
+  }
+
+  Mark mark() {
+    return new Mark(teavInserts.size(), teavUpdates.size(), teavDeletes.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(teavInserts, mark.teavInsertSize);
+    truncate(teavUpdates, mark.teavUpdateSize);
+    truncate(teavDeletes, mark.teavDeleteSize);
+  }
+
+  /**
+   * Applies all staged writes through the provided {@link EntityManager}. Temporary delegating
+   * implementation; Phase 6 swaps this for JDBC multi-row statements that take a {@link
+   * java.sql.Connection}.
+   */
+  void flush(EntityManager entityManager) {
+    if (teavInserts.isEmpty() && teavUpdates.isEmpty() && teavDeletes.isEmpty()) {
+      return;
+    }
+
+    for (TrackedEntityAttributeValue v : teavInserts) {
+      entityManager.persist(v);
+    }
+    for (TrackedEntityAttributeValue v : teavUpdates) {
+      entityManager.merge(v);
+    }
+    for (TrackedEntityAttributeValue v : teavDeletes) {
+      entityManager.remove(entityManager.contains(v) ? v : entityManager.merge(v));
+    }
+
+    teavInserts.clear();
+    teavUpdates.clear();
+    teavDeletes.clear();
+  }
+
+  private static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  record Mark(int teavInsertSize, int teavUpdateSize, int teavDeleteSize) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -74,7 +74,8 @@ public class RelationshipPersister
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // NOTHING TO DO
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -157,7 +157,8 @@ public class SingleEventPersister
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -65,8 +65,10 @@ public class TrackedEntityPersister
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
-    handleTrackedEntityAttributeValues(preheat, trackerDto.getAttributes(), te, user, changeLogs);
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
+    handleTrackedEntityAttributeValues(
+        preheat, trackerDto.getAttributes(), te, user, changeLogs, batch);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -160,7 +160,8 @@ public class TrackerEventPersister
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 


### PR DESCRIPTION
## Summary

  Phase 3 of the tracker import Hibernate → JDBC migration ([DHIS2-21378](https://dhis2.atlassian.net/browse/DHIS2-21378)). Introduces `EntityWriteBatch`, a per-persister accumulator that
  mirrors `ChangeLogAccumulator` (Phase 1) and collects entity-level writes for a single flush at the end of each persister's `persist()` call.

  - **Scope:** only `TrackedEntityAttributeValue` inserts / updates / deletes are routed through the batch in this phase. Top-level entities (TrackedEntity, Enrollment, events, relationships)
  follow in Phase 4; JDBC multi-row statements replace the delegating flush in Phase 6.
  - **No behaviour change for the wire path yet:** `EntityWriteBatch.flush()` still delegates back to `EntityManager` (`persist` / `merge` / `remove`). The point of this PR is the *shape* — a
  single deferred flush per persister, with mark/rollback semantics aligned to `ChangeLogAccumulator` for per-entity error isolation in non-atomic mode.

  ## Notable design call: cross-persister TEAV lookup

  The same logical TEAV (composite key `trackedentityid + trackedentityattributeid`) can appear on both a `TrackedEntity` payload and an `Enrollment` payload for the same TE —
  `tracker/base_data.json` already exercises this. Pre-Phase-3 inline `em.persist(teav)` masked the duplicate via the Hibernate session. With deferred staging, the lazy `PersistentSet` on
  `TrackedEntity.trackedEntityAttributeValues` doesn't re-sync once initialised, so a later persister can't see the earlier persister's in-memory add and stages a fresh instance with the same
  composite key — `EntityExistsException` at flush.

  `handleTrackedEntityAttributeValues` therefore builds the "what already exists for this TE" lookup from:
  1. A JPQL query against the EntityManager (sees both DB rows and TEAVs already attached to the session by a prior persister), and
  2. An overlay of TEAVs already staged in the current batch but not yet flushed (collapses two payload entries for the same `(te, attr)` within one persister run — e.g. two enrollments under
  the same TE each carrying the same attribute).

  Both go away in Phase 6 when `EntityWriteBatch` becomes the source of truth and writes use JDBC directly. The TODO at the JPQL site points at this. `em.merge` is *not* a workable substitute
  on inserts: TEAV's `composite-id key-many-to-one` mapping makes Hibernate's `entityIsTransient` path NPE on a freshly-constructed target via `getPlainValue()`.

[DHIS2-21378]: https://dhis2.atlassian.net/browse/DHIS2-21378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ