### PR TITLE
chore(ci): pin wait-on-check-action to SHA instead of @master

### DIFF
--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -26,7 +26,10 @@ jobs:
         # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
         # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
         # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
-        uses: t3chguy/wait-on-check-action@master
+        # SHA-pinned to immutable commit instead of mutable @master to mitigate supply-chain
+        # risk from this dormant single-maintainer fork. Update deliberately after reviewing
+        # upstream changes. Current pin equals master HEAD as of 2026-05-22.
+        uses: t3chguy/wait-on-check-action@18541021811b56544d90e0f073401c2b99e249d6 # master @ 2026-05-22 (fork has no tags)
         with:
           ref: ${{ github.head_ref }}
           check-name: 'api-test'


### PR DESCRIPTION
## Summary

- Replaces `t3chguy/wait-on-check-action@master` with the immutable SHA `18541021811b56544d90e0f073401c2b99e249d6` (master HEAD as of 2026-05-22) in `deploy-instance.yml`.
- Eliminates a supply-chain risk: the fork is a dormant single-maintainer repo (0 stars/forks/watchers, last push 2024-01-31). A force-push there would silently run attacker code with `IM_BOT_EMAIL`, `IM_BOT_PASSWORD`, and `GITHUB_TOKEN` in scope on every `deploy`-labeled PR.

## Why keep the fork (still)

Upstream `lewagon/wait-on-check-action` issue [#85](https://github.com/lewagon/wait-on-check-action/issues/85) — the very reason the fork exists (filter to latest workflow run only) — is still open. Switching back to upstream would reintroduce that bug. A SHA pin removes the mutable surface without regressing behavior.

## Test plan

- [ ] Add `deploy` label to a PR and confirm the workflow runs and the "Wait for API tests" step still gates correctly.

AI Assisted.