### PR TITLE
chore: drop redundant inline sessionId hash from auth log

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/AuthenticationLoggerListener.java
@@ -31,9 +31,6 @@ package org.hisp.dhis.security;
 
 import static org.apache.commons.lang3.StringUtils.firstNonEmpty;
 
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -59,7 +56,6 @@ import org.springframework.util.ClassUtils;
 @Slf4j
 public class AuthenticationLoggerListener
     implements ApplicationListener<AbstractAuthenticationEvent> {
-  private static final HashFunction ID_HASH_FUNCTION = Hashing.sha256();
 
   @Override
   public void onApplicationEvent(AbstractAuthenticationEvent event) {
@@ -87,7 +83,6 @@ public class AuthenticationLoggerListener
 
     String authName = firstNonEmpty(authentication.getName(), "");
     String ipAddress = "";
-    String sessionId = "";
     String exceptionMessage = "";
 
     if (event instanceof AbstractAuthenticationFailureEvent failureEvent) {
@@ -95,13 +90,11 @@ public class AuthenticationLoggerListener
     } else if (authentication.getDetails()
         instanceof ForwardedIpAwareWebAuthenticationDetails authDetails) {
       ipAddress = formatIpAddress(authDetails.getIp());
-      sessionId = hashSessionId(authDetails.getSessionId());
     } else if (authentication instanceof OAuth2LoginAuthenticationToken authenticationToken) {
       authName = getUsernameFromPrincipal(authenticationToken.getPrincipal());
       WebAuthenticationDetails oauthDetails =
           (WebAuthenticationDetails) authenticationToken.getDetails();
       ipAddress = formatIpAddress(oauthDetails.getRemoteAddress());
-      sessionId = hashSessionId(oauthDetails.getSessionId());
     } else if (event.getSource() instanceof OAuth2AuthenticationToken authenticationToken) {
       authName = getUsernameFromPrincipal(authenticationToken.getPrincipal());
     } else if (event.getSource() instanceof ApiTokenAuthenticationToken authenticationToken) {
@@ -114,14 +107,13 @@ public class AuthenticationLoggerListener
       ipAddress = formatIpAddress(apiTokenDetails.getRemoteAddress());
     }
 
-    logMessage(event, authName, ipAddress, sessionId, exceptionMessage);
+    logMessage(event, authName, ipAddress, exceptionMessage);
   }
 
   private void logMessage(
       AbstractAuthenticationEvent event,
       String authName,
       String ipAddress,
-      String sessionId,
       String exceptionMessage) {
     String eventClassName =
         String.format("Authentication event: %s; ", ClassUtils.getShortName(event.getClass()));
@@ -129,7 +121,7 @@ public class AuthenticationLoggerListener
         StringUtils.isEmpty(authName) ? "" : String.format("username: %s; ", authName);
     String msg =
         TextUtils.removeNonEssentialChars(
-            eventClassName + usernamePrefix + ipAddress + sessionId + exceptionMessage);
+            eventClassName + usernamePrefix + ipAddress + exceptionMessage);
 
     log.info(Strings.CS.removeEnd(msg.stripTrailing(), ";"));
   }
@@ -143,15 +135,5 @@ public class AuthenticationLoggerListener
       return dhisOidcUser.getUsername();
     }
     return "";
-  }
-
-  private static String hashSessionId(String sessionId) {
-    if (sessionId == null) {
-      return "";
-    }
-
-    String s =
-        ID_HASH_FUNCTION.newHasher().putString(sessionId, StandardCharsets.UTF_8).hash().toString();
-    return String.format("sessionId: %s; ", s);
   }
 }


### PR DESCRIPTION
## Summary

`AuthenticationLoggerListener` was emitting a SHA-256/hex hash of the HTTP session ID inline (`sessionId: <hex>;`), but `SessionIdFilter` already appends a SHA-256/Base64 hash of the same session ID via MDC (`%X{sessionId}` → trailing `ID...=` token) on every authenticated log line.

The inline value carried no extra information, only appeared on a subset of events (where `WebAuthenticationDetails#getSessionId()` happened to be non-null), and inconsistent presence between events made grepping `AuthenticationSuccessEvent` lines awkward. Removed.

AI Assisted