### PR TITLE
chore(ci): add explicit `permissions:` blocks to all workflows

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -33,6 +33,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   sonarqube:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,6 +5,9 @@ env:
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  checks: read           # for t3chguy/wait-on-check-action
+  pull-requests: write   # for actions-cool/maintain-one-comment
+
 jobs:
   deploy-instance:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write   # for actions-cool/maintain-one-comment delete
+  issues: read           # for gh api issues/<n>/events
+
 jobs:
   check-deploy-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-merge-boms.yml
+++ b/.github/workflows/generate-merge-boms.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   create-boms:
     runs-on: ubuntu-latest

--- a/.github/workflows/performance-tests-compare.yml
+++ b/.github/workflows/performance-tests-compare.yml
@@ -109,6 +109,9 @@ on:
         type: string
         default: manual
 
+permissions:
+  contents: read
+
 jobs:
   performance-tests:
     if: github.repository == 'dhis2/dhis2-core'

--- a/.github/workflows/performance-tests-scheduled.yml
+++ b/.github/workflows/performance-tests-scheduled.yml
@@ -11,6 +11,9 @@ on:
     # Run at 1 AM UTC every day
     - cron: "0 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   run-scheduled-tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -84,6 +84,9 @@ on:
         description: 'Slack webhook URL for failure notifications'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   performance-tests:
     if: github.repository == 'dhis2/dhis2-core'

--- a/.github/workflows/run-api-analytics-tests-clickhouse.yml
+++ b/.github/workflows/run-api-analytics-tests-clickhouse.yml
@@ -24,6 +24,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   api-analytics-test-clickhouse:
     env:

--- a/.github/workflows/run-api-analytics-tests-doris.yml
+++ b/.github/workflows/run-api-analytics-tests-doris.yml
@@ -26,6 +26,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   api-analytics-test-doris:
     env:

--- a/.github/workflows/run-api-analytics-tests.yml
+++ b/.github/workflows/run-api-analytics-tests.yml
@@ -26,6 +26,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   api-analytics-test:
     env:

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -26,6 +26,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   api-test:
     env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Hardens 13 GitHub Actions workflows by declaring an explicit `permissions:` block, so each runs with the minimum `GITHUB_TOKEN` scope it needs instead of inheriting the repo-level default.
- Pre-empts the supply-chain attack class confirmed by the **Megalodon campaign** (5,561 repos hit on 2026-05-18), which exploited workflows that inherited write-scope tokens to exfiltrate `GITHUB_TOKEN` + CI secrets.
- Surfaced during the in-flight DHIS2 security audit as finding F-04-02 — confirmed HIGH after `@dhis2/devops` verified the repo default is `write` + `can_approve_pull_request_reviews: true`.

## What changed

11 workflows are read-only and get `permissions: { contents: read }`. 2 workflows that comment on PRs or read check runs get the minimum extra scopes:

| Workflow | Scopes added |
|---|---|
| `deploy-instance.yml` | `contents: read`, `checks: read`, `pull-requests: write` |
| `destroy-instance.yml` | `contents: read`, `pull-requests: write`, `issues: read` |
| 11 others | `contents: read` only |

`dependabot.yml` and `stale-prs.yml` already had explicit blocks — left as-is.

## Why each scope

- `deploy-instance.yml`: `t3chguy/wait-on-check-action` reads check runs (`checks: read`); `actions-cool/maintain-one-comment` writes the instance-URL comment on the PR (`pull-requests: write`).
- `destroy-instance.yml`: same `maintain-one-comment` for the delete (`pull-requests: write`); the first job calls `gh api repos/.../issues/<n>/events` (`issues: read`).

## Follow-up (repo-settings change after this lands)

Once this is merged, **Settings → Actions → General → Workflow permissions**:
1. Switch default from "Read and write" to **"Read repository contents and packages"**
2. **Uncheck** "Allow GitHub Actions to create and approve pull requests"

It's safe to flip those toggles only **after** this PR is in because every workflow then declares its own scope and no longer depends on the inherited default. The auto-approve flag does still affect Dependabot's `gh pr review --approve` step — handle that separately.

## Test plan

- [ ] CI passes on this PR (workflows running on this PR are exempt from the change since the merged file is what matters; verify nothing else broke)
- [ ] After merge + repo-settings flip: watch the next labeled-`deploy` PR — confirm `deploy-instance.yml` posts its comment and `wait-on-check-action` doesn't 403
- [ ] After merge + repo-settings flip: watch a `destroy-instance.yml` run on PR close — confirm the comment-delete step succeeds
- [ ] Watch the next codecov upload on `run-tests.yml` — confirm no 403 (codecov v3 uses `CODECOV_TOKEN`, shouldn't need GITHUB_TOKEN write)
- [ ] Watch `analyse-pr.yml` — Sonar uses `SONAR_TOKEN`, should not need GITHUB_TOKEN write
- [ ] If any job 403s with "Resource not accessible by integration", widen the per-job scope; that's the expected debugging signal

## Refs

- F-04-02 finding: `dhis-2/security_review_2026/findings/TENTATIVE-phase-04-missing-workflow-permissions.md` (on the `sec_review_2026` review branch)
- Megalodon write-up: <https://safedep.io/megalodon-mass-github-repo-backdooring-ci-workflows/>
- Megalodon IOC sweep against dhis2-core: clean (0 hits on C2 IP, forged authors, base64-pipe payloads, `id-token: write`, `pull_request_target`)

AI Assisted