### PR TITLE
feat: add geometrySource to event coordinate fallback query

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -142,6 +142,8 @@ public class EventQueryParams extends DataQueryParams {
 
   public static final String TRACKER_COORDINATE_FIELD = "TRACKER";
 
+  public record GeometrySource(String coordinateField, String source) {}
+
   /** The query items. */
   private List<QueryItem> items = new ArrayList<>();
 
@@ -226,6 +228,9 @@ public class EventQueryParams extends DataQueryParams {
    * fields.
    */
   private List<String> coordinateFields;
+
+  /** The ordered source labels for resolved coordinate fields. */
+  private List<GeometrySource> geometrySources = List.of();
 
   /** Bounding box for events to include in clustering. */
   private String bbox;
@@ -340,6 +345,7 @@ public class EventQueryParams extends DataQueryParams {
     params.aggregateData = this.aggregateData;
     params.clusterSize = this.clusterSize;
     params.coordinateFields = this.coordinateFields;
+    params.geometrySources = new ArrayList<>(this.geometrySources);
     params.bbox = this.bbox;
     params.includeClusterPoints = this.includeClusterPoints;
     params.enrollmentStatus = new LinkedHashSet<>(this.enrollmentStatus);
@@ -631,6 +637,7 @@ public class EventQueryParams extends DataQueryParams {
         .addIgnoreNull("aggregateData", aggregateData)
         .addIgnoreNull("clusterSize", clusterSize)
         .addIgnoreNull("coordinateFields", coordinateFields)
+        .addIgnoreNull("geometrySources", geometrySources.isEmpty() ? null : geometrySources)
         .addIgnoreNull("bbox", bbox)
         .addIgnoreNull("includeClusterPoints", includeClusterPoints)
         .addIgnoreNull("enrollmentStatus", enrollmentStatus)
@@ -1495,6 +1502,14 @@ public class EventQueryParams extends DataQueryParams {
     return coordinateFields;
   }
 
+  public List<GeometrySource> getGeometrySources() {
+    return geometrySources;
+  }
+
+  public boolean hasGeometrySources() {
+    return isNotEmpty(geometrySources);
+  }
+
   public String getBbox() {
     return bbox;
   }
@@ -1809,6 +1824,11 @@ public class EventQueryParams extends DataQueryParams {
 
     public Builder withCoordinateFields(List<String> coordinateFields) {
       this.params.coordinateFields = coordinateFields;
+      return this;
+    }
+
+    public Builder withGeometrySources(List<GeometrySource> geometrySources) {
+      this.params.geometrySources = geometrySources == null ? List.of() : geometrySources;
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.analytics.AnalyticsConstants.KEY_USER_ORGUNIT_GRANDC
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_ENROLLMENT_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_EVENT_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_GEOMETRY_LIST;
+import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_OU_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_TRACKED_ENTITY_GEOMETRY;
 import static org.hisp.dhis.analytics.event.data.DefaultEventDataQueryService.SortableItems.isSortable;
 import static org.hisp.dhis.analytics.event.data.DefaultEventDataQueryService.SortableItems.translateItemIfNecessary;
@@ -56,6 +57,7 @@ import static org.hisp.dhis.common.EventDataQueryRequest.getStageInValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -170,7 +172,8 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       throwIllegalQueryEx(ErrorCode.E7130, request.getStage());
     }
 
-    List<String> coordinateFields = getCoordinateFields(request);
+    CoordinateFieldResolution coordinateFieldResolution = getCoordinateFieldResolution(request);
+    List<String> coordinateFields = coordinateFieldResolution.coordinateFields();
 
     Set<EnrollmentStatus> enrollmentStatuses = new LinkedHashSet<>();
     if (request.getEnrollmentStatus() != null) {
@@ -219,6 +222,7 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
             .withTimeField(request.getTimeField())
             .withOrgUnitField(new OrgUnitField(request.getOrgUnitField()))
             .withCoordinateFields(coordinateFields)
+            .withGeometrySources(coordinateFieldResolution.geometrySources())
             .withHeaders(request.getHeaders())
             .withPage(request.getPage())
             .withPageSize(request.getPageSize())
@@ -338,6 +342,10 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
    */
   @Override
   public List<String> getCoordinateFields(EventDataQueryRequest request) {
+    return getCoordinateFieldResolution(request).coordinateFields();
+  }
+
+  private CoordinateFieldResolution getCoordinateFieldResolution(EventDataQueryRequest request) {
     final String program = request.getProgram();
     // TODO Remove when all web apps stop using old names of coordinate fields
     final String coordinateField = mapCoordinateField(request.getCoordinateField());
@@ -345,6 +353,8 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
     final String fallbackCoordinateField = mapCoordinateField(request.getFallbackCoordinateField());
 
     List<String> coordinateFields = new ArrayList<>();
+    boolean fallbackActive =
+        request.getFallbackCoordinateField() != null || defaultCoordinateFallback;
 
     if (coordinateField == null) {
       coordinateFields.add(StringUtils.EMPTY);
@@ -392,8 +402,42 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
         eventCoordinateService.getFallbackCoordinateFields(
             program, fallbackCoordinateField, defaultCoordinateFallback));
 
-    return coordinateFields.stream().distinct().collect(Collectors.toList());
+    List<String> distinctCoordinateFields =
+        coordinateFields.stream().distinct().collect(Collectors.toList());
+
+    return new CoordinateFieldResolution(
+        distinctCoordinateFields,
+        fallbackActive ? getGeometrySources(distinctCoordinateFields) : List.of());
   }
+
+  private List<EventQueryParams.GeometrySource> getGeometrySources(List<String> coordinateFields) {
+    LinkedHashMap<String, String> geometrySources = new LinkedHashMap<>();
+
+    for (String coordinateField : coordinateFields) {
+      addGeometrySource(geometrySources, coordinateField);
+    }
+
+    return geometrySources.entrySet().stream()
+        .map(entry -> new EventQueryParams.GeometrySource(entry.getKey(), entry.getValue()))
+        .toList();
+  }
+
+  private void addGeometrySource(LinkedHashMap<String, String> geometrySources, String field) {
+    geometrySources.putIfAbsent(field, getGeometrySource(field));
+  }
+
+  private String getGeometrySource(String field) {
+    return switch (field) {
+      case COL_NAME_EVENT_GEOMETRY -> "psigeometry";
+      case COL_NAME_ENROLLMENT_GEOMETRY -> "pigeometry";
+      case COL_NAME_TRACKED_ENTITY_GEOMETRY -> "teigeometry";
+      case COL_NAME_OU_GEOMETRY -> COL_NAME_OU_GEOMETRY;
+      default -> StringUtils.removeEnd(field, "_geom");
+    };
+  }
+
+  private record CoordinateFieldResolution(
+      List<String> coordinateFields, List<EventQueryParams.GeometrySource> geometrySources) {}
 
   @Override
   public QueryItem getQueryItem(String dimensionString, Program program, EventOutputType type) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -402,8 +402,7 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
         eventCoordinateService.getFallbackCoordinateFields(
             program, fallbackCoordinateField, defaultCoordinateFallback));
 
-    List<String> distinctCoordinateFields =
-        coordinateFields.stream().distinct().collect(Collectors.toList());
+    List<String> distinctCoordinateFields = coordinateFields.stream().distinct().toList();
 
     return new CoordinateFieldResolution(
         distinctCoordinateFields,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventQueryService.java
@@ -288,8 +288,15 @@ public class EventQueryService {
     }
 
     if (isGeospatialSupport()) {
-      grid.addHeader(new GridHeader(GEOMETRY.getItem(), GEOMETRY.getName(), TEXT, false, true))
-          .addHeader(
+      grid.addHeader(new GridHeader(GEOMETRY.getItem(), GEOMETRY.getName(), TEXT, false, true));
+
+      if (params.hasGeometrySources()) {
+        grid.addHeader(
+            new GridHeader(
+                GEOMETRY_SOURCE.getItem(), GEOMETRY_SOURCE.getName(), TEXT, false, true));
+      }
+
+      grid.addHeader(
               new GridHeader(
                   ENROLLMENT_GEOMETRY.getItem(), ENROLLMENT_GEOMETRY.getName(), TEXT, false, true))
           .addHeader(new GridHeader(LONGITUDE.getItem(), LONGITUDE.getName(), NUMBER, false, true))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -387,8 +387,13 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
     }
 
     if (sqlBuilder.supportsGeospatialData()) {
+      columns.add(getCoordinateSelectExpression(params));
+
+      if (params.hasGeometrySources()) {
+        columns.add(getGeometrySourceSelectExpression(params));
+      }
+
       columns.add(
-          getCoordinateSelectExpression(params),
           getEnrollmentCoordinateSelectExpression(),
           EventAnalyticsColumnName.LONGITUDE_COLUMN_NAME,
           EventAnalyticsColumnName.LATITUDE_COLUMN_NAME);
@@ -428,6 +433,26 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
             params.getCoordinateFields(), FallbackCoordinateFieldType.EVENT_GEOMETRY.getValue());
 
     return String.format("ST_AsGeoJSON(%s, 6) as geometry", field);
+  }
+
+  /**
+   * Returns a geometry source select expression matching the coordinate coalesce priority.
+   *
+   * @param params the {@link EventQueryParams}.
+   * @return a geometry source select expression.
+   */
+  private String getGeometrySourceSelectExpression(EventQueryParams params) {
+    String whenClauses =
+        params.getGeometrySources().stream()
+            .map(
+                geometrySource ->
+                    String.format(
+                        "when %s is not null then %s",
+                        sqlBuilder.quoteAx(geometrySource.coordinateField()),
+                        singleQuote(geometrySource.source())))
+            .collect(joining(" "));
+
+    return String.format("(case %s end) as geometrySource", whenClauses);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -280,7 +280,34 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')";
 
     assertSql(expected, sql.getValue());
+    assertThat(sql.getValue(), not(containsString("geometrySource")));
     assertTrue(grid.hasLastDataRow());
+  }
+
+  @Test
+  void verifyGetEventSqlWithGeometrySourceWhenFallbackActive() {
+    mockEmptyRowSet();
+
+    EventQueryParams params =
+        createRequestParamsBuilder()
+            .withCoordinateFields(List.of("eventgeometry", "ougeometry"))
+            .withGeometrySources(
+                List.of(
+                    new EventQueryParams.GeometrySource("eventgeometry", "psigeometry"),
+                    new EventQueryParams.GeometrySource("ougeometry", "ougeometry")))
+            .build();
+
+    subject.getEvents(params, createGrid(), 100);
+
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    assertThat(
+        sql.getValue(),
+        containsString(
+            "ST_AsGeoJSON(coalesce(ax.\"eventgeometry\", ax.\"ougeometry\"), 6) as geometry, "
+                + "(case when ax.\"eventgeometry\" IS not NULL then 'psigeometry' "
+                + "when ax.\"ougeometry\" IS not NULL then 'ougeometry' end) as geometrySource, "
+                + "ST_AsGeoJSON(coalesce(ax.enrollmentgeometry), 6) as enrollmentgeometry"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryServiceTest.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.TestBase.createPeriodDimensions;
 import static org.hisp.dhis.test.TestBase.createProgram;
 import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doNothing;
@@ -41,6 +42,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.common.scheme.SchemeInfo;
 import org.hisp.dhis.analytics.common.scheme.SchemeInfo.Data;
@@ -53,6 +56,8 @@ import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.analytics.table.model.Partitions;
 import org.hisp.dhis.analytics.tracker.MetadataItemsHandler;
 import org.hisp.dhis.analytics.tracker.SchemeIdHandler;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -133,6 +138,51 @@ class EventQueryServiceTest {
     verify(schemeIdResponseMapper, never()).getSchemeIdResponseMap(mockSchemeInfo);
   }
 
+  @Test
+  void testGeometrySourceHeaderIsIncludedWhenGeometrySourcesExist() {
+    OrganisationUnit mockOrgUnit = createOrganisationUnit('A');
+    Program mockProgram = createProgram('A', null, mockOrgUnit);
+    EventQueryParams params = mockEventQueryParamsWithGeometrySource(mockOrgUnit, mockProgram);
+
+    doNothing().when(securityManager).decideAccessEventQuery(params);
+    when(securityManager.withUserConstraints(params)).thenReturn(params);
+    when(sqlBuilder.supportsGeospatialData()).thenReturn(true);
+
+    Grid grid = eventQueryService.getEvents(params);
+
+    assertEquals(
+        List.of("geometry", "geometrySource", "enrollmentgeometry"),
+        grid.getHeaders().stream()
+            .map(GridHeader::getName)
+            .filter(
+                name ->
+                    name.equals("geometry")
+                        || name.equals("geometrySource")
+                        || name.equals("enrollmentgeometry"))
+            .toList());
+  }
+
+  @Test
+  void testGeometrySourceHeaderCanBeRetainedByHeadersParam() {
+    OrganisationUnit mockOrgUnit = createOrganisationUnit('A');
+    Program mockProgram = createProgram('A', null, mockOrgUnit);
+    EventQueryParams params =
+        new EventQueryParams.Builder(
+                mockEventQueryParamsWithGeometrySource(mockOrgUnit, mockProgram))
+            .withHeaders(new LinkedHashSet<>(List.of("geometry", "geometrySource")))
+            .build();
+
+    doNothing().when(securityManager).decideAccessEventQuery(params);
+    when(securityManager.withUserConstraints(params)).thenReturn(params);
+    when(sqlBuilder.supportsGeospatialData()).thenReturn(true);
+
+    Grid grid = eventQueryService.getEvents(params);
+
+    assertEquals(
+        List.of("geometry", "geometrySource"),
+        grid.getHeaders().stream().map(GridHeader::getName).toList());
+  }
+
   private EventQueryParams mockEventQueryParams(
       OrganisationUnit mockOrgUnit, Program mockProgram, IdScheme scheme) {
     return new EventQueryParams.Builder()
@@ -141,6 +191,18 @@ class EventQueryServiceTest {
         .withOrganisationUnits(getList(mockOrgUnit))
         .withProgram(mockProgram)
         .withOutputIdScheme(scheme)
+        .build();
+  }
+
+  private EventQueryParams mockEventQueryParamsWithGeometrySource(
+      OrganisationUnit mockOrgUnit, Program mockProgram) {
+    return new EventQueryParams.Builder()
+        .withPeriods(createPeriodDimensions("2000Q1"), "monthly")
+        .withOrganisationUnits(getList(mockOrgUnit))
+        .withProgram(mockProgram)
+        .withSkipData(true)
+        .withGeometrySources(
+            List.of(new EventQueryParams.GeometrySource("eventgeometry", "psigeometry")))
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
@@ -34,6 +34,7 @@ public enum ColumnHeader {
   TRACKED_ENTITY("tei", "Tracked entity"),
   ENROLLMENT("pi", "Enrollment"),
   GEOMETRY("geometry", "Geometry"),
+  GEOMETRY_SOURCE("geometrySource", "Geometry source"),
   ENROLLMENT_GEOMETRY("enrollmentgeometry", "Enrollment geometry"),
   ENROLLMENT_DATE("enrollmentdate", "Enrollment date"),
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery4AutoTest.java
@@ -34,7 +34,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.analytics.ValidationHelper.*;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.HashSet;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.hisp.dhis.AnalyticsApiTest;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEventActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
@@ -658,72 +656,101 @@ public class EventsQuery4AutoTest extends AnalyticsApiTest {
     boolean expectPostgis = isPostgres();
 
     // Given
-    QueryParamsBuilder params = new QueryParamsBuilder().add("filter=pe:2022")
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=pe:2022")
             .add("headers=geometry,geometrySource")
             .add("coordinatesOnly=true")
             .add("stage=Zj7UnCAulEk")
             .add("coordinateField=EVENT")
             .add("dimension=ou:ImspTQPwCqd")
             .add("fallbackCoordinateField=F3ogKBuviRA")
-            .add("desc=lastupdated")
-            ;
+            .add("desc=lastupdated");
 
     // When
     ApiResponse response = actions.query().get("eBAyeGv0exc", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 28, 2, 1); // Pass runtime flag, row count, and expected header counts
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        28,
+        2,
+        1); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
             .map(obj -> (Map<String, Object>) obj) // Ensure correct type
             .collect(Collectors.toList());
 
-
     // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"total\":28,\"pageSize\":50,\"pageCount\":1},\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"eBAyeGv0exc\":{\"name\":\"Inpatient morbidity and mortality\"},\"ou\":{\"name\":\"Organisation unit\"},\"Zj7UnCAulEk\":{\"name\":\"Inpatient morbidity and mortality\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"total\":28,\"pageSize\":50,\"pageCount\":1},\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"eBAyeGv0exc\":{\"name\":\"Inpatient morbidity and mortality\"},\"ou\":{\"name\":\"Organisation unit\"},\"Zj7UnCAulEk\":{\"name\":\"Inpatient morbidity and mortality\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
     if (expectPostgis) {
-      validateHeaderPropertiesByName(response, actualHeaders,"geometry", "Geometry", "TEXT", "java.lang.String", false, true);
+      validateHeaderPropertiesByName(
+          response, actualHeaders, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     }
-    validateHeaderPropertiesByName(response, actualHeaders,"geometrySource", "Geometry source", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "geometrySource",
+        "Geometry source",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
 
     // rowContext not found or empty in the response, skipping assertions.
 
     // 7. Assert row values by name at specific indices (sorted results).
     // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "geometry", "{\"type\":\"Point\",\"coordinates\":[-12.262115,8.195179]}");
+    validateRowValueByName(
+        response,
+        actualHeaders,
+        0,
+        "geometry",
+        "{\"type\":\"Point\",\"coordinates\":[-12.262115,8.195179]}");
     validateRowValueByName(response, actualHeaders, 0, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 5
-    validateRowValueByName(response, actualHeaders, 5, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 5, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 5, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 10
-    validateRowValueByName(response, actualHeaders, 10, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 10, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 10, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 15
-    validateRowValueByName(response, actualHeaders, 15, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 15, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 15, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 20
-    validateRowValueByName(response, actualHeaders, 20, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 20, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 20, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 25
-    validateRowValueByName(response, actualHeaders, 25, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 25, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 25, "geometrySource", "psigeometry");
 
     // Validate selected values for row index 27
-    validateRowValueByName(response, actualHeaders, 27, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(
+        response, actualHeaders, 27, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
     validateRowValueByName(response, actualHeaders, 27, "geometrySource", "psigeometry");
   }
+
   @Test
   public void metadataForDataElementOfTypeOrgUnitFilterEq() throws JSONException {
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery4AutoTest.java
@@ -34,12 +34,15 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.analytics.ValidationHelper.*;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.AnalyticsApiTest;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEventActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
@@ -47,6 +50,7 @@ import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /** Groups e2e tests for "/events/query" endpoint. */
 public class EventsQuery4AutoTest extends AnalyticsApiTest {
@@ -647,6 +651,79 @@ public class EventsQuery4AutoTest extends AnalyticsApiTest {
             (expectPostgis ? new HashSet<>() : Set.of(10, 11, 12, 13))));
   }
 
+  @Test
+  @EnabledIf(value = "isPostgres", disabledReason = "Postgis not available in Doris/CH")
+  public void eventsWithFallbackCoordinateFieldReturnsGeometrySource() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("filter=pe:2022")
+            .add("headers=geometry,geometrySource")
+            .add("coordinatesOnly=true")
+            .add("stage=Zj7UnCAulEk")
+            .add("coordinateField=EVENT")
+            .add("dimension=ou:ImspTQPwCqd")
+            .add("fallbackCoordinateField=F3ogKBuviRA")
+            .add("desc=lastupdated")
+            ;
+
+    // When
+    ApiResponse response = actions.query().get("eBAyeGv0exc", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 28, 2, 1); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"total\":28,\"pageSize\":50,\"pageCount\":1},\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"eBAyeGv0exc\":{\"name\":\"Inpatient morbidity and mortality\"},\"ou\":{\"name\":\"Organisation unit\"},\"Zj7UnCAulEk\":{\"name\":\"Inpatient morbidity and mortality\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    if (expectPostgis) {
+      validateHeaderPropertiesByName(response, actualHeaders,"geometry", "Geometry", "TEXT", "java.lang.String", false, true);
+    }
+    validateHeaderPropertiesByName(response, actualHeaders,"geometrySource", "Geometry source", "TEXT", "java.lang.String", false, true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "geometry", "{\"type\":\"Point\",\"coordinates\":[-12.262115,8.195179]}");
+    validateRowValueByName(response, actualHeaders, 0, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 5
+    validateRowValueByName(response, actualHeaders, 5, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 5, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 10
+    validateRowValueByName(response, actualHeaders, 10, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 10, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 15
+    validateRowValueByName(response, actualHeaders, 15, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 15, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 20
+    validateRowValueByName(response, actualHeaders, 20, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 20, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 25
+    validateRowValueByName(response, actualHeaders, 25, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 25, "geometrySource", "psigeometry");
+
+    // Validate selected values for row index 27
+    validateRowValueByName(response, actualHeaders, 27, "geometry", "{\"type\":\"Point\",\"coordinates\":[0,0]}");
+    validateRowValueByName(response, actualHeaders, 27, "geometrySource", "psigeometry");
+  }
   @Test
   public void metadataForDataElementOfTypeOrgUnitFilterEq() throws JSONException {
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
@@ -328,6 +328,13 @@
       "version": {
         "min": 41
       }
+    },
+    {
+      "name": "eventsWithFallbackCoordinateFieldReturnsGeometrySource",
+      "query": "/api/analytics/events/query/eBAyeGv0exc.json?filter=pe:2022&coordinatesOnly=true&stage=Zj7UnCAulEk&coordinateField=EVENT&fallbackCoordinateField=F3ogKBuviRA&headers=geometry,geometrySource&dimension=ou:ImspTQPwCqd&desc=lastupdated",
+      "version": {
+        "min": 43
+      }
     }
   ]
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -194,6 +194,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
     assertEquals(1, params.getItems().size());
     assertEquals(2, params.getFilterPeriods().size());
     assertEquals(List.of("eventgeometry", "ougeometry"), params.getCoordinateFields());
+    assertEquals(List.of("psigeometry", "ougeometry"), getGeometrySources(params));
   }
 
   @Test
@@ -260,6 +261,7 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
     assertEquals(deA, params.getValue());
     assertEquals(AnalyticsAggregationType.AVERAGE, params.getAggregationType());
     assertEquals(List.of("eventgeometry", "ougeometry"), params.getCoordinateFields());
+    assertEquals(List.of("psigeometry", "ougeometry"), getGeometrySources(params));
   }
 
   @Test
@@ -523,6 +525,50 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void testGetDefaultGeometrySources() {
+    EventQueryParams params =
+        dataQueryService.getFromRequest(
+            toRequest(prA.getUid(), EventQueryParams.EVENT_COORDINATE_FIELD, null, true));
+
+    assertEquals(
+        List.of("eventgeometry", "enrollmentgeometry", "tegeometry", "ougeometry"),
+        params.getCoordinateFields());
+    assertEquals(
+        List.of("psigeometry", "pigeometry", "teigeometry", "ougeometry"),
+        getGeometrySources(params));
+  }
+
+  @Test
+  void testGetGeometrySourcesWithCoordinateDataElementFallback() {
+    EventQueryParams params =
+        dataQueryService.getFromRequest(
+            toRequest(prA.getUid(), EventQueryParams.EVENT_COORDINATE_FIELD, deC.getUid(), false));
+
+    assertEquals(List.of("eventgeometry", deC.getUid()), params.getCoordinateFields());
+    assertEquals(List.of("psigeometry", deC.getUid()), getGeometrySources(params));
+  }
+
+  @Test
+  void testGetGeometrySourcesWithOrgUnitDataElementFallback() {
+    DataElement orgUnitDataElement = createDataElement('D');
+    orgUnitDataElement.setValueType(ValueType.ORGANISATION_UNIT);
+    dataElementService.addDataElement(orgUnitDataElement);
+
+    EventQueryParams params =
+        dataQueryService.getFromRequest(
+            toRequest(
+                prA.getUid(),
+                EventQueryParams.EVENT_COORDINATE_FIELD,
+                orgUnitDataElement.getUid(),
+                false));
+
+    assertEquals(
+        List.of("eventgeometry", orgUnitDataElement.getUid() + "_geom"),
+        params.getCoordinateFields());
+    assertEquals(List.of("psigeometry", orgUnitDataElement.getUid()), getGeometrySources(params));
+  }
+
+  @Test
   void testGetBackwardCompatibleCoordinateField() {
     final String OLD_COL_NAME_EVENT_GEOMETRY = "psigeometry";
     final String OLD_COL_NAME_ENROLLMENT_GEOMETRY = "pigeometry";
@@ -594,5 +640,11 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
         .fallbackCoordinateField(fallbackCoordinateField)
         .defaultCoordinateFallback(isDefaultCoordinateFallback)
         .build();
+  }
+
+  private List<String> getGeometrySources(EventQueryParams params) {
+    return params.getGeometrySources().stream()
+        .map(EventQueryParams.GeometrySource::source)
+        .toList();
   }
 }


### PR DESCRIPTION
## Summary

- Adds `geometrySource` to `/analytics/events/query` responses **when coordinate fallback** is active.
- Reports the source as `psigeometry`, `pigeometry`, `teigeometry`, `ougeometry`, or the original DE/TEA UID.
- Preserves existing fallback behavior, including OU DE/TEA fields using `*_geom` internally while returning the original UID.


## Example request/response

```bash
/api/analytics/events/query/eBAyeGv0exc.json?filter=pe:2022
&coordinatesOnly=true
&stage=Zj7UnCAulEk
&coordinateField=EVENT
&fallbackCoordinateField=F3ogKBuviRA
&headers=geometry,geometrySource
&dimension=ou:ImspTQPwCqd
&desc=lastupdated
```

```json
{
    "headers": [
        {
            "name": "geometry",
            "column": "Geometry",
            "valueType": "TEXT",
            "type": "java.lang.String",
            "hidden": false,
            "meta": true
        },
        {
            "name": "geometrySource",
            "column": "Geometry source",
            "valueType": "TEXT",
            "type": "java.lang.String",
            "hidden": false,
            "meta": true
        }
    ],
    "metaData": {
        "pager": {
            "page": 1,
            "total": 28,
            "pageSize": 50,
            "pageCount": 1
        },
        "items": {
            "ImspTQPwCqd": {
                "name": "Sierra Leone"
            },
            "eBAyeGv0exc": {
                "name": "Inpatient morbidity and mortality"
            },
            "ou": {
                "name": "Organisation unit"
            },
            "Zj7UnCAulEk": {
                "name": "Inpatient morbidity and mortality"
            }
        },
        "dimensions": {
            "pe": [
                
            ],
            "ou": [
                "ImspTQPwCqd"
            ]
        }
    },
    "rowContext": {
        
    },
    "width": 2,
    "rows": [
        [
            "{\"type\":\"Point\",\"coordinates\":[-12.262115,8.195179]}",
            "psigeometry"
        ],
       ...
        [
            "{\"type\":\"Point\",\"coordinates\":[0,0]}",
            "psigeometry"
        ]
    ],
    "height": 28,
    "headerWidth": 2
}
```

ref: https://dhis2.atlassian.net/browse/DHIS2-20527