### PR TITLE
chore: Use auth user when persisting storedBy [DHIS2-21537][2.43]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/enrollments/EnrollmentsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/enrollments/EnrollmentsTests.java
@@ -209,7 +209,7 @@ public class EnrollmentsTests extends TrackerApiTest {
         .body("storedAt", notNullValue())
         .body("updatedAt", notNullValue())
         .body("value", notNullValue())
-        .body("storedBy", CoreMatchers.everyItem(equalTo(null)))
+        .body("storedBy", CoreMatchers.everyItem(equalTo("taadmin")))
         .body("createdBy.username", CoreMatchers.everyItem(equalTo("taadmin")));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.stream.Stream;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -51,8 +52,10 @@ import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -67,6 +70,8 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private EnrollmentService enrollmentService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private User importUser;
 
@@ -118,6 +123,22 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
         enrollmentService.getEnrollment(trackerObjects.getEnrollments().get(0).getUID());
 
     assertEnrollmentCompletedData(enrollment);
+  }
+
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForTrackedEntity() throws IOException {
+    testSetup.importTrackerData();
+
+    TrackedEntity te = manager.get(TrackedEntity.class, "QS6w44flWAf");
+    assertEquals(importUser.getUsername(), te.getStoredBy());
+  }
+
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForEnrollment() throws IOException {
+    testSetup.importTrackerData();
+
+    Enrollment enrollment = manager.get(Enrollment.class, "TvctPPhpD8z");
+    assertEquals(importUser.getUsername(), enrollment.getStoredBy());
   }
 
   public Stream<Arguments> statuses() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -66,12 +66,14 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager manager;
 
+  private User importUser;
+
   @BeforeAll
   void setUp() throws IOException {
     testSetup.importMetadata();
 
-    final User userA = userService.getUser("tTgjgobT1oS");
-    injectSecurityContextUser(userA);
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
 
     testSetup.importTrackerData("tracker/one_te.json");
     testSetup.importTrackerData("tracker/one_enrollment.json");
@@ -133,5 +135,15 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
         dataValueMap.get(updatedDataElementId).getCreated(),
         updatedDataValueMap.get(updatedDataElementId).getCreated());
     assertEquals("Fourth updated", updatedDataValueMap.get(updatedDataElementId).getValue());
+  }
+
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForEventDataValues() throws IOException {
+    testSetup.importTrackerData();
+
+    TrackerEvent event = manager.get(TrackerEvent.class, "pTzf9KYMk72");
+    for (EventDataValue dv : event.getEventDataValues()) {
+      assertEquals(importUser.getUsername(), dv.getStoredBy());
+    }
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventImportTest.java
@@ -169,6 +169,22 @@ class EventImportTest extends PostgresIntegrationTestBase {
     assertNotNull(singleEvent.getCompletedDate());
   }
 
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForTrackerEvent() throws IOException {
+    testSetup.importTrackerData();
+
+    TrackerEvent event = manager.get(TrackerEvent.class, "pTzf9KYMk72");
+    assertEquals(importUser.getUsername(), event.getStoredBy());
+  }
+
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForSingleEvent() throws IOException {
+    testSetup.importTrackerData();
+
+    SingleEvent event = manager.get(SingleEvent.class, "QRYjLTiJTrA");
+    assertEquals(importUser.getUsername(), event.getStoredBy());
+  }
+
   private void importTracker(TrackerImportParams params, TrackerObjects trackerObjects) {
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
     manager.flush();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -92,11 +92,13 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
 
   @Autowired private MetadataImportService metadataImportService;
 
+  private User importUser;
+
   @BeforeAll
   void setUp() throws IOException {
     testSetup.importMetadata("tracker/te_with_tea_metadata.json");
 
-    User importUser = userService.getUser("tTgjgobT1oS");
+    importUser = userService.getUser("tTgjgobT1oS");
     injectSecurityContextUser(importUser);
   }
 
@@ -124,6 +126,16 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
     List<TrackedEntityAttributeValue> attributeValues =
         trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
     assertEquals(3, attributeValues.size());
+  }
+
+  @Test
+  void shouldSetStoredByToAuthenticatedUserForTrackedEntityAttributeValue() throws IOException {
+    testSetup.importTrackerData("tracker/te_with_tea_data.json");
+
+    TrackedEntity trackedEntity = manager.getAll(TrackedEntity.class).get(0);
+    List<TrackedEntityAttributeValue> attributeValues =
+        trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
+    attributeValues.forEach(av -> assertEquals(importUser.getUsername(), av.getStoredBy()));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -227,7 +227,7 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
               .orElse(null);
       assertNotNull(dbNote);
       assertEquals(note.getValue(), dbNote.getNoteText());
-      assertEquals(note.getStoredBy(), dbNote.getCreator());
+      assertEquals(updatedBy.getUsername(), dbNote.getCreator());
       assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
       assertEquals(updatedBy.getUsername(), dbNote.getLastUpdatedBy().getUsername());
       assertEquals(updatedBy.getFirstName(), dbNote.getLastUpdatedBy().getFirstName());
@@ -235,11 +235,46 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
     }
   }
 
+  @Test
+  void shouldSetCreatorToAuthenticatedUserForEnrollmentNote()
+      throws ForbiddenException, NotFoundException {
+    Enrollment enrollment = enrollmentService.getEnrollment(UID.of("TvctPPhpD8z"));
+    org.hisp.dhis.note.Note note =
+        enrollment.getNotes().stream()
+            .filter(n -> "f9423652692".equals(n.getUid()))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(userDetails.getUsername(), note.getCreator());
+  }
+
+  @Test
+  void shouldSetCreatorToAuthenticatedUserForTrackerEventNote()
+      throws ForbiddenException, NotFoundException {
+    TrackerEvent event = trackerEventService.getEvent(UID.of("pTzf9KYMk72"));
+    org.hisp.dhis.note.Note note =
+        event.getNotes().stream()
+            .filter(n -> "SGuCABkhpgn".equals(n.getUid()))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(userDetails.getUsername(), note.getCreator());
+  }
+
+  @Test
+  void shouldSetCreatorToAuthenticatedUserForSingleEventNote()
+      throws ForbiddenException, NotFoundException {
+    SingleEvent event = singleEventService.getEvent(UID.of("QRYjLTiJTrA"));
+    org.hisp.dhis.note.Note note =
+        event.getNotes().stream()
+            .filter(n -> "r8Ge3bH7aF9".equals(n.getUid()))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(userDetails.getUsername(), note.getCreator());
+  }
+
   private Note note() {
-    return Note.builder()
-        .note(UID.generate())
-        .storedBy("This is the creator")
-        .value("This is a note")
-        .build();
+    return Note.builder().note(UID.generate()).value("This is a note").build();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/note/NoteServiceTest.java
@@ -236,8 +236,7 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldSetCreatorToAuthenticatedUserForEnrollmentNote()
-      throws ForbiddenException, NotFoundException {
+  void shouldSetCreatorToAuthenticatedUserForEnrollmentNote() throws NotFoundException {
     Enrollment enrollment = enrollmentService.getEnrollment(UID.of("TvctPPhpD8z"));
     org.hisp.dhis.note.Note note =
         enrollment.getNotes().stream()
@@ -249,8 +248,7 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldSetCreatorToAuthenticatedUserForTrackerEventNote()
-      throws ForbiddenException, NotFoundException {
+  void shouldSetCreatorToAuthenticatedUserForTrackerEventNote() throws NotFoundException {
     TrackerEvent event = trackerEventService.getEvent(UID.of("pTzf9KYMk72"));
     org.hisp.dhis.note.Note note =
         event.getNotes().stream()
@@ -262,8 +260,7 @@ class NoteServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldSetCreatorToAuthenticatedUserForSingleEventNote()
-      throws ForbiddenException, NotFoundException {
+  void shouldSetCreatorToAuthenticatedUserForSingleEventNote() throws NotFoundException {
     SingleEvent event = singleEventService.getEvent(UID.of("QRYjLTiJTrA"));
     org.hisp.dhis.note.Note note =
         event.getNotes().stream()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -40,7 +40,6 @@ import static org.hisp.dhis.tracker.imports.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_6;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -355,7 +354,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertNull(note.getCreator());
+              assertEquals(importUser.getUsername(), note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });
   }
@@ -378,7 +377,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
               Note note = getByNote(event.getNotes(), t);
               assertTrue(CodeGenerator.isValidUid(note.getUid()));
               assertTrue(note.getCreated().getTime() > now.getTime());
-              assertNull(note.getCreator());
+              assertEquals(importUser.getUsername(), note.getCreator());
               assertEquals(importUser.getUid(), note.getLastUpdatedBy().getUid());
             });
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapper.java
@@ -85,7 +85,7 @@ public class TrackerObjectsMapper {
       dbTrackedEntity.setUid(trackedEntity.getTrackedEntity().getValue());
       dbTrackedEntity.setCreated(now);
       dbTrackedEntity.setCreatedByUserInfo(UserInfoSnapshot.from(user));
-      dbTrackedEntity.setStoredBy(trackedEntity.getStoredBy());
+      dbTrackedEntity.setStoredBy(user.getUsername());
     }
 
     dbTrackedEntity.setLastUpdated(now);
@@ -119,7 +119,7 @@ public class TrackerObjectsMapper {
       dbEnrollment = new Enrollment();
       dbEnrollment.setUid(enrollment.getEnrollment().getValue());
       dbEnrollment.setCreated(now);
-      dbEnrollment.setStoredBy(enrollment.getStoredBy());
+      dbEnrollment.setStoredBy(user.getUsername());
       dbEnrollment.setCreatedByUserInfo(UserInfoSnapshot.from(user));
     }
 
@@ -196,7 +196,7 @@ public class TrackerObjectsMapper {
       dbEvent = new TrackerEvent();
       dbEvent.setUid(event.getEvent().getValue());
       dbEvent.setCreated(now);
-      dbEvent.setStoredBy(event.getStoredBy());
+      dbEvent.setStoredBy(user.getUsername());
       dbEvent.setCreatedByUserInfo(UserInfoSnapshot.from(user));
     }
     dbEvent.setLastUpdated(now);
@@ -268,7 +268,7 @@ public class TrackerObjectsMapper {
       dbEvent = new SingleEvent();
       dbEvent.setUid(event.getEvent().getValue());
       dbEvent.setCreated(now);
-      dbEvent.setStoredBy(event.getStoredBy());
+      dbEvent.setStoredBy(user.getUsername());
       dbEvent.setCreatedByUserInfo(UserInfoSnapshot.from(user));
     }
     dbEvent.setLastUpdated(now);
@@ -398,7 +398,7 @@ public class TrackerObjectsMapper {
     dbNote.setUid(note.getNote().getValue());
     dbNote.setCreated(now);
     dbNote.setLastUpdatedBy(user);
-    dbNote.setCreator(note.getStoredBy());
+    dbNote.setCreator(user != null ? user.getUsername() : null);
     dbNote.setNoteText(note.getValue());
 
     return dbNote;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -430,7 +430,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                         .setAttribute(
                             getTrackedEntityAttributeFromPreheat(preheat, attribute.getAttribute()))
                         .setTrackedEntity(trackedEntity))
-            .setStoredBy(attribute.getStoredBy())
+            .setStoredBy(user.getUsername())
             .setValue(attribute.getValue())
             .setLastUpdated(new Date());
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Attribute.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Attribute.java
@@ -46,7 +46,5 @@ import lombok.NoArgsConstructor;
 public class Attribute implements Serializable {
   @JsonProperty private MetadataIdentifier attribute;
 
-  @JsonProperty private String storedBy;
-
   @JsonProperty private String value;
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/DataValue.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/DataValue.java
@@ -45,8 +45,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 // TODO(DHIS2-18223) Remove unused fields when fixing data values logic
 public class DataValue implements Serializable {
-  @JsonProperty private String storedBy;
-
   @JsonProperty private boolean providedElsewhere;
 
   @JsonProperty private MetadataIdentifier dataElement;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
@@ -72,8 +72,6 @@ public class Enrollment implements TrackerDto, Serializable {
 
   @JsonProperty private boolean followUp;
 
-  @JsonProperty private String storedBy;
-
   @JsonProperty private Instant completedAt;
 
   @JsonProperty private Geometry geometry;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
@@ -62,8 +62,6 @@ public interface Event extends TrackerDto, Serializable {
 
   Instant getOccurredAt();
 
-  String getStoredBy();
-
   Instant getCreatedAtClient();
 
   Instant getUpdatedAtClient();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Note.java
@@ -52,6 +52,4 @@ public class Note implements Serializable {
   @Nonnull @JsonProperty private UID note;
 
   @JsonProperty private String value;
-
-  @JsonProperty private String storedBy;
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/SingleEvent.java
@@ -64,8 +64,6 @@ public class SingleEvent implements Event {
 
   @JsonProperty private Instant occurredAt;
 
-  @JsonProperty private String storedBy;
-
   @JsonProperty private Instant createdAtClient;
 
   @JsonProperty private Instant updatedAtClient;
@@ -103,7 +101,6 @@ public class SingleEvent implements Event {
         .programStage(event.getProgramStage())
         .orgUnit(event.getOrgUnit())
         .occurredAt(event.getOccurredAt())
-        .storedBy(event.getStoredBy())
         .createdAtClient(event.getCreatedAtClient())
         .updatedAtClient(event.getUpdatedAtClient())
         .attributeOptionCombo(event.getAttributeOptionCombo())

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
@@ -67,8 +67,6 @@ public class TrackedEntity implements TrackerDto, Serializable {
 
   @JsonProperty private Geometry geometry;
 
-  @JsonProperty private String storedBy;
-
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerEvent.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerEvent.java
@@ -65,8 +65,6 @@ public class TrackerEvent implements Event {
 
   @JsonProperty private Instant scheduledAt;
 
-  @JsonProperty private String storedBy;
-
   @JsonProperty private Instant createdAtClient;
 
   @JsonProperty private Instant updatedAtClient;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/note/JdbcNoteStore.java
@@ -127,7 +127,7 @@ public class JdbcNoteStore {
 
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("text", note.getValue());
-    params.addValue("creator", note.getStoredBy());
+    params.addValue("creator", user.getUsername());
     params.addValue("lastUpdatedBy", user.getUid());
     params.addValue("uid", note.getNote().getValue());
     params.addValue("created", new Date());

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -113,7 +113,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, program, trackedEntity, smsCreatedBy.getUsername());
+    TrackerObjects trackerObjects = map(subm, program, trackedEntity);
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -181,7 +181,6 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
             smsCommand,
             dataValues,
             smsCreatedBy.getUserOrgUnitIds().iterator().next(),
-            smsCreatedBy.getUsername(),
             categoryService,
             trackedEntity.getUid(),
             enrollment);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
@@ -78,7 +78,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, smsCreatedBy.getUsername());
+    TrackerObjects trackerObjects = map(subm);
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
@@ -99,7 +99,6 @@ public class SingleEventListener extends CommandSMSListener {
             smsCommand,
             dataValues,
             smsCreatedBy.getUserOrgUnitIds().iterator().next(),
-            smsCreatedBy.getUsername(),
             dataElementCategoryService);
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapper.java
@@ -122,8 +122,7 @@ class SmsImportMapper {
   static TrackerObjects map(
       @Nonnull EnrollmentSmsSubmission submission,
       @Nonnull Program program,
-      @CheckForNull org.hisp.dhis.tracker.model.TrackedEntity trackedEntity,
-      @Nonnull String username) {
+      @CheckForNull org.hisp.dhis.tracker.model.TrackedEntity trackedEntity) {
     Set<String> programAttributes =
         emptyIfNull(program.getProgramAttributes()).stream()
             .map(ProgramTrackedEntityAttribute::getAttribute)
@@ -146,7 +145,7 @@ class SmsImportMapper {
             List.of(mapToEnrollment(submission, programAttributes, existingAttributeValues)))
         .events(
             emptyIfNull(submission.getEvents()).stream()
-                .map(e -> mapToTrackerEvent(e, username, submission.getEnrollment()))
+                .map(e -> mapToTrackerEvent(e, submission.getEnrollment()))
                 .toList())
         .build();
   }
@@ -282,66 +281,59 @@ class SmsImportMapper {
 
   @Nonnull
   private static TrackerEvent mapToTrackerEvent(
-      @Nonnull SmsEvent submission, @Nonnull String username, @Nonnull Uid enrollment) {
+      @Nonnull SmsEvent submission, @Nonnull Uid enrollment) {
     return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .enrollment(UID.of(enrollment.getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
         .programStage(metadataUid(submission.getProgramStage()))
         .attributeOptionCombo(metadataUid(submission.getAttributeOptionCombo()))
-        .storedBy(username)
         .occurredAt(toInstant(submission.getEventDate()))
         .scheduledAt(toInstant(submission.getDueDate()))
         .status(map(submission.getEventStatus()))
         .geometry(map(submission.getCoordinates()))
-        .dataValues(map(submission.getValues(), username))
+        .dataValues(map(submission.getValues()))
         .build();
   }
 
   @Nonnull
-  static TrackerObjects map(
-      @Nonnull TrackerEventSmsSubmission submission, @Nonnull String username) {
-    return TrackerObjects.builder().events(List.of(mapTrackerEvent(submission, username))).build();
+  static TrackerObjects map(@Nonnull TrackerEventSmsSubmission submission) {
+    return TrackerObjects.builder().events(List.of(mapTrackerEvent(submission))).build();
   }
 
   @Nonnull
-  private static TrackerEvent mapTrackerEvent(
-      @Nonnull TrackerEventSmsSubmission submission, @Nonnull String username) {
+  private static TrackerEvent mapTrackerEvent(@Nonnull TrackerEventSmsSubmission submission) {
     return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .enrollment(UID.of(submission.getEnrollment().getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
         .programStage(metadataUid(submission.getProgramStage()))
         .attributeOptionCombo(metadataUid(submission.getAttributeOptionCombo()))
-        .storedBy(username)
         .occurredAt(toInstant(submission.getEventDate()))
         .scheduledAt(toInstant(submission.getDueDate()))
         .status(map(submission.getEventStatus()))
         .geometry(map(submission.getCoordinates()))
-        .dataValues(map(submission.getValues(), username))
+        .dataValues(map(submission.getValues()))
         .build();
   }
 
   @Nonnull
-  static TrackerObjects map(
-      @Nonnull SimpleEventSmsSubmission submission, @Nonnull String username) {
-    return TrackerObjects.builder().events(List.of(mapTrackerEvent(submission, username))).build();
+  static TrackerObjects map(@Nonnull SimpleEventSmsSubmission submission) {
+    return TrackerObjects.builder().events(List.of(mapTrackerEvent(submission))).build();
   }
 
   @Nonnull
-  private static TrackerEvent mapTrackerEvent(
-      @Nonnull SimpleEventSmsSubmission submission, @Nonnull String username) {
+  private static TrackerEvent mapTrackerEvent(@Nonnull SimpleEventSmsSubmission submission) {
     return TrackerEvent.builder()
         .event(UID.of(submission.getEvent().getUid()))
         .orgUnit(metadataUid(submission.getOrgUnit()))
         .program(metadataUid(submission.getEventProgram()))
         .attributeOptionCombo(metadataUid(submission.getAttributeOptionCombo()))
-        .storedBy(username)
         .occurredAt(toInstant(submission.getEventDate()))
         .scheduledAt(toInstant(submission.getDueDate()))
         .status(map(submission.getEventStatus()))
         .geometry(map(submission.getCoordinates()))
-        .dataValues(map(submission.getValues(), username))
+        .dataValues(map(submission.getValues()))
         .build();
   }
 
@@ -361,15 +353,13 @@ class SmsImportMapper {
   }
 
   @Nonnull
-  private static Set<DataValue> map(
-      @CheckForNull List<SmsDataValue> dataValues, @Nonnull String username) {
+  private static Set<DataValue> map(@CheckForNull List<SmsDataValue> dataValues) {
     return emptyIfNull(dataValues).stream()
         .map(
             dv ->
                 DataValue.builder()
                     .dataElement(metadataUid(dv.getDataElement()))
                     .value(dv.getValue())
-                    .storedBy(username)
                     .build())
         .collect(Collectors.toSet());
   }
@@ -409,7 +399,6 @@ class SmsImportMapper {
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
       @Nonnull String orgUnit,
-      @Nonnull String username,
       @Nonnull CategoryService categoryService,
       @Nonnull String trackedEntity,
       @CheckForNull UID enrollmentUid) {
@@ -431,8 +420,7 @@ class SmsImportMapper {
       enrollments = List.of(enrollment);
     }
 
-    TrackerEvent event =
-        mapCommandEvent(sms, smsCommand, dataValues, orgUnit, username, categoryService);
+    TrackerEvent event = mapCommandEvent(sms, smsCommand, dataValues, orgUnit, categoryService);
     event.setEnrollment(enrollmentUid);
 
     return TrackerObjects.builder().enrollments(enrollments).events(List.of(event)).build();
@@ -444,13 +432,11 @@ class SmsImportMapper {
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
       @Nonnull String orgUnit,
-      @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService) {
     return TrackerObjects.builder()
         .events(
             List.of(
-                mapCommandEvent(
-                    sms, smsCommand, dataValues, orgUnit, username, dataElementCategoryService)))
+                mapCommandEvent(sms, smsCommand, dataValues, orgUnit, dataElementCategoryService)))
         .build();
   }
 
@@ -511,7 +497,6 @@ class SmsImportMapper {
       @Nonnull SMSCommand smsCommand,
       @Nonnull Map<String, String> dataValues,
       @Nonnull String orgUnit,
-      @Nonnull String username,
       @Nonnull CategoryService dataElementCategoryService) {
     return TrackerEvent.builder()
         .event(UID.generate())
@@ -522,16 +507,13 @@ class SmsImportMapper {
         .scheduledAt(sms.getSentDate().toInstant())
         .attributeOptionCombo(
             metadataUid(dataElementCategoryService.getDefaultCategoryOptionCombo()))
-        .storedBy(username)
-        .dataValues(map(smsCommand.getCodes(), dataValues, username))
+        .dataValues(map(smsCommand.getCodes(), dataValues))
         .build();
   }
 
   @Nonnull
   private static Set<DataValue> map(
-      @Nonnull Set<SMSCode> codes,
-      @Nonnull Map<String, String> dataValues,
-      @Nonnull String username) {
+      @Nonnull Set<SMSCode> codes, @Nonnull Map<String, String> dataValues) {
     Set<DataValue> result = new HashSet<>();
     for (SMSCode code : codes) {
       String value = dataValues.get(code.getCode());
@@ -545,7 +527,6 @@ class SmsImportMapper {
           DataValue.builder()
               .dataElement(MetadataIdentifier.ofUid(code.getDataElement().getUid()))
               .value(value)
-              .storedBy(username)
               .build());
     }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListener.java
@@ -78,7 +78,7 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
         TrackerImportParams.builder()
             .importStrategy(TrackerImportStrategy.CREATE_AND_UPDATE)
             .build();
-    TrackerObjects trackerObjects = map(subm, smsCreatedBy.getUsername());
+    TrackerObjects trackerObjects = map(subm);
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     if (Status.OK == importReport.getStatus()) {

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
@@ -206,7 +206,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .occurredAt(YESTERDAY.toInstant())
             .status(ACTIVE)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -231,7 +231,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -258,7 +258,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.COMPLETED)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -285,7 +285,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.CANCELLED)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -312,7 +312,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
 
@@ -359,7 +359,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .build();
 
     TrackerEvent result = TrackerObjectsMapper.map(preheat, event, updatingUser);
@@ -385,7 +385,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .build();
 
     TrackerEvent result = TrackerObjectsMapper.map(preheat, event, updatingUser);
@@ -416,7 +416,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .assignedUser(user)
             .build();
 
@@ -447,7 +447,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .notes(notes(creatingUser))
+            .notes(notes())
             .assignedUser(user)
             .attributeOptionCombo(MetadataIdentifier.ofUid(COC_UID))
             .build();
@@ -690,7 +690,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
     return dbEvent;
   }
 
-  private List<org.hisp.dhis.tracker.imports.domain.Note> notes(UserDetails user) {
+  private List<org.hisp.dhis.tracker.imports.domain.Note> notes() {
     return List.of(
         org.hisp.dhis.tracker.imports.domain.Note.builder()
             .note(NOTE_UID)

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerObjectsMapperTest.java
@@ -166,7 +166,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .trackedEntityType(MetadataIdentifier.ofUid(trackerEntityType))
             .createdAtClient(NOW.toInstant())
             .updatedAtClient(NOW.toInstant())
-            .storedBy(creatingUser.getUsername())
             .inactive(true)
             .build();
 
@@ -185,7 +184,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .trackedEntityType(MetadataIdentifier.ofUid(trackerEntityType))
             .createdAtClient(NOW.toInstant())
             .updatedAtClient(NOW.toInstant())
-            .storedBy(creatingUser.getUsername())
             .inactive(true)
             .build();
 
@@ -208,7 +206,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .enrolledAt(NOW.toInstant())
             .occurredAt(YESTERDAY.toInstant())
             .status(ACTIVE)
-            .storedBy(creatingUser.getUsername())
             .notes(notes(creatingUser))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
@@ -234,7 +231,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
-            .storedBy(creatingUser.getUsername())
             .notes(notes(creatingUser))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
@@ -262,7 +258,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.COMPLETED)
-            .storedBy(creatingUser.getUsername())
             .notes(notes(creatingUser))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
@@ -290,7 +285,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(EnrollmentStatus.CANCELLED)
-            .storedBy(creatingUser.getUsername())
             .notes(notes(creatingUser))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
@@ -318,7 +312,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .updatedAtClient(NOW.toInstant())
             .enrolledAt(NOW.toInstant())
             .status(ACTIVE)
-            .storedBy(creatingUser.getUsername())
             .notes(notes(creatingUser))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
             .build();
@@ -344,7 +337,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
             .program(MetadataIdentifier.ofUid(PROGRAM_UID))
             .orgUnit(MetadataIdentifier.ofUid(ORGANISATION_UNIT_UID))
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
-            .storedBy(creatingUser.getUsername())
             .build();
 
     TrackerEvent result = TrackerObjectsMapper.map(preheat, event, creatingUser);
@@ -635,7 +627,7 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
               .orElse(null);
       assertNotNull(dbNote);
       assertEquals(note.getValue(), dbNote.getNoteText());
-      assertEquals(note.getStoredBy(), dbNote.getCreator());
+      assertEquals(updatedBy.getUsername(), dbNote.getCreator());
       assertEquals(updatedBy.getUid(), dbNote.getLastUpdatedBy().getUid());
     }
   }
@@ -703,7 +695,6 @@ class TrackerObjectsMapperTest extends TrackerTestBase {
         org.hisp.dhis.tracker.imports.domain.Note.builder()
             .note(NOTE_UID)
             .value("This is a note")
-            .storedBy(user.getUsername())
             .build());
   }
 }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/SmsImportMapperTest.java
@@ -81,7 +81,7 @@ class SmsImportMapperTest extends TrackerTestBase {
     input.setEnrollmentStatus(SmsEnrollmentStatus.COMPLETED);
     input.setAttributeOptionCombo(CodeGenerator.generateUid());
 
-    TrackerObjects actual = map(input, program(), null, "francis");
+    TrackerObjects actual = map(input, program(), null);
 
     TrackerObjects expected =
         TrackerObjects.builder()
@@ -121,7 +121,7 @@ class SmsImportMapperTest extends TrackerTestBase {
     input.setValues(List.of(new SmsAttributeValue("fN8skWVI8JS", "soap")));
     input.setAttributeOptionCombo(CodeGenerator.generateUid());
 
-    TrackerObjects actual = map(input, program("YjToz9y10ZZ"), null, "francis");
+    TrackerObjects actual = map(input, program("YjToz9y10ZZ"), null);
 
     TrackerObjects expected =
         TrackerObjects.builder()
@@ -171,7 +171,7 @@ class SmsImportMapperTest extends TrackerTestBase {
     input.setIncidentDate(occurredDate);
     input.setCoordinates(new GeoPoint(48.8575f, 2.3514f));
 
-    TrackerObjects actual = map(input, program(), null, "francis");
+    TrackerObjects actual = map(input, program(), null);
 
     List<Enrollment> expected =
         List.of(
@@ -213,7 +213,7 @@ class SmsImportMapperTest extends TrackerTestBase {
         List.of(new SmsDataValue(CodeGenerator.generateUid(), "oHvZHthw9Y0", "hello")));
     input.setEvents(List.of(smsEvent));
 
-    TrackerObjects actual = map(input, program(), null, "francis");
+    TrackerObjects actual = map(input, program(), null);
 
     List<Event> expected =
         List.of(
@@ -224,13 +224,11 @@ class SmsImportMapperTest extends TrackerTestBase {
                 .attributeOptionCombo(
                     MetadataIdentifier.ofUid(smsEvent.getAttributeOptionCombo().getUid()))
                 .status(EventStatus.SCHEDULE)
-                .storedBy("francis")
                 .dataValues(
                     Set.of(
                         DataValue.builder()
                             .dataElement(MetadataIdentifier.ofUid("oHvZHthw9Y0"))
                             .value("hello")
-                            .storedBy("francis")
                             .build()))
                 .enrollment(UID.of(input.getEnrollment().getUid()))
                 .build());
@@ -265,7 +263,7 @@ class SmsImportMapperTest extends TrackerTestBase {
             new SmsAttributeValue("cCR4QVathUM", "twoWasUpdated"),
             new SmsAttributeValue("zjOPAEZyQxu", "threeWasAdded")));
 
-    TrackerObjects actual = map(input, program("YjToz9y10ZZ"), trackedEntity, "francis");
+    TrackerObjects actual = map(input, program("YjToz9y10ZZ"), trackedEntity);
 
     List<Attribute> expected =
         List.of(
@@ -351,7 +349,7 @@ class SmsImportMapperTest extends TrackerTestBase {
     input.setAttributeOptionCombo(CodeGenerator.generateUid());
     input.setEventStatus(SmsEventStatus.COMPLETED);
 
-    TrackerObjects actual = map(input, "francis");
+    TrackerObjects actual = map(input);
 
     TrackerEvent expected =
         TrackerEvent.builder()
@@ -362,7 +360,6 @@ class SmsImportMapperTest extends TrackerTestBase {
             .attributeOptionCombo(
                 MetadataIdentifier.ofUid(input.getAttributeOptionCombo().getUid()))
             .status(EventStatus.COMPLETED)
-            .storedBy("francis")
             .build();
     assertContainsOnly(List.of(expected), actual.getEvents());
   }
@@ -385,7 +382,7 @@ class SmsImportMapperTest extends TrackerTestBase {
     // that is necessary though.
     input.setValues(List.of(new SmsDataValue(CodeGenerator.generateUid(), "oHvZHthw9Y0", "hello")));
 
-    TrackerObjects actual = map(input, "francis");
+    TrackerObjects actual = map(input);
 
     TrackerEvent expected =
         TrackerEvent.builder()
@@ -396,7 +393,6 @@ class SmsImportMapperTest extends TrackerTestBase {
             .attributeOptionCombo(
                 MetadataIdentifier.ofUid(input.getAttributeOptionCombo().getUid()))
             .status(EventStatus.ACTIVE)
-            .storedBy("francis")
             .occurredAt(occurredDate.toInstant())
             .scheduledAt(scheduledDate.toInstant())
             .geometry(new GeometryFactory().createPoint(new Coordinate(2.3514f, 48.8575f)))
@@ -405,7 +401,6 @@ class SmsImportMapperTest extends TrackerTestBase {
                     DataValue.builder()
                         .dataElement(MetadataIdentifier.ofUid("oHvZHthw9Y0"))
                         .value("hello")
-                        .storedBy("francis")
                         .build()))
             .build();
     assertContainsOnly(List.of(expected), actual.getEvents());


### PR DESCRIPTION
In v44, we removed the `storedBy` field from notes, tracked entities, enrollments, events, and event data values.

However, in older versions, we still want to persist the authenticated user in this field, since it currently stores the user from the payload.
