### PR TITLE
fix: remove analytics 0-partition tables on scheduled full update [DHIS2-19473]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -100,7 +100,6 @@ public class ContinuousAnalyticsTableJob implements Job {
 
       AnalyticsTableUpdateParams params =
           AnalyticsTableUpdateParams.newBuilder()
-              .withLastYears(parameters.getLastYears())
               .withSkipResourceTables(false)
               .withSkipOutliers(parameters.getSkipOutliers())
               .withSkipTableTypes(parameters.getSkipTableTypes())


### PR DESCRIPTION
Back-port from https://github.com/dhis2/dhis2-core/pull/21959