### PR TITLE
test: convert eligible integration tests to @Transactional

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerMinIOTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerMinIOTest.java
@@ -58,6 +58,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Test class configured for use cases when DHIS2 is configured to use MinIO storage. The default
@@ -65,6 +66,7 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @ExtendWith(MinIOTestExtension.class)
 @ContextConfiguration(classes = {DhisConfig.class})
+@Transactional
 class AppManagerMinIOTest extends PostgresIntegrationTestBase {
 
   private static final String MOCK_CONTEXT_PATH = "/context";

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/app/AppManagerTest.java
@@ -53,11 +53,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Test class configured for use cases when DHIS2 is configured to use local file system storage
  * (default)
  */
+@Transactional
 class AppManagerTest extends PostgresIntegrationTestBase {
 
   private static final String MOCK_CONTEXT_PATH = "/context";

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
@@ -55,7 +55,9 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class MinMaxOutlierAnalysisServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private MinMaxOutlierAnalysisService minMaxOutlierAnalysisService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests the features of the {@link DatastoreService} that do require a postgres database.
@@ -58,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Jan Bernitt
  */
+@Transactional
 class DatastoreIntegrationTest extends PostgresIntegrationTestBase {
   @Autowired private DatastoreService datastore;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
@@ -48,10 +48,12 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen
  */
+@Transactional
 class JsonPatchManagerTest extends PostgresIntegrationTestBase {
 
   private final ObjectMapper jsonMapper = JacksonObjectMapperConfig.staticJsonMapper();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/indicator/IndicatorMergeServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/indicator/IndicatorMergeServiceTest.java
@@ -62,10 +62,12 @@ import org.hisp.dhis.visualization.Visualization;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author david mackessy
  */
+@Transactional
 class IndicatorMergeServiceTest extends PostgresIntegrationTestBase {
   @Autowired private MergeService indicatorMergeService;
   @Autowired private IdentifiableObjectManager manager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
@@ -36,10 +36,12 @@ import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Jan Bernitt
  */
+@Transactional
 class OrganisationUnitGroupStoreTest extends OrganisationUnitBaseSpringTest {
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
@@ -46,10 +46,12 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
  */
+@Transactional
 class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest {
 
   @Autowired private DataSetService dataSetService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceMinMaxTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceMinMaxTest.java
@@ -63,10 +63,12 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
  */
+@Transactional
 class OutlierDetectionServiceMinMaxTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager idObjectManager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceModifiedZScoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceModifiedZScoreTest.java
@@ -69,7 +69,9 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class OutlierDetectionServiceModifiedZScoreTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager idObjectManager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceZScoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceZScoreTest.java
@@ -67,10 +67,12 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
  */
+@Transactional
 class OutlierDetectionServiceZScoreTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager idObjectManager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -50,10 +50,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Jim Grace
  */
+@Transactional
 class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
 
   @Autowired private ProgramIndicatorService programIndicatorService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -58,7 +58,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class ProgramRuleServiceTest extends PostgresIntegrationTestBase {
 
   private Program programA;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
@@ -46,10 +46,12 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Transactional
 class QueryParserTest extends PostgresIntegrationTestBase {
 
   private QueryParser queryParser;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingsTranslationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingsTranslationServiceTest.java
@@ -37,12 +37,14 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests the settings translation feature included in {@link SystemSettingsService}
  *
  * @author Jan Bernitt
  */
+@Transactional
 class SystemSettingsTranslationServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private SystemSettingsTranslationService settingsTranslationService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
@@ -48,10 +48,12 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Chau Thu Tran
  */
+@Transactional
 class TrackedEntityAttributeStoreTest extends PostgresIntegrationTestBase {
 
   @Autowired private TrackedEntityAttributeService attributeService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceIntegrationTest.java
@@ -51,7 +51,9 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class DeduplicationServiceIntegrationTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
@@ -58,12 +58,14 @@ import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * ValidationService tests that need to run against a Postgres db.
  *
  * @author Jim Grace
  */
+@Transactional
 class ValidationServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   @Autowired private ValidationService validationService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -98,10 +98,12 @@ import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Jim Grace
  */
+@Transactional
 class ValidationServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private ValidationService validationService;


### PR DESCRIPTION
## Summary

Converts **19** integration-test classes in `dhis-test-integration` from the expensive `emptyDatabase()` truncate-all cleanup path to `@Transactional` rollback-based cleanup. Each change is a 2-line addition (`@Transactional` + import); no test logic was modified.

## Why these tests were targeted

`SpringIntegrationTestExtension` cleans DB state between tests in one of two ways:
- **`@Transactional` tests** — the test runs in a transaction that is rolled back. Nothing is committed, no cleanup query runs. Cheap.
- **Non-`@Transactional` tests** — the extension calls `dbmsManager.emptyDatabase()` (truncate/delete across all tables) in `afterEach`, i.e. **once per test method**. This is the expensive path.

273/339 classes already use `@Transactional`; the ~66 stragglers fall back to the truncate path and pay it repeatedly, contributing to the ~17-min `integration-test` job. This PR converts the subset that can safely switch.

## Why we could convert *these* (and not the rest)

A test is only safe to convert if it writes **and reads back through Hibernate** — Hibernate auto-flushes before HQL/Criteria/session queries, so the test sees its own un-committed writes inside the rollback transaction.

Every conversion here was **verified with a local `mvn -Pintegration-test` run** and kept only if green. Classes that genuinely depend on committed state were left as-is, because converting them makes tests fail (verified) or pass for the wrong reason:
- **Raw `jdbcTemplate`/SQL reads** (data-value-set export, analytics aggregation, the tracker SQL exporter) — these don't trigger a Hibernate flush, so they can't see un-flushed session writes (`NotFoundException`, wrong counts).
- **Flush/commit-time constraint assertions** — `assertThrows(DataIntegrityViolationException/DeleteNotAllowedException)` never fires in a rolled-back transaction.
- **Cross-transaction behaviour** — e.g. cache-invalidation message publishing.

These are tracked as deferred; converting them would require per-test rework (explicit flushes / not depending on committed reads), not a simple annotation flip.

### Converted classes (19)
`ProgramRuleServiceTest`, `ProgramIndicatorServiceVariableTest`, `OrganisationUnitGroupStoreTest`, `OrganisationUnitStoreTest`, `TrackedEntityAttributeStoreTest`, `SystemSettingsTranslationServiceTest`, `QueryParserTest`, `JsonPatchManagerTest`, `IndicatorMergeServiceTest`, `MinMaxOutlierAnalysisServiceTest`, `DatastoreIntegrationTest`, `OutlierDetectionServiceMinMaxTest`, `OutlierDetectionServiceModifiedZScoreTest`, `OutlierDetectionServiceZScoreTest`, `DeduplicationServiceIntegrationTest`, `ValidationServiceIntegrationTest`, `ValidationServiceTest`, `AppManagerTest`, `AppManagerMinIOTest`.

## Performance gain (measured)

Ran the same 19 classes before (master) vs after (this branch) in one JVM with a shared Spring context, comparing the sum of surefire per-class "Time elapsed". The constant ~62s context startup and the build are identical in both runs and cancel out, so the delta isolates the eliminated `emptyDatabase()` work.

| | Test execution |
|---|---|
| Before (truncate cleanup) | 162.3s |
| After (`@Transactional`) | 132.1s |
| **Saved** | **30.2s — 18.6%** |

≈ **0.14s saved per eliminated truncate** (214 test methods), and higher for data-heavy classes (e.g. `ValidationServiceTest` alone saved 10s). Single run each; absolute numbers will split differently under sharded CI, but the work removed is real.

## Test plan
- [x] `mvn test -pl dhis-test-integration -am -Pintegration-test -Dtest=<19 classes>` green locally
- [x] `mvn spotless:check` passes
- [ ] CI green

> Note: `AppManagerTest` / `AppManagerMinIOTest` have one pre-existing local failure (`fileResourceContentLengthUnknownTest`) caused by a JDK-21/Mockito-inline env issue (`cannot mock UrlResource`) — confirmed identical on master without this change, and unrelated to transactionality. Expected green on CI (JDK 17). Happy to drop these two if CI disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)