### PR TITLE
test: convert eligible integration tests to @Transactional

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -74,10 +74,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Jim Grace
  */
+@Transactional
 class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTestBase {
   private static final String ACCESS_NONE = "--------";
 
@@ -630,6 +632,9 @@ class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTest
     settingsService.put("keyIgnoreAnalyticsApprovalYearThreshold", 0);
     settingsService.put("keyAcceptanceRequiredForApproval", true);
     settingsService.clearCurrentSettings();
+
+    // flush so the raw-SQL data-approval reads see the setup metadata
+    entityManager.flush();
   }
 
   @AfterEach
@@ -738,6 +743,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTest
     setUser(user);
     try {
       dataApprovalService.approveData(Arrays.asList(da));
+      entityManager.flush();
       return true;
     } catch (DataApprovalException ex) {
       return false;
@@ -766,6 +772,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTest
     setUser(user);
     try {
       dataApprovalService.unapproveData(Arrays.asList(da));
+      entityManager.flush();
       return true;
     } catch (DataApprovalException ex) {
       return false;
@@ -794,6 +801,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTest
     setUser(user);
     try {
       dataApprovalService.acceptData(Arrays.asList(da));
+      entityManager.flush();
       return true;
     } catch (DataApprovalException ex) {
       return false;
@@ -822,6 +830,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends PostgresIntegrationTest
     setUser(user);
     try {
       dataApprovalService.unacceptData(Arrays.asList(da));
+      entityManager.flush();
       return true;
     } catch (DataApprovalException ex) {
       return false;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
@@ -50,10 +50,12 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Jim Grace
  */
+@Transactional
 class DataApprovalStoreUserTest extends PostgresIntegrationTestBase {
 
   @Autowired private DataApprovalStore dataApprovalStore;
@@ -145,6 +147,8 @@ class DataApprovalStoreUserTest extends PostgresIntegrationTestBase {
     categoryService.addCategoryCombo(catComboA);
     CategoryOptionCombo catOptionComboA = createCategoryOptionCombo(catComboA, catOptionA);
     categoryService.addCategoryOptionCombo(catOptionComboA);
+    // flush so the raw-SQL data-approval status query sees the session writes
+    entityManager.flush();
     List<DataApprovalStatus> statuses =
         dataApprovalStore.getDataApprovalStatuses(
             workflowA,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsEventStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsEventStoreTest.java
@@ -47,11 +47,13 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Yrjan A. F. Fraschetti
  * @author Julie Hill Roa
  */
+@Transactional
 class DataStatisticsEventStoreTest extends PostgresIntegrationTestBase {
   @Autowired private DataStatisticsEventStore dataStatisticsEventStore;
 
@@ -95,6 +97,9 @@ class DataStatisticsEventStoreTest extends PostgresIntegrationTestBase {
 
     // Add one dashboard.
     assertTrue(dashboardService.saveDashboard(dashboard) != 0);
+
+    // flush so the raw-SQL statistics-store reads see the session writes
+    entityManager.flush();
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderInheritanceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderInheritanceIntegrationTest.java
@@ -41,7 +41,9 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class PostgreSqlBuilderInheritanceIntegrationTest extends PostgresIntegrationTestBase {
   @Autowired private JdbcTemplate jdbcTemplate;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandlerTest.java
@@ -60,10 +60,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
  */
+@Transactional
 class DataOrgUnitMergeHandlerTest extends PostgresIntegrationTestBase {
 
   @Autowired private CategoryService categoryService;
@@ -127,6 +129,8 @@ class DataOrgUnitMergeHandlerTest extends PostgresIntegrationTestBase {
     CategoryCombo ccA = categoryService.getDefaultCategoryCombo();
     dwA = new DataApprovalWorkflow("DataApprovalWorkflowA", monthly, ccA, Sets.newHashSet(dlA));
     idObjectManager.save(dwA);
+    // flush so the raw-SQL count/merge queries see the setup metadata
+    entityManager.flush();
   }
 
   @Test
@@ -194,5 +198,7 @@ class DataOrgUnitMergeHandlerTest extends PostgresIntegrationTestBase {
 
   private void addDataApprovals(DataApproval... dataApprovals) {
     Stream.of(dataApprovals).forEach(dataApprovalService::addDataApproval);
+    // flush so the raw-SQL data-approval count/merge queries see the session writes
+    entityManager.flush();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
@@ -57,10 +57,12 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
  */
+@Transactional
 class PredictorServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private PredictorService predictorService;
@@ -434,6 +436,8 @@ class PredictorServiceTest extends PostgresIntegrationTestBase {
   @Test
   void testCannotDeleteCategoryOptionComboUsedByPredictor() {
     setUpPredictorGroups();
+    // flush so the raw-SQL deletion-veto query sees the predictor rows
+    entityManager.flush();
     DeleteNotAllowedException ex =
         assertThrows(
             DeleteNotAllowedException.class,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramStageDataElementServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramStageDataElementServiceTest.java
@@ -49,10 +49,12 @@ import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Chau Thu Tran
  */
+@Transactional
 class ProgramStageDataElementServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private ProgramStageDataElementService programStageDataElementService;
@@ -182,6 +184,8 @@ class ProgramStageDataElementServiceTest extends PostgresIntegrationTestBase {
     programStageDataElementService.addProgramStageDataElement(stageDataElementA);
     stageA.getProgramStageDataElements().addAll(Set.of(stageDataElementA));
     programStageService.updateProgramStage(stageA);
+    // flush so the raw-SQL deletion-veto query sees the program-stage-data-element link
+    entityManager.flush();
     assertThrows(
         DeleteNotAllowedException.class, () -> dataElementService.deleteDataElement(dataElementA));
   }
@@ -197,6 +201,8 @@ class ProgramStageDataElementServiceTest extends PostgresIntegrationTestBase {
     programStageDataElementService.addProgramStageDataElement(stageDataElementB);
     programStageDataElementService.addProgramStageDataElement(stageDataElementC);
     programStageDataElementService.addProgramStageDataElement(stageDataElementD);
+    // flush so the raw-SQL store read sees the newly added program-stage-data-elements
+    entityManager.flush();
 
     Map<String, Set<String>> result =
         programStageDataElementService


### PR DESCRIPTION
## Summary

Follow-up to #24012. Converts a further **7** non-`@Transactional` integration tests in
`dhis-test-integration` to `@Transactional`, so `SpringIntegrationTestExtension` cleans up
between tests via a cheap transaction **rollback** instead of the expensive
`dbmsManager.emptyDatabase()` truncate-all that runs once per test **method** for
non-transactional, `PER_METHOD` classes.

Where a test reads back through raw `jdbcTemplate` SQL (which does **not** trigger Hibernate
auto-flush) or writes via `session.doWork` on the shared connection, an explicit
`entityManager.flush()` is added so those reads see the un-committed session writes within the
same transaction. `jdbcTemplate` and Hibernate share the transaction-bound connection under
`@Transactional`, so a flush (not a commit) is sufficient.

This was the careful, per-class audit called for in improvement plan #2 — each conversion was
verified green individually; classes that could not be safely converted were left unchanged with
the reason recorded (see below).

## Changes (file by file)

| File | Change | Why it needed it |
|---|---|---|
| `PostgreSqlBuilderInheritanceIntegrationTest` | `@Transactional` only | Pure DDL via jdbcTemplate; transactional in Postgres, self-cleans. |
| `PredictorServiceTest` | `@Transactional` + flush before the delete-veto `assertThrows` | `DeleteNotAllowedException` is an app-level veto backed by a raw-SQL count on `predictor`; the predictor rows must be flushed first. |
| `ProgramStageDataElementServiceTest` | `@Transactional` + 2 flushes | Delete-veto raw-SQL query, and a jdbc store read (`getProgramStageDataElementsWithSkipSynchronizationSetToTrue`). |
| `DataOrgUnitMergeHandlerTest` | `@Transactional` + flush in setUp & `addDataApprovals` | Counts/merge run raw `NamedParameterJdbcTemplate`; approvals written via Hibernate must be flushed. |
| `DataApprovalStoreUserTest` | `@Transactional` + flush before read | `HibernateDataApprovalStore.getDataApprovalStatuses` is raw jdbc. |
| `DataApprovalServiceCategoryOptionGroupTest` | `@Transactional` + flush in setUp & in approve/unapprove/accept/unaccept helpers | Status reads go through raw-jdbc store; flushing inside the write helpers covers the interleaved approve→read cycles. |
| `DataStatisticsEventStoreTest` | `@Transactional` + flush at end of setUp | `HibernateDataStatisticsEventStore` reads are raw jdbc. |

## Performance

Single shared-context JVM, surefire per-class "Time elapsed", master baseline vs branch:

| Converted class | before | after | Δ |
|---|--:|--:|--:|
| PredictorServiceTest | 4.069s | 1.785s | −56% |
| ProgramStageDataElementServiceTest | 2.324s | 1.126s | −52% |
| DataStatisticsEventStoreTest | 1.277s | 0.617s | −52% |
| DataOrgUnitMergeHandlerTest | 0.663s | 0.306s | −54% |
| PostgreSqlBuilderInheritanceIntegrationTest | 0.783s | 0.430s | −45% |
| DataApprovalStoreUserTest | 0.501s | 0.367s | −27% |

Sum of those 6 separable classes: **9.62s → 4.63s (−51.9%)** — each roughly halves, consistent
with removing one `emptyDatabase()` truncate per test method. (`DataApprovalServiceCategoryOptionGroupTest`
also converted, but it absorbs the one-time Spring context startup in a shared-JVM run, so its own
saving isn't separable from the startup it carries.)

Caveat: single run, shared-context JVM; the full-suite sum is dominated by the one ~startup the
run carries, so the per-class deltas are the meaningful signal. Real CI (sharded, per-shard
startup) will differ in absolute terms — the win is removing *work done*, not just wall-clock.

## Deferred (audited, intentionally NOT converted)

- **Async tracker exporter** (reads TEs on a separate thread pool / connection in
  `TrackedEntityAggregate.find()` → can't see un-committed data, flush can't bridge):
  `PotentialDuplicateRemoveTrackedEntityTest`, `DeduplicationServiceMergeIntegrationTest`,
  `MaintenanceServiceTest`.
- **Spring exception-translation gap** (`assertThrows` expects `DataIntegrityViolationException`,
  but a raw `em.flush()` throws untranslated `jakarta.persistence.PersistenceException`;
  translation only happens at tx commit / via `@Repository` proxy):
  `TrackedEntityTypeServiceTest`, `UidDBConstraintCheckTest`.
- **idScheme / import-pipeline metadata resolution** (code/attribute-based lookups and the import
  preheat don't see un-committed data even with a setUp flush — import returns 0 rows):
  `AdxDataServiceIntegrationTest`, `DataExportServiceExportTest`, `DataExportServiceIntegrationTest`.

## Test plan

- [x] `mvn test -pl dhis-test-integration -am -Pintegration-test -Dtest=<7 classes>` → BUILD SUCCESS, all green
- [x] Each converted class verified green; failing candidates reverted, not shipped
- [x] `mvn spotless:check -pl dhis-test-integration` passes
- [ ] CI green on JDK 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)