### PR TITLE
feat: remove EntityManager from DefaultTrackerBundleService [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -32,13 +32,11 @@ package org.hisp.dhis.tracker.imports.bundle;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import jakarta.persistence.EntityManager;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.Session;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -58,6 +56,8 @@ import org.hisp.dhis.tracker.imports.programrule.ProgramRuleService;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,7 +69,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DefaultTrackerBundleService implements TrackerBundleService {
   private final TrackerPreheatService trackerPreheatService;
 
-  private final EntityManager entityManager;
+  private final NamedParameterJdbcTemplate jdbcTemplate;
 
   private final CommitService commitService;
 
@@ -141,31 +141,30 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
       return;
     }
 
-    List<List<UID>> uidsPartitions =
-        Lists.partition(Lists.newArrayList(bundle.getUpdatedTrackedEntities()), 20000);
-
-    try (Session session = entityManager.unwrap(Session.class)) {
-      for (List<UID> trackedEntities : uidsPartitions) {
-        if (trackedEntities.isEmpty()) {
-          continue;
-        }
-        executeLastUpdatedQuery(session, UID.toValueList(trackedEntities), bundle.getUser());
-      }
-    }
-  }
-
-  private void executeLastUpdatedQuery(
-      Session session, List<String> trackedEntities, UserDetails user) {
+    String userInfoJson;
     try {
-      UserInfoSnapshot userInfo = UserInfoSnapshot.from(user);
-      session
-          .getNamedQuery("updateTrackedEntitiesLastUpdated")
-          .setParameter("trackedEntities", trackedEntities)
-          .setParameter("lastUpdated", new Date())
-          .setParameter("lastupdatedbyuserinfo", mapper.writeValueAsString(userInfo))
-          .executeUpdate();
+      userInfoJson = mapper.writeValueAsString(UserInfoSnapshot.from(bundle.getUser()));
     } catch (JsonProcessingException e) {
       throw new PersistenceException(e);
+    }
+
+    Date lastUpdated = new Date();
+    String sql =
+        "update trackedentity set lastUpdated = :lastUpdated,"
+            + " lastupdatedbyuserinfo = CAST(:lastupdatedbyuserinfo as jsonb)"
+            + " where uid in (:trackedEntities)";
+
+    for (List<UID> partition :
+        Lists.partition(Lists.newArrayList(bundle.getUpdatedTrackedEntities()), 20000)) {
+      if (partition.isEmpty()) {
+        continue;
+      }
+      MapSqlParameterSource params =
+          new MapSqlParameterSource()
+              .addValue("trackedEntities", UID.toValueList(partition))
+              .addValue("lastUpdated", lastUpdated)
+              .addValue("lastupdatedbyuserinfo", userInfoJson);
+      jdbcTemplate.update(sql, params);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
@@ -40,7 +40,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
@@ -82,10 +81,6 @@ import org.locationtech.jts.geom.Geometry;
 @Setter
 @Getter
 @Table(name = "trackedentity")
-@NamedNativeQuery(
-    name = "updateTrackedEntitiesLastUpdated",
-    query =
-        "update trackedentity set lastUpdated = :lastUpdated, lastupdatedbyuserinfo = CAST(:lastupdatedbyuserinfo as jsonb) WHERE uid in :trackedEntities")
 @Auditable(scope = AuditScope.TRACKER)
 public class TrackedEntity extends BaseTrackerObject
     implements IdentifiableObject, SoftDeletableEntity {


### PR DESCRIPTION
## Summary

  Phase 5 of the tracker import Hibernate → JDBC migration ([DHIS2-21378](https://dhis2.atlassian.net/browse/DHIS2-21378)). Replaces the `updateTrackedEntitiesLastUpdated` named native query — the last Hibernate dependency in `DefaultTrackerBundleService` — with a direct
   `NamedParameterJdbcTemplate` call, and removes the now-unused `@NamedNativeQuery` annotation from `TrackedEntity`.

  - **`DefaultTrackerBundleService`:** the `EntityManager` field and the `org.hibernate.Session` / `jakarta.persistence.EntityManager` imports are gone; a `NamedParameterJdbcTemplate` is injected via the Lombok-generated constructor. The bulk UPDATE on `trackedentity`
  still partitions by 20k UIDs and still casts `lastupdatedbyuserinfo` as `jsonb`. `UserInfoSnapshot` is serialised once per `postCommit()` call instead of once per partition.
  - **`TrackedEntity`:** `@NamedNativeQuery("updateTrackedEntitiesLastUpdated", ...)` and the `jakarta.persistence.NamedNativeQuery` import are removed — no other call site referenced this query.
  - **No behaviour change** beyond the persistence-layer swap: same SQL, same parameters, same partition size.

  ## Next steps

  - **Quick fix** ✅ `formatDate`: `SimpleDateFormat` → `static final DateTimeFormatter`
  - **Phase 0** ✅ Remove `EntityManager` from `TrackerPersister` interface and all method parameters — #23797
  - **Phase 1** ✅ Decouple `ChangeLogAccumulator` from Hibernate `Session` — #23836
  - **Phase 2** ✅ Extract `FileResource` assignment update into `FileResourceStore` — #23879
  - **Phase 3** ✅ Introduce `EntityWriteBatch`; accumulate and batch-flush TEAV writes — #23970
  - **Phase 4 (4b only)** ✅ Stage top-level entity inserts and updates through `EntityWriteBatch` — #24005
  - **Phase 5** 👈 this PR — Replace `updateTrackedEntitiesLastUpdated` named query with `NamedParameterJdbcTemplate`; remove last Hibernate dependency from `DefaultTrackerBundleService`
  - **Phase 4a + Phase 6** — Pre-allocate IDs from PostgreSQL sequences and swap the `EntityWriteBatch.flush()` Hibernate delegation for JDBC multi-row INSERT / unnest UPDATE, one entity type at a time. (Phase 4a does not ship alone: with `@GeneratedValue(SEQUENCE)`,
  Hibernate 6 rejects a pre-assigned non-zero id on `em.persist`, so pre-allocation lands together with the JDBC INSERT for the same entity type.)

[DHIS2-21378]: https://dhis2.atlassian.net/browse/DHIS2-21378