### PR TITLE
[2.40] fix: prevent NPE in event report table-layout download when dimensions/items metadata entries are missing

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -331,7 +331,8 @@ public class DefaultEventAnalyticsService extends AbstractAnalyticsService
       MetadataItem metadataItem =
           (MetadataItem) ((Map<String, Object>) grid.getMetaData().get(ITEMS.getKey())).get(row);
 
-      String name = StringUtils.defaultIfEmpty(metadataItem.getName(), row);
+      String name =
+          metadataItem == null ? row : StringUtils.defaultIfEmpty(metadataItem.getName(), row);
       String col = StringUtils.defaultIfEmpty(COLUMN_NAMES.get(row), row);
 
       outputGrid.addHeader(new GridHeader(name, col, ValueType.TEXT, false, true));
@@ -495,7 +496,7 @@ public class DefaultEventAnalyticsService extends AbstractAnalyticsService
           (List<String>)
               ((Map<String, Object>) grid.getMetaData().get(DIMENSIONS.getKey())).get(dimension);
 
-      if (legendOptions.isEmpty()) {
+      if (legendOptions == null || legendOptions.isEmpty()) {
         List<Legend> legends = eventDimensionalItemObject.getLegendSet().getSortedLegends();
 
         for (Legend legend : legends) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
@@ -39,7 +39,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
+import org.hisp.dhis.analytics.EventAnalyticsDimensionalItem;
 import org.hisp.dhis.analytics.Partitions;
 import org.hisp.dhis.analytics.cache.AnalyticsCache;
 import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
@@ -49,11 +55,13 @@ import org.hisp.dhis.analytics.event.EventDataQueryService;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryPlanner;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
+import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.system.database.DatabaseInfo;
+import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,5 +163,43 @@ class DefaultEventAnalyticsServiceTest {
         .withProgram(mockProgram)
         .withOutputIdScheme(scheme)
         .build();
+  }
+
+  @Test
+  void shouldNotNpeWhenItemsMetadataOmitsRowDimension() throws Exception {
+    String missingDimensionUid = "deUidAAAAA";
+
+    Grid grid = new ListGrid();
+    grid.getMetaData().put(AnalyticsMetaDataKey.ITEMS.getKey(), new HashMap<String, Object>());
+
+    EventQueryParams params = new EventQueryParams.Builder().build();
+
+    invokeGenerateOutputGrid(grid, params, List.of(), List.of(), List.of(missingDimensionUid));
+  }
+
+  private Grid invokeGenerateOutputGrid(
+      Grid grid,
+      EventQueryParams params,
+      List<Map<String, EventAnalyticsDimensionalItem>> rowPermutations,
+      List<Map<String, EventAnalyticsDimensionalItem>> columnPermutations,
+      List<String> rowDimensions)
+      throws Exception {
+    Method method =
+        DefaultEventAnalyticsService.class.getDeclaredMethod(
+            "generateOutputGrid",
+            Grid.class,
+            EventQueryParams.class,
+            List.class,
+            List.class,
+            List.class);
+    method.setAccessible(true);
+    return (Grid)
+        method.invoke(
+            defaultEventAnalyticsService,
+            grid,
+            params,
+            rowPermutations,
+            columnPermutations,
+            rowDimensions);
   }
 }


### PR DESCRIPTION
Backport from 48fdb7c51bd0ade56001b9b7921a5b1a255fd681