### PR TITLE
test: enable DataIntegrity integration tests missing the Test suffix

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOptionGroupsWithoutOptionsTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOptionGroupsWithoutOptionsTest.java
@@ -30,51 +30,57 @@
 package org.hisp.dhis.webapi.controller.dataintegrity;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
-import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonString;
-import org.hisp.dhis.test.webapi.json.domain.JsonUserRole;
 import org.junit.jupiter.api.Test;
 
-class DataIntegrityUserRolesNoAuthorities extends AbstractDataIntegrityIntegrationTest {
+class DataIntegrityOptionGroupsWithoutOptionsTest extends AbstractDataIntegrityIntegrationTest {
+  private static final String CHECK_NAME = "option_groups_empty";
 
-  private static final String CHECK_NAME = "user_roles_no_authorities";
-
-  private static final String DETAILS_ID_TYPE = "userRoles";
-
-  private String userRoleUid;
+  private static final String DETAILS_ID_TYPE = "optionGroups";
 
   @Test
-  void testUserRolesNoAuthorities() {
-    userRoleUid =
+  void testOptionGroupsWithNoOptions() {
+
+    String goodOptionGroup =
         assertStatus(
-            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Empty role', 'authorities': [] }"));
-    assertStatus(
-        HttpStatus.CREATED,
-        POST("/userRoles", "{ 'name': 'Good role', 'authorities': ['F_DATAVALUE_ADD'] }"));
-
-    JsonObject content = GET("/userRoles?fields=id,authorities").content();
-    JsonList<JsonUserRole> userRolesInSystem = content.getList("userRoles", JsonUserRole.class);
-    assertEquals(3, userRolesInSystem.size());
-
-    List<Integer> authorityCount =
-        userRolesInSystem.stream()
-            .map(userRole -> userRole.getList("authorities", JsonString.class).size())
-            .toList();
-
-    // Two of the roles have no authorities, one has one authority.
-    assertEquals(Set.of(0, 1), new HashSet<>(authorityCount));
-    assertEquals(1, Collections.frequency(authorityCount, 0));
-    assertEquals(2, Collections.frequency(authorityCount, 1));
+            HttpStatus.CREATED, POST("/optionGroups", "{ 'name': 'Taste', 'shortName': 'Taste' }"));
 
     assertHasDataIntegrityIssues(
-        DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Empty role", null, true);
+        DETAILS_ID_TYPE, CHECK_NAME, 100, goodOptionGroup, "Taste", null, true);
+  }
+
+  @Test
+  void testOptionGroupsWithOptions() {
+    String goodOptionSet =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/optionSets", "{ 'name': 'Taste', 'shortName': 'Taste', 'valueType' : 'TEXT' }"));
+
+    String sweetOption =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/options",
+                "{ 'code': 'SWEET',"
+                    + "  'sortOrder': 1,"
+                    + "  'name': 'Sweet',"
+                    + "  'optionSet': { "
+                    + "    'id': '"
+                    + goodOptionSet
+                    + "'"
+                    + "  }}"));
+
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/optionGroups",
+            "{ 'name': 'Taste', 'shortName': 'Taste' , 'optionSet' : { 'id' : '"
+                + goodOptionSet
+                + "' }, 'options' : [ { 'id' : '"
+                + sweetOption
+                + "' } ] }"));
+
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, true);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramInconsistentlyLinkedTrackedEntityTypeTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramInconsistentlyLinkedTrackedEntityTypeTest.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.webapi.controller.dataintegrity;
 
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Jason P. Pickering
  */
-class DataIntegrityProgramInconsistentlyLinkedTrackedEntityType
+class DataIntegrityProgramInconsistentlyLinkedTrackedEntityTypeTest
     extends AbstractDataIntegrityIntegrationTest {
 
   @Autowired private ProgramService programService;
@@ -54,24 +53,18 @@ class DataIntegrityProgramInconsistentlyLinkedTrackedEntityType
   void testSingleEventProgramWithTrackedEntityType() {
     // Single event with no tracked entity type should not be flagged
     // Use the service layer, since hopefully the API layer will block this in future
-    Program programA = new Program();
-    programA.setAutoFields();
+    Program programA = createProgramWithoutRegistration('A');
     programA.setName("Program A");
     programA.setShortName("Program A");
-    programA.setProgramType(ProgramType.WITHOUT_REGISTRATION);
-    programA.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
     programService.addProgram(programA);
 
     TrackedEntityType tet = createTrackedEntityType('A');
     manager.save(tet);
 
     // Single event with tracked entity type should be flagged
-    Program programB = new Program();
-    programB.setAutoFields();
+    Program programB = createProgramWithoutRegistration('B');
     programB.setName("Program B");
     programB.setShortName("Program B");
-    programB.setProgramType(ProgramType.WITHOUT_REGISTRATION);
-    programB.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
     programB.setTrackedEntityType(tet);
     programService.addProgram(programB);
 
@@ -90,24 +83,18 @@ class DataIntegrityProgramInconsistentlyLinkedTrackedEntityType
   @Test
   void testTrackerProgramWithoutTrackedEntityType() {
     // Tracker program without tracked entity type should be flagged
-    Program programA = new Program();
-    programA.setAutoFields();
+    Program programA = createProgram('A');
     programA.setName("Program A");
     programA.setShortName("Program A");
-    programA.setProgramType(ProgramType.WITH_REGISTRATION);
-    programA.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
     programService.addProgram(programA);
 
     TrackedEntityType tet = createTrackedEntityType('A');
     manager.save(tet);
 
     // Tracker program with tracked entity type should not be flagged
-    Program programB = new Program();
-    programB.setAutoFields();
+    Program programB = createProgram('B');
     programB.setName("Program B");
     programB.setShortName("Program B");
-    programB.setProgramType(ProgramType.WITH_REGISTRATION);
-    programB.setCategoryCombo(categoryService.getCategoryCombo(getDefaultCatCombo()));
     programB.setTrackedEntityType(tet);
     programService.addProgram(programB);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramStagesNoProgramsTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityProgramStagesNoProgramsTest.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.tracker.model.SingleEvent;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class DataIntegrityProgramStagesNoPrograms extends AbstractDataIntegrityIntegrationTest {
+class DataIntegrityProgramStagesNoProgramsTest extends AbstractDataIntegrityIntegrationTest {
 
   @Autowired private ProgramService programService;
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthoritiesTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthoritiesTest.java
@@ -32,32 +32,49 @@ package org.hisp.dhis.webapi.controller.dataintegrity;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
-import org.hisp.dhis.test.webapi.json.domain.JsonDataIntegritySummary;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.test.webapi.json.domain.JsonUserRole;
 import org.junit.jupiter.api.Test;
 
-class DataIntegrityUserRolesNoUsers extends AbstractDataIntegrityIntegrationTest {
-  private static final String CHECK_NAME = "user_roles_with_no_users";
+class DataIntegrityUserRolesNoAuthoritiesTest extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "user_roles_no_authorities";
 
   private static final String DETAILS_ID_TYPE = "userRoles";
 
   private String userRoleUid;
 
   @Test
-  void testUserRolesNoUsers() {
+  void testUserRolesNoAuthorities() {
     userRoleUid =
         assertStatus(
-            HttpStatus.CREATED,
-            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
-    // Note that two user roles already exist as part of the setup in the
-    // AbstractDataIntegrityIntegrationTest class
-    // Thus, there should be three roles in total, two of which are valid since they already have
-    // users associated with them.
-    postSummary(CHECK_NAME);
+            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Empty role', 'authorities': [] }"));
+    assertStatus(
+        HttpStatus.CREATED,
+        POST("/userRoles", "{ 'name': 'Good role', 'authorities': ['F_DATAVALUE_ADD'] }"));
 
-    JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
-    assertEquals(1, summary.getCount());
+    JsonObject content = GET("/userRoles?fields=id,authorities").content();
+    JsonList<JsonUserRole> userRolesInSystem = content.getList("userRoles", JsonUserRole.class);
+    assertEquals(3, userRolesInSystem.size());
+
+    List<Integer> authorityCount =
+        userRolesInSystem.stream()
+            .map(userRole -> userRole.getList("authorities", JsonString.class).size())
+            .toList();
+
+    // Two of the roles have no authorities, one has one authority.
+    assertEquals(Set.of(0, 1), new HashSet<>(authorityCount));
+    assertEquals(1, Collections.frequency(authorityCount, 0));
+    assertEquals(2, Collections.frequency(authorityCount, 1));
+
     assertHasDataIntegrityIssues(
-        DETAILS_ID_TYPE, CHECK_NAME, 50, userRoleUid, "Test role", null, true);
+        DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Empty role", null, true);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsersTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsersTest.java
@@ -30,57 +30,34 @@
 package org.hisp.dhis.webapi.controller.dataintegrity;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.webapi.json.domain.JsonDataIntegritySummary;
 import org.junit.jupiter.api.Test;
 
-class DataIntegrityOptionGroupsWithoutOptions extends AbstractDataIntegrityIntegrationTest {
-  private static final String CHECK_NAME = "option_groups_empty";
+class DataIntegrityUserRolesNoUsersTest extends AbstractDataIntegrityIntegrationTest {
+  private static final String CHECK_NAME = "user_roles_with_no_users";
 
-  private static final String DETAILS_ID_TYPE = "optionGroups";
+  private static final String DETAILS_ID_TYPE = "userRoles";
+
+  private String userRoleUid;
 
   @Test
-  void testOptionGroupsWithNoOptions() {
-
-    String goodOptionGroup =
+  void testUserRolesNoUsers() {
+    userRoleUid =
         assertStatus(
-            HttpStatus.CREATED, POST("/optionGroups", "{ 'name': 'Taste', 'shortName': 'Taste' }"));
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+    // Note that two user roles already exist as part of the setup in the
+    // AbstractDataIntegrityIntegrationTest class
+    // Thus, there should be three roles in total, two of which are valid since they already have
+    // users associated with them.
+    postSummary(CHECK_NAME);
 
+    JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
+    assertEquals(1, summary.getCount());
     assertHasDataIntegrityIssues(
-        DETAILS_ID_TYPE, CHECK_NAME, 100, goodOptionGroup, "Taste", null, true);
-  }
-
-  @Test
-  void testOptionGroupsWithOptions() {
-    String goodOptionSet =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST("/optionSets", "{ 'name': 'Taste', 'shortName': 'Taste', 'valueType' : 'TEXT' }"));
-
-    String sweetOption =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST(
-                "/options",
-                "{ 'code': 'SWEET',"
-                    + "  'sortOrder': 1,"
-                    + "  'name': 'Sweet',"
-                    + "  'optionSet': { "
-                    + "    'id': '"
-                    + goodOptionSet
-                    + "'"
-                    + "  }}"));
-
-    assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/optionGroups",
-            "{ 'name': 'Taste', 'shortName': 'Taste' , 'optionSet' : { 'id' : '"
-                + goodOptionSet
-                + "' }, 'options' : [ { 'id' : '"
-                + sweetOption
-                + "' } ] }"));
-
-    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, true);
+        DETAILS_ID_TYPE, CHECK_NAME, 50, userRoleUid, "Test role", null, true);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchyTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchyTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Jason P. Pickering
  */
-class DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchy
+class DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchyTest
     extends AbstractDataIntegrityIntegrationTest {
 
   private static final String CHECK_NAME = "users_capture_ou_not_in_tei_search_ou";

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataViewTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataViewTest.java
@@ -49,7 +49,8 @@ import org.junit.jupiter.api.Test;
  *
  * @author Jason P. Pickering
  */
-class DataIntegrityUsersCaptureOrgunitNotInDataView extends AbstractDataIntegrityIntegrationTest {
+class DataIntegrityUsersCaptureOrgunitNotInDataViewTest
+    extends AbstractDataIntegrityIntegrationTest {
 
   private static final String CHECK_NAME = "users_capture_ou_not_in_data_view_ou";
 


### PR DESCRIPTION
## What

Seven integration tests under `dhis-test-web-api/.../controller/dataintegrity` had file/class names that **don't match surefire's include patterns** (`Test*`, `*Test`, `*Tests`, `*TestCase`). The `integration-test` profile applies `groups=integration` only to classes surefire has *already scanned*, so these were never picked up — they have not run since they were committed. They extend `AbstractDataIntegrityIntegrationTest` exactly like their ~82 siblings in the same package; only the name differed.

This renames all seven to end in `Test`:

| Before | After |
|---|---|
| `DataIntegrityProgramStagesNoPrograms` | `…NoProgramsTest` |
| `DataIntegrityOptionGroupsWithoutOptions` | `…WithoutOptionsTest` |
| `DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchy` | `…HierarchyTest` |
| `DataIntegrityUserRolesNoUsers` | `…NoUsersTest` |
| `DataIntegrityUsersCaptureOrgunitNotInDataView` | `…NotInDataViewTest` |
| `DataIntegrityProgramInconsistentlyLinkedTrackedEntityType` | `…TrackedEntityTypeTest` |
| `DataIntegrityUserRolesNoAuthorities` | `…NoAuthoritiesTest` |

## One real bug surfaced

Enabling these revealed that `DataIntegrityProgramInconsistentlyLinkedTrackedEntityType` built `Program` instances without `enrollmentCategoryCombo`, which became a **not-null** property in #22698 — added *after* this test was written but, because the test never ran, never caught.

Fixed by constructing its Programs through the `createProgram` / `createProgramWithoutRegistration` `TestBase` helpers, which #22698 updated to set both the category combo and the enrollment category combo to the default. This is the same pattern #22698 applied to the other DataIntegrity tests (e.g. `DataIntegrityProgramStagesNoPrograms`); it was simply missed here because this class doesn't run and so never failed. The check under test (`programs_inconsistent_tracked_entity_type`) is unchanged and orthogonal to category combos — the assertions on program type / tracked entity type are untouched.

## Context

This is **not** a regression from the sharding PR #24010 — that PR's shard `find` uses the exact same four patterns as surefire's defaults, so its coverage-parity claim is unaffected. This is a pre-existing gap. Caught by @david-mackessy in review of #24010.

## Test plan

- [x] `mvn test -pl dhis-test-web-api -am -Pintegration-test -Dtest=<7 classes>` → **12 tests, 0 failures, 0 errors**
- [x] `mvn spotless:check -pl dhis-test-web-api` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)