### PR TITLE
[spike] cross-run incremental build cache (B1) — superseded by build-once-test-many

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,8 +39,24 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: maven
+      # PILOT (task 07 / B1): cross-run incremental build cache, scoped to this one job.
+      # Persists the Maven build-cache extension's storage across runs. On a PR the first
+      # run restores master's cache, so unchanged modules are not recompiled. The key is
+      # unique per commit (always saves a fresh generation); restore-keys falls back to the
+      # newest prior cache for this job (incl. the base branch). All other jobs are unchanged.
+      - name: Cache Maven build outputs (incremental compile)
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.build-cache
+          key: maven-build-cache-unit-${{ github.sha }}
+          restore-keys: |
+            maven-build-cache-unit-
       - name: Run unit tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
+        # -Dmaven.build.cache.enabled=true opts THIS invocation into the build-cache
+        # extension (off by default in .mvn/maven-build-cache-config.xml). Surefire and
+        # JaCoCo are forced to always run, so a cache hit reuses compilation only — test
+        # counts and coverage are identical to a non-cached build.
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test -Dmaven.build.cache.enabled=true -Dmaven.build.cache.location=${{ github.workspace }}/.build-cache
         timeout-minutes: 30
       - name: Run dependency analysis
         run: mvn dependency:analyze --file ./dhis-2/pom.xml

--- a/dhis-2/.mvn/extensions.xml
+++ b/dhis-2/.mvn/extensions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <!--
+    Apache Maven Build Cache extension. Hashes each module's inputs (sources, config,
+    upstream module outputs) and restores compiled output for modules whose inputs are
+    unchanged, so only changed modules (and their dependents) recompile across runs.
+
+    It is DISABLED by default (see .mvn/maven-build-cache-config.xml -> <enabled>false</enabled>)
+    so this declaration is a no-op for every Maven invocation unless a build explicitly
+    opts in with -Dmaven.build.cache.enabled=true. Today only the unit-test CI job does
+    (pilot rollout); all other CI jobs and local builds behave exactly as before.
+  -->
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>1.2.3</version>
+  </extension>
+</extensions>

--- a/dhis-2/.mvn/maven-build-cache-config.xml
+++ b/dhis-2/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0 https://maven.apache.org/xsd/build-cache-config-1.0.0.xsd">
+
+  <configuration>
+    <!--
+      OFF by default. The build-cache extension is declared in .mvn/extensions.xml but
+      stays a no-op for every build unless explicitly enabled per-invocation with
+      -Dmaven.build.cache.enabled=true. This keeps the pilot scoped to the single CI job
+      that opts in (unit-test); all other CI jobs and local builds are unaffected.
+    -->
+    <enabled>false</enabled>
+
+    <!-- Fast non-cryptographic hash; we only need change-detection, not security. -->
+    <hashAlgorithm>XX</hashAlgorithm>
+
+    <!-- Fail loudly on a malformed cache config rather than silently degrading. -->
+    <validateXml>true</validateXml>
+
+    <!-- No shared cache server; the cache lives only in the local storage dir, which CI
+         persists across runs via actions/cache (keyed so a PR restores master's cache). -->
+    <remote enabled="false"/>
+
+    <local>
+      <!-- Keep a few generations so a small source change still finds a near-neighbour. -->
+      <maxBuildsCached>3</maxBuildsCached>
+    </local>
+
+    <!--
+      By default the cache saves only the project's published artifact (the main jar),
+      which restores target/classes but NOT target/test-classes. Because we force surefire
+      to re-run on every cache hit (see <executionControl> below), the compiled TEST classes
+      and test resources must also be restored — otherwise surefire finds "No tests to run"
+      and JaCoCo emits no data. Caching test-classes makes a restored module run the exact
+      same tests against the exact same compiled classes, so test counts and coverage match
+      a no-cache build bit-for-bit.
+    -->
+    <attachedOutputs>
+      <dirNames>
+        <dirName>test-classes</dirName>
+      </dirNames>
+    </attachedOutputs>
+  </configuration>
+
+  <!--
+    CORRECTNESS GUARD — the heart of this change.
+
+    On a cache hit the extension restores a module's saved outputs (compiled main/test
+    classes) and SKIPS the mojos that produced them. We want it to skip only COMPILATION.
+    Test execution and coverage must ALWAYS run, otherwise a cache hit would silently skip
+    tests and/or emit no JaCoCo data — turning a green build into a false negative and
+    zeroing out coverage.
+
+    JaCoCo here is on-the-fly: prepare-agent sets @{argLine} and the agent instruments
+    classes in-JVM at test time, so cached *.class files are plain (uninstrumented) and are
+    re-instrumented fresh every run. Forcing surefire + jacoco to always run therefore
+    yields identical test counts and identical coverage to a no-cache build, while the
+    expensive compile is what gets reused.
+  -->
+  <executionControl>
+    <runAlways>
+      <plugins>
+        <!-- Always execute every JaCoCo goal: prepare-agent, report, report-aggregate. -->
+        <plugin artifactId="jacoco-maven-plugin"/>
+      </plugins>
+      <executions>
+        <!-- Always run the test goals even when the module is restored from cache. -->
+        <execution artifactId="maven-surefire-plugin">
+          <execIds>
+            <execId>default-test</execId>
+          </execIds>
+        </execution>
+        <execution artifactId="maven-failsafe-plugin">
+          <execIds>
+            <execId>default-integration-test</execId>
+            <execId>default-verify</execId>
+          </execIds>
+        </execution>
+      </executions>
+    </runAlways>
+  </executionControl>
+
+</cache>


### PR DESCRIPTION
## What

Pilots **lever B1 — a cross-run incremental build cache** — on a single CI job
(`unit-test`), using the [Apache Maven Build Cache extension](https://maven.apache.org/extensions/maven-build-cache-extension/).
On a cache hit the extension restores compiled output for modules whose inputs are
unchanged, so only changed modules (and their dependents) recompile across runs.

This is the wall-clock follow-up to the integration-test sharding (#24010). After
sharding, the workflow is co-limited by `unit-test` and `integration-h2-test`, and a
floor analysis found that **~99% of every test job is a single `mvn clean test` on the
whole ~39-module reactor** — non-Maven overhead (checkout, JDK setup, `~/.m2` restore)
is only ~10s. Every one of the 6 jobs recompiles the full reactor regardless of which
tests it runs. That compile, paid 6× per run, is the binding constraint. B1 attacks it
by not recompiling unchanged modules.

## Changes

- **`dhis-2/.mvn/extensions.xml`** — declares `maven-build-cache-extension:1.2.3`.
- **`dhis-2/.mvn/maven-build-cache-config.xml`** — cache config (see correctness guard below).
- **`.github/workflows/run-tests.yml`** — only the `unit-test` job: an `actions/cache`
  step to persist the cache storage across runs, plus `-Dmaven.build.cache.enabled=true`
  on its `mvn` line.

## Gain

- **What it saves:** the per-job full-reactor *compile*. On a typical PR touching a few
  modules, the heavy upstream modules (e.g. `dhis-api`, 1245 source files) are restored
  from cache instead of recompiled; only the changed modules + their dependents compile.
- **Why it lowers the floor for all jobs (eventually):** unlike build-once-test-many
  (B2), this shrinks each job's compile **in parallel, without serializing a build in
  front of them**. This PR proves it on one job; if green and stable, the same two lines
  extend it to the other five.
- **PR-first-run behaviour:** `actions/cache` lets a PR restore the base branch
  (`master`) cache, so even a PR's first run recompiles only what the PR changed.

> Headline number (full reactor compile reuse) will be read off this PR's own CI run vs a
> `master` baseline and added here — see the validation section.

## Risk

Cache correctness is the classic footgun: a stale restore could make tests pass/fail
against the wrong classes, or skip tests/coverage and report a false green. This change
is deliberately conservative:

- **Off by default.** `maven.build.cache.enabled=false` in config; the extension is a
  declared-but-inert no-op for every build except the one job that opts in with
  `-Dmaven.build.cache.enabled=true`. The other five jobs and all local builds are
  byte-for-byte unchanged. *(Verified locally: a build without the flag shows zero cache
  activity, normal compile, identical test counts.)*
- **Compile is reused; tests and coverage always run.** `executionControl/runAlways`
  forces `maven-surefire-plugin` and `jacoco-maven-plugin` to execute on every cache hit,
  and `test-classes` is added to the cached outputs so surefire has classes to run. So a
  cache hit reuses compilation **only** — test counts and coverage are identical to a
  non-cached build.
- **JaCoCo is on-the-fly** (`prepare-agent` → `@{argLine}` agent), so cached `.class`
  files are plain and re-instrumented in-JVM every run; caching compiled output cannot
  skew coverage as long as the test phase runs (it does — forced).
- **Stale restores are impossible by construction:** the extension hashes each module's
  inputs (sources, effective POM/config, upstream module outputs). A module is restored
  only if its hash matches exactly; any change → rebuild.
- **Scoped pilot.** One job first, exactly as #24010 rolled out and validated coverage
  parity before trusting it.

### Residual risks to watch on CI
- **Coverage parity at scale:** local validation covered a module subset. This PR's CI
  run must show the `unit-test` codecov upload + `jacoco-aggregate` report match a
  `master` baseline (sum unchanged), including the `dhis-test-coverage` aggregate
  (`report-aggregate` is forced via the JaCoCo runAlways entry — to be confirmed on CI).
- **Annotation-processor / generated sources** (Lombok, MapStruct): generated classes
  live in cached `target/classes`; a source change rehashes the module. To be confirmed
  green on the full reactor.
- **Cache size / restore time:** `target/` outputs are larger than `~/.m2` metadata;
  watch that cache restore doesn't eat the compile savings.

## Local validation (done)

Run on a representative module slice (`dhis-support-commons -am`, unit-test profile):

| Scenario | Result |
|---|---|
| Cold cache | compiles + runs tests (1108 + 88), coverage produced |
| Warm cache, no changes | compile **skipped** (`compiler:compile`/`testCompile` cached); surefire forced → **same** 1108 + 88; JaCoCo `Analyzed bundle ... 45 classes` (not "missing data") |
| One module changed | only that module recompiles (51 main + 18 test files); `dhis-api` + upstream **restored** from cache; tests still pass |
| Extension declared but **not** enabled | zero cache activity, normal compile, identical tests — confirms the other 5 jobs are unaffected |

## CI validation (this PR)

- [ ] All jobs green on this PR.
- [ ] `unit-test` log shows cache restore + skipped compilation, with tests still executing.
- [ ] `unit-test` coverage (codecov `unit` flag + `jacoco-aggregate`) matches a `master` baseline.
- [ ] Record the `unit-test` wall-clock delta (cached run vs cold/baseline) in this description.

---

Tracked in claude-brain: `shard-integration-tests / 07-incremental-build-cache`. Part of
the post-sharding floor work (B1, priority 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
