### PR TITLE
chore(ci): trim test-job startup — drop -U, re-enable CDS in test forks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run unit tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
       - name: Run dependency analysis
         run: mvn dependency:analyze --file ./dhis-2/pom.xml
@@ -121,7 +121,7 @@ jobs:
           head -n 5 "$GITHUB_WORKSPACE/shard-includes.txt"
       - name: Run integration tests (shard ${{ matrix.shard }}/${{ env.SHARD_TOTAL }})
         run: >
-          mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots
+          mvn clean test --threads 2C --batch-mode --no-transfer-progress
           --file ./dhis-2/pom.xml --activate-profiles integration-test
           -Dsurefire.includesFile=$GITHUB_WORKSPACE/shard-includes.txt
         timeout-minutes: 30
@@ -206,7 +206,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v7
         name: Upload test logs on failure

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -83,7 +83,10 @@
 
     <byte-buddy.version>1.17.5</byte-buddy.version>
     <byte-buddy-agent.version>1.17.5</byte-buddy-agent.version>
-    <surefireArgLine>-Xmx2024m -Xshare:off -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy-agent.version}/byte-buddy-agent-${byte-buddy-agent.version}.jar</surefireArgLine>
+    <!-- -Xshare:auto lets the JVM use Class Data Sharing for faster test-fork startup. The byte-buddy
+         startup agent below supplies the Instrumentation the inline mock maker needs; CDS and the agent
+         coexist on JDK 17 (a class redefined by the agent simply isn't served from the shared archive). -->
+    <surefireArgLine>-Xmx2024m -Xshare:auto -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy-agent.version}/byte-buddy-agent-${byte-buddy-agent.version}.jar</surefireArgLine>
 
     <jrebel-maven-plugin.version>1.1.6</jrebel-maven-plugin.version>
     <maven-war-plugin.version>3.5.1</maven-war-plugin.version>


### PR DESCRIPTION
Two small, low-risk tweaks to the test jobs' startup. Both are seconds-scale wins — this is housekeeping, not a big speedup — but they're free and remove cruft. Draft so CI can confirm both before merge.

## Drop `--update-snapshots` from the test jobs

The test jobs run `mvn clean test ... --update-snapshots`, but the build has **no external SNAPSHOT dependencies**. The only SNAPSHOTs are the reactor's own `2.44-SNAPSHOT` modules, which are built in-reactor rather than resolved from a remote. `-U` therefore only forces remote snapshot-metadata lookups at dependency resolution — pure startup overhead, paid by all six test jobs (unit, the four integration shards, and integration-h2) on every run.

## Use `-Xshare:auto` instead of `-Xshare:off` for the Surefire forks

`-Xshare:off` disables Class Data Sharing, which slows every test JVM's startup. It was introduced alongside the byte-buddy startup agent during the Mockito 5.18 upgrade. On modern JDKs the agent and CDS coexist fine: a class the inline mock maker redefines simply isn't served from the shared archive, so CDS can stay on (`-Xshare:auto`) and only the redefined classes miss the archive.

Verified locally on `dhis-support-system` (the mock-heavy module that exercises the inline mock maker) on **Java 21** — the stricter case for the agent than CI's JDK 17:

| argLine | result |
|---|---|
| `-Xshare:auto` + byte-buddy agent | 227 tests, 0 failures, 0 errors |
| `-Xshare:off` (baseline) | 227 tests, 0 failures, 0 errors |

A JVM cold-start micro-benchmark put the CDS saving at ~25 ms per forked JVM. Letting CI confirm it holds green across the full mock-heavy suites before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)