### PR TITLE
chore(ci): drop --update-snapshots from the test jobs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run unit tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
       - name: Run dependency analysis
         run: mvn dependency:analyze --file ./dhis-2/pom.xml
@@ -121,7 +121,7 @@ jobs:
           head -n 5 "$GITHUB_WORKSPACE/shard-includes.txt"
       - name: Run integration tests (shard ${{ matrix.shard }}/${{ env.SHARD_TOTAL }})
         run: >
-          mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots
+          mvn clean test --threads 2C --batch-mode --no-transfer-progress
           --file ./dhis-2/pom.xml --activate-profiles integration-test
           -Dsurefire.includesFile=$GITHUB_WORKSPACE/shard-includes.txt
         timeout-minutes: 30
@@ -206,7 +206,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
+        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --activate-profiles integration-h2-test
         timeout-minutes: 30
       - uses: actions/upload-artifact@v7
         name: Upload test logs on failure


### PR DESCRIPTION
The test jobs run `mvn clean test ... --update-snapshots`, but this build has **no external SNAPSHOT dependencies**. The only SNAPSHOTs are the reactor's own `2.44-SNAPSHOT` modules, which are built in-reactor rather than resolved from a remote.

`--update-snapshots` (`-U`) was added across the board in #15868 ("Add update snapshots to all github actions") — a blanket change rather than something this build needs. With no remote SNAPSHOTs to refresh, all it does here is force remote snapshot-metadata lookups during dependency resolution: pure startup overhead, paid by all six test jobs (unit, the four integration shards, and integration-h2) on every run. Removing it changes nothing about what gets built or resolved.

This is housekeeping, not a measurable speedup — it removes a flag that does nothing useful here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)