### PR TITLE
chore: remove unneeded -Xshare:off from the Surefire argLine

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -83,7 +83,7 @@
 
     <byte-buddy.version>1.17.5</byte-buddy.version>
     <byte-buddy-agent.version>1.17.5</byte-buddy-agent.version>
-    <surefireArgLine>-Xmx2024m -Xshare:off -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy-agent.version}/byte-buddy-agent-${byte-buddy-agent.version}.jar</surefireArgLine>
+    <surefireArgLine>-Xmx2024m -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy-agent.version}/byte-buddy-agent-${byte-buddy-agent.version}.jar</surefireArgLine>
 
     <jrebel-maven-plugin.version>1.1.6</jrebel-maven-plugin.version>
     <maven-war-plugin.version>3.5.1</maven-war-plugin.version>


### PR DESCRIPTION
`-Xshare:off` was added to `surefireArgLine` in the Mockito 5.18 upgrade (#24006), alongside the byte-buddy startup agent. It disables Class Data Sharing — a JVM default that speeds fork startup — but it turns out not to be needed here: the byte-buddy agent and CDS coexist fine, because a class the inline mock maker redefines simply isn't served from the shared archive.

This removes the flag and restores the JVM's default (`-Xshare:auto`), leaving the byte-buddy agent untouched.

Safety is already established:
- The full test workflow runs green with CDS enabled.
- `dhis-support-system` (the inline-mock module) passes 227/0/0 locally on Java 21 — the stricter case for the agent than CI's JDK 17 — with CDS on.

No measurable wall-clock change is expected (CDS saves on the order of tens of milliseconds per forked JVM); this is cleanup of a flag that was added without need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)