### PR TITLE
fix: stabilize flaky UserGroupServiceTest.testGetAllUserGroups (backport to 2.43)

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserGroupServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserGroupServiceTest.java
@@ -29,13 +29,13 @@
  */
 package org.hisp.dhis.user;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -134,20 +134,17 @@ class UserGroupServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetAllUserGroups() {
-    List<UserGroup> userGroups = new ArrayList<>();
     Set<User> members = new HashSet<>();
     members.add(user1);
     members.add(user3);
     UserGroup userGroupA = createUserGroup('A', members);
-    userGroups.add(userGroupA);
     userGroupService.addUserGroup(userGroupA);
     members = new HashSet<>();
     members.add(user1);
     members.add(user2);
     UserGroup userGroupB = createUserGroup('B', members);
-    userGroups.add(userGroupB);
     userGroupService.addUserGroup(userGroupB);
-    assertEquals(userGroupService.getAllUserGroups(), userGroups);
+    assertContainsOnly(List.of(userGroupA, userGroupB), userGroupService.getAllUserGroups());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Backport of #23775 to **2.43**.

`UserGroupServiceTest.testGetAllUserGroups` is flaky on the PostgreSQL `integration-test` job. It inserts two user groups (A then B) and asserts that `getAllUserGroups()` returns them in that exact insertion order. The underlying query has no `ORDER BY`, so PostgreSQL is free to return the rows in any order — the test then passes or fails depending purely on row order, unrelated to the change under test:

```
expected: [UserGroupB, UserGroupA]
but was:  [UserGroupA, UserGroupB]
```

It was caught again recently on an unrelated dependency PR (#23536) on this branch, where it was the only red check.

## Fix

The test really just means "these are the only two groups present" — set semantics, not order — so it now uses `assertContainsOnly` instead of an order-sensitive `assertEquals`. The now-unused intermediate `List`/`ArrayList` is dropped.

This is a clean cherry-pick of the fix already merged to `master` (#23775).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
