### PR TITLE
chore(deps): bump micrometer to 1.16.5 and align prometheus-metrics-model

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -214,8 +214,8 @@
 
     <!-- Monitoring -->
     <micrometer-spring-legacy.version>1.3.20</micrometer-spring-legacy.version>
-    <micrometer.version>1.15.4</micrometer.version>
-    <prometheus-metrics-model.version>1.3.1</prometheus-metrics-model.version>
+    <micrometer.version>1.16.5</micrometer.version>
+    <prometheus-metrics-model.version>1.4.3</prometheus-metrics-model.version>
 
     <!-- Logging -->
     <log4j.version>2.25.4</log4j.version>


### PR DESCRIPTION
## What

Bumps `micrometer` 1.15.4 → 1.16.5 and `prometheus-metrics-model` 1.3.1 → 1.4.3 together.

## Why

Dependabot opened #23907 to bump micrometer on its own, but that build fails `api-test`
(`MetricsEndpointTest`). The reason is a version skew in the Prometheus client libraries:

- `micrometer-registry-prometheus` 1.16.5 pulls in `io.prometheus:prometheus-metrics-core`
  **1.4.3**.
- The `io.prometheus` client_java modules ship in lockstep — `prometheus-metrics-core`
  depends on `prometheus-metrics-model` at its own version (1.4.3).
- We pin `prometheus-metrics-model` explicitly in `dhis-2/pom.xml`, so bumping micrometer
  alone leaves the model behind at **1.3.1** while core moves to **1.4.3**.

At runtime the `/api/metrics` scrape endpoint then blows up with:

```
java.lang.NoClassDefFoundError: io/prometheus/metrics/model/snapshots/SnapshotEscaper
```

`SnapshotEscaper` was added in the model 1.4.x line and doesn't exist in 1.3.1.

This is the mirror image of #21735, where the model was bumped *ahead* of core and the
JVM metrics broke — the root cause both times is the model and core drifting apart. The
fix is to keep them aligned: move the model up to 1.4.3 alongside the micrometer bump.

## Testing

- `mvn dependency:tree` confirms the whole `io.prometheus.metrics.*` train resolves to a
  consistent 1.4.3.
- Verified locally that scraping the registry (the `/api/metrics` path) with the JVM metric
  binders renders cleanly with the model at 1.4.3, and reproduces the `SnapshotEscaper`
  error with it left at 1.3.1.
- `api-test` / `MetricsEndpointTest` should now pass in CI.

Supersedes #23907.