### PR TITLE
chore(ci): run dependency:analyze in its own parallel job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Run unit tests
         run: mvn clean test --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml --activate-profiles unit-test
         timeout-minutes: 30
-      - name: Run dependency analysis
-        run: mvn dependency:analyze --file ./dhis-2/pom.xml
-        timeout-minutes: 2
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v3
         with:
@@ -74,6 +71,24 @@ jobs:
             dhis-2/target/site/surefire-report.html
             surefire_reports.tar
           retention-days: 5
+
+  # dependency:analyze used to run inside unit-test, but the goal forks its own build up
+  # to test-compile, so it bolted a second full reactor compile onto the unit-test job
+  # (~1m35s) for a check unrelated to unit tests. It runs here in its own job instead, in
+  # parallel and off the critical path, with the same fail-on-warning behaviour.
+  dependency-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+      - name: Run dependency analysis
+        run: mvn dependency:analyze --threads 2C --batch-mode --no-transfer-progress --update-snapshots --file ./dhis-2/pom.xml
+        timeout-minutes: 10
 
   # The integration-test suite is the slowest part of CI, so it is split across a
   # matrix of shards that run in parallel, each on its own runner with its own
@@ -253,7 +268,7 @@ jobs:
       contains(needs.*.result, 'failure') &&
       github.ref == 'refs/heads/master'
 
-    needs: [unit-test, integration-test, integration-h2-test]
+    needs: [unit-test, integration-test, integration-h2-test, dependency-analysis]
     steps:
       - uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
## Why

The `unit-test` job runs two Maven invocations back to back:

```yaml
- name: Run unit tests
  run: mvn clean test ... --activate-profiles unit-test
- name: Run dependency analysis
  run: mvn dependency:analyze --file ./dhis-2/pom.xml
```

`dependency:analyze` (the standalone goal) **forks its own build up to `test-compile`**. So that second step quietly recompiles the entire reactor a second time, inside the unit-test job, just to run a dependency check that has nothing to do with unit tests. On recent runs that step costs **~1m35s**.

## What this does

- Removes the `dependency:analyze` step from `unit-test`.
- Adds a dedicated `dependency-analysis` job that runs `mvn dependency:analyze` on its own runner, in parallel with the test jobs.
- Adds the new job to the Slack-on-failure notification's `needs` list so a failure on `master` is still reported.

The check still runs on **every PR and push**, with the **same fail-on-warning behaviour** (`<failOnWarning>true</failOnWarning>` is configured on the plugin in `dhis-2/pom.xml`, including the same `ignoredUnusedDeclaredDependencies` allowlist) — it just no longer sits on the unit-test critical path.

## Effect

- `unit-test` drops ~1m35s and the confusing hidden recompile.
- The dependency check moves off to a parallel job. The integration jobs gate the overall workflow, so a ~3–4 min analysis job runs for free on wall-clock.

> **Note:** this does not change the overall workflow wall-clock (the integration jobs are the critical path, not `unit-test`) — it's a cleanup that speeds up the `unit-test` check itself and removes a hidden second compile.

## For a maintainer to check

If `dependency:analyze` (previously surfaced under the `unit-test` check) was a **required** status check in branch protection, the new `dependency-analysis` check name needs to be added there so it stays required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)