### PR TITLE
chore(ci): remove the temporary jacoco coverage-debug artifacts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,15 +52,6 @@ jobs:
           flags: unit
           fail_ci_if_error: false
           verbose: true
-      # delete the next 2 steps once we are confident in the coverage setup
-      - name: Tar jacoco coverage report to debug
-        run: tar -cvf coverage.tar dhis-2/dhis-test-coverage/target/site/jacoco-aggregate
-      - uses: actions/upload-artifact@v7
-        name: Upload jacoco coverage report to debug
-        with:
-          name: unit-test-coverage
-          path: coverage.tar
-          retention-days: 5
       - name: Generate surefire aggregate report
         run: mvn surefire-report:report-only -Daggregate=true --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --projects -dhis-test-coverage
       # tar due to https://github.com/actions/upload-artifact/blob/3cea5372237819ed00197afe530f5a7ea3e805c8/README.md?plain=1#L254
@@ -223,15 +214,6 @@ jobs:
           flags: integration-h2
           fail_ci_if_error: false
           verbose: true
-      # delete the next 2 steps once we are confident in the coverage setup
-      - name: Tar jacoco coverage report to debug
-        run: tar -cvf coverage.tar dhis-2/dhis-test-coverage/target/site/jacoco-aggregate
-      - uses: actions/upload-artifact@v7
-        name: Upload jacoco coverage report to debug
-        with:
-          name: integration-h2-test-coverage
-          path: coverage.tar
-          retention-days: 5
       - name: Generate surefire aggregate report
         run: mvn surefire-report:report-only -Daggregate=true --batch-mode --no-transfer-progress --file ./dhis-2/pom.xml --projects -dhis-test-coverage
       # tar due to https://github.com/actions/upload-artifact/blob/3cea5372237819ed00197afe530f5a7ea3e805c8/README.md?plain=1#L254


### PR DESCRIPTION
## Why

The `unit-test` and `integration-h2-test` jobs each carry two steps prefaced by this comment:

```yaml
# delete the next 2 steps once we are confident in the coverage setup
- name: Tar jacoco coverage report to debug
  run: tar -cvf coverage.tar dhis-2/dhis-test-coverage/target/site/jacoco-aggregate
- uses: actions/upload-artifact@v7
  name: Upload jacoco coverage report to debug
  ...
```

They tar up the jacoco-aggregate report and upload it as a 5-day build artifact, purely so someone could download it and eyeball coverage by hand. They were added back in 2022 and have quietly been running on every build ever since — the "temporary" debug crutch became permanent.

## Why it's safe to remove

- **Coverage reporting doesn't depend on them.** Codecov is fed by the separate `codecov/codecov-action` step, which reads the jacoco reports directly. These tar/upload steps are not an input to codecov — removing them changes nothing about what codecov receives.
- **The manual artifact has gone unused.** Three-plus years of building it; if it were needed to chase a coverage discrepancy it would have been acted on long ago.

This removes the four steps (two per job) and leaves the real coverage path (codecov) and the surefire report steps untouched.

## Suggested sanity check before merge

Confirm the codecov dashboard / a recent PR's codecov comment is reporting unit, integration and integration-h2 coverage normally — i.e. we no longer need the manual artifact to trust the setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)