### PR TITLE
fix(deps): align all io.netty:* to 4.2.13.Final via netty-bom

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -176,7 +176,7 @@
 
     <!-- Apache Artemis -->
     <artemis-jakarta.version>2.42.0</artemis-jakarta.version>
-    <netty-all.version>4.2.1.Final</netty-all.version>
+    <netty-all.version>4.2.13.Final</netty-all.version>
     <classgraph.version>4.8.181</classgraph.version>
 
     <!-- SMS/SMPP -->
@@ -1472,6 +1472,17 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty-all.version}</version>
+      </dependency>
+      <!-- Align every io.netty:* artifact (incl. modules Artemis pulls transitively,
+           e.g. netty-codec-haproxy / netty-transport-classes-*) to the same version as
+           netty-all. Without this, the netty-all uber jar mixes with older individual
+           netty modules on the classpath, causing AbstractMethodError at runtime. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty-all.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.github.classgraph</groupId>


### PR DESCRIPTION
## What

Bumps `netty-all` from `4.2.1.Final` to `4.2.13.Final` and imports the **`netty-bom`** in dependency management so that every `io.netty:*` module on the classpath resolves to one consistent version.

## Why

We currently pin `netty-all` (an uber jar) to one version, but the individual netty modules pulled in transitively — via Artemis, reactor-netty and others — are free to resolve to *older* versions. That mix on a single classpath leads to runtime failures like `AbstractMethodError` and `NoClassDefFoundError` (for example a missing `io/netty/util/LeakPresenceDetector`), which a green compile does not catch.

Importing the `netty-bom` forces all netty modules to the same `4.2.13.Final`, removing the skew.

## Notes

- This is the **same alignment already merged on the `2.41` and `2.42` branches**; this PR closes the identical gap on `master`.
- It also clears the path for the upcoming **reactor-netty-http 1.3.x** upgrade, whose code references netty classes that only exist in newer `4.2.x` — without this alignment that upgrade fails at runtime.
- `4.2.1 → 4.2.13` is a patch-level move within the `4.2.x` line and is already running on `2.42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)