### PR TITLE
fix: add missing translation for metadata management app authority [DHIS2-21388] [2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -72,6 +72,7 @@ dhis-web-sms-configuration=SMS Configuration
 dhis-web-login=Login
 dhis-web-user-profile=User Profile
 dhis-web-line-listing=Line Listing
+dhis-web-metadata-management=Metadata Management
 
 #-- Intro modules -------------------------------------------------------------#
 
@@ -142,6 +143,7 @@ M_dhis-web-scheduler=Scheduler app
 M_dhis-web-data-visualizer=Data Visualizer app
 M_dhis-web-sms-configuration=SMS Configuration app
 M_dhis-web-line-listing=Line Listing app
+M_dhis-web-metadata-management=Metadata Management app
 
 #-- User action privilegies ---------------------------------------------------#
 


### PR DESCRIPTION
## Summary
- Backport of #23826 to 2.42.
- Adds missing `M_dhis-web-metadata-management` and `dhis-web-metadata-management` entries to `i18n_global.properties`.
- Without it, the Users app displays the raw fallback `dhis-web-metadata-management app` (from `AuthoritiesController.getAuthName()`) instead of `Metadata Management app` in the user role's app authorities list.

Jira: [DHIS2-21388](https://dhis2.atlassian.net/browse/DHIS2-21388)

AI Assisted


[DHIS2-21388]: https://dhis2.atlassian.net/browse/DHIS2-21388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ