### PR TITLE
feat: Enrollment JDBC insert/update [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -53,11 +55,14 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -67,6 +72,8 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private EnrollmentService enrollmentService;
+
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   private User importUser;
 
@@ -135,6 +142,73 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
         Arguments.of(COMPLETED, COMPLETED),
         Arguments.of(COMPLETED, CANCELLED),
         Arguments.of(COMPLETED, COMPLETED));
+  }
+
+  @Test
+  void shouldInsertNoteRowsAndJoinTableEntriesWhenEnrollmentIsCreatedWithNotes()
+      throws IOException {
+    testSetup.importTrackerData("tracker/one_te.json");
+    ImportReport report =
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_notes.json"));
+    assertNoErrors(report);
+
+    List<Map<String, Object>> joinRows =
+        jdbcTemplate.queryForList(
+            "select n.uid as noteuid, n.notetext, en.sort_order"
+                + " from enrollment_notes en"
+                + " join enrollment e on e.enrollmentid = en.enrollmentid"
+                + " join note n on n.noteid = en.noteid"
+                + " where e.uid = :uid"
+                + " order by en.sort_order",
+            new MapSqlParameterSource("uid", "TvctPPhpD8u"));
+
+    assertEquals(2, joinRows.size(), "expected two notes linked to the enrollment");
+    assertAll(
+        () -> assertEquals("NoteAlpha01", joinRows.get(0).get("noteuid")),
+        () -> assertEquals("First enrollment note", joinRows.get(0).get("notetext")),
+        () -> assertEquals(1, ((Number) joinRows.get(0).get("sort_order")).intValue()),
+        () -> assertEquals("NoteBeta002", joinRows.get(1).get("noteuid")),
+        () -> assertEquals("Second enrollment note", joinRows.get(1).get("notetext")),
+        () -> assertEquals(2, ((Number) joinRows.get(1).get("sort_order")).intValue()));
+  }
+
+  @Test
+  void shouldAppendNewNoteAndKeepExistingOnesWhenEnrollmentIsUpdatedWithExtraNote()
+      throws IOException {
+    testSetup.importTrackerData("tracker/one_te.json");
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_notes.json")));
+
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_extra_note.json")));
+
+    List<Map<String, Object>> joinRows =
+        jdbcTemplate.queryForList(
+            "select n.uid as noteuid, n.notetext, en.sort_order"
+                + " from enrollment_notes en"
+                + " join enrollment e on e.enrollmentid = en.enrollmentid"
+                + " join note n on n.noteid = en.noteid"
+                + " where e.uid = :uid"
+                + " order by en.sort_order",
+            new MapSqlParameterSource("uid", "TvctPPhpD8u"));
+
+    assertEquals(3, joinRows.size(), "expected three notes (two from create, one appended)");
+    assertAll(
+        () -> assertEquals("NoteAlpha01", joinRows.get(0).get("noteuid")),
+        () -> assertEquals(1, ((Number) joinRows.get(0).get("sort_order")).intValue()),
+        () -> assertEquals("NoteBeta002", joinRows.get(1).get("noteuid")),
+        () -> assertEquals(2, ((Number) joinRows.get(1).get("sort_order")).intValue()),
+        () -> assertEquals("NoteGamma01", joinRows.get(2).get("noteuid")),
+        () ->
+            assertEquals(
+                "Third enrollment note appended on update", joinRows.get(2).get("notetext")),
+        () -> assertEquals(3, ((Number) joinRows.get(2).get("sort_order")).intValue()));
   }
 
   private void assertEnrollmentCompletedData(Enrollment enrollment) {

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_extra_note.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_extra_note.json
@@ -1,0 +1,46 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": { "idScheme": "UID" },
+    "orgUnitIdScheme": { "idScheme": "UID" },
+    "programIdScheme": { "idScheme": "UID" },
+    "programStageIdScheme": { "idScheme": "UID" },
+    "idScheme": { "idScheme": "UID" },
+    "categoryOptionComboIdScheme": { "idScheme": "UID" },
+    "categoryOptionIdScheme": { "idScheme": "UID" }
+  },
+  "importStrategy": "UPDATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": { "idScheme": "UID", "identifier": "BFcipDERJnf" },
+      "status": "ACTIVE",
+      "orgUnit": { "idScheme": "UID", "identifier": "h4w96yEMlzO" },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": [
+        { "note": "NoteGamma01", "value": "Third enrollment note appended on update" }
+      ],
+      "attributeOptionCombo": { "idScheme": "UID", "identifier": "HllvX50cXC0" }
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_notes.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_notes.json
@@ -1,0 +1,47 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": { "idScheme": "UID" },
+    "orgUnitIdScheme": { "idScheme": "UID" },
+    "programIdScheme": { "idScheme": "UID" },
+    "programStageIdScheme": { "idScheme": "UID" },
+    "idScheme": { "idScheme": "UID" },
+    "categoryOptionComboIdScheme": { "idScheme": "UID" },
+    "categoryOptionIdScheme": { "idScheme": "UID" }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": { "idScheme": "UID", "identifier": "BFcipDERJnf" },
+      "status": "ACTIVE",
+      "orgUnit": { "idScheme": "UID", "identifier": "h4w96yEMlzO" },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": [
+        { "note": "NoteAlpha01", "value": "First enrollment note" },
+        { "note": "NoteBeta002", "value": "Second enrollment note" }
+      ],
+      "attributeOptionCombo": { "idScheme": "UID", "identifier": "HllvX50cXC0" }
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -161,23 +161,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           V convertedDto = convert(bundle, trackerDto);
 
           //
-          // Assign the pre-allocated id (if any) before staging so the flush path can emit it
-          // unchanged, and so any TEAV/changelog code that reads convertedDto.getId() sees the
-          // final value.
-          //
-          if (preAllocatedIds != null && isNew(bundle, trackerDto)) {
-            assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
-          }
-
-          //
-          // Handle ownership records, if required
-          //
-          persistOwnership(bundle, trackerDto, convertedDto);
-
-          //
           // Save or update the entity
           //
           if (isNew(bundle, trackerDto)) {
+            if (preAllocatedIds != null) {
+              assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
+            }
+            persistOwnership(bundle, trackerDto, convertedDto);
             stageInsert(convertedDto, batch);
             updateDataValues(
                 bundle.getPreheat(),
@@ -304,6 +294,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   private void assignId(V convertedDto, long id) {
     if (convertedDto instanceof TrackedEntity te) {
       te.setId(id);
+    } else if (convertedDto instanceof Enrollment e) {
+      e.setId(id);
     } else {
       throw new IllegalStateException(
           "Pre-allocated id assignment not implemented for "

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -71,7 +71,7 @@ public class EnrollmentPersister
 
   @Override
   protected String sequenceName() {
-    return null;
+    return "programinstance_sequence";
   }
 
   @Override
@@ -155,14 +155,13 @@ public class EnrollmentPersister
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
       Enrollment entity) {
-    if (isNew(bundle, trackerDto)
-        && (bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
-            || bundle
-                    .getPreheat()
-                    .getProgramOwner()
-                    .get(entity.getTrackedEntity().getUID())
-                    .get(entity.getProgram().getUid())
-                == null)) {
+    if ((bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
+        || bundle
+                .getPreheat()
+                .getProgramOwner()
+                .get(entity.getTrackedEntity().getUID())
+                .get(entity.getProgram().getUid())
+            == null)) {
       trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
           entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
     }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -90,11 +90,8 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  */
 class EntityWriteBatch {
 
-  /** Cap on rows per multi-row INSERT statement, to keep query text manageable. */
+  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
   private static final int INSERT_BATCH_SIZE = 128;
-
-  /** Cap on rows per unnest UPDATE statement, to bound peak array memory per chunk. */
-  private static final int UPDATE_BATCH_SIZE = 128;
 
   private static final int TRACKED_ENTITY_SRID = 4326;
 
@@ -385,8 +382,8 @@ class EntityWriteBatch {
     if (teUpdates.isEmpty()) {
       return;
     }
-    for (int from = 0; from < teUpdates.size(); from += UPDATE_BATCH_SIZE) {
-      int to = Math.min(from + UPDATE_BATCH_SIZE, teUpdates.size());
+    for (int from = 0; from < teUpdates.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, teUpdates.size());
       List<TrackedEntity> chunk = teUpdates.subList(from, to);
       int n = chunk.size();
 
@@ -560,8 +557,8 @@ class EntityWriteBatch {
     if (enrollmentUpdates.isEmpty()) {
       return;
     }
-    for (int from = 0; from < enrollmentUpdates.size(); from += UPDATE_BATCH_SIZE) {
-      int to = Math.min(from + UPDATE_BATCH_SIZE, enrollmentUpdates.size());
+    for (int from = 0; from < enrollmentUpdates.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, enrollmentUpdates.size());
       List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
       int n = chunk.size();
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -60,9 +60,11 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
  *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
  *       trackedentityinstance_sequence} in one round-trip.
- *   <li>TrackedEntity updates and all other entity types (Enrollment, TrackerEvent, SingleEvent,
- *       Relationship) still delegate to {@link EntityManager}; their Phase 6 JDBC replacements
- *       follow.
+ *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
+ *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
+ *       update branch.
+ *   <li>All other entity types (Enrollment, TrackerEvent, SingleEvent, Relationship) still delegate
+ *       to {@link EntityManager}; their Phase 6 JDBC replacements follow.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -81,6 +83,9 @@ class EntityWriteBatch {
   /** Cap on rows per multi-row INSERT statement, to keep query text manageable. */
   private static final int INSERT_BATCH_SIZE = 128;
 
+  /** Cap on rows per unnest UPDATE statement, to bound peak array memory per chunk. */
+  private static final int UPDATE_BATCH_SIZE = 128;
+
   private static final int TRACKED_ENTITY_SRID = 4326;
 
   private static final String TRACKED_ENTITY_INSERT_PREFIX =
@@ -95,6 +100,37 @@ class EntityWriteBatch {
       "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, "
           + TRACKED_ENTITY_SRID
           + "), ?::jsonb, ?::jsonb)";
+
+  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch (see lines 90-104). Insert-
+  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths
+  // (deleted, lastsynchronized -- the latter is bulk-updated by
+  // DefaultTrackerBundleService.postCommit) are deliberately excluded.
+  private static final String TRACKED_ENTITY_UPDATE_SQL =
+      "update trackedentity te set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " organisationunitid = v.organisationunitid,"
+          + " trackedentitytypeid = v.trackedentitytypeid,"
+          + " potentialduplicate = v.potentialduplicate,"
+          + " inactive = v.inactive,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as trackedentitytypeid,"
+          + " unnest(?::boolean[]) as potentialduplicate,"
+          + " unnest(?::boolean[]) as inactive,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where te.trackedentityid = v.trackedentityid";
 
   private final ObjectMapper objectMapper;
 
@@ -219,9 +255,9 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes. TrackedEntity inserts go through a JDBC multi-row INSERT on {@code
-   * conn}; everything else still delegates to {@code entityManager}. The connection must be the one
-   * bound to the current Spring-managed transaction so that the JDBC INSERT and any subsequent
+   * Applies all staged writes. TrackedEntity inserts and updates go through JDBC on {@code conn};
+   * everything else still delegates to {@code entityManager}. The connection must be the one bound
+   * to the current Spring-managed transaction so that the JDBC statements and any subsequent
    * Hibernate flush execute under the same commit.
    */
   void flush(EntityManager entityManager, Connection conn) throws SQLException {
@@ -230,7 +266,7 @@ class EntityWriteBatch {
     }
 
     insertTrackedEntities(conn);
-    mergeAll(entityManager, teUpdates);
+    updateTrackedEntities(entityManager, conn);
     persistAll(entityManager, enrollmentInserts);
     mergeAll(entityManager, enrollmentUpdates);
     persistAll(entityManager, trackerEventInserts);
@@ -261,6 +297,69 @@ class EntityWriteBatch {
     teavInserts.clear();
     teavUpdates.clear();
     teavDeletes.clear();
+  }
+
+  private void updateTrackedEntities(EntityManager entityManager, Connection conn)
+      throws SQLException {
+    if (teUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teUpdates.size(); from += UPDATE_BATCH_SIZE) {
+      int to = Math.min(from + UPDATE_BATCH_SIZE, teUpdates.size());
+      List<TrackedEntity> chunk = teUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] trackedEntityTypeIds = new Long[n];
+      Boolean[] potentialDuplicate = new Boolean[n];
+      Boolean[] inactive = new Boolean[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        TrackedEntity te = chunk.get(i);
+        ids[i] = te.getId();
+        lastUpdated[i] = toTimestamp(te.getLastUpdated());
+        createdAtClient[i] = toTimestamp(te.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(te.getLastUpdatedAtClient());
+        organisationUnitIds[i] = te.getOrganisationUnit().getId();
+        trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
+        potentialDuplicate[i] = te.isPotentialDuplicate();
+        inactive[i] = te.isInactive();
+        lastUpdatedByUserInfo[i] = toJson(te.getLastUpdatedByUserInfo());
+        geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(TRACKED_ENTITY_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
+        ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
+        ps.setArray(8, conn.createArrayOf("boolean", inactive));
+        ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(10, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // The TrackedEntity entities passed in here are detached copies from the preheat. The
+    // Hibernate persistence context separately holds the entities loaded by the preheat's queries
+    // (M_managed), and they still carry their pre-update state. Detach them so any subsequent
+    // JPQL read in this session reloads the fresh DB row instead of returning the stale L1
+    // instance. This detaching will be removed once all entity types are migrated to JDBC and
+    // entityManager is no longer needed.
+    for (TrackedEntity te : teUpdates) {
+      TrackedEntity managed = entityManager.find(TrackedEntity.class, te.getId());
+      if (managed != null) {
+        entityManager.detach(managed);
+      }
+    }
   }
 
   private void insertTrackedEntities(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -91,10 +91,7 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
 class EntityWriteBatch {
 
   /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
-  private static final int INSERT_BATCH_SIZE = 128;
-
-  /** Cap on rows per unnest UPDATE statement, to bound peak array memory per chunk. */
-  private static final int UPDATE_BATCH_SIZE = 128;
+  private static final int BATCH_SIZE = 128;
 
   private static final int TRACKED_ENTITY_SRID = 4326;
 
@@ -385,8 +382,8 @@ class EntityWriteBatch {
     if (teUpdates.isEmpty()) {
       return;
     }
-    for (int from = 0; from < teUpdates.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, teUpdates.size());
+    for (int from = 0; from < teUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teUpdates.size());
       List<TrackedEntity> chunk = teUpdates.subList(from, to);
       int n = chunk.size();
 
@@ -447,8 +444,8 @@ class EntityWriteBatch {
     if (teInserts.isEmpty()) {
       return;
     }
-    for (int from = 0; from < teInserts.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, teInserts.size());
+    for (int from = 0; from < teInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teInserts.size());
       List<TrackedEntity> chunk = teInserts.subList(from, to);
       String sql =
           buildMultiRowInsertSql(
@@ -498,8 +495,8 @@ class EntityWriteBatch {
     if (enrollmentInserts.isEmpty()) {
       return;
     }
-    for (int from = 0; from < enrollmentInserts.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, enrollmentInserts.size());
+    for (int from = 0; from < enrollmentInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, enrollmentInserts.size());
       List<Enrollment> chunk = enrollmentInserts.subList(from, to);
       String sql =
           buildMultiRowInsertSql(ENROLLMENT_INSERT_PREFIX, ENROLLMENT_INSERT_ROW, chunk.size());
@@ -560,8 +557,8 @@ class EntityWriteBatch {
     if (enrollmentUpdates.isEmpty()) {
       return;
     }
-    for (int from = 0; from < enrollmentUpdates.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, enrollmentUpdates.size());
+    for (int from = 0; from < enrollmentUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, enrollmentUpdates.size());
       List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
       int n = chunk.size();
 
@@ -691,8 +688,8 @@ class EntityWriteBatch {
 
   private void insertNoteRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
       throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, newNotes.size());
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
       List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
       String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
       try (PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -720,8 +717,8 @@ class EntityWriteBatch {
 
   private void insertEnrollmentNotesJoinRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
       throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, newNotes.size());
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
       List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
       String sql =
           buildMultiRowInsertSql(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
@@ -63,8 +65,16 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
  *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
  *       update branch.
- *   <li>All other entity types (Enrollment, TrackerEvent, SingleEvent, Relationship) still delegate
- *       to {@link EntityManager}; their Phase 6 JDBC replacements follow.
+ *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
+ *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
+ *       programinstance_sequence}.
+ *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
+ *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
+ *   <li>Any new {@code note}s on either inserted or updated enrollments are cascade-inserted in two
+ *       further multi-row INSERTs (into {@code note} and {@code enrollment_notes}), replacing
+ *       Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on UPDATE.
+ *   <li>All remaining entity types (TrackerEvent, SingleEvent, Relationship) still delegate to
+ *       {@link EntityManager}; their Phase 6 JDBC replacements follow.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -131,6 +141,75 @@ class EntityWriteBatch {
           + " unnest(?::text[]) as lastupdatedbyuserinfo,"
           + " unnest(?::text[]) as geometry"
           + " ) v where te.trackedentityid = v.trackedentityid";
+
+  private static final String ENROLLMENT_INSERT_PREFIX =
+      "insert into enrollment ("
+          + "enrollmentid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " enrollmentdate, occurreddate, completeddate, completedby,"
+          + " status, followup, deleted,"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
+          + " geometry) values ";
+
+  private static final String ENROLLMENT_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+          + "ST_GeomFromText(?, "
+          + TRACKED_ENTITY_SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch (see
+  // lines 124-180). Insert-only columns (uid, created, createdbyuserinfo) and columns owned by
+  // other code paths (deleted) are deliberately excluded. status, completeddate, completedby are
+  // included even though the mapper only touches them on a status change -- writing the unchanged
+  // values back is a no-op against the existing row.
+  private static final String ENROLLMENT_UPDATE_SQL =
+      "update enrollment e set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " trackedentityid = v.trackedentityid,"
+          + " programid = v.programid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " enrollmentdate = v.enrollmentdate,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " status = v.status,"
+          + " followup = v.followup,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::timestamptz[]) as enrollmentdate,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::boolean[]) as followup,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where e.enrollmentid = v.enrollmentid";
+
+  // Cascade-INSERT targets for new enrollments that carry notes. See Enrollment.java:192-199.
+  private static final String NOTE_INSERT_PREFIX =
+      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
+  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
+
+  private static final String ENROLLMENT_NOTES_INSERT_PREFIX =
+      "insert into enrollment_notes (enrollmentid, noteid, sort_order) values ";
+  private static final String ENROLLMENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
   private final ObjectMapper objectMapper;
 
@@ -255,10 +334,11 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes. TrackedEntity inserts and updates go through JDBC on {@code conn};
-   * everything else still delegates to {@code entityManager}. The connection must be the one bound
-   * to the current Spring-managed transaction so that the JDBC statements and any subsequent
-   * Hibernate flush execute under the same commit.
+   * Applies all staged writes. TrackedEntity and Enrollment writes go through JDBC on {@code conn}
+   * (including cascade INSERTs into {@code note} / {@code enrollment_notes}); TrackerEvent,
+   * SingleEvent, Relationship and TEAV writes still delegate to {@code entityManager}. The
+   * connection must be the one bound to the current Spring-managed transaction so that the JDBC
+   * statements and any subsequent Hibernate flush execute under the same commit.
    */
   void flush(EntityManager entityManager, Connection conn) throws SQLException {
     if (isEmpty()) {
@@ -267,8 +347,9 @@ class EntityWriteBatch {
 
     insertTrackedEntities(conn);
     updateTrackedEntities(entityManager, conn);
-    persistAll(entityManager, enrollmentInserts);
-    mergeAll(entityManager, enrollmentUpdates);
+    insertEnrollments(conn);
+    updateEnrollments(entityManager, conn);
+    insertEnrollmentNotes(conn);
     persistAll(entityManager, trackerEventInserts);
     mergeAll(entityManager, trackerEventUpdates);
     persistAll(entityManager, singleEventInserts);
@@ -411,6 +492,276 @@ class EntityWriteBatch {
     ps.setString(p++, toJson(te.getCreatedByUserInfo()));
     ps.setString(p++, toJson(te.getLastUpdatedByUserInfo()));
     return p;
+  }
+
+  private void insertEnrollments(Connection conn) throws SQLException {
+    if (enrollmentInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < enrollmentInserts.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, enrollmentInserts.size());
+      List<Enrollment> chunk = enrollmentInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(ENROLLMENT_INSERT_PREFIX, ENROLLMENT_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (Enrollment e : chunk) {
+          p = bindEnrollmentRow(ps, p, e);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindEnrollmentRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "Enrollment "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
+    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, e.getStatus().name());
+    if (e.getFollowup() != null) {
+      ps.setBoolean(p++, e.getFollowup());
+    } else {
+      ps.setNull(p++, Types.BOOLEAN);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    ps.setLong(p++, e.getTrackedEntity().getId());
+    ps.setLong(p++, e.getProgram().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void updateEnrollments(EntityManager entityManager, Connection conn) throws SQLException {
+    if (enrollmentUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < enrollmentUpdates.size(); from += UPDATE_BATCH_SIZE) {
+      int to = Math.min(from + UPDATE_BATCH_SIZE, enrollmentUpdates.size());
+      List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      Long[] trackedEntityIds = new Long[n];
+      Long[] programIds = new Long[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] attributeOptionComboIds = new Long[n];
+      Timestamp[] enrollmentDate = new Timestamp[n];
+      Timestamp[] occurredDate = new Timestamp[n];
+      Timestamp[] completedDate = new Timestamp[n];
+      String[] completedBy = new String[n];
+      String[] status = new String[n];
+      Boolean[] followup = new Boolean[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        Enrollment e = chunk.get(i);
+        ids[i] = e.getId();
+        lastUpdated[i] = toTimestamp(e.getLastUpdated());
+        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
+        trackedEntityIds[i] = e.getTrackedEntity().getId();
+        programIds[i] = e.getProgram().getId();
+        organisationUnitIds[i] = e.getOrganisationUnit().getId();
+        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+        enrollmentDate[i] = toTimestamp(e.getEnrollmentDate());
+        occurredDate[i] = toTimestamp(e.getOccurredDate());
+        completedDate[i] = toTimestamp(e.getCompletedDate());
+        completedBy[i] = e.getCompletedBy();
+        status[i] = e.getStatus().name();
+        followup[i] = e.getFollowup();
+        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(ENROLLMENT_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
+        ps.setArray(7, conn.createArrayOf("bigint", programIds));
+        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+        ps.setArray(10, conn.createArrayOf("timestamptz", enrollmentDate));
+        ps.setArray(11, conn.createArrayOf("timestamptz", occurredDate));
+        ps.setArray(12, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(13, conn.createArrayOf("text", completedBy));
+        ps.setArray(14, conn.createArrayOf("text", status));
+        ps.setArray(15, conn.createArrayOf("boolean", followup));
+        ps.setArray(16, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // Same L1 staleness fix as updateTrackedEntities -- the JDBC UPDATE bypasses Hibernate, so the
+    // preheat-loaded managed Enrollment in the persistence context still carries the pre-update
+    // state. Detach it so any subsequent JPQL read reloads the fresh DB row.
+    for (Enrollment e : enrollmentUpdates) {
+      Enrollment managed = entityManager.find(Enrollment.class, e.getId());
+      if (managed != null) {
+        entityManager.detach(managed);
+      }
+    }
+  }
+
+  /**
+   * Cascade-insert any notes attached to enrollments that were just inserted by {@link
+   * #insertEnrollments} or appended to existing enrollments by {@link #updateEnrollments}. Mirrors
+   * what Hibernate did via {@code @OneToMany(cascade=ALL)} on {@code Enrollment.notes} (see {@code
+   * Enrollment.java:192-199}): allocate ids for the new {@code note} rows from {@code
+   * note_sequence}, insert the {@code note} rows, then insert the join rows in {@code
+   * enrollment_notes} with {@code sort_order} taken from the list position (1-based, per
+   * {@code @ListIndexBase(1)}). On INSERT every Note is new; on UPDATE only Notes with {@code id ==
+   * 0} are new (existing ones were loaded by the preheat).
+   */
+  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder) {}
+
+  private void insertEnrollmentNotes(Connection conn) throws SQLException {
+    List<EnrollmentNoteToInsert> newNotes = collectNewEnrollmentNotes();
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertEnrollmentNotesJoinRows(conn, newNotes);
+  }
+
+  /**
+   * For each enrollment being inserted or updated, collect the {@link Note}s that are new (no DB
+   * id) along with their 1-based sort order, which is the position in the {@code getNotes()} list.
+   * For inserts every note is new; for updates the preheat-loaded list already contains existing
+   * notes with non-zero ids, so we skip those.
+   */
+  private List<EnrollmentNoteToInsert> collectNewEnrollmentNotes() {
+    List<EnrollmentNoteToInsert> newNotes = new ArrayList<>();
+    collectNewNotesFrom(enrollmentInserts, newNotes);
+    collectNewNotesFrom(enrollmentUpdates, newNotes);
+    return newNotes;
+  }
+
+  private static void collectNewNotesFrom(
+      List<Enrollment> enrollments, List<EnrollmentNoteToInsert> out) {
+    for (Enrollment e : enrollments) {
+      if (e.getNotes() == null) {
+        continue;
+      }
+      List<Note> notes = e.getNotes();
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new EnrollmentNoteToInsert(e.getId(), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertNoteRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
+      throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, newNotes.size());
+      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (EnrollmentNoteToInsert item : chunk) {
+          Note n = item.note();
+          ps.setLong(p++, n.getId());
+          ps.setString(p++, n.getUid());
+          ps.setTimestamp(p++, toTimestamp(n.getCreated()));
+          if (n.getLastUpdatedBy() != null) {
+            ps.setLong(p++, n.getLastUpdatedBy().getId());
+          } else {
+            ps.setNull(p++, Types.BIGINT);
+          }
+          if (n.getNoteText() != null) {
+            ps.setString(p++, n.getNoteText());
+          } else {
+            ps.setNull(p++, Types.VARCHAR);
+          }
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void insertEnrollmentNotesJoinRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
+      throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, newNotes.size());
+      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              ENROLLMENT_NOTES_INSERT_PREFIX, ENROLLMENT_NOTES_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (EnrollmentNoteToInsert item : chunk) {
+          ps.setLong(p++, item.enrollmentId());
+          ps.setLong(p++, item.note().getId());
+          ps.setInt(p++, item.sortOrder());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  /**
+   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
+   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
+   * a {@code regclass}; the value is always a static literal controlled by us. Mirrors the helper
+   * in {@code AbstractTrackerPersister}.
+   */
+  private static long[] allocateIds(Connection conn, String sequenceName, int count)
+      throws SQLException {
+    long[] ids = new long[count];
+    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setInt(1, count);
+      try (ResultSet rs = ps.executeQuery()) {
+        int i = 0;
+        while (rs.next()) {
+          ids[i++] = rs.getLong(1);
+        }
+        if (i != count) {
+          throw new SQLException(
+              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
+        }
+      }
+    }
+    return ids;
   }
 
   private static String buildMultiRowInsertSql(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateEnrollmentStore.java
@@ -49,7 +49,9 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher,
       AclService aclService) {
-    super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, true);
+    // cacheable=false: enrollments are written via raw JDBC in the importer, which bypasses
+    // Hibernate's query-cache invalidation -- cached results would go stale across imports.
+    super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, false);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
@@ -56,8 +56,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ListIndexBase;
 import org.hibernate.annotations.Type;
 import org.hisp.dhis.attribute.AttributeValues;
@@ -87,7 +85,6 @@ import org.locationtech.jts.geom.Geometry;
  */
 @Entity
 @Table(name = "enrollment")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Auditable(scope = AuditScope.TRACKER)
 @Data
 public class Enrollment extends BaseTrackerObject


### PR DESCRIPTION
  ## feat: Enrollment JDBC insert/update [DHIS2-21378]

  ### Summary

  Continues the Hibernate→JDBC tracker import migration (Phase 6) by moving **Enrollment** writes off `EntityManager` and onto raw JDBC, following the same pattern already established for
  `TrackedEntity`. This includes cascade-handling for enrollment notes, which Hibernate previously managed via `@OneToMany(cascade=ALL)`, and removal of L2 caching for `Enrollment`, which is
  incompatible with writes that bypass Hibernate.

  ### Changes

  **`EntityWriteBatch`** — the bulk of the work:
  - **Enrollment inserts** are now flushed via a multi-row JDBC `INSERT` into `enrollment`. Ids are pre-allocated from `programinstance_sequence` by `AbstractTrackerPersister`.
  - **Enrollment updates** are flushed via a single JDBC `unnest` `UPDATE` against `enrollment`, writing only the columns mutated by `TrackerObjectsMapper.map` on the update branch.
  Insert-only columns (`uid`, `created`, `createdbyuserinfo`) and externally-owned columns (`deleted`) are deliberately excluded.
  - **Enrollment notes** are cascade-inserted in two further multi-row `INSERT`s (`note` and the `enrollment_notes` join table), replacing Hibernate's cascade behaviour. New note ids are
  allocated from `note_sequence`; `sort_order` is derived from the 1-based list position (per `@ListIndexBase(1)`). Notes are append-only on update — only notes with `id == 0` are treated as
  new.
  - Applies the same **L1-staleness fix** used for `TrackedEntity`: after the JDBC `UPDATE` bypasses Hibernate, the preheat-loaded managed `Enrollment` is detached so any subsequent JPQL read
  reloads fresh DB state.

  **L2 cache removal for `Enrollment`**:
  - Dropped the `@Cache(usage = READ_WRITE)` annotation from the `Enrollment` entity and switched `HibernateEnrollmentStore` to `cacheable=false`. The importer now writes enrollments via raw
  JDBC, which bypasses Hibernate's entity- and query-cache invalidation — cached results would go stale across imports.

  **`AbstractTrackerPersister`**:
  - `assignId` now handles `Enrollment` (in addition to `TrackedEntity`) for pre-allocated ids.
  - Reordered the staging logic so id assignment and ownership persistence happen inside the `isNew` branch.

  **`EnrollmentPersister`**:
  - `sequenceName()` now returns `programinstance_sequence` (was `null`), enabling id pre-allocation.
  - Program-owner creation no longer gated on `isNew`.

  ### Testing

  Added two integration tests to `EnrollmentImportTest`, verifying note rows and `enrollment_notes` join entries against the DB via JDBC:
  - `shouldInsertNoteRowsAndJoinTableEntriesWhenEnrollmentIsCreatedWithNotes` — notes inserted with correct `sort_order` on create.
  - `shouldAppendNewNoteAndKeepExistingOnesWhenEnrollmentIsUpdatedWithExtraNote` — new note appended on update while existing notes are preserved.

  New test fixtures: `one_enrollment_with_notes.json`, `one_enrollment_with_extra_note.json`.

  ### Notes
  - `TrackerEvent`, `SingleEvent`, `Relationship` and `TEAV` writes still delegate to `EntityManager`; their Phase 6 JDBC replacements follow.

[DHIS2-21378]: https://dhis2.atlassian.net/browse/DHIS2-21378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
