### PR TITLE
fix: Skip validation if no data value on event [DHIS2-21588][2.42]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventService.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.util.DateUtils;
@@ -197,13 +196,12 @@ class CsvEventService implements CsvService<Event> {
         events.add(event);
       }
 
-      if (ObjectUtils.anyNotNull(
-          dataValue.getProvidedElsewhere(),
-          dataValue.getDataElement(),
-          dataValue.getValue(),
-          dataValue.getCreatedAtDataValue(),
-          dataValue.getUpdatedAtDataValue(),
-          dataValue.getStoredByDataValue())) {
+      if (dataValue.getProvidedElsewhere() != null
+          || StringUtils.isNotEmpty(dataValue.getDataElement())
+          || StringUtils.isNotEmpty(dataValue.getValue())
+          || StringUtils.isNotEmpty(dataValue.getCreatedAtDataValue())
+          || StringUtils.isNotEmpty(dataValue.getUpdatedAtDataValue())
+          || StringUtils.isNotEmpty(dataValue.getStoredByDataValue())) {
         DataValue value = new DataValue();
         value.setProvidedElsewhere(
             dataValue.getProvidedElsewhere() != null && dataValue.getProvidedElsewhere());

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventServiceTest.java
@@ -228,6 +228,51 @@ class CsvEventServiceTest {
             });
   }
 
+  @Test
+  void shouldProduceNoDataValuesWhenReadingEventWithEmptyDataValueColumns()
+      throws IOException, ParseException {
+    String csv =
+        """
+        event,status,program,programStage,enrollment,orgUnit,occurredAt,scheduledAt,\
+        geometry,latitude,longitude,followUp,deleted,createdAt,createdAtClient,updatedAt,\
+        updatedAtClient,completedBy,completedAt,updatedBy,attributeOptionCombo,\
+        attributeCategoryOptions,assignedUser,dataElement,value,storedBy,\
+        providedElsewhere,storedByDataValue,updatedAtDataValue,createdAtDataValue
+        BuA2R2Gr4vt,ACTIVE,programId,programStageId,,orgUnitId,,,,,,false,false,,,,,,,,,,,,,,,,,
+        """;
+
+    List<Event> events =
+        service.read(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), true);
+
+    assertEquals(1, events.size());
+    assertTrue(
+        events.get(0).getDataValues().isEmpty(),
+        "Event without data values must not produce phantom DataValues on import");
+  }
+
+  @Test
+  void shouldProduceNoDataValuesWhenWritingAndReadingBackEventWithoutDataValues()
+      throws IOException, ParseException {
+    Event event =
+        Event.builder()
+            .event(UID.of("BuA2R2Gr4vt"))
+            .status(EventStatus.ACTIVE)
+            .program("programId")
+            .programStage("programStageId")
+            .orgUnit("orgUnitId")
+            .build();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    service.write(out, List.of(event), true);
+
+    List<Event> imported = service.read(new ByteArrayInputStream(out.toByteArray()), true);
+
+    assertEquals(1, imported.size());
+    assertTrue(
+        imported.get(0).getDataValues().isEmpty(),
+        "Round-tripped event without data values must not produce phantom DataValues");
+  }
+
   @ValueSource(
       strings = {
         ",,,,,,,,POINT (-11.4283223849698 8.06311527044516)",


### PR DESCRIPTION
When exporting events without data values, in the CSV file, the `dataElement` column is empty.

On import, Jackson parses empty CSV cells as empty string rather than `null`. The previous check used `ObjectUtils.anyNotNull(...)`, which treated empty strings as non-null and created a phantom `DataValue` with an empty `dataElement`.

This caused the import to fail with: `E1304: DataElement `` is not a valid DataElement`

The fix is to replace `anyNotNull(...)` with `StringUtils.isNotEmpty(...)` checks for all `String` fields so empty cells are correctly treated as absent.

The `Boolean` `providedElsewhere` field retains a null check, since its semantics are distinct.
