### PR TITLE
Removed master as on-push target for SonarCloud check

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -11,7 +11,6 @@ env:
 on:
   push:
     branches:
-      - master
       - "2.3[1-9]"
       - "2.4[0-9]"
   pull_request:


### PR DESCRIPTION
Remove master as the "on push" target for the SonarCloud analysis.

Since the check always fails due to the sheer amount of issues caught accross the whole codebase, it's not really adding any value here.

The check will still work in PRs against master.