### PR TITLE
fix: prevent openapi.html crash on operation paths that cannot be escaped as JSON paths

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -144,6 +144,17 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
     assertContains("#DataElement", html);
   }
 
+  /**
+   * Regression: the full HTML document (no scope filter) must render without error. It previously
+   * failed with HTTP 500 because resolving a schema/parameter shared name stringified a JSON path
+   * containing an operation path that cannot be escaped (e.g. {@code .../{trackedEntityType}.csv}).
+   */
+  @Test
+  void testGetOpenApiDocumentHtml_FullDocument() {
+    String html = GET("/openapi/openapi.html", Accept(TEXT_HTML_VALUE)).content(TEXT_HTML_VALUE);
+    assertContains("DHIS2 Full API", html);
+  }
+
   @Test
   void testGetOpenApiDocument_DefaultValue() {
     // defaults in parameter objects (from Property analysis)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiObject.java
@@ -405,12 +405,17 @@ public interface OpenApiObject extends JsonObject {
     }
 
     default boolean isShared() {
-      String path = node().path().toString();
-      return path.substring(0, path.lastIndexOf('.')).equals(".components.parameters");
+      // A shared parameter is a direct member of components.parameters. Inspect the path segments
+      // structurally rather than via toString(), which throws for path keys that cannot be escaped
+      // (e.g. operation paths like /api/.../{trackedEntityType}.csv).
+      List<Text> path = node().path().segments();
+      return path.size() == 3
+          && path.get(0).contentEquals("components")
+          && path.get(1).contentEquals("parameters");
     }
 
     default String getSharedName() {
-      return isShared() ? node().path().toString().substring(24) : null;
+      return isShared() ? node().path().segments().get(2).toString() : null;
     }
 
     /**
@@ -493,12 +498,17 @@ public interface OpenApiObject extends JsonObject {
 
     default boolean isShared() {
       if (!exists()) return false;
-      String path = node().path().toString();
-      return path.substring(0, path.lastIndexOf('.')).equals(".components.schemas");
+      // A shared schema is a direct member of components.schemas. Inspect the path segments
+      // structurally rather than via toString(), which throws for path keys that cannot be escaped
+      // (e.g. operation paths like /api/.../{trackedEntityType}.csv).
+      List<Text> path = node().path().segments();
+      return path.size() == 3
+          && path.get(0).contentEquals("components")
+          && path.get(1).contentEquals("schemas");
     }
 
     default String getSharedName() {
-      return isShared() ? node().path().toString().substring(20) : null;
+      return isShared() ? node().path().segments().get(2).toString() : null;
     }
 
     default String x_kind() {


### PR DESCRIPTION
### Problem
`GET /api/openapi.html` (the full document, no `scope` filter) returned **HTTP 500**:

```
JsonPathException: Path segment /api/analytics/trackedEntities/query/{trackedEntityType}.csv cannot be escaped
```

`openapi.json` was unaffected. The HTML renderer derives a component's shared name via `node().path().toString()`, and `jsontree` cannot escape a `paths` key where a path variable `{…}` is followed by more text (e.g. `.csv`). These routes exist on the analytics CSV endpoints (`/query/{trackedEntityType}.csv`, `/{program}.csv`), so any full render crashed. Latent since the HTML renderer landed (2.42).

### Fix
`OpenApiObject.SchemaObject`/`ParameterObject` `isShared()`/`getSharedName()` now inspect the path **structurally** via `node().path().segments()` (raw, unescaped) instead of stringifying it — the same idiom `OperationObject` already uses. No escaping, no crash. Also fixes a latent off-by-one in the parameter name derivation (dotted parameter names).

### Test
`OpenApiControllerTest.testGetOpenApiDocumentHtml_FullDocument` renders the full HTML document and asserts success. It fails on the unfixed renderer with the exact `JsonPathException` and passes with the fix.

AI Assisted.
