### PR TITLE
chore: update postgis version in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-web-base: &web-base
     DB_PASSWORD: ${DB_PASSWORD}
 
 x-db-base: &db-base
-  image: ghcr.io/baosystems/postgis:12-3.3
+  image: ghcr.io/baosystems/postgis:16-3.5
   # uncomment to enable query logging
   # command:
   #   ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]


### PR DESCRIPTION
The [`12-3.3`](https://github.com/baosystems/docker-postgis/pkgs/container/postgis/118686125?tag=12-3.3) tag was last published almost 3 years ago.