### PR TITLE
chore(docker): add CHAP compose overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ When running compose up with multiple compose files, you need to pass the same f
 docker compose -f docker-compose.yml -f docker-compose.doris.yml down
 ```
 
+### Launch for CHAP
+
+This overlay configures DHIS2 for the Climate Health Analytics Platform (CHAP). It uses `docker/chap/dhis-chap.conf`, which allows the route API to reach any HTTP server (`route.remote_servers_allowed = http://*`), and loads the Laos climate demo database.
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.chap.yml up
+```
+
+```
+docker compose -f docker-compose.yml -f docker-compose.chap.yml down
+```
+
 ### Synchronization between DHIS2 instances
 
 You can run multiple DHIS2 instances to test data and metadata [synchronization](https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/exchanging-data/metadata-synchronization.html) by running the following command.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker compose -f docker-compose.yml -f docker-compose.doris.yml down
 This overlay configures DHIS2 for the Climate Health Analytics Platform (CHAP). It uses `docker/chap/dhis-chap.conf`, which allows the route API to reach any HTTP server (`route.remote_servers_allowed = http://*`), and loads the Laos climate demo database.
 
 ```sh
-docker compose -f docker-compose.yml -f docker-compose.chap.yml up
+docker compose -f docker-compose.yml -f docker-compose.chap.yml up -d
 ```
 
 ```

--- a/docker-compose.chap.yml
+++ b/docker-compose.chap.yml
@@ -1,0 +1,8 @@
+services:
+  web:
+    volumes:
+      - ./docker/chap/dhis-chap.conf:/opt/dhis2/dhis.conf:ro
+
+  db-dump:
+    environment:
+      DHIS2_DB_DUMP_URL: "https://databases.dhis2.org/climate/laos/2.42/demo.sql.gz"

--- a/docker/chap/dhis-chap.conf
+++ b/docker/chap/dhis-chap.conf
@@ -1,0 +1,11 @@
+connection.dialect = org.hibernate.dialect.PostgreSQLDialect
+connection.driver_class = org.postgresql.Driver
+connection.url = jdbc:postgresql://${DB_HOSTNAME}/${DB_NAME}
+connection.username = ${DB_USERNAME}
+connection.password = ${DB_PASSWORD}
+
+tracker.import.preheat.cache.enabled=off
+
+server.https = true
+
+route.remote_servers_allowed = http://*


### PR DESCRIPTION
Adds a `docker-compose.chap.yml` overlay that mounts `docker/chap/dhis-chap.conf` (sets `route.remote_servers_allowed = http://*`) and loads the Laos climate demo DB. 

Test by running:
```sh
docker compose -f docker-compose.yml -f docker-compose.chap.yml up
```