### PR TITLE
refactor: Restructure UserDetails for clarity

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
@@ -114,7 +114,7 @@ public class CurrentUserUtil {
     }
 
     UserDetails currentUserDetails = getCurrentUserDetails();
-    return currentUserDetails.getAuthorities().stream()
+    return currentUserDetails.getLoginCredentials().getAuthorities().stream()
         .map(GrantedAuthority::getAuthority)
         .toList();
   }
@@ -141,7 +141,8 @@ public class CurrentUserUtil {
 
   public static void injectUserInSecurityContext(UserDetails actingUser) {
     Authentication authentication =
-        new UsernamePasswordAuthenticationToken(actingUser, "", actingUser.getAuthorities());
+        new UsernamePasswordAuthenticationToken(
+            actingUser, "", actingUser.getLoginCredentials().getAuthorities());
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
     SecurityContextHolder.setContext(context);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -46,9 +46,9 @@ public class SystemUser implements UserDetails {
   static final LoginCredentials SUPER =
       new LoginCredentials(
           List.of((GrantedAuthority) Authorities.ALL::name),
+          "system-process_" + CodeGenerator.generateUid(),
           null,
           // Never rely on this method to get the username of the system user for identification.
-          "system-process_" + CodeGenerator.generateUid(),
           true,
           true,
           true,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -43,47 +43,27 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class SystemUser implements UserDetails {
 
+  static final LoginCredentials SUPER =
+      new LoginCredentials(
+          List.of((GrantedAuthority) Authorities.ALL::name),
+          null,
+          // Never rely on this method to get the username of the system user for identification.
+          "system-process_" + CodeGenerator.generateUid(),
+          true,
+          true,
+          true,
+          true);
+
   @Nonnull
   @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of((GrantedAuthority) Authorities.ALL::name);
+  public LoginCredentials getLoginCredentials() {
+    return SUPER;
   }
 
   @Nonnull
   @Override
   public Set<String> getAllAuthorities() {
     return Set.of(Authorities.ALL.name());
-  }
-
-  @Override
-  public String getPassword() {
-    return null;
-  }
-
-  @Override
-  public String getUsername() {
-    // Never rely on this method to get the username of the system user for identification.
-    return "system-process_" + CodeGenerator.generateUid();
-  }
-
-  @Override
-  public boolean isAccountNonExpired() {
-    return true;
-  }
-
-  @Override
-  public boolean isAccountNonLocked() {
-    return true;
-  }
-
-  @Override
-  public boolean isCredentialsNonExpired() {
-    return true;
-  }
-
-  @Override
-  public boolean isEnabled() {
-    return true;
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -30,17 +30,13 @@
 package org.hisp.dhis.user;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UidObject;
 import org.hisp.dhis.common.UsageTestOnly;
 import org.hisp.dhis.security.Authorities;
@@ -48,8 +44,32 @@ import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.user.UserDetailsImpl.UserDetailsImplBuilder;
 import org.springframework.security.core.GrantedAuthority;
 
-public interface UserDetails
-    extends org.springframework.security.core.userdetails.UserDetails, UidObject {
+public interface UserDetails extends UidObject {
+
+  /**
+   * Spring level user details as required by {@link
+   * org.springframework.security.core.userdetails.UserDetails}.
+   */
+  record LoginCredentials(
+      @Nonnull Collection<? extends GrantedAuthority> getAuthorities,
+      String getPassword,
+      String getUsername,
+      boolean isAccountNonExpired,
+      boolean isAccountNonLocked,
+      boolean isCredentialsNonExpired,
+      boolean isEnabled)
+      implements org.springframework.security.core.userdetails.UserDetails {
+
+    @Override
+    public int hashCode() {
+      return getUsername.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof LoginCredentials other && getUsername.equals(other.getUsername);
+    }
+  }
 
   /**
    * @return a {@link UserDetails} object that is all initialized to empty (no anything) but which
@@ -84,7 +104,7 @@ public interface UserDetails
     if (user == null) {
       return null;
     }
-    return createUserDetails(
+    return UserDetailsImpl.createUserDetails(
         user, user.isAccountNonLocked(), user.isCredentialsNonExpired(), null, null, null, true);
   }
 
@@ -99,7 +119,7 @@ public interface UserDetails
     if (user == null) {
       return null;
     }
-    return createUserDetails(
+    return UserDetailsImpl.createUserDetails(
         user, user.isAccountNonLocked(), user.isCredentialsNonExpired(), null, null, null, false);
   }
 
@@ -111,128 +131,26 @@ public interface UserDetails
       @CheckForNull Set<String> orgUnitUids,
       @CheckForNull Set<String> searchOrgUnitUids,
       @CheckForNull Set<String> dataViewUnitUids) {
-    return createUserDetails(
+    return UserDetailsImpl.createUserDetails(
         user,
         accountNonLocked,
         credentialsNonExpired,
         orgUnitUids,
         searchOrgUnitUids,
-        dataViewUnitUids,
-        true);
-  }
-
-  @CheckForNull
-  static UserDetails createUserDetails(
-      @CheckForNull User user,
-      boolean accountNonLocked,
-      boolean credentialsNonExpired,
-      @CheckForNull Set<String> orgUnitUids,
-      @CheckForNull Set<String> searchOrgUnitUids,
-      @CheckForNull Set<String> dataViewUnitUids,
-      boolean loadOrgUnits) {
-
-    if (user == null) {
-      return null;
-    }
-
-    UserDetailsImplBuilder userDetailsImplBuilder =
-        UserDetailsImpl.builder()
-            .id(user.getId())
-            .uid(user.getUid())
-            .code(user.getCode())
-            .username(user.getUsername())
-            .password(user.getPassword())
-            .externalAuth(user.isExternalAuth())
-            .isTwoFactorEnabled(user.isTwoFactorEnabled())
-            .twoFactorType(user.getTwoFactorType())
-            .secret(user.getSecret())
-            .email(user.getEmail())
-            .isEmailVerified(user.isEmailVerified())
-            .firstName(user.getFirstName())
-            .surname(user.getSurname())
-            .enabled(user.isEnabled())
-            .accountNonExpired(user.isAccountNonExpired())
-            .accountNonLocked(accountNonLocked)
-            .credentialsNonExpired(credentialsNonExpired)
-            .dataViewMaxOrganisationUnitLevel(user.getDataViewMaxOrganisationUnitLevel())
-            .authorities(user.getAuthorities())
-            .allAuthorities(
-                new HashSet<>(
-                    Set.copyOf(
-                        user.getAuthorities().stream()
-                            .map(GrantedAuthority::getAuthority)
-                            .toList())))
-            .isSuper(user.isSuper())
-            .userRoleIds(new HashSet<>(setOfIds(user.getUserRoles())))
-            .userGroupIds(
-                new HashSet<>(user.getUid() == null ? Set.of() : setOfIds(user.getGroups())))
-            .managedGroupLongIds(
-                new HashSet<>(
-                    user.getUid() == null ? Set.of() : setOfPrimaryKeys(user.getManagedGroups())))
-            .userRoleLongIds(
-                new HashSet<>(
-                    user.getUid() == null ? Set.of() : setOfPrimaryKeys(user.getUserRoles())));
-
-    if (loadOrgUnits) {
-      Set<String> userOrgUnitIds =
-          (orgUnitUids == null) ? setOfIds(user.getOrganisationUnits()) : orgUnitUids;
-
-      Set<String> userSearchOrgUnitIds =
-          (searchOrgUnitUids == null)
-              ? setOfIds(user.getTeiSearchOrganisationUnitsWithFallback())
-              : (searchOrgUnitUids.isEmpty() ? orgUnitUids : searchOrgUnitUids);
-
-      Set<String> userEffectiveSearchOrgUnitIds =
-          Stream.of(userOrgUnitIds, userSearchOrgUnitIds)
-              .filter(Objects::nonNull)
-              .flatMap(Collection::stream)
-              .collect(Collectors.toSet());
-
-      Set<String> userDataOrgUnitIds =
-          (dataViewUnitUids == null)
-              ? setOfIds(user.getDataViewOrganisationUnitsWithFallback())
-              : (dataViewUnitUids.isEmpty() ? orgUnitUids : dataViewUnitUids);
-
-      userDetailsImplBuilder
-          .userOrgUnitIds(new HashSet<>(userOrgUnitIds))
-          .userSearchOrgUnitIds(new HashSet<>(userSearchOrgUnitIds))
-          .userEffectiveSearchOrgUnitIds(new HashSet<>(userEffectiveSearchOrgUnitIds))
-          .userDataOrgUnitIds(new HashSet<>(userDataOrgUnitIds))
-          .allRestrictions(new HashSet<>(user.getAllRestrictions()));
-
-    } else {
-      userDetailsImplBuilder
-          .userOrgUnitIds(new HashSet<>())
-          .userSearchOrgUnitIds(new HashSet<>())
-          .userEffectiveSearchOrgUnitIds(new HashSet<>())
-          .userDataOrgUnitIds(new HashSet<>())
-          .allRestrictions(new HashSet<>());
-    }
-
-    return userDetailsImplBuilder.build();
+        dataViewUnitUids);
   }
 
   @Nonnull
-  @Override
-  Collection<? extends GrantedAuthority> getAuthorities();
+  LoginCredentials getLoginCredentials();
 
-  @Override
-  String getPassword();
-
-  @Override
-  String getUsername();
-
-  @Override
-  boolean isAccountNonExpired();
-
-  @Override
-  boolean isAccountNonLocked();
-
-  @Override
-  boolean isCredentialsNonExpired();
-
-  @Override
-  boolean isEnabled();
+  /**
+   * For convenience as this is a much used property
+   *
+   * @return the username as defined by {@link #getLoginCredentials()}
+   */
+  default String getUsername() {
+    return getLoginCredentials().getUsername();
+  }
 
   boolean isSuper();
 
@@ -358,21 +276,5 @@ public interface UserDetails
       }
     }
     return false;
-  }
-
-  @Nonnull
-  private static Set<String> setOfIds(
-      @CheckForNull Collection<? extends IdentifiableObject> objects) {
-    return objects == null || objects.isEmpty()
-        ? Set.of()
-        : Set.copyOf(objects.stream().map(IdentifiableObject::getUid).toList());
-  }
-
-  @Nonnull
-  private static Set<Long> setOfPrimaryKeys(
-      @CheckForNull Collection<? extends IdentifiableObject> objects) {
-    return objects == null || objects.isEmpty()
-        ? Set.of()
-        : Set.copyOf(objects.stream().map(IdentifiableObject::getId).toList());
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -52,13 +52,17 @@ public interface UserDetails extends UidObject {
    */
   record LoginCredentials(
       @Nonnull Collection<? extends GrantedAuthority> getAuthorities,
-      String getPassword,
       String getUsername,
+      String getPassword,
+      boolean isEnabled,
       boolean isAccountNonExpired,
       boolean isAccountNonLocked,
-      boolean isCredentialsNonExpired,
-      boolean isEnabled)
+      boolean isCredentialsNonExpired)
       implements org.springframework.security.core.userdetails.UserDetails {
+
+    public LoginCredentials(String username, String password) {
+      this(List.of(), username, password, true, true, true, true);
+    }
 
     @Override
     public int hashCode() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
@@ -93,12 +93,12 @@ public class UserDetailsImpl implements UserDetails {
     LoginCredentials credentials =
         new LoginCredentials(
             authorities,
-            password,
             username,
+            password,
+            enabled,
             accountNonExpired,
             accountNonLocked,
-            credentialsNonExpired,
-            enabled);
+            credentialsNonExpired);
     return UserDetailsImpl.builder()
         .uid(uid)
         .code(code)
@@ -236,12 +236,12 @@ public class UserDetailsImpl implements UserDetails {
     LoginCredentials credentials =
         new LoginCredentials(
             user.getAuthorities(),
-            user.getPassword(),
             user.getUsername(),
+            user.getPassword(),
+            user.isEnabled(),
             user.isAccountNonExpired(),
             accountNonLocked,
-            credentialsNonExpired,
-            user.isEnabled());
+            credentialsNonExpired);
     UserDetailsImplBuilder userDetailsImplBuilder =
         UserDetailsImpl.builder()
             .id(user.getId())

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
@@ -34,13 +34,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.springframework.security.core.GrantedAuthority;
@@ -84,23 +90,27 @@ public class UserDetailsImpl implements UserDetails {
       @JsonProperty("userRoleIds") Set<String> userRoleIds,
       @JsonProperty("managedGroupLongIds") Set<Long> managedGroupLongIds,
       @JsonProperty("userRoleLongIds") Set<Long> userRoleLongIds) {
+    LoginCredentials credentials =
+        new LoginCredentials(
+            authorities,
+            password,
+            username,
+            accountNonExpired,
+            accountNonLocked,
+            credentialsNonExpired,
+            enabled);
     return UserDetailsImpl.builder()
         .uid(uid)
         .code(code)
-        .username(username)
+        .loginCredentials(credentials)
         .firstName(firstName)
         .surname(surname)
-        .password(password)
         .externalAuth(externalAuth)
         .isTwoFactorEnabled(isTwoFactorEnabled)
         .twoFactorType(twoFactorType)
         .secret(secret)
         .email(email)
         .isEmailVerified(isEmailVerified)
-        .enabled(enabled)
-        .accountNonExpired(accountNonExpired)
-        .accountNonLocked(accountNonLocked)
-        .credentialsNonExpired(credentialsNonExpired)
         .dataViewMaxOrganisationUnitLevel(dataViewMaxOrganisationUnitLevel)
         .authorities(authorities)
         .allAuthorities(allAuthorities)
@@ -120,20 +130,15 @@ public class UserDetailsImpl implements UserDetails {
   private final String uid;
   @Setter private Long id;
   private final String code;
-  @EqualsAndHashCode.Include private final String username;
+  @EqualsAndHashCode.Include private final LoginCredentials loginCredentials;
   private final String firstName;
   private final String surname;
-  private final String password;
   private final boolean externalAuth;
   private final boolean isTwoFactorEnabled;
   private final TwoFactorType twoFactorType;
   private final String secret;
   private final String email;
   private final boolean isEmailVerified;
-  private final boolean enabled;
-  private final boolean accountNonExpired;
-  private final boolean accountNonLocked;
-  private final boolean credentialsNonExpired;
   private final boolean isSuper;
   private final Integer dataViewMaxOrganisationUnitLevel;
   @Nonnull private final Collection<GrantedAuthority> authorities;
@@ -194,5 +199,134 @@ public class UserDetailsImpl implements UserDetails {
   @Override
   public boolean isAuthorized(@Nonnull Authorities auth) {
     return isAuthorized(auth.toString());
+  }
+
+  @CheckForNull
+  static UserDetails createUserDetails(
+      @CheckForNull User user,
+      boolean accountNonLocked,
+      boolean credentialsNonExpired,
+      @CheckForNull Set<String> orgUnitUids,
+      @CheckForNull Set<String> searchOrgUnitUids,
+      @CheckForNull Set<String> dataViewUnitUids) {
+    return createUserDetails(
+        user,
+        accountNonLocked,
+        credentialsNonExpired,
+        orgUnitUids,
+        searchOrgUnitUids,
+        dataViewUnitUids,
+        true);
+  }
+
+  @CheckForNull
+  static UserDetails createUserDetails(
+      @CheckForNull User user,
+      boolean accountNonLocked,
+      boolean credentialsNonExpired,
+      @CheckForNull Set<String> orgUnitUids,
+      @CheckForNull Set<String> searchOrgUnitUids,
+      @CheckForNull Set<String> dataViewUnitUids,
+      boolean loadOrgUnits) {
+
+    if (user == null) {
+      return null;
+    }
+
+    LoginCredentials credentials =
+        new LoginCredentials(
+            user.getAuthorities(),
+            user.getPassword(),
+            user.getUsername(),
+            user.isAccountNonExpired(),
+            accountNonLocked,
+            credentialsNonExpired,
+            user.isEnabled());
+    UserDetailsImplBuilder userDetailsImplBuilder =
+        UserDetailsImpl.builder()
+            .id(user.getId())
+            .uid(user.getUid())
+            .code(user.getCode())
+            .loginCredentials(credentials)
+            .externalAuth(user.isExternalAuth())
+            .isTwoFactorEnabled(user.isTwoFactorEnabled())
+            .twoFactorType(user.getTwoFactorType())
+            .secret(user.getSecret())
+            .email(user.getEmail())
+            .isEmailVerified(user.isEmailVerified())
+            .firstName(user.getFirstName())
+            .surname(user.getSurname())
+            .dataViewMaxOrganisationUnitLevel(user.getDataViewMaxOrganisationUnitLevel())
+            .authorities(user.getAuthorities())
+            .allAuthorities(
+                new HashSet<>(
+                    Set.copyOf(
+                        user.getAuthorities().stream()
+                            .map(GrantedAuthority::getAuthority)
+                            .toList())))
+            .isSuper(user.isSuper())
+            .userRoleIds(new HashSet<>(setOfIds(user.getUserRoles())))
+            .userGroupIds(
+                new HashSet<>(user.getUid() == null ? Set.of() : setOfIds(user.getGroups())))
+            .managedGroupLongIds(
+                new HashSet<>(
+                    user.getUid() == null ? Set.of() : setOfPrimaryKeys(user.getManagedGroups())))
+            .userRoleLongIds(
+                new HashSet<>(
+                    user.getUid() == null ? Set.of() : setOfPrimaryKeys(user.getUserRoles())));
+
+    if (loadOrgUnits) {
+      Set<String> userOrgUnitIds =
+          (orgUnitUids == null) ? setOfIds(user.getOrganisationUnits()) : orgUnitUids;
+
+      Set<String> userSearchOrgUnitIds =
+          (searchOrgUnitUids == null)
+              ? setOfIds(user.getTeiSearchOrganisationUnitsWithFallback())
+              : (searchOrgUnitUids.isEmpty() ? orgUnitUids : searchOrgUnitUids);
+
+      Set<String> userEffectiveSearchOrgUnitIds =
+          Stream.of(userOrgUnitIds, userSearchOrgUnitIds)
+              .filter(Objects::nonNull)
+              .flatMap(Collection::stream)
+              .collect(Collectors.toSet());
+
+      Set<String> userDataOrgUnitIds =
+          (dataViewUnitUids == null)
+              ? setOfIds(user.getDataViewOrganisationUnitsWithFallback())
+              : (dataViewUnitUids.isEmpty() ? orgUnitUids : dataViewUnitUids);
+
+      userDetailsImplBuilder
+          .userOrgUnitIds(new HashSet<>(userOrgUnitIds))
+          .userSearchOrgUnitIds(new HashSet<>(userSearchOrgUnitIds))
+          .userEffectiveSearchOrgUnitIds(new HashSet<>(userEffectiveSearchOrgUnitIds))
+          .userDataOrgUnitIds(new HashSet<>(userDataOrgUnitIds))
+          .allRestrictions(new HashSet<>(user.getAllRestrictions()));
+
+    } else {
+      userDetailsImplBuilder
+          .userOrgUnitIds(new HashSet<>())
+          .userSearchOrgUnitIds(new HashSet<>())
+          .userEffectiveSearchOrgUnitIds(new HashSet<>())
+          .userDataOrgUnitIds(new HashSet<>())
+          .allRestrictions(new HashSet<>());
+    }
+
+    return userDetailsImplBuilder.build();
+  }
+
+  @Nonnull
+  private static Set<String> setOfIds(
+      @CheckForNull Collection<? extends IdentifiableObject> objects) {
+    return objects == null || objects.isEmpty()
+        ? Set.of()
+        : Set.copyOf(objects.stream().map(IdentifiableObject::getUid).toList());
+  }
+
+  @Nonnull
+  private static Set<Long> setOfPrimaryKeys(
+      @CheckForNull Collection<? extends IdentifiableObject> objects) {
+    return objects == null || objects.isEmpty()
+        ? Set.of()
+        : Set.copyOf(objects.stream().map(IdentifiableObject::getId).toList());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManagerTest.java
@@ -85,7 +85,10 @@ class DefaultAnalyticsSecurityManagerTest extends TestBase {
     lenient().when(currentUser.getDataViewOrganisationUnits()).thenReturn(Set.of(ouB));
     lenient().when(currentUser.getUsername()).thenReturn("tester");
 
-    UserDetails currentUserDetails = UserDetails.empty().username("tester").build();
+    UserDetails currentUserDetails =
+        UserDetails.empty()
+            .loginCredentials(new UserDetails.LoginCredentials("tester", null))
+            .build();
     CurrentUserUtil.injectUserInSecurityContext(currentUserDetails);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultLdapUserDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultLdapUserDetailsService.java
@@ -73,6 +73,6 @@ public class DefaultLdapUserDetailsService implements UserDetailsService {
     String password = "EXTERNAL_LDAP_" + CodeGenerator.generateCode(10);
     user.setPassword(password);
 
-    return userService.createUserDetails(user);
+    return userService.createUserDetails(user).getLoginCredentials();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
@@ -60,6 +60,7 @@ public class DefaultUserDetailsService implements UserDetailsService {
           String.format("User with username '%s' not found", username));
     }
 
-    return userService.createUserDetails(user);
+    // TODO maybe there can be a slimmer version of just loading the LoginCredentials here
+    return userService.createUserDetails(user).getLoginCredentials();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAuthenticationToken.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAuthenticationToken.java
@@ -50,7 +50,7 @@ public final class ApiTokenAuthenticationToken extends AbstractAuthenticationTok
   }
 
   public ApiTokenAuthenticationToken(ApiToken token, UserDetails user) {
-    super(user.getAuthorities());
+    super(user.getLoginCredentials().getAuthorities());
     this.tokenRef = token;
     this.user = user;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -231,7 +231,7 @@ public class Dhis2JwtAuthenticationManagerResolver
       }
 
       Collection<GrantedAuthority> grantedAuthorities =
-          List.copyOf(currentUserDetails.getAuthorities());
+          List.copyOf(currentUserDetails.getLoginCredentials().getAuthorities());
 
       return new DhisJwtAuthenticationToken(
           jwt, grantedAuthorities, mappingValue, currentUserDetails);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -93,11 +93,6 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
   }
 
   @Override
-  public String getUsername() {
-    return user.getUsername();
-  }
-
-  @Override
   public boolean isSuper() {
     return user.isSuper();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -67,7 +67,7 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
       Map<String, Object> attributes,
       String nameAttributeKey,
       OidcIdToken idToken) {
-    super(user.getAuthorities(), attributes, nameAttributeKey);
+    super(user.getLoginCredentials().getAuthorities(), attributes, nameAttributeKey);
     this.oidcIdToken = idToken;
     this.user = user;
   }
@@ -87,38 +87,14 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
     return oidcIdToken;
   }
 
-  public org.springframework.security.core.userdetails.UserDetails getUser() {
-    return user;
+  @Nonnull
+  public LoginCredentials getLoginCredentials() {
+    return user.getLoginCredentials();
   }
 
   @Override
   public String getUsername() {
     return user.getUsername();
-  }
-
-  @Override
-  public String getPassword() {
-    return user.getPassword();
-  }
-
-  @Override
-  public boolean isAccountNonExpired() {
-    return user.isAccountNonExpired();
-  }
-
-  @Override
-  public boolean isAccountNonLocked() {
-    return user.isAccountNonLocked();
-  }
-
-  @Override
-  public boolean isCredentialsNonExpired() {
-    return user.isCredentialsNonExpired();
-  }
-
-  @Override
-  public boolean isEnabled() {
-    return user.isEnabled();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultAuthenticationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultAuthenticationService.java
@@ -66,7 +66,8 @@ public class DefaultAuthenticationService implements AuthenticationService {
   private static void setupInContext(UserDetails principal) {
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(
-        new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        new UsernamePasswordAuthenticationToken(
+            principal, null, principal.getLoginCredentials().getAuthorities()));
     SecurityContextHolder.setContext(context);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserReplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserReplicationServiceTest.java
@@ -128,12 +128,7 @@ class UserReplicationServiceTest {
         UserDetails.empty()
             .id(42L)
             .uid("a1234567890")
-            .username("admin")
-            .password("secret")
-            .enabled(true)
-            .accountNonExpired(true)
-            .accountNonLocked(true)
-            .credentialsNonExpired(true)
+            .loginCredentials(new UserDetails.LoginCredentials("admin", "secret"))
             .build());
 
     User existingUser = new User();
@@ -174,12 +169,7 @@ class UserReplicationServiceTest {
         UserDetails.empty()
             .id(42L)
             .uid("a1234567890")
-            .username("admin")
-            .password("secret")
-            .enabled(true)
-            .accountNonExpired(true)
-            .accountNonLocked(true)
-            .credentialsNonExpired(true)
+            .loginCredentials(new UserDetails.LoginCredentials("admin", "secret"))
             .build());
 
     UserGroup group = new UserGroup();
@@ -212,12 +202,7 @@ class UserReplicationServiceTest {
         UserDetails.empty()
             .id(42L)
             .uid("a1234567890")
-            .username("admin")
-            .password("secret")
-            .enabled(true)
-            .accountNonExpired(true)
-            .accountNonLocked(true)
-            .credentialsNonExpired(true)
+            .loginCredentials(new UserDetails.LoginCredentials("admin", "secret"))
             .build());
 
     User existingUser = new User();

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/TestBase.java
@@ -2551,7 +2551,7 @@ public abstract class TestBase {
   public static void injectSecurityContextNoSettings(UserDetails currentUserDetails) {
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(
-            currentUserDetails, "", currentUserDetails.getAuthorities());
+            currentUserDetails, "", currentUserDetails.getLoginCredentials().getAuthorities());
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
     SecurityContextHolder.setContext(context);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
@@ -111,7 +111,8 @@ class UserRoleTest extends PostgresIntegrationTestBase {
     Object principal = authentication.getPrincipal();
     assertEquals(dhisOidcUser, principal);
 
-    Collection<? extends GrantedAuthority> authorities = oidc.getAuthorities();
+    Collection<? extends GrantedAuthority> authorities =
+        oidc.getLoginCredentials().getAuthorities();
 
     for (GrantedAuthority authority : authorities) {
       assertTrue(oidc.isAuthorized(authority.getAuthority()));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationListener.java
@@ -80,7 +80,7 @@ public class AuthenticationListener {
       DhisOidcUser principal = (DhisOidcUser) authenticationToken.getPrincipal();
 
       if (principal != null) {
-        username = principal.getUser().getUsername();
+        username = principal.getLoginCredentials().getUsername();
       }
 
       WebAuthenticationDetails tokenDetails =
@@ -119,7 +119,7 @@ public class AuthenticationListener {
     if (OAuth2LoginAuthenticationToken.class.isAssignableFrom(auth.getClass())) {
       OAuth2LoginAuthenticationToken authenticationToken = (OAuth2LoginAuthenticationToken) auth;
       DhisOidcUser principal = (DhisOidcUser) authenticationToken.getPrincipal();
-      username = principal.getUser().getUsername();
+      username = principal.getLoginCredentials().getUsername();
 
       WebAuthenticationDetails tokenDetails =
           (WebAuthenticationDetails) authenticationToken.getDetails();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -108,7 +108,10 @@ class AnalyticsControllerTest {
   @BeforeEach
   @SuppressWarnings("unchecked")
   void setUp() {
-    CurrentUserUtil.injectUserInSecurityContext(UserDetails.empty().username("testuser").build());
+    CurrentUserUtil.injectUserInSecurityContext(
+        UserDetails.empty()
+            .loginCredentials(new UserDetails.LoginCredentials("testuser", null))
+            .build());
 
     DataQueryService dataQueryService =
         new DefaultDataQueryService(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
@@ -128,7 +128,7 @@ class DataItemServiceFacadeTest {
   public static void injectSecurityContext(UserDetails currentUserDetails) {
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(
-            currentUserDetails, "", currentUserDetails.getAuthorities());
+            currentUserDetails, "", currentUserDetails.getLoginCredentials().getAuthorities());
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
     SecurityContextHolder.setContext(context);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -177,7 +177,7 @@ class UserControllerTest {
   public static void injectSecurityContext(UserDetails currentUserDetails) {
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(
-            currentUserDetails, "", currentUserDetails.getAuthorities());
+            currentUserDetails, "", currentUserDetails.getLoginCredentials().getAuthorities());
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
     SecurityContextHolder.setContext(context);


### PR DESCRIPTION
The `UserDetails` interface was getting wide and had an inheritance tree to it making it harder to understand and maintain than necessary. To bring more clarity the properties got restructured.

1. Sping's `UserDetails` (which I understand to be about login related integration into spring) got extracted to a new record `LoginCredentials` (which implements the spring interface). DHIS2's `UserDetails` does no longer extend Sping's. 