### PR TITLE
fix: Wrong column name in variable [DHIS2-21591]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
@@ -46,7 +46,7 @@ public class vEnrollmentStatus implements ProgramVariable {
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
     if (AnalyticsType.EVENT == visitor.getProgParams().getProgramIndicator().getAnalyticsType()) {
-      return "pistatus";
+      return "eventstatus";
     }
 
     return "enrollmentstatus";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -185,7 +185,7 @@ class ProgramSqlGeneratorVariablesTest extends TestBase {
   @Test
   void testEnrollmentStatus() {
     String sql = castString(test("V{enrollment_status}", new DefaultLiteral(), eventIndicator));
-    assertThat(sql, is("pistatus"));
+    assertThat(sql, is("eventstatus"));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -173,7 +173,7 @@ class ProgramIndicatorServiceVariableTest extends PostgresIntegrationTestBase {
 
   @Test
   void testEnrollmentStatus() {
-    assertEquals("pistatus", getSql("V{enrollment_status}"));
+    assertEquals("eventstatus", getSql("V{enrollment_status}"));
     assertEquals("enrollmentstatus", getSqlEnrollment("V{enrollment_status}"));
   }
 


### PR DESCRIPTION
The `vEnrollmentStatus.java` variable is pointing to an invalid column name.
It should be`enrollmentstatus`, instead.

This PR updated the name and fixes the related test.