### PR TITLE
chore(deps): bump artemis-jakarta 2.42.0 → 2.54.0 and migrate groupId to org.apache.artemis

### DIFF
--- a/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
@@ -82,7 +82,7 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
+      <groupId>org.apache.artemis</groupId>
       <artifactId>artemis-jakarta-client</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -46,11 +46,11 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
+      <groupId>org.apache.artemis</groupId>
       <artifactId>artemis-jakarta-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
+      <groupId>org.apache.artemis</groupId>
       <artifactId>artemis-jakarta-client</artifactId>
     </dependency>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -175,7 +175,7 @@
     <jts.version>1.20.0</jts.version>
 
     <!-- Apache Artemis -->
-    <artemis-jakarta.version>2.42.0</artemis-jakarta.version>
+    <artemis-jakarta.version>2.54.0</artemis-jakarta.version>
     <netty-all.version>4.2.13.Final</netty-all.version>
     <classgraph.version>4.8.181</classgraph.version>
 
@@ -1393,12 +1393,12 @@
 
       <!-- Apache Artemis -->
       <dependency>
-        <groupId>org.apache.activemq</groupId>
+        <groupId>org.apache.artemis</groupId>
         <artifactId>artemis-jakarta-client</artifactId>
         <version>${artemis-jakarta.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.activemq</groupId>
+        <groupId>org.apache.artemis</groupId>
         <artifactId>artemis-jakarta-server</artifactId>
         <version>${artemis-jakarta.version}</version>
         <exclusions>
@@ -2132,7 +2132,7 @@ jasperreports.version=${jasperreports.version}
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-commons</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-dataentry</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-approval</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.apache.activemq:artemis-jakarta-server</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.artemis:artemis-jakarta-server</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <ignoredUsedUndeclaredDependencies>
               <ignoredUsedUndeclaredDependency>javax.cache:cache-api:jar</ignoredUsedUndeclaredDependency>
@@ -2141,14 +2141,14 @@ jasperreports.version=${jasperreports.version}
               <ignoredUsedUndeclaredDependency>org.antlr:antlr4-runtime</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.junit.jupiter:junit-jupiter-api</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>io.prometheus:simpleclient</ignoredUsedUndeclaredDependency>
-              <ignoredUsedUndeclaredDependency>org.apache.activemq:artemis-commons</ignoredUsedUndeclaredDependency>
+              <ignoredUsedUndeclaredDependency>org.apache.artemis:artemis-commons</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.apache.kafka:connect-api</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>io.prometheus:simpleclient_common</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.springframework:spring-jcl</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>ognl:ognl</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.springframework.session:spring-session-core</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>jakarta.jms:jakarta.jms-api</ignoredUsedUndeclaredDependency>
-              <ignoredUsedUndeclaredDependency>org.apache.activemq:artemis-server</ignoredUsedUndeclaredDependency>
+              <ignoredUsedUndeclaredDependency>org.apache.artemis:artemis-server</ignoredUsedUndeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.mock-server:mockserver-core:jar</ignoredUnusedDeclaredDependency>
               <!-- AWS SDK v2 splits its API across several modules (auth/regions/sdk-core/aws-core/
                    http-client-spi/utils); we declare the service module (s3) only and treat the SDK


### PR DESCRIPTION
## What

Bumps `artemis-jakarta.version` from **2.42.0 → 2.54.0** and migrates the Artemis Maven groupId from `org.apache.activemq` to **`org.apache.artemis`**.

This ports the same fix already merged on the `2.42` branch (#24049) to `master`. There is no open Dependabot Artemis PR on this branch; the bump and the groupId move are coupled (the new groupId only exists for Artemis ≥ 2.50), so they are done together here.

## Why the groupId change is needed

Apache Artemis became its own Apache top-level project and migrated its Maven coordinates from `org.apache.activemq` to `org.apache.artemis` starting in **2.50.0**. The old coordinates are still published, but only as *relocation stubs* that point at the new ones.

The consequence: with just a version bump, we still **declare** `org.apache.activemq:*` while Maven **resolves** the relocated `org.apache.artemis:*` artifacts. `dependency:analyze` then fails the `dhis-support-artemis` module — it sees the new coordinates as "used but undeclared" and the old ones as "unused declared", and the existing analyze ignore entries (pinned to the old groupId) no longer match.

This PR updates the groupId at every declaration and in the three analyze ignore entries, which is the change the upstream migration asks consumers to make. Artemis keeps full package & code compatibility across the move, so there are no Java/API changes — only Maven coordinates.

## Security

This upgrade also fixes **CVE-2026-27446** (CWE-306, missing authentication for a critical function — CVSS 9.8). An unauthenticated client using the Core protocol could force the broker to open an outbound federation connection to a rogue broker, enabling message injection/exfiltration. It affects Artemis 2.11.0–2.44.0 and is fixed in 2.52.0. Exposure here is limited because the broker is embedded, but the fix is worth having.

## Netty alignment

This branch carries the `netty-bom` import (added in 24047), so the larger Netty tree pulled in by Artemis ≥ 2.50 stays aligned at 4.2.13.Final — no class-skew.

## Notes on 2.54.0 release changes

The breaking items in the 2.50→2.54 notes do not apply to our embedded usage: Docker image path change, deprecated (non-functional) HTTP transport params, deprecated `addSecuritySettings` management methods, and default `broker.xml` security-setting clarifications.

## Testing

- `dependency:analyze` on `dhis-support-artemis` passes (the failure a version-only bump hits).
- Dependency tree confirms all Artemis artifacts resolve to `org.apache.artemis:*:2.54.0` and all Netty artifacts stay aligned at 4.2.13.Final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
