### PR TITLE
fix: disable flaky postBasedOnSchema e2e test [2.42]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.test.e2e.dto.schemas.SchemaProperty;
 import org.hisp.dhis.test.e2e.utils.DataGenerator;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,6 +86,7 @@ public class MetadataImportBasedOnSchemasTest extends ApiTest {
     schemasActions.validateObjectAgainstSchema(schema, firstObject).validate().statusCode(200);
   }
 
+  @Disabled
   @ParameterizedTest(name = "POST to /{1}")
   @MethodSource("getSchemaEndpoints")
   public void postBasedOnSchema(String endpoint, String schema) {


### PR DESCRIPTION
Backports the `@Disabled` on `MetadataImportBasedOnSchemasTest.postBasedOnSchema` from master (commit `d5b5e46`, #22057) to **2.42**.

That test was disabled on master and 2.43, but the disable was never backported to 2.42/2.41 — so it still runs there and intermittently red-fails the `api-test` lane. Root cause: it generates a body from a schema's *required* properties only, but some schemas have conditionally-required fields that random generation can't satisfy (e.g. `Document.url` is interpreted as a FileResource reference unless the non-required `external` flag is set), so the importer rejects it with `E4015`. The first-failing schema varies run to run, hence the flakiness.

Test-only change; matches master + 2.43. No production code touched.

Sibling PR (2.41): #24106

AI Assisted
