### PR TITLE
perf: isolate UsersPerformanceTest scenarios and reuse session

### DIFF
--- a/.github/workflows/performance-tests-scheduled.yml
+++ b/.github/workflows/performance-tests-scheduled.yml
@@ -39,13 +39,13 @@ jobs:
               DHIS2_IMAGE=dhis2/core-dev:latest
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
               WARMUP=2
-              MVN_ARGS="-Diterations=3 -Dprofile=smoke"
+              MVN_ARGS="-Diterations=10 -Dprofile=smoke"
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
           - name: users-load
             env: |
               DHIS2_IMAGE=dhis2/core-dev:latest
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
-              MVN_ARGS=-Diterations=10
+              MVN_ARGS=-Diterations=30
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
     uses: ./.github/workflows/performance-tests.yml
     with:

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -93,7 +93,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  *   <li>{@code orgUnitUid} (default: {@code ImspTQPwCqd} — "Sierra Leone" root)
  *   <li>{@code userGroupUid} (default: {@code wl5cDMuUhmF} — "Administrators")
  *   <li>{@code iterations} (default: {@code 3})
- *   <li>{@code mode} (default: {@code parallel}; use {@code sequential} to chain scenarios)
+ *   <li>{@code mode} (default: {@code sequential}; runs each scenario in isolation so timings
+ *       reflect single-endpoint latency. Use {@code parallel} to run all scenarios concurrently as
+ *       a mixed-load stress test.)
  * </ul>
  */
 public class UsersPerformanceTest extends Simulation {
@@ -137,11 +139,16 @@ public class UsersPerformanceTest extends Simulation {
   private static final String BASE_URL = prop("baseUrl", "http://localhost:8080");
   private static final String USERNAME = prop("username", "admin");
   private static final String PASSWORD = prop("password", "district");
+  private static final String BASIC_AUTH =
+      Base64.getEncoder()
+          .encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
   private static final String USER_ROLE_UID = prop("userRoleUid", "Euq3XfEIEbx");
   private static final String ORG_UNIT_UID = prop("orgUnitUid", "ImspTQPwCqd");
   private static final String USER_GROUP_UID = prop("userGroupUid", "wl5cDMuUhmF");
   private static final int ITERATIONS = Integer.parseInt(prop("iterations", "3"));
-  private static final String MODE = prop("mode", "parallel");
+  // Default to sequential so each scenario is measured in isolation (single-endpoint latency).
+  // Set -Dmode=parallel for a mixed-load stress test where all scenarios run concurrently.
+  private static final String MODE = prop("mode", "sequential");
 
   private enum Profile {
     SMOKE,
@@ -167,10 +174,18 @@ public class UsersPerformanceTest extends Simulation {
   private static final int PATCH_GROUP_COUNT = Integer.parseInt(prop("patchGroupCount", "7"));
 
   // Thresholds per profile, slack 1.5× observed p95/max, rounded to nearest 50ms.
-  // LOAD:  10 nightly runs × 10 iterations (2026-04-02 – 2026-04-11), 100 samples each.
-  // SMOKE: 14 nightly runs × 3 iterations (2026-04-09 – 2026-04-22), 42–90 samples each.
-  //        Recalibrate with: scripts/download-user-perf-results.sh --test-name users-smoke
-  //                          scripts/analyze-user-perf-results.py --profile smoke
+  //
+  // STALE — PENDING RECALIBRATION. The values below were calibrated under the OLD regime: all
+  // scenarios run in parallel, which on the shared CI runner caused CPU contention that inflated
+  // the
+  // tail (GET p95 reached 783ms on CI vs ~81ms in isolation). As of 2026-06-03 the test runs
+  // scenarios sequentially (in isolation) and authenticates once per virtual user, moving the
+  // one-time session-establishing bcrypt out of the measured requests, so measured times dropped
+  // sharply. These thresholds are now far too loose and provide little regression protection until
+  // recalibrated from fresh nightly baselines (~1 week of runs).
+  // Old baselines: LOAD 10 nightly × 10 iter (2026-04-02–04-11); SMOKE 14 nightly × 3 iter.
+  // Recalibrate with: scripts/download-user-perf-results.sh --test-name users-smoke
+  //                   scripts/analyze-user-perf-results.py --profile smoke
   private static final Map<Profile, Thresholds> POST_THRESH =
       Map.of(Profile.SMOKE, new Thresholds(1150, 1200), Profile.LOAD, new Thresholds(1250, 1500));
 
@@ -371,16 +386,35 @@ public class UsersPerformanceTest extends Simulation {
   }
 
   public UsersPerformanceTest() {
+    // No protocol-level basicAuth. DHIS2 is stateful (SessionCreationPolicy.IF_REQUIRED +
+    // HttpSessionSecurityContextRepository), so once a session exists Spring Security reuses the
+    // SecurityContext and skips re-authentication; bcrypt password verification (~70ms) is only
+    // paid on the FIRST request that establishes the session. With protocol basicAuth + the default
+    // cookie jar, that first-request bcrypt landed inside the measured GET/PUT/... requests and
+    // surfaced in their p95 (a fixed ~80ms auth artifact, not endpoint latency). Instead we
+    // authenticate once per virtual user via a separately-named request (see `authenticate`) so the
+    // measured requests reflect endpoint cost only.
     HttpProtocolBuilder httpProtocol =
-        http.baseUrl(BASE_URL)
-            .acceptHeader("application/json")
-            .disableCaching()
-            .basicAuth(USERNAME, PASSWORD);
+        http.baseUrl(BASE_URL).acceptHeader("application/json").disableCaching();
+
+    // Authenticate once per virtual user (paying the one-time bcrypt to establish the session),
+    // then
+    // reuse the JSESSIONID cookie for all measured requests. The login request is named separately
+    // so its bcrypt cost is NOT counted in the per-endpoint assertions. Relies on CSRF being
+    // disabled (the DHIS2 default) so session-cookie writes (POST/PUT/PATCH/DELETE) are accepted
+    // without a CSRF token.
+    ChainBuilder authenticate =
+        exec(flushCookieJar())
+            .exec(
+                http("Authenticate (session login)")
+                    .get("/api/me")
+                    .header("Authorization", "Basic " + BASIC_AUTH)
+                    .check(status().is(200)));
 
     // ── Scenario: POST /api/users ────────────────────────────────────────────
     ScenarioBuilder postScenario =
         scenario(POST_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -398,7 +432,7 @@ public class UsersPerformanceTest extends Simulation {
     // ── Scenario: GET /api/users/{uid} ──────────────────────────────────────
     ScenarioBuilder getScenario =
         scenario(GET_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -412,7 +446,7 @@ public class UsersPerformanceTest extends Simulation {
     // ── Scenario: PUT /api/users/{uid} ──────────────────────────────────────
     ScenarioBuilder putScenario =
         scenario(PUT_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -433,7 +467,7 @@ public class UsersPerformanceTest extends Simulation {
     // ── Scenario: PATCH /api/users/{uid} ────────────────────────────────────
     ScenarioBuilder patchScenario =
         scenario(PATCH_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -456,7 +490,7 @@ public class UsersPerformanceTest extends Simulation {
     // ── Scenario: PATCH /api/users/{uid} userGroups ────────────────────────
     ScenarioBuilder patchGroupsScenario =
         scenario(PATCH_GROUPS_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -476,7 +510,7 @@ public class UsersPerformanceTest extends Simulation {
     // ── Scenario: POST /api/users/{uid}/replica ─────────────────────────────
     ScenarioBuilder replicaScenario =
         scenario(REPLICA_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {
@@ -503,7 +537,7 @@ public class UsersPerformanceTest extends Simulation {
     // Users are pre-created in before(), so this scenario measures only DELETE time.
     ScenarioBuilder deleteScenario =
         scenario(DELETE_REQUEST)
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(
                 exec(session -> {


### PR DESCRIPTION
## Problem

The `GET User - by uid` p95 assertion in `UsersPerformanceTest` (`users-load`) keeps failing on CI — e.g. [run 26858887961](https://github.com/dhis2/dhis2-core/actions/runs/26858887961) reported **783ms vs the 700ms threshold** — even though the endpoint responds in **~10–24ms** in isolation. Repeatedly bumping the threshold hasn't stopped the flapping.

## Root cause (it's not the endpoint)

Investigation (parsing the failing run's `simulation.csv`, re-running the original test locally in isolation, and direct curl measurements) showed the GET endpoint itself is ~10–24ms. The inflation came from how the test measured:

1. **Parallel mode — the primary cause.** Default `mode=parallel` runs all 7 scenarios concurrently. On the single shared self-hosted CI runner, the bcrypt-heavy write scenarios (server-side password hashing on POST/PUT/REPLICA payloads, plus each virtual user's one-time login) saturate CPU and stretch the GET tail. Running the same scenario **sequentially** takes GET p95 from 783ms (CI) to **~24ms**. Multi-core dev machines absorb the contention, which is why it never reproduces locally.
2. **One-time auth bcrypt charged to the first measured request — secondary.** DHIS2 is stateful (`SessionCreationPolicy.IF_REQUIRED` + `HttpSessionSecurityContextRepository`), so with Gatling's default cookie jar the session is reused and bcrypt is paid **only once per virtual user**. But with protocol-level `.basicAuth()`, that one-time ~90ms cost landed inside the *first* GET/POST/… request of each scenario and surfaced in their p95/max. **There is no per-request bcrypt and no missing auth cache — this is expected Spring Security behaviour** (`BasicAuthenticationFilter` reuses the `SecurityContext` from the session and skips re-auth).
3. **Tiny sample size** (~10–20 samples/scenario) made p95 effectively a coin flip.

## Changes

- **Default `mode` → `sequential`** so each scenario is measured in isolation. `parallel` remains available as an opt-in mixed-load stress mode. (The CI workflow doesn't pin `mode`, so this takes effect automatically.)
- **Authenticate once per virtual user** via a separately-named request and reuse the `JSESSIONID` cookie, so the one-time auth bcrypt is excluded from the per-endpoint assertions (and the test better reflects real session-based clients). Write scenarios still pay legitimate *server-side* payload password hashing — correctly retained. Relies on CSRF being disabled (the DHIS2 default; `CSRF_ENABLED=OFF`).
- **Bump iterations** (load 10→30, smoke 3→10) for a more stable p95.

## Verification

`gstat compare` of the original test vs this PR, **both sequential** (so the parallel-contention effect is already removed and this isolates only the auth-isolation effect):

### p95 (ms)
| Request | original (seq) | this PR (seq) | Change |
|:---|---:|---:|:---|
| POST User - create | 172 | 103 | −40% |
| GET User - by uid | 24 | 19 | −21% |
| PUT User - full update | 169 | 159 | −6% |
| PATCH User - partial update | 63 | 50 | −21% |
| POST User - replicate | 82 | 77 | −6% |
| DELETE User - delete | 132 | 122 | −7% |
| Authenticate (session login) | — | 103 | (one-time auth, now isolated) |

GET p50 is ~11ms in both. All write scenarios succeed under session-cookie auth (confirms CSRF is a non-issue). The headline CI number — GET p95 **783ms → ~24ms** — comes almost entirely from removing parallel contention; session reuse then trims the auth artifact from the tails (notably POST −40%).

## Follow-up: thresholds need recalibration

All thresholds were calibrated under the old (parallel) regime and are now far too loose. They're flagged in-code as **pending recalibration** from fresh nightly baselines (~1 week of runs) via the existing `scripts/analyze-user-perf-results.py`. The test passes meanwhile but provides limited regression protection until recalibrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
