### PR TITLE
perf: run UsersPerformanceTest against the platform-perf DB

### DIFF
--- a/.github/workflows/performance-tests-scheduled.yml
+++ b/.github/workflows/performance-tests-scheduled.yml
@@ -38,6 +38,9 @@ jobs:
             env: |
               DHIS2_IMAGE=dhis2/core-dev:latest
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
+              DB_DIR=dev
+              DB_TYPE=platform-perf
+              DB_VERSION=43-2026-03-10
               WARMUP=2
               MVN_ARGS="-Diterations=10 -Dprofile=smoke"
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
@@ -45,6 +48,9 @@ jobs:
             env: |
               DHIS2_IMAGE=dhis2/core-dev:latest
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
+              DB_DIR=dev
+              DB_TYPE=platform-perf
+              DB_VERSION=43-2026-03-10
               MVN_ARGS=-Diterations=30
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
     uses: ./.github/workflows/performance-tests.yml

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -35,6 +35,10 @@ ENV POSTGRES_USER=dhis \
 
 COPY --from=downloader /tmp/dump.sql.gz /tmp/dump.sql.gz
 
+# Interim post-restore fix: advance hibernate_sequence past the platform-perf dump's seeded ids
+# (see fix-hibernate-sequence.sql). Forward-only, so it is a no-op on other dumps.
+COPY fix-hibernate-sequence.sql /tmp/fix-hibernate-sequence.sql
+
 COPY docker-entrypoint-build.sh /usr/local/bin/
 # Initialize the database and restore the dump at build time
 # Uses a modified version of the official PostgreSQL docker-entrypoint.sh

--- a/dhis-2/dhis-test-performance/docker/docker-entrypoint-build.sh
+++ b/dhis-2/dhis-test-performance/docker/docker-entrypoint-build.sh
@@ -145,6 +145,15 @@ build_init() {
 		echo "Restoring database dump..."
 		gunzip -c /tmp/dump.sql.gz | docker_process_sql -d "$POSTGRES_DB"
 		echo "Database dump restored successfully"
+
+		# Interim fix: advance hibernate_sequence past the dump's seeded ids so write
+		# operations don't collide with existing primary keys. Forward-only and harmless on
+		# dumps that don't need it. See fix-hibernate-sequence.sql. Remove once the dump is fixed.
+		if [ -f /tmp/fix-hibernate-sequence.sql ]; then
+			echo "Applying hibernate_sequence fix..."
+			docker_process_sql -d "$POSTGRES_DB" -f /tmp/fix-hibernate-sequence.sql
+			echo "hibernate_sequence fix applied"
+		fi
 	fi
 
 	docker_temp_server_stop

--- a/dhis-2/dhis-test-performance/docker/fix-hibernate-sequence.sql
+++ b/dhis-2/dhis-test-performance/docker/fix-hibernate-sequence.sql
@@ -1,0 +1,22 @@
+-- Interim workaround for a defect in the platform-perf DB dump.
+--
+-- DHIS2 assigns primary keys for most tables (userinfo, organisationunit, usergroup, ...) from a
+-- single shared sequence, `hibernate_sequence`. The platform-perf dump was bulk-seeded with ~250k
+-- users and ~250k org units at high ids, but ships `hibernate_sequence` set to ~965. As a result
+-- every insert reuses an id that already exists and fails with e.g.
+--   ERROR: duplicate key value violates unique constraint "userinfo_pkey"
+--   Detail: Key (userinfoid)=(973) already exists.
+-- which makes every write operation (user create/replicate/delete) return HTTP 409. The users
+-- performance test is write-heavy, so it cannot run against the dump until the sequence is advanced
+-- past the seeded ids.
+--
+-- This advances `hibernate_sequence` to a value comfortably above any seeded id. It is FORWARD-ONLY
+-- (GREATEST with the current value), so it is a harmless no-op on correctly generated dumps
+-- (sierra-leone, hmis) and never moves a sequence backwards (which would reintroduce collisions).
+--
+-- This is a stopgap applied at DB-image build time. The proper fix is to regenerate the
+-- platform-perf dump with the sequence set correctly; remove this script once that lands.
+SELECT setval(
+    'hibernate_sequence',
+    GREATEST(100000000::bigint, (SELECT last_value FROM hibernate_sequence)),
+    true);

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -55,7 +55,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Performance test for single-user CRUD operations on {@code /api/users}.
  *
- * <p>Five scenarios, all running against the Sierra Leone demo DB by default:
+ * <p>Five scenarios, all running against the platform-perf DB (~250k users / ~250k org units) by
+ * default:
  *
  * <ol>
  *   <li><b>POST</b> — creates a new user (with optional group assignment)
@@ -71,7 +72,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * itself — no existing database users are touched.
  *
  * <p>Run with {@code -DuserGroupUid=<uid>} pointing at a group with large membership to expose N+1
- * problems in POST and DELETE. The default points at "Administrators" on the SL demo DB.
+ * problems in POST and DELETE. The default points at a ~83k-member group on the platform-perf DB.
  *
  * <p>Configuration can be provided via a {@code .properties} file instead of individual {@code -D}
  * flags:
@@ -82,16 +83,16 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * Individual {@code -D} flags always override values from the config file.
  *
- * <p>Available properties (with SL demo DB defaults):
+ * <p>Available properties (with platform-perf DB defaults):
  *
  * <ul>
  *   <li>{@code configFile} — path to a {@code .properties} file (optional)
  *   <li>{@code baseUrl} (default: {@code http://localhost:8080})
  *   <li>{@code username} (default: {@code admin})
  *   <li>{@code password} (default: {@code district})
- *   <li>{@code userRoleUid} (default: {@code Euq3XfEIEbx} — "Data entry clerk")
- *   <li>{@code orgUnitUid} (default: {@code ImspTQPwCqd} — "Sierra Leone" root)
- *   <li>{@code userGroupUid} (default: {@code wl5cDMuUhmF} — "Administrators")
+ *   <li>{@code userRoleUid} (default: {@code MoRvPzDH7lc} — generic role with ~83k users)
+ *   <li>{@code orgUnitUid} (default: {@code VCCdfC9pvMA} — root org unit)
+ *   <li>{@code userGroupUid} (default: {@code KOvR9SAEeEZ} — group with ~83k members)
  *   <li>{@code iterations} (default: {@code 3})
  *   <li>{@code mode} (default: {@code sequential}; runs each scenario in isolation so timings
  *       reflect single-endpoint latency. Use {@code parallel} to run all scenarios concurrently as
@@ -142,9 +143,13 @@ public class UsersPerformanceTest extends Simulation {
   private static final String BASIC_AUTH =
       Base64.getEncoder()
           .encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
-  private static final String USER_ROLE_UID = prop("userRoleUid", "Euq3XfEIEbx");
-  private static final String ORG_UNIT_UID = prop("orgUnitUid", "ImspTQPwCqd");
-  private static final String USER_GROUP_UID = prop("userGroupUid", "wl5cDMuUhmF");
+  // Defaults target the platform-perf DB (~250k users / ~250k org units). Role and group are the
+  // largest available (~83k each) to expose user create/delete N+1s; org unit is the hierarchy
+  // root.
+  // Override via -D or a configFile to run against a different instance.
+  private static final String USER_ROLE_UID = prop("userRoleUid", "MoRvPzDH7lc");
+  private static final String ORG_UNIT_UID = prop("orgUnitUid", "VCCdfC9pvMA");
+  private static final String USER_GROUP_UID = prop("userGroupUid", "KOvR9SAEeEZ");
   private static final int ITERATIONS = Integer.parseInt(prop("iterations", "3"));
   // Default to sequential so each scenario is measured in isolation (single-endpoint latency).
   // Set -Dmode=parallel for a mixed-load stress test where all scenarios run concurrently.
@@ -175,14 +180,13 @@ public class UsersPerformanceTest extends Simulation {
 
   // Thresholds per profile, slack 1.5× observed p95/max, rounded to nearest 50ms.
   //
-  // STALE — PENDING RECALIBRATION. The values below were calibrated under the OLD regime: all
-  // scenarios run in parallel, which on the shared CI runner caused CPU contention that inflated
-  // the
-  // tail (GET p95 reached 783ms on CI vs ~81ms in isolation). As of 2026-06-03 the test runs
-  // scenarios sequentially (in isolation) and authenticates once per virtual user, moving the
-  // one-time session-establishing bcrypt out of the measured requests, so measured times dropped
-  // sharply. These thresholds are now far too loose and provide little regression protection until
-  // recalibrated from fresh nightly baselines (~1 week of runs).
+  // STALE — PENDING RECALIBRATION on the platform-perf DB. These values were calibrated against the
+  // Sierra Leone demo DB under the old parallel regime. As of 2026-06-03 the test (a) runs
+  // scenarios
+  // sequentially and authenticates once per virtual user, and (b) targets the platform-perf DB
+  // (~250k users / ~250k org units), where operations are materially slower (e.g. GET ~6× SL). The
+  // numbers below reflect neither change and must be recalibrated from fresh nightly baselines on
+  // platform-perf (~1 week of runs) before they provide meaningful regression protection.
   // Old baselines: LOAD 10 nightly × 10 iter (2026-04-02–04-11); SMOKE 14 nightly × 3 iter.
   // Recalibrate with: scripts/download-user-perf-results.sh --test-name users-smoke
   //                   scripts/analyze-user-perf-results.py --profile smoke


### PR DESCRIPTION
## What

Switches `UsersPerformanceTest` to run against the new **platform-perf** DB (~250k users / ~250k org units) instead of the Sierra Leone demo DB, so the numbers reflect a realistically sized instance.

> Stacked on #24107 (sequential + session reuse). **Base this PR's review on the diff against that branch.** Merge #24107 first.

## Changes

- **Default metadata UIDs** (`UsersPerformanceTest`) now target platform-perf:
  - `userRoleUid` = `MoRvPzDH7lc` (generic role, ~83k users)
  - `userGroupUid` = `KOvR9SAEeEZ` (~83k members)
  - `orgUnitUid` = `VCCdfC9pvMA` (hierarchy root)

  Role and group are the largest available, to exercise user create/delete N+1s. Still overridable via `-D` / `configFile`. Class javadoc updated.
- **CI** (`performance-tests-scheduled.yml`): `users-smoke` and `users-load` now build the platform-perf DB (`DB_DIR=dev`, `DB_TYPE=platform-perf`, `DB_VERSION=43-2026-03-10`).
- **Interim DB sequence fix** (`docker/`): the dump ships `hibernate_sequence` at ~965 while holding ~250k bulk-seeded rows that draw from that shared sequence, so every insert collides on the primary key (`duplicate key ... userinfo_pkey ... (userinfoid)=(973)`) and **all write operations 409**. A post-restore step in the DB image build advances `hibernate_sequence` past the seeded ids. It is **forward-only** (`GREATEST` with the current value), so it's a harmless no-op on dumps that don't need it (sierra-leone, hmis). This is a **stopgap** — the proper fix is regenerating the dump with the sequence set correctly (being reported internally); remove this once that lands.

## Timings / thresholds

**Not adjusted in this PR.** The existing thresholds are loose enough that platform-perf passes (verified below), and they're already flagged stale pending recalibration. The plan is to gather ~1 week of nightly baselines *on platform-perf* and recalibrate from those — adjusting them now (to local numbers, which run faster than the shared CI runner) would just be undone. The threshold comment is updated to say so.

For reference, platform-perf is materially slower than SL (the point): GET ~6× SL, POST/DELETE ~2×.

## Verification

- Built the platform-perf DB image end-to-end: restore + fix applied → `hibernate_sequence = 100000000`, `max(userinfoid) = 250004`; a `nextval`-based insert into `userinfo` succeeds (was 409 before).
- Ran the full users test against a local platform-perf instance with the new defaults: **120/120 OK**, all assertions pass, `before()` pre-creates users into the ~83k group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
