### PR TITLE
chore: UserDetails cleanup

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/message/MessageConversation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/message/MessageConversation.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Lars Helge Overland
@@ -225,7 +226,7 @@ public class MessageConversation extends BaseIdentifiableObject {
 
   public void markReplied(User sender, Message message) {
     for (UserMessage userMessage : userMessages) {
-      User user = userMessage.getUser();
+      UserDetails user = UserDetails.fromUser(userMessage.getUser());
       if (user != null
           && !user.equals(sender)
           && (!message.isInternal()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
@@ -29,12 +29,10 @@
  */
 package org.hisp.dhis.user;
 
-import java.util.Collection;
-import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -68,19 +66,9 @@ public class CurrentUserUtil {
    */
   @Nonnull
   public static String getCurrentUsername() {
-    Authentication authentication = getAuthentication();
-
-    Object principal = authentication.getPrincipal();
-
-    if (principal instanceof org.springframework.security.core.userdetails.UserDetails) {
-      org.springframework.security.core.userdetails.UserDetails userDetails =
-          (org.springframework.security.core.userdetails.UserDetails) authentication.getPrincipal();
-      return userDetails.getUsername();
-
-    } else {
-      throw new IllegalStateException(
-          "Authentication principal is not supported; principal:" + principal);
-    }
+    UserDetails details = getCurrentUserDetailsOrNull();
+    if (details != null) return details.getUsername();
+    throw noUserDetailsPrincipal();
   }
 
   /**
@@ -90,53 +78,28 @@ public class CurrentUserUtil {
    */
   @Nonnull
   public static UserDetails getCurrentUserDetails() {
-    Authentication authentication = getAuthentication();
-
-    Object principal = authentication.getPrincipal();
-
-    if (principal instanceof UserDetails) {
-      return (UserDetails) authentication.getPrincipal();
-    } else {
-      throw new IllegalStateException(
-          "Authentication principal is not supported; principal:" + principal);
-    }
+    UserDetails res = getCurrentUserDetailsOrNull();
+    if (res != null) return res;
+    throw noUserDetailsPrincipal();
   }
 
-  /**
-   * Get all authorities assigned to the current user Return an empty list if the current session is
-   * anonymous
-   *
-   * @return list of authority names
-   */
-  public static List<String> getCurrentUserAuthorities() {
-    if (!CurrentUserUtil.hasCurrentUser()) {
-      return List.of();
-    }
-
-    UserDetails currentUserDetails = getCurrentUserDetails();
-    return currentUserDetails.getAuthorities().stream()
-        .map(GrantedAuthority::getAuthority)
-        .toList();
+  private static IllegalStateException noUserDetailsPrincipal() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Object principal = authentication == null ? null : authentication.getPrincipal();
+    return new IllegalStateException(
+        "Authentication principal is not supported; principal:" + principal);
   }
 
-  /**
-   * Check if the current user has any of the passed candidate authorities
-   *
-   * @param candidateAuthorities a list of possible authorities to check against
-   * @return true if the user has one or more of the candidateAuthorities
-   */
-  public static Boolean hasAnyAuthority(Collection<String> candidateAuthorities) {
-    List<String> currentUserAuthorities = getCurrentUserAuthorities();
-    return candidateAuthorities.stream().anyMatch(currentUserAuthorities::contains);
+  @CheckForNull
+  public static UserDetails getCurrentUserDetailsOrNull() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null) return null;
+    if ((authentication.getPrincipal() instanceof UserDetails details)) return details;
+    return null;
   }
 
   public static boolean hasCurrentUser() {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    return authentication != null
-        && authentication.isAuthenticated()
-        && authentication.getPrincipal() != null
-        && authentication.getPrincipal()
-            instanceof org.springframework.security.core.userdetails.UserDetails;
+    return getCurrentUserDetailsOrNull() != null;
   }
 
   public static void injectUserInSecurityContext(UserDetails actingUser) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserUtil.java
@@ -85,9 +85,9 @@ public class CurrentUserUtil {
 
   private static IllegalStateException noUserDetailsPrincipal() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Object principal = authentication == null ? null : authentication.getPrincipal();
+    if (authentication == null) return new IllegalStateException("No authentication found");
     return new IllegalStateException(
-        "Authentication principal is not supported; principal:" + principal);
+        "Authentication principal is not supported; principal:" + authentication.getPrincipal());
   }
 
   @CheckForNull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -30,24 +30,17 @@
 package org.hisp.dhis.user;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
-import org.springframework.security.core.GrantedAuthority;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public class SystemUser implements UserDetails {
-
-  @Nonnull
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of((GrantedAuthority) Authorities.ALL::name);
-  }
 
   @Nonnull
   @Override
@@ -124,6 +117,11 @@ public class SystemUser implements UserDetails {
   @Override
   public String getEmail() {
     return "";
+  }
+
+  @Override
+  public UID getAvatar() {
+    return null;
   }
 
   @Nonnull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -49,7 +49,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.Category;
@@ -67,8 +66,6 @@ import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * @author Nguyen Hong Duc
@@ -238,7 +235,7 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
   }
 
   /** Returns a set of the aggregated authorities for all user authority groups of this user. */
-  public Set<String> getAllAuthorities() {
+  public Set<String> getAuthorities() {
     return userRoles == null
         ? Set.of()
         : userRoles.stream()
@@ -259,32 +256,6 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
             .collect(Collectors.toUnmodifiableSet());
   }
 
-  /** Indicates whether this user has at least one authority through its user authority groups. */
-  public boolean hasAuthorities() {
-    return userRoles != null
-        && userRoles.stream().anyMatch(role -> role != null && !role.getAuthorities().isEmpty());
-  }
-
-  /**
-   * Tests whether this user has any of the authorities in the given set.
-   *
-   * @param auths the authorities to compare with.
-   * @return true or false.
-   */
-  public boolean hasAnyAuthority(Collection<String> auths) {
-    return getAllAuthorities().stream().anyMatch(auths::contains);
-  }
-
-  /**
-   * Tests whether this user has any of the {@link Authorities} in the given set.
-   *
-   * @param auths the {@link Authorities} to compare with.
-   * @return true or false.
-   */
-  public boolean hasAnyAuth(@Nonnull Collection<Authorities> auths) {
-    return hasAnyAuthority(auths.stream().map(Authorities::toString).toList());
-  }
-
   /**
    * "Return true if any of the restrictions in the collection are in the list of all restrictions."
    *
@@ -294,20 +265,6 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
    */
   public boolean hasAnyRestrictions(Collection<String> restrictions) {
     return getAllRestrictions().stream().anyMatch(restrictions::contains);
-  }
-
-  /**
-   * Tests whether the user has the given authority. Returns true in any case if the user has the
-   * ALL authority.
-   */
-  public boolean isAuthorized(String auth) {
-    if (auth == null) {
-      return false;
-    }
-
-    final Set<String> auths = getAllAuthorities();
-
-    return auths.contains(Authorities.ALL.toString()) || auths.contains(auth);
   }
 
   /**
@@ -333,7 +290,7 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
       return false;
     }
 
-    final Set<String> authorities = getAllAuthorities();
+    final Set<String> authorities = getAuthorities();
 
     if (authorities.contains(Authorities.ALL.toString())) {
       return true;
@@ -374,13 +331,13 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
       return false;
     }
 
-    final Set<String> authorities = getAllAuthorities();
+    final Set<String> authorities = getAuthorities();
 
     if (authorities.contains(Authorities.ALL.toString())) {
       return true;
     }
 
-    return authorities.containsAll(other.getAllAuthorities());
+    return authorities.containsAll(other.getAuthorities());
   }
 
   /** Sets the last login property to the current date. */
@@ -653,15 +610,6 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
     this.settings = settings;
   }
 
-  public Collection<GrantedAuthority> getAuthorities() {
-    Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
-
-    getAllAuthorities()
-        .forEach(authority -> grantedAuthorities.add(new SimpleGrantedAuthority(authority)));
-
-    return grantedAuthorities;
-  }
-
   public boolean isAccountNonExpired() {
     return accountExpiry == null || accountExpiry.after(new Date());
   }
@@ -827,16 +775,6 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
 
   public String getOrganisationUnitsName() {
     return IdentifiableObjectUtils.join(organisationUnits);
-  }
-
-  /**
-   * Tests whether the user has the given authority. Returns true in any case if the user has the
-   * ALL authority.
-   *
-   * @param auth the {@link Authorities}.
-   */
-  public boolean isAuthorized(@Nonnull Authorities auth) {
-    return isAuthorized(auth.toString());
   }
 
   public Set<UserGroup> getManagedGroups() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -41,12 +42,14 @@ import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.UidObject;
 import org.hisp.dhis.common.UsageTestOnly;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.user.UserDetailsImpl.UserDetailsImplBuilder;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public interface UserDetails
     extends org.springframework.security.core.userdetails.UserDetails, UidObject {
@@ -59,7 +62,6 @@ public interface UserDetails
   static UserDetailsImplBuilder empty() {
     return UserDetailsImpl.builder()
         .isSuper(false)
-        .authorities(List.of())
         .allAuthorities(Set.of())
         .allRestrictions(Set.of())
         .userGroupIds(Set.of())
@@ -135,6 +137,7 @@ public interface UserDetails
       return null;
     }
 
+    Set<String> authorities = Set.copyOf(user.getAuthorities());
     UserDetailsImplBuilder userDetailsImplBuilder =
         UserDetailsImpl.builder()
             .id(user.getId())
@@ -147,6 +150,7 @@ public interface UserDetails
             .twoFactorType(user.getTwoFactorType())
             .secret(user.getSecret())
             .email(user.getEmail())
+            .avatar(UID.of(user.getAvatar()))
             .isEmailVerified(user.isEmailVerified())
             .firstName(user.getFirstName())
             .surname(user.getSurname())
@@ -155,14 +159,8 @@ public interface UserDetails
             .accountNonLocked(accountNonLocked)
             .credentialsNonExpired(credentialsNonExpired)
             .dataViewMaxOrganisationUnitLevel(user.getDataViewMaxOrganisationUnitLevel())
-            .authorities(user.getAuthorities())
-            .allAuthorities(
-                new HashSet<>(
-                    Set.copyOf(
-                        user.getAuthorities().stream()
-                            .map(GrantedAuthority::getAuthority)
-                            .toList())))
-            .isSuper(user.isSuper())
+            .allAuthorities(authorities)
+            .isSuper(authorities.contains(Authorities.ALL.toString()))
             .userRoleIds(new HashSet<>(setOfIds(user.getUserRoles())))
             .userGroupIds(
                 new HashSet<>(user.getUid() == null ? Set.of() : setOfIds(user.getGroups())))
@@ -214,7 +212,9 @@ public interface UserDetails
 
   @Nonnull
   @Override
-  Collection<? extends GrantedAuthority> getAuthorities();
+  default Collection<? extends GrantedAuthority> getAuthorities() {
+    return getAllAuthorities().stream().map(SimpleGrantedAuthority::new).toList();
+  }
 
   @Override
   String getPassword();
@@ -251,6 +251,9 @@ public interface UserDetails
 
   String getEmail();
 
+  @CheckForNull
+  UID getAvatar();
+
   @Nonnull
   Set<String> getUserGroupIds();
 
@@ -276,6 +279,17 @@ public interface UserDetails
   Set<Long> getUserRoleLongIds();
 
   boolean hasAnyAuthority(Collection<String> auths);
+
+  default boolean hasAnyAuthority(String... auths) {
+    return hasAnyAuthority(Arrays.asList(auths));
+  }
+
+  default boolean hasAnyAuthority(Authorities... auths) {
+    Set<String> authorities = getAllAuthorities();
+    if (authorities.isEmpty()) return false;
+    for (Authorities a : auths) if (authorities.contains(a.toString())) return true;
+    return false;
+  }
 
   boolean hasAnyAuthorities(Collection<Authorities> auths);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
@@ -41,9 +41,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
-import org.springframework.security.core.GrantedAuthority;
 
 @Getter
 @Builder
@@ -72,7 +72,6 @@ public class UserDetailsImpl implements UserDetails {
       @JsonProperty("accountNonLocked") boolean accountNonLocked,
       @JsonProperty("credentialsNonExpired") boolean credentialsNonExpired,
       @JsonProperty("dataViewMaxOrganisationUnitLevel") int dataViewMaxOrganisationUnitLevel,
-      @JsonProperty("authorities") Collection<GrantedAuthority> authorities,
       @JsonProperty("allAuthorities") Set<String> allAuthorities,
       @JsonProperty("allRestrictions") Set<String> allRestrictions,
       @JsonProperty("userGroupIds") Set<String> userGroupIds,
@@ -102,7 +101,6 @@ public class UserDetailsImpl implements UserDetails {
         .accountNonLocked(accountNonLocked)
         .credentialsNonExpired(credentialsNonExpired)
         .dataViewMaxOrganisationUnitLevel(dataViewMaxOrganisationUnitLevel)
-        .authorities(authorities)
         .allAuthorities(allAuthorities)
         .allRestrictions(allRestrictions)
         .userGroupIds(userGroupIds)
@@ -129,6 +127,7 @@ public class UserDetailsImpl implements UserDetails {
   private final TwoFactorType twoFactorType;
   private final String secret;
   private final String email;
+  private final UID avatar;
   private final boolean isEmailVerified;
   private final boolean enabled;
   private final boolean accountNonExpired;
@@ -136,7 +135,6 @@ public class UserDetailsImpl implements UserDetails {
   private final boolean credentialsNonExpired;
   private final boolean isSuper;
   private final Integer dataViewMaxOrganisationUnitLevel;
-  @Nonnull private final Collection<GrantedAuthority> authorities;
   @Nonnull private final Set<String> allAuthorities;
   @Nonnull private final Set<String> allRestrictions;
   @Nonnull private final Set<String> userGroupIds;
@@ -159,7 +157,7 @@ public class UserDetailsImpl implements UserDetails {
       return true;
     }
 
-    return auths.containsAll(other.getAllAuthorities());
+    return auths.containsAll(other.getAuthorities());
   }
 
   @Override

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/UserTest.java
@@ -31,23 +31,17 @@ package org.hisp.dhis.user;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.security.Authorities.ALL;
-import static org.hisp.dhis.security.Authorities.F_SYSTEM_SETTING;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * Unit tests for {@link User}.
@@ -104,9 +98,9 @@ class UserTest {
   void getAllAuthorities() {
     final User user = new User();
     user.setUserRoles(new HashSet<>(Arrays.asList(userRole1, userRole1Super)));
-    Set<String> authorities1 = user.getAllAuthorities();
+    Set<String> authorities1 = user.getAuthorities();
     assertThat(authorities1, Matchers.containsInAnyOrder("x1", "x2", "z1", ALL.toString()));
-    Set<String> authorities2 = user.getAllAuthorities();
+    Set<String> authorities2 = user.getAuthorities();
     assertEquals(authorities1, authorities2);
   }
 
@@ -114,10 +108,10 @@ class UserTest {
   void getAllAuthoritiesChanged() {
     final User user = new User();
     user.setUserRoles(new HashSet<>(Arrays.asList(userRole1, userRole1Super)));
-    Set<String> authorities1 = user.getAllAuthorities();
+    Set<String> authorities1 = user.getAuthorities();
     assertThat(authorities1, Matchers.containsInAnyOrder("x1", "x2", "z1", ALL.toString()));
     user.setUserRoles(new HashSet<>(Arrays.asList(userRole1, userRole2)));
-    Set<String> authorities2 = user.getAllAuthorities();
+    Set<String> authorities2 = user.getAuthorities();
     assertThat(authorities2, Matchers.containsInAnyOrder("x1", "x2", "y1", "y2"));
   }
 
@@ -125,7 +119,7 @@ class UserTest {
   void testGetAllAuthoritiesWhenUserRolesNull() {
     final User user = new User();
     user.setUserRoles(null);
-    Set<String> authorities = assertDoesNotThrow(user::getAllAuthorities);
+    Set<String> authorities = assertDoesNotThrow(user::getAuthorities);
     assertTrue(authorities.isEmpty());
   }
 
@@ -135,84 +129,8 @@ class UserTest {
     UserRole userRole = new UserRole();
     userRole.setAuthorities(null);
     user.setUserRoles(Set.of(userRole));
-    Set<String> authorities = assertDoesNotThrow(user::getAllAuthorities);
+    Set<String> authorities = assertDoesNotThrow(user::getAuthorities);
     assertTrue(authorities.isEmpty());
-  }
-
-  @Test
-  void testHasAuthoritiesWhenUserRolesNull() {
-    final User user = new User();
-    user.setUserRoles(null);
-    assertFalse(user.hasAuthorities());
-  }
-
-  @Test
-  void testHasAuthoritiesWhenHasUserRole() {
-    final User user = new User();
-    user.setUserRoles(new HashSet<>(Arrays.asList(userRole1)));
-    assertTrue(user.hasAuthorities());
-  }
-
-  @Test
-  void testHasAnyAuthorityWhenUserRolesNull() {
-    final User user = new User();
-    user.setUserRoles(null);
-    assertFalse(user.hasAnyAuthority(Set.of("AUTH1", "AUTH2")));
-  }
-
-  @Test
-  void testHasAnyAuthorityWhenUserRolesHasNullAuthority() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(null);
-    user.setUserRoles(Set.of(role));
-    assertFalse(user.hasAnyAuthority(Set.of("AUTH1", "AUTH2")));
-  }
-
-  @Test
-  void testHasAnyAuthorityWhenUserRolesAuthorityMatches() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH2"));
-    user.setUserRoles(Set.of(role));
-    assertTrue(user.hasAnyAuthority(Set.of("AUTH0", "AUTH2")));
-  }
-
-  @Test
-  void testHasAnyAuthorityWhenNoMatchingUserRoleAuthority() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH2"));
-    user.setUserRoles(Set.of(role));
-    assertFalse(user.hasAnyAuthority(Set.of("AUTH3", "AUTH4")));
-  }
-
-  @Test
-  void testIsAuthorizedWhenUserHasAllAuthority() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", ALL.toString()));
-    user.setUserRoles(Set.of(role));
-    assertTrue(user.isAuthorized("AUTH9"));
-  }
-
-  @Test
-  void testIsAuthorizedWhenAuthorityPassedIsNull() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", ALL.toString()));
-    user.setUserRoles(Set.of(role));
-    String auth = null;
-    assertFalse(user.isAuthorized(auth));
-  }
-
-  @Test
-  void testIsAuthorizedWhenAuthorityPassedMatchesUserAuthority() {
-    final User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH2"));
-    user.setUserRoles(Set.of(role));
-    assertTrue(user.isAuthorized("AUTH2"));
   }
 
   @Test
@@ -292,18 +210,6 @@ class UserTest {
     otherRole.setAuthorities(Set.of("AUTH1", "AUTH2", "AUTH3"));
     otherUser.setUserRoles(Set.of(otherRole));
     assertFalse(user.canModifyUser(otherUser));
-  }
-
-  @Test
-  void testGetAuthorities() {
-    User user = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH3"));
-    user.setUserRoles(Set.of(role));
-    Collection<GrantedAuthority> authorities = user.getAuthorities();
-    assertTrue(
-        authorities.containsAll(
-            Set.of(new SimpleGrantedAuthority("AUTH1"), new SimpleGrantedAuthority("AUTH3"))));
   }
 
   @Test
@@ -407,57 +313,5 @@ class UserTest {
     user.setGroups(Set.of(group));
 
     assertTrue(user.hasManagedGroups());
-  }
-
-  @Test
-  @DisplayName("When checking if a User has any auth and they do")
-  void whenUserHasMultiAuthCheck() {
-    // given
-    User userWithAllAuth = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "ALL"));
-    userWithAllAuth.setUserRoles(Set.of(role));
-
-    // then
-    assertTrue(userWithAllAuth.hasAnyAuth(List.of(ALL, F_SYSTEM_SETTING)));
-  }
-
-  @Test
-  @DisplayName("When checking if a User has any auth and they don't")
-  void whenUserHasNoMultiAuthCheck() {
-    // given
-    User userWithNoAuth = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH2"));
-    userWithNoAuth.setUserRoles(Set.of(role));
-
-    // then
-    assertFalse(userWithNoAuth.hasAnyAuth(List.of(ALL, F_SYSTEM_SETTING)));
-  }
-
-  @Test
-  @DisplayName("When checking if a User has a specific auth and they don't")
-  void whenUserHasNoSingleAuthCheck() {
-    // given
-    User userWithNoAuth = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("AUTH1", "AUTH2"));
-    userWithNoAuth.setUserRoles(Set.of(role));
-
-    // then
-    assertFalse(userWithNoAuth.isAuthorized(ALL));
-  }
-
-  @Test
-  @DisplayName("When checking if a User has a specific auth and they do")
-  void whenUserHasSingleAuthCheck() {
-    // given
-    User userWithNoAuth = new User();
-    UserRole role = new UserRole();
-    role.setAuthorities(Set.of("F_SYSTEM_SETTING", "AUTH2"));
-    userWithNoAuth.setUserRoles(Set.of(role));
-
-    // then
-    assertTrue(userWithNoAuth.isAuthorized(F_SYSTEM_SETTING));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -210,7 +210,7 @@ public class DefaultAnalyticsSecurityManager implements AnalyticsSecurityManager
   @Override
   @Transactional(readOnly = true)
   public void decideAccessEventAnalyticsAuthority() {
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetailsOrNull();
 
     boolean notAuthorized =
         currentUser != null && !currentUser.isAuthorized(F_VIEW_EVENT_ANALYTICS);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -94,16 +94,18 @@ public class DefaultAnalyticsSecurityManager implements AnalyticsSecurityManager
   @Override
   @Transactional(readOnly = true)
   public void decideAccess(DataQueryParams params) {
-    decideAccessDataViewOrganisationUnits(params, CurrentUserUtil.getCurrentUserDetails());
-    decideAccessDataReadObjects(params, CurrentUserUtil.getCurrentUserDetails());
+    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
+    decideAccessDataViewOrganisationUnits(params, currentUserDetails);
+    decideAccessDataReadObjects(params, currentUserDetails);
   }
 
   @Override
   @Transactional(readOnly = true)
   public void decideAccess(
       List<OrganisationUnit> queryOrgUnits, Set<IdentifiableObject> readObjects) {
-    decideAccessDataViewOrganisationUnits(queryOrgUnits, CurrentUserUtil.getCurrentUserDetails());
-    decideAccessDataReadObjects(readObjects, CurrentUserUtil.getCurrentUserDetails());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    decideAccessDataViewOrganisationUnits(queryOrgUnits, currentUser);
+    decideAccessDataReadObjects(readObjects, currentUser);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -210,7 +210,7 @@ public class DefaultAnalyticsSecurityManager implements AnalyticsSecurityManager
   @Override
   @Transactional(readOnly = true)
   public void decideAccessEventAnalyticsAuthority() {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     boolean notAuthorized =
         currentUser != null && !currentUser.isAuthorized(F_VIEW_EVENT_ANALYTICS);
@@ -235,7 +235,7 @@ public class DefaultAnalyticsSecurityManager implements AnalyticsSecurityManager
   public DataQueryParams withDataApprovalConstraints(DataQueryParams params) {
     DataQueryParams.Builder paramsBuilder = DataQueryParams.newBuilder(params);
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     boolean hideUnapprovedData =
         settingsProvider.getCurrentSettings().isHideUnapprovedDataInAnalytics();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -84,6 +84,7 @@ import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -553,12 +554,12 @@ public class DefaultAppManager implements AppManager {
 
   @Override
   public boolean isAccessible(App app) {
-    return ALWAYS_ACCESSIBLE_APPS.contains(app.getKey())
-        || CurrentUserUtil.hasAnyAuthority(
-            List.of(
-                Authorities.ALL.toString(),
-                Authorities.M_DHIS_WEB_APP_MANAGEMENT.toString(),
-                app.getSeeAppAuthority()));
+    if (ALWAYS_ACCESSIBLE_APPS.contains(app.getKey())) return true;
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetailsOrNull();
+    if (currentUser == null) return false;
+    if (currentUser.isSuper()) return true;
+    return currentUser.hasAnyAuthority(
+        Authorities.M_DHIS_WEB_APP_MANAGEMENT.toString(), app.getSeeAppAuthority());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalPermissionsEvaluator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalPermissionsEvaluator.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 
 /**
@@ -110,15 +111,16 @@ class DataApprovalPermissionsEvaluator {
     ev.idObjectManager = idObjectManager;
     ev.dataApprovalLevelService = dataApprovalLevelService;
 
-    ev.user = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    ev.user = userService.getUserByUsername(currentUser.getUsername());
 
     ev.acceptanceRequiredForApproval = settings.getAcceptanceRequiredForApproval();
     boolean hideUnapprovedData = settings.isHideUnapprovedDataInAnalytics();
 
-    ev.authorizedToApprove = ev.user.isAuthorized(F_APPROVE_DATA);
-    ev.authorizedToApproveAtLowerLevels = ev.user.isAuthorized(F_APPROVE_DATA_LOWER_LEVELS);
-    ev.authorizedToAcceptAtLowerLevels = ev.user.isAuthorized(F_ACCEPT_DATA_LOWER_LEVELS);
-    boolean authorizedToViewUnapprovedData = ev.user.isAuthorized(F_VIEW_UNAPPROVED_DATA);
+    ev.authorizedToApprove = currentUser.isAuthorized(F_APPROVE_DATA);
+    ev.authorizedToApproveAtLowerLevels = currentUser.isAuthorized(F_APPROVE_DATA_LOWER_LEVELS);
+    ev.authorizedToAcceptAtLowerLevels = currentUser.isAuthorized(F_ACCEPT_DATA_LOWER_LEVELS);
+    boolean authorizedToViewUnapprovedData = currentUser.isAuthorized(F_VIEW_UNAPPROVED_DATA);
 
     ev.mayViewLowerLevelUnapprovedData = !hideUnapprovedData || authorizedToViewUnapprovedData;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalLevelService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalLevelService.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -403,7 +404,8 @@ public class DefaultDataApprovalLevelService implements DataApprovalLevelService
   public Map<OrganisationUnit, Integer> getUserReadApprovalLevels() {
     Map<OrganisationUnit, Integer> map = new HashMap<>();
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    User user = userService.getUserByUsername(currentUser.getUsername());
 
     List<DataApprovalLevel> approvalLevels = getAllDataApprovalLevels();
 
@@ -412,12 +414,12 @@ public class DefaultDataApprovalLevelService implements DataApprovalLevelService
     // ---------------------------------------------------------------------
 
     if (currentUser.isAuthorized(F_APPROVE_DATA_LOWER_LEVELS)) {
-      for (OrganisationUnit orgUnit : currentUser.getOrganisationUnits()) {
+      for (OrganisationUnit orgUnit : user.getOrganisationUnits()) {
         map.put(orgUnit, APPROVAL_LEVEL_UNAPPROVED);
       }
     } else {
-      for (OrganisationUnit orgUnit : currentUser.getOrganisationUnits()) {
-        int level = requiredApprovalLevel(orgUnit, currentUser, approvalLevels);
+      for (OrganisationUnit orgUnit : user.getOrganisationUnits()) {
+        int level = requiredApprovalLevel(orgUnit, user, approvalLevels);
 
         map.put(orgUnit, level);
       }
@@ -427,7 +429,7 @@ public class DefaultDataApprovalLevelService implements DataApprovalLevelService
     // Add data view organisation units with approval levels
     // ---------------------------------------------------------------------
 
-    Collection<OrganisationUnit> dataViewOrgUnits = currentUser.getDataViewOrganisationUnits();
+    Collection<OrganisationUnit> dataViewOrgUnits = user.getDataViewOrganisationUnits();
 
     if (dataViewOrgUnits == null || dataViewOrgUnits.isEmpty()) {
       dataViewOrgUnits = organisationUnitService.getRootOrganisationUnits();
@@ -435,7 +437,7 @@ public class DefaultDataApprovalLevelService implements DataApprovalLevelService
 
     for (OrganisationUnit orgUnit : dataViewOrgUnits) {
       if (!map.containsKey(orgUnit)) {
-        int level = requiredApprovalLevel(orgUnit, currentUser, approvalLevels);
+        int level = requiredApprovalLevel(orgUnit, user, approvalLevels);
 
         map.put(orgUnit, level);
       }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.external.conf.ConfigurationKey.OIDC_DHIS2_INTERNAL_C
 
 import com.nimbusds.jwt.JWTParser;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +51,6 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -230,11 +228,7 @@ public class Dhis2JwtAuthenticationManagerResolver
                 mappingClaimKey, mappingValue));
       }
 
-      Collection<GrantedAuthority> grantedAuthorities =
-          List.copyOf(currentUserDetails.getAuthorities());
-
-      return new DhisJwtAuthenticationToken(
-          jwt, grantedAuthorities, mappingValue, currentUserDetails);
+      return new DhisJwtAuthenticationToken(jwt, mappingValue, currentUserDetails);
     };
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationToken.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationToken.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.security.jwt;
 
 import java.util.Collection;
+import java.util.List;
 import org.hisp.dhis.security.oidc.DhisOidcUser;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.security.core.GrantedAuthority;
@@ -74,9 +75,8 @@ public class DhisJwtAuthenticationToken extends JwtAuthenticationToken {
    *     authentication)
    * @param user the DHIS2 {@link UserDetails} the mapping claim resolved to
    */
-  public DhisJwtAuthenticationToken(
-      Jwt jwt, Collection<? extends GrantedAuthority> authorities, String name, UserDetails user) {
-    super(jwt, authorities, name);
+  public DhisJwtAuthenticationToken(Jwt jwt, String name, UserDetails user) {
+    super(jwt, List.of(), name);
 
     this.dhisOidcUser = new DhisOidcUser(user, jwt.getClaims(), IdTokenClaimNames.SUB, null);
   }
@@ -89,5 +89,10 @@ public class DhisJwtAuthenticationToken extends JwtAuthenticationToken {
   @Override
   public Object getPrincipal() {
     return this.dhisOidcUser;
+  }
+
+  @Override
+  public Collection<GrantedAuthority> getAuthorities() {
+    return (Collection<GrantedAuthority>) dhisOidcUser.getAuthorities();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -33,7 +33,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.user.User;
@@ -159,6 +161,12 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
   @Override
   public String getEmail() {
     return user.getEmail();
+  }
+
+  @CheckForNull
+  @Override
+  public UID getAvatar() {
+    return user.getAvatar();
   }
 
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.user.UserConstants.MAX_LENGTH_NAME;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.auth.RegistrationParams;
@@ -49,7 +49,7 @@ import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -193,12 +193,10 @@ public class DefaultUserAccountService implements UserAccountService {
   }
 
   public void authenticate(
-      String username,
-      String rawPassword,
-      Collection<GrantedAuthority> authorities,
-      HttpServletRequest request) {
+      String username, String rawPassword, Set<String> authorities, HttpServletRequest request) {
     UsernamePasswordAuthenticationToken token =
-        new UsernamePasswordAuthenticationToken(username, rawPassword, authorities);
+        new UsernamePasswordAuthenticationToken(
+            username, rawPassword, authorities.stream().map(SimpleGrantedAuthority::new).toList());
     token.setDetails(new TwoFactorWebAuthenticationDetails(request));
     Authentication auth = twoFactorAuthProvider.authenticate(token);
     SecurityContextHolder.getContext().setAuthentication(auth);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -625,7 +625,7 @@ public class DefaultUserService implements UserService {
     User user = userStore.getUserByOpenId(openId);
 
     if (user != null) {
-      user.getAllAuthorities();
+      user.getAuthorities();
     }
 
     return user;

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.jsonpatch.JsonPatchManager;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -308,10 +309,8 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService {
   }
 
   private void validateSameUser(MetadataProposal proposal) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-    if (currentUser != null
-        && !currentUser.isSuper()
-        && currentUser.getUid().equals(proposal.getCreatedBy().getUid())) {
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    if (!currentUser.isSuper() && !currentUser.getUid().equals(proposal.getCreatedBy().getUid())) {
       throw new IllegalStateException("Only the user created the proposal can adjust it later.");
     }
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.SystemUser;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.utils.FileResourceUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,7 +82,7 @@ class FileResourceControllerMockTest {
 
     when(fileResourceService.getFileResource(id.getValue())).thenReturn(fileResource);
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     controller.getFileResourceData(id, new MockHttpServletResponse(), null, currentUser);
 
     verify(fileResourceService).copyFileResourceContent(any(), any());
@@ -99,7 +99,7 @@ class FileResourceControllerMockTest {
 
     when(fileResourceService.getFileResource(id.getValue())).thenReturn(fileResource);
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     assertThrows(
         ForbiddenException.class,
         () -> controller.getFileResourceData(id, new MockHttpServletResponse(), null, currentUser));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -318,7 +318,7 @@ class ProgramControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testCopyProgramWithUserWithNoAuthorities() {
     User userWithNoAuthorities = switchToNewUser("test1");
-    Set<String> authorities = userWithNoAuthorities.getAllAuthorities();
+    Set<String> authorities = userWithNoAuthorities.getAuthorities();
     assertEquals(0, authorities.size());
 
     JsonWebMessage response =
@@ -331,7 +331,7 @@ class ProgramControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testCopyProgramWithUserWithProgramPrivateAddAuthority() {
     User userWithInsufficientAuthorities = switchToNewUser("test1", "F_PROGRAM_PRIVATE_ADD");
-    Set<String> authorities = userWithInsufficientAuthorities.getAllAuthorities();
+    Set<String> authorities = userWithInsufficientAuthorities.getAuthorities();
     assertEquals(1, authorities.size());
 
     JsonWebMessage response =
@@ -344,7 +344,7 @@ class ProgramControllerTest extends H2ControllerIntegrationTestBase {
   @Test
   void testCopyProgramWithUserWithProgramAuthorityOnly() {
     User userWithInsufficientAuthorities = switchToNewUser("test1", "F_PROGRAM_PUBLIC_ADD");
-    Set<String> authorities = userWithInsufficientAuthorities.getAllAuthorities();
+    Set<String> authorities = userWithInsufficientAuthorities.getAuthorities();
     assertEquals(1, authorities.size());
 
     assertStatus(HttpStatus.FORBIDDEN, POST("/programs/%s/copy".formatted(PROGRAM_UID)));
@@ -354,7 +354,7 @@ class ProgramControllerTest extends H2ControllerIntegrationTestBase {
   void testCopyProgramWithUserWithProgramAndIndicatorAuthority() {
     User userWithRequiredAuthorities =
         switchToNewUser("test1", "F_PROGRAM_PUBLIC_ADD", "F_PROGRAM_INDICATOR_PUBLIC_ADD");
-    Set<String> authorities = userWithRequiredAuthorities.getAllAuthorities();
+    Set<String> authorities = userWithRequiredAuthorities.getAuthorities();
     assertEquals(2, authorities.size());
 
     assertStatus(HttpStatus.CREATED, POST("/programs/%s/copy".formatted(PROGRAM_UID)));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -593,7 +593,7 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
     peter = userService.getUser(this.peter.getUid());
     assertTrue(
         peter
-            .getAllAuthorities()
+            .getAuthorities()
             .containsAll(Set.of("F_REPLICATE_USER", "F_USER_ADD", "F_USER_DELETE")));
     switchContextToUser(this.peter);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
@@ -109,6 +109,8 @@ class ImpersonateUserControllerTest extends H2ControllerIntegrationTestBase {
     String username = me.getUsername();
     assertEquals(usernameToImpersonate, username);
 
+    //FIXME seems legit that the impersonated user itself cannot exit
+    // as he does not have the authority required to call the endpoint
     JsonImpersonateUserResponse responseExit =
         POST("/auth/impersonateExit").content(HttpStatus.OK).as(JsonImpersonateUserResponse.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
@@ -109,7 +109,7 @@ class ImpersonateUserControllerTest extends H2ControllerIntegrationTestBase {
     String username = me.getUsername();
     assertEquals(usernameToImpersonate, username);
 
-    //FIXME seems legit that the impersonated user itself cannot exit
+    // FIXME seems legit that the impersonated user itself cannot exit
     // as he does not have the authority required to call the endpoint
     JsonImpersonateUserResponse responseExit =
         POST("/auth/impersonateExit").content(HttpStatus.OK).as(JsonImpersonateUserResponse.class);

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityTrackedEntityValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityTrackedEntityValidatorTest.java
@@ -235,7 +235,10 @@ class SecurityTrackedEntityValidatorTest extends TrackerTestBase {
             .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
             .trackedEntityType(MetadataIdentifier.ofUid(TE_TYPE_ID))
             .build();
-    user.getAllAuthorities().add(Authorities.F_TEI_CASCADE_DELETE.name());
+
+    User userA = makeUser("A", List.of(Authorities.F_TEI_CASCADE_DELETE.toString()));
+    userA.addOrganisationUnit(organisationUnit);
+    user = UserDetails.fromUser(userA);
 
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithEnrollments();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -40,6 +40,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.OpenApi;
@@ -62,7 +63,6 @@ import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.query.GetObjectParams;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.user.CurrentUser;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.utils.FileResourceUtils;
 import org.hisp.dhis.webapi.utils.HeaderUtils;
@@ -128,7 +128,7 @@ public class FileResourceController
       @PathVariable UID uid,
       HttpServletResponse response,
       @RequestParam(required = false) ImageFileDimension dimension,
-      @CurrentUser User currentUser)
+      @CurrentUser UserDetails currentUser)
       throws NotFoundException, ForbiddenException, WebMessageException {
     FileResource fileResource = fileResourceService.getFileResource(uid.getValue());
 
@@ -208,7 +208,7 @@ public class FileResourceController
    *
    * @return true if user has access, false if not.
    */
-  private boolean checkSharing(FileResource fileResource, User currentUser) {
+  private boolean checkSharing(FileResource fileResource, UserDetails currentUser) {
     /*
      * Serving DATA_VALUE fileResources from this endpoint doesn't make sense
      * So we will return false if the fileResource have this domain.
@@ -220,7 +220,7 @@ public class FileResourceController
 
     if (domain == FileResourceDomain.USER_AVATAR) {
       return currentUser.isAuthorized("F_USER_VIEW")
-          || fileResource.equals(currentUser.getAvatar());
+          || Objects.equals(UID.of(fileResource), currentUser.getAvatar());
     }
 
     return true;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -292,8 +292,9 @@ public class InterpretationController
       return notFound("Interpretation does not exist: " + uid);
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-    if (!currentUser.equals(interpretation.getCreatedBy()) && !currentUser.isSuper()) {
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    if (!currentUser.getUid().equals(interpretation.getCreatedBy().getUid())
+        && !currentUser.isSuper()) {
       throw new ForbiddenException("You are not allowed to update this interpretation.");
     }
 
@@ -365,11 +366,12 @@ public class InterpretationController
       return conflict("Interpretation does not exist: " + uid);
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     for (InterpretationComment comment : interpretation.getComments()) {
       if (comment.getUid().equals(cuid)) {
-        if (!currentUser.equals(comment.getCreatedBy()) && !currentUser.isSuper()) {
+        if (!currentUser.getUid().equals(comment.getCreatedBy().getUid())
+            && !currentUser.isSuper()) {
           throw new ForbiddenException("You are not allowed to update this comment.");
         }
 
@@ -396,12 +398,13 @@ public class InterpretationController
 
     Iterator<InterpretationComment> iterator = interpretation.getComments().iterator();
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     while (iterator.hasNext()) {
       InterpretationComment comment = iterator.next();
       if (comment.getUid().equals(cuid)) {
-        if (!currentUser.equals(comment.getCreatedBy()) && !currentUser.isSuper()) {
+        if (!currentUser.getUid().equals(comment.getCreatedBy().getUid())
+            && !currentUser.isSuper()) {
           throw new ForbiddenException("You are not allowed to delete this comment.");
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -62,7 +62,7 @@ import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.service.ContextService;
@@ -281,9 +281,7 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
   }
 
   private boolean canCapture(OrganisationUnit captureTarget) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-    return currentUser.isSuper()
-        || currentUser.getOrganisationUnits().stream()
-            .anyMatch(ou -> captureTarget.getStoredPath().startsWith(ou.getStoredPath()));
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    return currentUser.isSuper() || currentUser.isInUserHierarchy(captureTarget.getStoredPath());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
@@ -30,13 +30,10 @@
 package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.security.Authorities.F_IMPERSONATE_USER;
-import static org.hisp.dhis.security.Authorities.F_PREVIOUS_IMPERSONATOR_AUTHORITY;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.OpenApi;
@@ -56,7 +53,6 @@ import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
@@ -66,8 +62,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent;
-import org.springframework.security.web.authentication.switchuser.SwitchUserAuthorityChanger;
-import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -103,21 +97,39 @@ public class ImpersonateUserController {
   private final SecurityContextRepository securityContextRepository =
       new HttpSessionSecurityContextRepository();
 
-  private SwitchUserAuthorityChanger switchUserAuthorityChanger;
-
   @RequiresAuthority(anyOf = F_IMPERSONATE_USER)
   @PostMapping("/impersonate")
   public ImpersonateUserResponse impersonateUser(
       HttpServletRequest request, HttpServletResponse response, @RequestParam String username)
       throws ForbiddenException, NotFoundException {
 
-    validateReq(request);
+    validateAllowed(request);
 
     try {
-      Authentication targetUser = attemptSwitchUser(request, username);
+      username = (username != null) ? username : "";
+      UserDetails targetUser = this.userDetailsService.loadUserByUsername(username);
+      this.userDetailsChecker.check(targetUser);
+
+      // remember the impersonator Authentication object in session
+      // which will be used to 'exit' from the current switched user.
+      Authentication impersonator = getEffectiveImpersonatorUserAuth(request);
+      request.getSession().setAttribute("ORIGINAL_AUTH", impersonator);
+
+      // create the new authentication token
+      UsernamePasswordAuthenticationToken targetUserRequest =
+          UsernamePasswordAuthenticationToken.authenticated(
+              targetUser, targetUser.getPassword(), targetUser.getAuthorities());
+
+      targetUserRequest.setDetails(authenticationDetailsSource.buildDetails(request));
+
+      if (this.eventPublisher != null) {
+        this.eventPublisher.publishEvent(
+            new AuthenticationSwitchUserEvent(
+                this.securityContextHolderStrategy.getContext().getAuthentication(), targetUser));
+      }
 
       SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
-      context.setAuthentication(targetUser);
+      context.setAuthentication(targetUserRequest);
       this.securityContextHolderStrategy.setContext(context);
       this.securityContextRepository.saveContext(context, request, response);
 
@@ -134,13 +146,13 @@ public class ImpersonateUserController {
     }
   }
 
-  private void validateReq(HttpServletRequest request) throws ForbiddenException {
+  private void validateAllowed(HttpServletRequest request) throws ForbiddenException {
     String remoteAddr = request.getRemoteAddr();
     boolean enabled = config.isEnabled(ConfigurationKey.SWITCH_USER_FEATURE_ENABLED);
     if (!enabled) {
       log.error(
           "Impersonation attempt when feature is disabled, from username: {}, IP address: {}",
-          getCurrentAuthentication().getName(),
+          getEffectiveImpersonatorUserAuth(request).getName(),
           remoteAddr);
       throw new ForbiddenException(
           "Forbidden, user not allowed to impersonate user, feature disabled");
@@ -149,13 +161,12 @@ public class ImpersonateUserController {
       log.error(
           "Impersonation attempt from non allow-listed IP address: {}, username: {}",
           remoteAddr,
-          getCurrentAuthentication().getName());
+          getEffectiveImpersonatorUserAuth(request).getName());
       throw new ForbiddenException(
           "Forbidden, user not allowed to impersonate user from IP: %s".formatted(remoteAddr));
     }
   }
 
-  @RequiresAuthority(anyOf = {F_IMPERSONATE_USER, F_PREVIOUS_IMPERSONATOR_AUTHORITY})
   @PostMapping("/impersonateExit")
   public ImpersonateUserResponse impersonateExit(
       HttpServletRequest request,
@@ -163,125 +174,47 @@ public class ImpersonateUserController {
       @CurrentUser org.hisp.dhis.user.UserDetails userDetails)
       throws ForbiddenException, BadRequestException {
 
-    validateReq(request);
+    validateAllowed(request);
 
-    Authentication originalUser = null;
-    try {
-      originalUser = attemptExitUser();
-    } catch (AuthenticationCredentialsNotFoundException e) {
+    Authentication impersonator = getImpersonatorUserAuth(request);
+    if (impersonator == null)
       throw new BadRequestException(
           "User not impersonating anyone, user: %s".formatted(userDetails.getUsername()));
+
+    request.getSession().removeAttribute("ORIGINAL_AUTH");
+    // publish event
+    if (this.eventPublisher != null) {
+      Authentication impersonated = securityContextHolderStrategy.getContext().getAuthentication();
+      this.eventPublisher.publishEvent(
+          new AuthenticationSwitchUserEvent(
+              impersonated, (UserDetails) impersonator.getPrincipal()));
     }
 
     // update the current context back to the original user
     SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
-    context.setAuthentication(originalUser);
+    context.setAuthentication(impersonator);
     this.securityContextHolderStrategy.setContext(context);
     this.securityContextRepository.saveContext(context, request, response);
 
     return ImpersonateUserResponse.builder()
         .status(ImpersonateUserResponse.STATUS.IMPERSONATION_EXIT_SUCCESS)
-        .username(originalUser.getName())
+        .username(impersonator.getName())
         .build();
   }
 
-  private Authentication attemptSwitchUser(HttpServletRequest request, String username)
-      throws AuthenticationException {
-
-    UsernamePasswordAuthenticationToken targetUserRequest;
-    username = (username != null) ? username : "";
-    UserDetails targetUser = this.userDetailsService.loadUserByUsername(username);
-    this.userDetailsChecker.check(targetUser);
-
-    targetUserRequest = createSwitchUserToken(request, targetUser);
-
-    if (this.eventPublisher != null) {
-      this.eventPublisher.publishEvent(
-          new AuthenticationSwitchUserEvent(
-              this.securityContextHolderStrategy.getContext().getAuthentication(), targetUser));
-    }
-
-    return targetUserRequest;
-  }
-
-  private UsernamePasswordAuthenticationToken createSwitchUserToken(
-      HttpServletRequest request, UserDetails targetUser) {
-
-    UsernamePasswordAuthenticationToken targetUserRequest;
-
-    // grant an additional authority that contains the original Authentication object
-    // which will be used to 'exit' from the current switched user.
-    Authentication currentAuthentication = getCurrentAuthentication();
-    GrantedAuthority switchAuthority =
-        new SwitchUserGrantedAuthority(
-            F_PREVIOUS_IMPERSONATOR_AUTHORITY.name(), currentAuthentication);
-
-    // add the new switch user authority
-    List<GrantedAuthority> newAuths = new ArrayList<>(targetUser.getAuthorities());
-    newAuths.add(switchAuthority);
-
-    // create the new authentication token
-    targetUserRequest =
-        UsernamePasswordAuthenticationToken.authenticated(
-            targetUser, targetUser.getPassword(), newAuths);
-
-    targetUserRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
-
-    return targetUserRequest;
-  }
-
-  private Authentication getCurrentAuthentication() {
-    try {
-      // SEC-1763. Check first if we are already switched.
-      return attemptExitUser();
-    } catch (AuthenticationCredentialsNotFoundException ex) {
-      return this.securityContextHolderStrategy.getContext().getAuthentication();
-    }
-  }
-
-  protected Authentication attemptExitUser() throws AuthenticationCredentialsNotFoundException {
-    // need to check to see if the current user has a SwitchUserGrantedAuthority
-    Authentication current = this.securityContextHolderStrategy.getContext().getAuthentication();
-    if (current == null) {
+  @Nonnull
+  private Authentication getEffectiveImpersonatorUserAuth(HttpServletRequest request) {
+    Authentication impersonator = getImpersonatorUserAuth(request);
+    if (impersonator != null) return impersonator;
+    Authentication current = securityContextHolderStrategy.getContext().getAuthentication();
+    if (current == null)
       throw new AuthenticationCredentialsNotFoundException(
           "No current user associated with this request");
-    }
-
-    // check to see if the current user did actual switch to another user
-    // if so, get the original source user, so we can switch back
-    Authentication original = getSourceAuthentication(current);
-    if (original == null) {
-      throw new AuthenticationCredentialsNotFoundException("Failed to find original user");
-    }
-
-    // get the source user details
-    UserDetails originalUser = null;
-
-    Object obj = original.getPrincipal();
-    if (obj instanceof UserDetails userDetails) {
-      originalUser = userDetails;
-    }
-
-    // publish event
-    if (this.eventPublisher != null) {
-      this.eventPublisher.publishEvent(new AuthenticationSwitchUserEvent(current, originalUser));
-    }
-
-    return original;
+    return current;
   }
 
-  private Authentication getSourceAuthentication(Authentication current) {
-    Authentication original = null;
-
-    // iterate over granted authorities and find the 'switch user' authority
-    Collection<? extends GrantedAuthority> authorities = current.getAuthorities();
-    for (GrantedAuthority auth : authorities) {
-      // check for switch user type of authority
-      if (auth instanceof SwitchUserGrantedAuthority switchUserGrantedAuthority) {
-        original = switchUserGrantedAuthority.getSource();
-      }
-    }
-    return original;
+  private static Authentication getImpersonatorUserAuth(HttpServletRequest request) {
+    return (Authentication) request.getSession().getAttribute("ORIGINAL_AUTH");
   }
 
   public static boolean hasAllowListedIp(String remoteAddr, DhisConfigurationProvider config) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.ImpersonatingUserDetailsChecker;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.CurrentUser;
@@ -213,7 +214,7 @@ public class ImpersonateUserController {
     return current;
   }
 
-  private static Authentication getImpersonatorUserAuth(HttpServletRequest request) {
+  public static Authentication getImpersonatorUserAuth(HttpServletRequest request) {
     return (Authentication) request.getSession().getAttribute("ORIGINAL_AUTH");
   }
 
@@ -225,5 +226,14 @@ public class ImpersonateUserController {
       }
     }
     return false;
+  }
+
+  public static boolean canImpersonate(
+      org.hisp.dhis.user.UserDetails currentUser,
+      HttpServletRequest request,
+      DhisConfigurationProvider config) {
+    return config.isEnabled(ConfigurationKey.SWITCH_USER_FEATURE_ENABLED)
+        && hasAllowListedIp(request.getRemoteAddr(), config)
+        && currentUser.hasAnyAuthority(Authorities.ALL, Authorities.F_IMPERSONATE_USER);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -194,7 +194,7 @@ public class MeController {
         settingKeys.isEmpty() ? settings.toJson(false) : settings.toJson(true, settingKeys);
     MeDto meDto =
         new MeDto(user, s, programs, dataSets, patTokens, filteredUserGroups, filteredUserRoles);
-    determineUserImpersonation(meDto, user.getAllAuthorities(), request);
+    determineUserImpersonation(meDto, user.getAuthorities(), request);
 
     ObjectNode jsonNodes = fieldFilterService.toObjectNodes(of(meDto, fields)).get(0);
 
@@ -318,14 +318,14 @@ public class MeController {
       produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<Set<String>> getAuthorities(
       @CurrentUser(required = true) User currentUser) {
-    return ResponseEntity.ok().cacheControl(noStore()).body(currentUser.getAllAuthorities());
+    return ResponseEntity.ok().cacheControl(noStore()).body(currentUser.getAuthorities());
   }
 
   @GetMapping(
       value = {"/authorization/{authority}", "/authorities/{authority}"},
       produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<Boolean> hasAuthority(
-      @PathVariable String authority, @CurrentUser(required = true) User currentUser) {
+      @PathVariable String authority, @CurrentUser(required = true) UserDetails currentUser) {
     return ResponseEntity.ok().cacheControl(noStore()).body(currentUser.isAuthorized(authority));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -30,7 +30,6 @@
 package org.hisp.dhis.webapi.controller.user;
 
 import static org.hisp.dhis.fieldfiltering.FieldFilterParams.*;
-import static org.hisp.dhis.webapi.controller.security.ImpersonateUserController.hasAllowListedIp;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.CacheControl.noStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -41,7 +40,6 @@ import com.google.common.collect.Lists;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +54,6 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataapproval.DataApprovalLevel;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.dataset.DataSetService;
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
@@ -76,7 +73,6 @@ import org.hisp.dhis.node.types.SimpleNode;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.query.GetObjectParams;
 import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.PasswordManager;
 import org.hisp.dhis.security.acl.Access;
 import org.hisp.dhis.security.acl.AclService;
@@ -94,15 +90,13 @@ import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.webapi.controller.security.ImpersonateUserController;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.webdomain.Dashboard;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -194,7 +188,7 @@ public class MeController {
         settingKeys.isEmpty() ? settings.toJson(false) : settings.toJson(true, settingKeys);
     MeDto meDto =
         new MeDto(user, s, programs, dataSets, patTokens, filteredUserGroups, filteredUserRoles);
-    determineUserImpersonation(meDto, user.getAuthorities(), request);
+    determineUserImpersonation(meDto, userDetails, request);
 
     ObjectNode jsonNodes = fieldFilterService.toObjectNodes(of(meDto, fields)).get(0);
 
@@ -202,26 +196,11 @@ public class MeController {
   }
 
   private void determineUserImpersonation(
-      MeDto meDto, Set<String> allAuthorities, HttpServletRequest request) {
-    Authentication current = SecurityContextHolder.getContext().getAuthentication();
-
-    // iterate over granted authorities and find the 'switch user' authority
-    Collection<? extends GrantedAuthority> authorities = current.getAuthorities();
-    for (GrantedAuthority auth : authorities) {
-      // check for switch user type of authority
-      if (auth instanceof SwitchUserGrantedAuthority userGrantedAuthority) {
-        meDto.setImpersonation(userGrantedAuthority.getSource().getName());
-      }
-    }
-
-    String remoteAddr = request.getRemoteAddr();
-    boolean enabled = config.isEnabled(ConfigurationKey.SWITCH_USER_FEATURE_ENABLED);
-    if (enabled
-        && (allAuthorities.contains(Authorities.ALL.name())
-            || allAuthorities.contains(Authorities.F_IMPERSONATE_USER.name()))
-        && hasAllowListedIp(remoteAddr, config)) {
-      meDto.setCanImpersonate(true);
-    }
+      MeDto meDto, UserDetails currentUser, HttpServletRequest request) {
+    Authentication current = ImpersonateUserController.getImpersonatorUserAuth(request);
+    if (current != null && current.getPrincipal() instanceof UserDetails impersonator)
+      meDto.setImpersonation(impersonator.getName());
+    meDto.setCanImpersonate(ImpersonateUserController.canImpersonate(currentUser, request, config));
   }
 
   private boolean fieldsContains(String key, List<String> fields) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
@@ -106,7 +106,7 @@ public class MeDto {
     this.twitter = user.getTwitter();
 
     this.userRoles = filteredUserRoles;
-    this.authorities = new ArrayList<>(user.getAllAuthorities());
+    this.authorities = new ArrayList<>(user.getAuthorities());
 
     this.settings = settings;
     this.programs = programs;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserControllerUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserControllerUtils.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -115,9 +116,10 @@ public class UserControllerUtils {
    * @return a node with the ordered list of data approval levels
    */
   private ArrayNode getWorkflowLevelNodes(User user, DataApprovalWorkflow workflow) {
-    boolean canApprove = user.isAuthorized(F_APPROVE_DATA);
-    boolean canApproveLowerLevels = user.isAuthorized(F_APPROVE_DATA_LOWER_LEVELS);
-    boolean canAccept = user.isAuthorized(F_ACCEPT_DATA_LOWER_LEVELS);
+    UserDetails currentUser = UserDetails.fromUser(user);
+    boolean canApprove = currentUser.isAuthorized(F_APPROVE_DATA);
+    boolean canApproveLowerLevels = currentUser.isAuthorized(F_APPROVE_DATA_LOWER_LEVELS);
+    boolean canAccept = currentUser.isAuthorized(F_ACCEPT_DATA_LOWER_LEVELS);
 
     boolean acceptConfigured =
         settingsProvider.getCurrentSettings().getAcceptanceRequiredForApproval();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/AuthorityInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/AuthorityInterceptor.java
@@ -87,7 +87,6 @@ public class AuthorityInterceptor implements HandlerInterceptor {
     if (currentUser == null) throw accessDenied(requires);
     if (currentUser.isSuper()) return;
     if (!currentUser.hasAnyAuthority(requires.anyOf())) throw accessDenied(requires);
-    throw accessDenied(requires);
   }
 
   private static AccessDeniedException accessDenied(RequiresAuthority requires) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/AuthorityInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/AuthorityInterceptor.java
@@ -31,19 +31,13 @@ package org.hisp.dhis.webapi.mvc.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.RequiresAuthority;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.session.SessionAuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -77,51 +71,28 @@ public class AuthorityInterceptor implements HandlerInterceptor {
       @Nonnull HttpServletResponse response,
       @Nonnull Object handler) {
 
-    if (!(handler instanceof HandlerMethod)) {
-      return true;
-    }
+    if (!(handler instanceof HandlerMethod handlerMethod)) return true;
 
-    HandlerMethod handlerMethod = (HandlerMethod) handler;
     // check if RequiresAuthority is at method level
-    if (handlerMethod.hasMethodAnnotation(RequiresAuthority.class)) {
-      RequiresAuthority requiresMethodAuthority =
-          handlerMethod.getMethodAnnotation(RequiresAuthority.class);
-      if (requiresMethodAuthority != null)
-        return checkForRequiredAuthority(requiresMethodAuthority);
-    }
-
-    // heck if RequiresAuthority is at method level
-    if (handlerMethod.getBeanType().isAnnotationPresent(RequiresAuthority.class)) {
-      RequiresAuthority requiresClassAuthority =
-          handlerMethod.getBeanType().getAnnotation(RequiresAuthority.class);
-      return checkForRequiredAuthority(requiresClassAuthority);
-    }
+    RequiresAuthority requires = handlerMethod.getMethodAnnotation(RequiresAuthority.class);
+    if (requires == null)
+      // check if RequiresAuthority is at Class level
+      requires = handlerMethod.getBeanType().getAnnotation(RequiresAuthority.class);
+    if (requires != null) checkForRequiredAuthority(requires);
     return true;
   }
 
-  private boolean checkForRequiredAuthority(RequiresAuthority requiresAuthority) {
-    // include 'ALL' authority in required authorities
-    List<Authorities> requiredAuthorities = new ArrayList<>(List.of(Authorities.ALL));
-    requiredAuthorities.addAll(List.of(requiresAuthority.anyOf()));
+  private void checkForRequiredAuthority(RequiresAuthority requires) {
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetailsOrNull();
+    if (currentUser == null) throw accessDenied(requires);
+    if (currentUser.isSuper()) return;
+    if (!currentUser.hasAnyAuthority(requires.anyOf())) throw accessDenied(requires);
+    throw accessDenied(requires);
+  }
 
-    // get user authorities
-    final SecurityContext securityContext = SecurityContextHolder.getContext();
-    Authentication authentication = securityContext.getAuthentication();
-    if (authentication == null)
-      throw new SessionAuthenticationException("Error trying to get user authentication details");
-
-    Collection<? extends GrantedAuthority> userAuthorities = authentication.getAuthorities();
-
-    // check if user has any of the required authorities passed in
-    if (requiredAuthorities.stream()
-        .noneMatch(
-            reqAuth ->
-                userAuthorities.stream()
-                    .anyMatch(userAuth -> reqAuth.toString().equals(userAuth.getAuthority())))) {
-      throw new AccessDeniedException(
-          "Access is denied, requires one Authority from [%s]"
-              .formatted(StringUtils.join(requiresAuthority.anyOf(), ", ")));
-    }
-    return true;
+  private static AccessDeniedException accessDenied(RequiresAuthority requires) {
+    return new AccessDeniedException(
+        "Access is denied, requires one Authority from [%s]"
+            .formatted(StringUtils.join(requires.anyOf(), ", ")));
   }
 }


### PR DESCRIPTION
### User Access Check via `UserDetails`
The goal is that any and all user access goes via `UserDetails` (and not `User`).

Changes:

* :ab: `User.getAuthorities()` provides `Set<String>` (no `GrantedAuthority` here any more) 
* :x: removed all `hasAnyAuthority` and `isAuthorized` variants from `User` (=> use `UserDetails`)
* :x: removed all tests for deleted method on `User`
* :sparkles: `isSuper` is computed from set of authorities (has `ALL`?)
* :sparkles: `Collection<? extends GrantedAuthority> getAuthorities()` from Spring's `UserDetails` is just a projection onto `Set<String>` authorities (computed on the fly, not store in addition)
* :new: the user's avatar file resource `UID` is available via `UserDetails`
* :ab: interceptor for `@RequiresAuthority` uses `UserDetails` authorities from `Set<String>` (their actual source)
* :timer_clock: `@RequiresAuthority` and `hasAnyAuthority` without crating intermediate collections

Issues found:
* :bug: set of authorities wasn't always immutable and got modified
* :bug: "is owner user" check was missing negation (see comment)
* :bug: accidental exit of impersonation (try-catch-recover anti-pattern)

### Impersonation 
* :ab: The impersonator `Authentication` is stored in the HTTP session attribute (to not require a "magic" `GrantedAuthority`)
* :ab: exiting impersonation does not require any specific authority, it simply fails if no impersonation is in progress

### Future Work
* The `User` still has a few usages of `isSuper()` which ultimately should also go via `UserDetails` but the remaining ones are hard(er) to replace.
* Remove `extends` Spring's `UserDetails` from DHIS2 `UserDetails`
* Eliminate `SuperUser` in favor of a constant
* Eliminate `DhisUser` in favor of single `UserDetails` record