### PR TITLE
fix: resolve metadata management app authority name on unbundled install [DHIS2-21388] [2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -144,6 +144,8 @@ M_dhis-web-data-visualizer=Data Visualizer app
 M_dhis-web-sms-configuration=SMS Configuration app
 M_dhis-web-line-listing=Line Listing app
 M_dhis-web-metadata-management=Metadata Management app
+# Authority used when the app is installed unbundled (app hub); see App.getSeeAppAuthority()
+M_metadatamanagement=Metadata Management app
 
 #-- User action privilegies ---------------------------------------------------#
 


### PR DESCRIPTION
## Summary
Follow-up to the merged backport #24053, which did not actually fix the issue on 2.42.

On 2.42 the metadata-management app is **not bundled** (it is not in `apps-to-bundle.json`), so `App.getSeeAppAuthority()` takes the non-bundled path, strips the hyphen from the short name, and produces the authority `M_metadatamanagement` — not `M_dhis-web-metadata-management`. #24053 only added the bundled-form key, so the Users app still showed the raw fallback `metadatamanagement app`.

This adds the `M_metadatamanagement` translation so the unbundled authority resolves to **Metadata Management app**.

Verified against the runtime authority on `play.im.dhis2.org/dev-2-42` (`/api/authorities` returns id `M_metadatamanagement`).

Jira: [DHIS2-21388](https://dhis2.atlassian.net/browse/DHIS2-21388)

AI Assisted

[DHIS2-21388]: https://dhis2.atlassian.net/browse/DHIS2-21388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ