### PR TITLE
fix: resolve metadata management app authority name on unbundled install [DHIS2-21388] [2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -144,6 +144,8 @@ M_dhis-web-scheduler=Scheduler app
 M_dhis-web-data-visualizer=Data Visualizer app
 M_dhis-web-sms-configuration=SMS Configuration app
 M_dhis-web-metadata-management=Metadata Management app
+# Authority used when the app is installed unbundled (app hub); see App.getSeeAppAuthority()
+M_metadatamanagement=Metadata Management app
 
 #-- User action privilegies ---------------------------------------------------#
 


### PR DESCRIPTION
## Summary
Follow-up to the merged backport #24054, which did not actually fix the issue on 2.41.

On 2.41 the metadata-management app is **not bundled** (it is not in `apps-to-bundle.json`), so `App.getSeeAppAuthority()` takes the non-bundled path, strips the hyphen from the short name, and produces the authority `M_metadatamanagement` — not `M_dhis-web-metadata-management`. #24054 only added the bundled-form key, so the Users app still showed the raw fallback `metadatamanagement app`.

This adds the `M_metadatamanagement` translation so the unbundled authority resolves to **Metadata Management app**.

Verified against the runtime authority on the per-branch dev play instance (`/api/apps` reports the app installed unbundled with shortName `metadata-management`).

Jira: [DHIS2-21388](https://dhis2.atlassian.net/browse/DHIS2-21388)

AI Assisted

[DHIS2-21388]: https://dhis2.atlassian.net/browse/DHIS2-21388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ