### PR TITLE
fix: Map updatedBy on TEAV API response [DHIS2-21537]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@ docker-compose.yml @dhis2/devops
 
 jib.yaml @dhis2/devops
 
-dhis-2/dhis-tracker/** @dhis2/tracker-backend
+dhis-2/dhis-tracker/** @dhis2/team-tracker-backend

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
@@ -44,4 +44,8 @@ public interface JsonAttribute extends JsonObject {
   default String value() {
     return getString("value").string();
   }
+
+  default String updatedBy() {
+    return getString("updatedBy").string();
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -344,6 +344,27 @@ class TrackedEntitiesExportControllerTest extends PostgresControllerIntegrationT
   }
 
   @Test
+  void shouldReturnUpdatedByOnAttributeWhenTrackedEntityAttributeValueIsExported() {
+    TrackedEntity te = get(TrackedEntity.class, "dUE514NMOlo");
+
+    JsonList<JsonAttribute> attributes =
+        GET(
+                "/tracker/trackedEntities/{id}?fields=attributes[attribute,value,updatedBy]",
+                te.getUid())
+            .content(HttpStatus.OK)
+            .getList("attributes", JsonAttribute.class);
+
+    assertNotEmpty(attributes.stream().toList());
+    attributes.stream()
+        .forEach(
+            a ->
+                assertEquals(
+                    "trackeradmin",
+                    a.updatedBy(),
+                    "updatedBy mismatch on attribute " + a.getAttribute()));
+  }
+
+  @Test
   void
       shouldGetTrackedEntityWithoutRelationshipsWhenRelationshipIsDeletedAndIncludeDeletedIsFalse() {
     TrackedEntity from = get(TrackedEntity.class, "mHWCacsGYYn");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Attribute.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Attribute.java
@@ -62,7 +62,7 @@ public class Attribute {
 
   @JsonProperty private Instant updatedAt;
 
-  @JsonProperty private String storedBy;
+  @JsonProperty private String updatedBy;
 
   @JsonProperty private ValueType valueType;
 


### PR DESCRIPTION
After the changes introduced in https://github.com/dhis2/dhis2-core/pull/23992, the API mapper still attempted to map the `storedBy` field, which no longer exists. This caused a bug that is fixed by this PR.