### PR TITLE
security backport:#148 #188 #213 #214 → patch/2.42.5.1

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -257,7 +257,7 @@ public class DefaultSqlViewService implements SqlViewService {
     filter +=
         sqlHelper.whereAnd()
             + " "
-            + columnName
+            + SqlUtils.quote(columnName)
             + " "
             + operatorWithPlaceHolderAndArg.operatorWithPlaceholder();
 

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -175,10 +175,6 @@
       <artifactId>jakarta.persistence-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jasypt</groupId>
       <artifactId>jasypt</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DimensionalItemId;
@@ -64,6 +63,7 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeOptionDimensionItem;
 import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -447,7 +447,9 @@ public class DataDimensionExtractor {
     }
 
     try {
-      BaseDimensionalItemObject clone = (BaseDimensionalItemObject) BeanUtils.cloneBean(item);
+      BaseDimensionalItemObject clone =
+          (BaseDimensionalItemObject) item.getClass().getDeclaredConstructor().newInstance();
+      BeanUtils.copyProperties(item, clone);
       clone.setQueryMods(id.getQueryMods());
       return clone;
     } catch (Exception e) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/SchemaToDataFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/SchemaToDataFetcher.java
@@ -39,11 +39,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.beanutils.BeanUtils;
 import org.hibernate.jpa.QueryHints;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.stereotype.Component;
 
 /**
@@ -135,8 +136,10 @@ public class SchemaToDataFetcher {
   private void addToResult(
       Schema schema, Map<String, Object> valuesMap, List<IdentifiableObject> resultsObjects) {
     try {
-      IdentifiableObject identifiableObject = (IdentifiableObject) schema.getKlass().newInstance();
-      BeanUtils.populate(identifiableObject, valuesMap);
+      IdentifiableObject identifiableObject =
+          (IdentifiableObject) schema.getKlass().getDeclaredConstructor().newInstance();
+      BeanWrapper wrapper = new BeanWrapperImpl(identifiableObject);
+      valuesMap.forEach(wrapper::setPropertyValue);
       resultsObjects.add(identifiableObject);
     } catch (Exception e) {
       log.error(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.scheduling.JobType.values;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Primitives;
+import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -57,7 +58,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.beanutils.PropertyUtils;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -375,10 +375,15 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
       return jobParameters;
     }
 
-    final Set<PropertyDescriptor> properties =
-        Stream.of(PropertyUtils.getPropertyDescriptors(paramsType))
-            .filter(pd -> pd.getReadMethod() != null && pd.getWriteMethod() != null)
-            .collect(Collectors.toSet());
+    final Set<PropertyDescriptor> properties;
+    try {
+      properties =
+          Stream.of(Introspector.getBeanInfo(paramsType).getPropertyDescriptors())
+              .filter(pd -> pd.getReadMethod() != null && pd.getWriteMethod() != null)
+              .collect(Collectors.toSet());
+    } catch (java.beans.IntrospectionException e) {
+      return jobParameters;
+    }
 
     for (Field field : paramsType.getDeclaredFields()) {
       PropertyDescriptor descriptor =

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
@@ -58,14 +58,15 @@ import org.springframework.stereotype.Repository;
 public class HibernateUserSettingStore extends HibernateNativeStore<UserSetting>
     implements UserSettingStore {
 
-  static final String DESERIALIZATION_FILTER =
-      "maxdepth=5;maxrefs=20;maxarray=0;maxbytes=65536;"
-          + "java.lang.String;java.lang.Boolean;"
-          + "java.lang.Number;java.lang.Integer;java.lang.Long;"
-          + "java.lang.Double;java.lang.Float;java.lang.Enum;"
-          + "java.util.Locale;java.util.Date;"
-          + "org.hisp.dhis.common.Locale;org.hisp.dhis.common.DisplayProperty;"
-          + "!*";
+  private static final ObjectInputFilter DESERIALIZATION_FILTER =
+      ObjectInputFilter.Config.createFilter(
+          "maxdepth=5;maxrefs=20;maxarray=0;maxbytes=65536;"
+              + "java.lang.String;java.lang.Boolean;"
+              + "java.lang.Number;java.lang.Integer;java.lang.Long;"
+              + "java.lang.Double;java.lang.Float;java.lang.Enum;"
+              + "java.util.Locale;java.util.Date;"
+              + "org.hisp.dhis.common.Locale;org.hisp.dhis.common.DisplayProperty;"
+              + "!*");
 
   public HibernateUserSettingStore(EntityManager em) {
     super(em, UserSetting.class);
@@ -144,7 +145,7 @@ public class HibernateUserSettingStore extends HibernateNativeStore<UserSetting>
       try {
         ByteArrayInputStream bis = new ByteArrayInputStream(binary);
         ObjectInputStream ois = new ObjectInputStream(bis);
-        ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(DESERIALIZATION_FILTER));
+        ois.setObjectInputFilter(DESERIALIZATION_FILTER);
         return Settings.valueOf((Serializable) ois.readObject());
       } catch (InvalidClassException ex) {
         log.error(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStore.java
@@ -34,6 +34,8 @@ import static java.util.stream.Collectors.toMap;
 import jakarta.persistence.EntityManager;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -55,6 +57,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class HibernateUserSettingStore extends HibernateNativeStore<UserSetting>
     implements UserSettingStore {
+
+  static final String DESERIALIZATION_FILTER =
+      "maxdepth=5;maxrefs=20;maxarray=0;maxbytes=65536;"
+          + "java.lang.String;java.lang.Boolean;"
+          + "java.lang.Number;java.lang.Integer;java.lang.Long;"
+          + "java.lang.Double;java.lang.Float;java.lang.Enum;"
+          + "java.util.Locale;java.util.Date;"
+          + "org.hisp.dhis.common.Locale;org.hisp.dhis.common.DisplayProperty;"
+          + "!*";
 
   public HibernateUserSettingStore(EntityManager em) {
     super(em, UserSetting.class);
@@ -127,24 +138,30 @@ public class HibernateUserSettingStore extends HibernateNativeStore<UserSetting>
    * only using strings outside the store layer. Also, once settings are updated they always are
    * {@link String}s just still in their binary form.
    */
-  private static String fromBinary(String key, Object value) {
+  static String fromBinary(String key, Object value) {
     if (value == null) return "";
     if (value instanceof byte[] binary) {
       try {
         ByteArrayInputStream bis = new ByteArrayInputStream(binary);
         ObjectInputStream ois = new ObjectInputStream(bis);
+        ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(DESERIALIZATION_FILTER));
         return Settings.valueOf((Serializable) ois.readObject());
+      } catch (InvalidClassException ex) {
+        log.error(
+            "Deserialization filter rejected class for user setting '{}': {}",
+            key,
+            ex.getMessage());
+        return "";
       } catch (Exception ex) {
-        log.warn(
-            "Failed to de-serialize user setting %s from binary representation, using default"
-                .formatted(key));
+        log.warn("Failed to de-serialize user setting '{}' from binary, using default", key);
         return "";
       }
     }
     if (value instanceof Serializable s) return Settings.valueOf(s);
     log.warn(
-        "Failed to de-serialize user setting %s from unknown source type: %s, using default"
-            .formatted(key, value.getClass()));
+        "Failed to de-serialize user setting '{}' from unknown source type: {}, using default",
+        key,
+        value.getClass());
     return "";
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OrderTest.java
@@ -32,8 +32,9 @@ package org.hisp.dhis.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 
+import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import org.apache.commons.beanutils.PropertyUtils;
+import java.util.stream.Stream;
 import org.hisp.dhis.schema.Property;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +61,11 @@ class OrderTest {
   void setUp() throws Exception {
     object1 = new TestObject();
     object2 = new TestObject();
-    PropertyDescriptor propertyDescriptor = PropertyUtils.getPropertyDescriptor(object1, "value");
+    PropertyDescriptor propertyDescriptor =
+        Stream.of(Introspector.getBeanInfo(object1.getClass()).getPropertyDescriptors())
+            .filter(d -> d.getName().equals("value"))
+            .findFirst()
+            .orElseThrow();
     valueProperty =
         new Property(
             String.class, propertyDescriptor.getReadMethod(), propertyDescriptor.getWriteMethod());

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStoreFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStoreFilterTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Date;
 import java.util.Locale;
 import java.util.stream.Stream;
 import javax.management.BadAttributeValueExpException;
@@ -60,6 +61,8 @@ class HibernateUserSettingStoreFilterTest {
         Arguments.of("Long value", 100L, "100"),
         Arguments.of("Double value", 3.14, "3.14"),
         Arguments.of("java.util.Locale", Locale.FRENCH, "fr"),
+        Arguments.of("java.util.Date", new Date(1700000000000L), "1700000000000"),
+        Arguments.of("DHIS2 Locale", org.hisp.dhis.common.Locale.FRENCH, "fr"),
         Arguments.of("DisplayProperty enum", DisplayProperty.NAME, "NAME"));
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStoreFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/HibernateUserSettingStoreFilterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.stream.Stream;
+import javax.management.BadAttributeValueExpException;
+import org.hisp.dhis.common.DisplayProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the {@link java.io.ObjectInputFilter} on {@link
+ * HibernateUserSettingStore#fromBinary(String, Object)} accepts known safe types and rejects
+ * potential gadget classes.
+ *
+ * @author Morten Svanaes
+ */
+class HibernateUserSettingStoreFilterTest {
+
+  static Stream<Arguments> allowedTypes() {
+    return Stream.of(
+        Arguments.of("String value", "hello", "hello"),
+        Arguments.of("Boolean value", Boolean.TRUE, "true"),
+        Arguments.of("Integer value", 42, "42"),
+        Arguments.of("Long value", 100L, "100"),
+        Arguments.of("Double value", 3.14, "3.14"),
+        Arguments.of("java.util.Locale", Locale.FRENCH, "fr"),
+        Arguments.of("DisplayProperty enum", DisplayProperty.NAME, "NAME"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allowedTypes")
+  void fromBinary_acceptsAllowedType(String label, Serializable input, String expected) {
+    byte[] binary = serialize(input);
+    assertEquals(expected, HibernateUserSettingStore.fromBinary("testKey", binary));
+  }
+
+  @Test
+  void fromBinary_rejectsGadgetClass() {
+    BadAttributeValueExpException gadget = new BadAttributeValueExpException("exploit");
+    byte[] binary = serialize(gadget);
+    assertEquals("", HibernateUserSettingStore.fromBinary("testKey", binary));
+  }
+
+  @Test
+  void fromBinary_returnsEmptyForNull() {
+    assertEquals("", HibernateUserSettingStore.fromBinary("testKey", null));
+  }
+
+  @Test
+  void fromBinary_handlesNonByteArraySerializable() {
+    assertEquals("hello", HibernateUserSettingStore.fromBinary("testKey", "hello"));
+  }
+
+  private static byte[] serialize(Serializable obj) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bos)) {
+      out.writeObject(obj);
+      out.flush();
+      return bos.toByteArray();
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -250,11 +250,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.fieldfilter;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,7 +41,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.beanutils.PropertyUtils;
+import java.util.stream.Stream;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.NoOpCache;
@@ -173,7 +174,11 @@ class DefaultFieldFilterServiceTest {
 
   private static Property addProperty(
       Map<String, Property> propertyMap, Object bean, String property) throws Exception {
-    PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor(bean, property);
+    PropertyDescriptor pd =
+        Stream.of(Introspector.getBeanInfo(bean.getClass()).getPropertyDescriptors())
+            .filter(d -> d.getName().equals(property))
+            .findFirst()
+            .orElseThrow();
     Property p = new Property(pd.getPropertyType(), pd.getReadMethod(), pd.getWriteMethod());
     p.setName(pd.getName());
     p.setReadable(true);

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -270,11 +270,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core-jakarta</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -66,7 +66,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.ParserException;
@@ -113,6 +112,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -792,7 +792,9 @@ class ExpressionServiceTest extends PostgresIntegrationTestBase {
 
   private Object clone(Object object) {
     try {
-      return BeanUtils.cloneBean(object);
+      Object clone = object.getClass().getDeclaredConstructor().newInstance();
+      BeanUtils.copyProperties(object, clone);
+      return clone;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -61,6 +61,8 @@ import org.hisp.dhis.webapi.openapi.OpenApiObject.ResponseObject;
 import org.hisp.dhis.webapi.openapi.OpenApiObject.SchemaObject;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.springframework.transaction.annotation.Transactional;
@@ -140,6 +142,49 @@ class OpenApiControllerTest extends H2ControllerIntegrationTestBase {
         GET("/openapi/openapi.html?scope=entity.DataElement", Accept(TEXT_HTML_VALUE))
             .content(TEXT_HTML_VALUE);
     assertContains("#DataElement", html);
+  }
+
+  /**
+   * Reflected XSS regression: the {@code scope} request parameter is echoed into the page header,
+   * both as the scope key (rendered as a {@code <dt>}) and the scope value (rendered as the text of
+   * an {@code <a>}). HTML-significant characters are stripped when the scope is parsed, so an
+   * injected payload can never become live markup. The remaining inert text is still reflected.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    // malicious scope KEY -> <dt> sink
+    "'<script>alert(1)</script>:x', 'scriptalert(1)/script'",
+    // malicious scope VALUE -> <a> text sink
+    "'entity:<img/onerror=alert(1)>', 'img/onerror=alert(1)'",
+  })
+  void testGetOpenApiDocumentHtml_ScopeHtmlIsStripped(String scope, String strippedReflection) {
+    // MockMvc percent-encodes the raw payload into the request URI; the controller decodes it back.
+    String html =
+        GET("/openapi/openapi.html?scope={s}", scope, Accept(TEXT_HTML_VALUE))
+            .content(TEXT_HTML_VALUE);
+
+    assertFalse(html.contains("<script>alert(1)"), "script payload must not be live markup");
+    assertFalse(html.contains("<img/onerror=alert(1)"), "img payload must not be live markup");
+    // the scope is still reflected, only with the HTML-significant characters removed
+    assertContains(strippedReflection, html);
+  }
+
+  /**
+   * Reflected XSS regression: the scope value is concatenated into the inline {@code onclick}
+   * JavaScript ({@code setLocationSearch('scope', '...')}). A single quote previously broke out of
+   * that JS string literal; stripping it on input removes the breakout entirely.
+   */
+  @Test
+  void testGetOpenApiDocumentHtml_ScopeQuoteIsStrippedFromOnclickJs() {
+    String html =
+        GET("/openapi/openapi.html?scope={s}", "entity:x');alert(1);//", Accept(TEXT_HTML_VALUE))
+            .content(TEXT_HTML_VALUE);
+
+    // appendAttr HTML-escapes the onclick attribute, so a surviving single quote would appear as
+    // the entity &#039; right before the breakout. Stripping the quote on input removes it.
+    assertFalse(
+        html.contains("&#039;);alert(1)"),
+        "scope value must not break out of the onclick JS string");
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -90,6 +91,46 @@ class SqlViewControllerIntegrationTest extends PostgresControllerIntegrationTest
             .getObject("message")
             .toString()
             .contains("Query failed because of a syntax error"));
+  }
+
+  @Test
+  void sqlInjectionFilterColumnNameUnionTest() {
+    // The fixture views select 4 columns from optionvalue (uid, name, description,
+    // sort_order). On vulnerable master a payload that smuggles a 4-column UNION
+    // through the column-name slot returns userinfo.password (bcrypt) in the grid.
+    // After the fix, SqlUtils.quote() turns the entire payload into a non-existent
+    // identifier and Postgres rejects it. Either way, the response must not contain
+    // a bcrypt-formatted hash.
+    String injection = "1=1 UNION SELECT password, '', '', 0 FROM userinfo WHERE 'a'";
+    HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":neq:x");
+
+    JsonMixed body = response.contentUnchecked();
+    assertFalse(
+        body.toString().contains("$2a$"),
+        "Filter column-name slot is injectable: response leaked a bcrypt hash. Body: " + body);
+  }
+
+  @Test
+  void sqlInjectionFilterColumnNameCastTest() {
+    // Ahmed/M4xIq PoC (GHSA-pwmg-mvjw-4m23): smuggle a subquery via CAST(... AS int)
+    // in the column-name slot, exfiltrate via the Postgres type-cast error message
+    // ("invalid input syntax for type integer: \"<value>\"" embeds the subquery's
+    // text result). After the fix, the entire CAST(...) expression becomes a quoted
+    // identifier; Postgres errors out with "column does not exist" at parse time, so
+    // the inner SELECT never executes and no value is leaked.
+    String injection =
+        "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
+    HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":eq:1");
+
+    JsonMixed body = response.contentUnchecked();
+    String s = body.toString();
+    assertFalse(
+        s.contains("$2a$"),
+        "Filter column-name slot is injectable: response leaked a bcrypt hash. Body: " + body);
+    assertFalse(
+        s.toLowerCase().contains("invalid input syntax for type integer"),
+        "Filter column-name slot is injectable: Postgres CAST error surfaces attacker subquery output. Body: "
+            + body);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -118,8 +118,7 @@ class SqlViewControllerIntegrationTest extends PostgresControllerIntegrationTest
     // text result). After the fix, the entire CAST(...) expression becomes a quoted
     // identifier; Postgres errors out with "column does not exist" at parse time, so
     // the inner SELECT never executes and no value is leaked.
-    String injection =
-        "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
+    String injection = "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
     HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":eq:1");
 
     JsonMixed body = response.contentUnchecked();

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -216,10 +216,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-hibernate</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
@@ -38,11 +38,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.Response.Status;
@@ -61,6 +59,7 @@ import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -198,14 +197,11 @@ public class DatastoreController extends AbstractDatastoreController {
       @PathVariable String namespace,
       @PathVariable String key,
       @CurrentUser UserDetails currentUser)
-      throws NotFoundException,
-          InvocationTargetException,
-          IllegalAccessException,
-          ForbiddenException {
+      throws NotFoundException, ForbiddenException {
     DatastoreEntry entry = getExistingEntry(namespace, key);
 
     DatastoreEntry metaData = new DatastoreEntry();
-    BeanUtils.copyProperties(metaData, entry);
+    BeanUtils.copyProperties(entry, metaData);
     metaData.setValue(null);
     metaData.setJbPlainValue(null);
     metaData.setEncryptedValue(null);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -279,8 +279,11 @@ public class OpenApiController {
     for (String s : scoping.scope) {
       int split = s.indexOf(':');
       if (split > 0) {
-        String key = s.substring(0, split);
-        String value = s.substring(split + 1);
+        // The scope key/value come from the `scope` request parameter and are reflected into the
+        // generated HTML page header. Strip any HTML-significant characters here, at the single
+        // point where the scope is parsed, so no untrusted markup can reach those rendering sinks.
+        String key = OpenApiHtmlUtils.stripHtml(s.substring(0, split));
+        String value = OpenApiHtmlUtils.stripHtml(s.substring(split + 1));
         filters.computeIfAbsent(key, k -> new HashSet<>()).add(value);
       }
     }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -195,7 +195,6 @@
     <joda-time.version>2.14.1</joda-time.version>
     <cron-utils.version>9.2.1</cron-utils.version>
     <commons-collections4.version>4.5.0</commons-collections4.version>
-    <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-text.version>1.15.0</commons-text.version>
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
@@ -851,17 +850,6 @@
         <version>${commons-collections4.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>${commons-beanutils.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
@@ -886,6 +874,10 @@
         <artifactId>commons-validator</artifactId>
         <version>${commons-validator.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-digester</groupId>
             <artifactId>commons-digester</artifactId>
@@ -1187,6 +1179,10 @@
             <groupId>org.jfree</groupId>
             <artifactId>jcommon</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1476,6 +1472,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Security fixes backported to `patch/2.42.5.1` for the coordinated release.

- #148 — quote SQL view filter column name to block identifier-slot SQL injection (CRITICAL)
- #188 — strip HTML from `openapi.html` scope parameter to prevent reflected XSS
- #213 — add ObjectInputFilter allowlist to HibernateUserSettingStore deserialization
- #214 — remove commons-collections 3.x gadget classes from the classpath

All commits GPG-signed; cherry-picked from the embargoed fixes and dry-run-verified clean against this branch. For the security release.

AI Assisted
