### PR TITLE
security backport:#148 → patch/2.40.11.1

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -264,7 +264,7 @@ public class DefaultSqlViewService implements SqlViewService {
     filter +=
         sqlHelper.whereAnd()
             + " "
-            + columnName
+            + SqlUtils.quote(columnName)
             + " "
             + operatorWithPlaceHolderAndArg.getOperatorWithPlaceholder();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.query.QueryUtils.OperatorWithPlaceHolderAndArg;
 import org.hisp.dhis.query.QueryUtils.PlaceholderQueryWithArgs;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
@@ -123,7 +123,7 @@ class RouteControllerTest extends DhisControllerIntegrationTest {
   @BeforeAll
   public static void beforeAll() {
     upstreamMockServerContainer =
-        new GenericContainer<>("mockserver/mockserver")
+        new GenericContainer<>("mockserver/mockserver:5.15.0")
             .waitingFor(new HttpWaitStrategy().forStatusCode(404))
             .withExposedPorts(1080);
     upstreamMockServerContainer.start();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -100,7 +100,7 @@ class SqlViewControllerIntegrationTest extends DhisControllerIntegrationTest {
     String injection = "1=1 UNION SELECT password, '', '', 0 FROM userinfo WHERE 'a'";
     HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":neq:x");
 
-    JsonMixed body = response.contentUnchecked();
+    String body = response.contentUnchecked().toString();
     assertFalse(
         body.toString().contains("$2a$"),
         "Filter column-name slot is injectable: response leaked a bcrypt hash. Body: " + body);
@@ -117,7 +117,7 @@ class SqlViewControllerIntegrationTest extends DhisControllerIntegrationTest {
     String injection = "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
     HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":eq:1");
 
-    JsonMixed body = response.contentUnchecked();
+    String body = response.contentUnchecked().toString();
     String s = body.toString();
     assertFalse(
         s.contains("$2a$"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -114,8 +114,7 @@ class SqlViewControllerIntegrationTest extends DhisControllerIntegrationTest {
     // text result). After the fix, the entire CAST(...) expression becomes a quoted
     // identifier; Postgres errors out with "column does not exist" at parse time, so
     // the inner SELECT never executes and no value is leaked.
-    String injection =
-        "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
+    String injection = "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
     HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":eq:1");
 
     JsonMixed body = response.contentUnchecked();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.web.HttpStatus.CONFLICT;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.HttpStatus.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -86,6 +87,46 @@ class SqlViewControllerIntegrationTest extends DhisControllerIntegrationTest {
             .getObject("message")
             .toString()
             .contains("Query failed because of a syntax error"));
+  }
+
+  @Test
+  void sqlInjectionFilterColumnNameUnionTest() {
+    // The fixture views select 4 columns from optionvalue (uid, name, description,
+    // sort_order). On vulnerable master a payload that smuggles a 4-column UNION
+    // through the column-name slot returns userinfo.password (bcrypt) in the grid.
+    // After the fix, SqlUtils.quote() turns the entire payload into a non-existent
+    // identifier and Postgres rejects it. Either way, the response must not contain
+    // a bcrypt-formatted hash.
+    String injection = "1=1 UNION SELECT password, '', '', 0 FROM userinfo WHERE 'a'";
+    HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":neq:x");
+
+    JsonMixed body = response.contentUnchecked();
+    assertFalse(
+        body.toString().contains("$2a$"),
+        "Filter column-name slot is injectable: response leaked a bcrypt hash. Body: " + body);
+  }
+
+  @Test
+  void sqlInjectionFilterColumnNameCastTest() {
+    // Ahmed/M4xIq PoC (GHSA-pwmg-mvjw-4m23): smuggle a subquery via CAST(... AS int)
+    // in the column-name slot, exfiltrate via the Postgres type-cast error message
+    // ("invalid input syntax for type integer: \"<value>\"" embeds the subquery's
+    // text result). After the fix, the entire CAST(...) expression becomes a quoted
+    // identifier; Postgres errors out with "column does not exist" at parse time, so
+    // the inner SELECT never executes and no value is leaked.
+    String injection =
+        "CAST((SELECT password FROM userinfo WHERE username='admin') AS int)";
+    HttpResponse response = GET(QUERY_PATH + "?filter=" + injection + ":eq:1");
+
+    JsonMixed body = response.contentUnchecked();
+    String s = body.toString();
+    assertFalse(
+        s.contains("$2a$"),
+        "Filter column-name slot is injectable: response leaked a bcrypt hash. Body: " + body);
+    assertFalse(
+        s.toLowerCase().contains("invalid input syntax for type integer"),
+        "Filter column-name slot is injectable: Postgres CAST error surfaces attacker subquery output. Body: "
+            + body);
   }
 
   @Test


### PR DESCRIPTION
Security fixes backported to `patch/2.40.11.1` for the coordinated release.

- #148 — quote SQL view filter column name to block identifier-slot SQL injection (CRITICAL)

All commits GPG-signed; cherry-picked from the embargoed fixes and dry-run-verified clean against this branch. For the security release.

AI Assisted
