### PR TITLE
security backport:#148 → 2.38

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -208,7 +208,7 @@ public class DefaultSqlViewService implements SqlViewService {
     query +=
         sqlHelper.whereAnd()
             + " "
-            + columnName
+            + statementBuilder.columnQuote(columnName)
             + " "
             + QueryUtils.parseFilterOperator(operator, value);
 


### PR DESCRIPTION
Security fixes backported to `2.38` for the coordinated release.

- #148 — quote SQL view filter column name to block identifier-slot SQL injection (CRITICAL)

All commits GPG-signed; cherry-picked from the embargoed fixes and dry-run-verified clean against this branch. For the security release.

AI Assisted
