### PR TITLE
ci: build and publish EOS docker image

### DIFF
--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -13,11 +13,18 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout(time: 30)
+        timeout(time: 60)
     }
 
     environment {
         MAVEN_OPTS = '-Xms1024m -Xmx4096m -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125'
+        DHIS2_VERSION = readMavenPom(file: 'dhis-2/pom.xml').getVersion()
+        DOCKER_IMAGE_NAME = "${DOCKER_HUB_OWNER}/core"
+        DOCKER_IMAGE_TAG = "${env.GIT_BRANCH}-eos"
+        DOCKER_IMAGE_NAME_FULL = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+        IMAGE_REPOSITORY = "${DOCKER_IMAGE_NAME}"
+        // THIS MUST be kept in sync with the jib.from.image in the dhis-web-portal pom.xml
+        BASE_IMAGE = "tomcat:9.0.96-jre11"
     }
 
     stages {
@@ -28,6 +35,42 @@ pipeline {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
                         sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
                         sh 'mvn -X -T 4 --batch-mode --no-transfer-progress package -f dhis-2/dhis-web/pom.xml --update-snapshots'
+                    }
+                }
+            }
+        }
+
+        stage ('Build and publish Docker image') {
+            steps {
+                withDockerRegistry([credentialsId: "docker-hub-credentials", url: ""]) {
+                    withMaven(options: [artifactsPublisher(disabled: true)]) {
+                        // EOS maintenance build: publish a single rolling "<major.minor>-eos" tag.
+                        // -d skips the immutable timestamp and rolling M/M.m tags (reserved for releases).
+                        sh './dhis-2/build-docker-image.sh -t "${DOCKER_IMAGE_TAG}" -d'
+                    }
+                }
+            }
+        }
+
+        stage ('Smoke test') {
+            steps {
+                // Non-blocking: a stale e2e suite must not block publishing the EOS image.
+                catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'EOS smoke test failed') {
+                    dir('dhis-2/dhis-test-e2e') {
+                        sh "docker pull ${DOCKER_IMAGE_NAME_FULL}"
+                        sh "DHIS2_IMAGE=${DOCKER_IMAGE_NAME_FULL} docker compose --file docker-compose.yml --file docker-compose.e2e.yml up --remove-orphans --exit-code-from test"
+                    }
+                }
+            }
+
+            post {
+                always {
+                    script {
+                        dir('dhis-2/dhis-test-e2e') {
+                            archiveArtifacts artifacts: 'coverage.csv', allowEmptyArchive: true
+                            sh 'docker compose logs web > web-logs.txt || true'
+                            archiveArtifacts artifacts: 'web-logs.txt', allowEmptyArchive: true
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adds Docker image build, publish, and a non-blocking smoke test to the EOS pipeline for the `2.39` branch.

Publishes `dhis2/core:2.39-eos` (base `tomcat:9.0.96-jre11`) via `build-docker-image.sh -d`, then runs the e2e suite as a non-blocking smoke test. The eos pipeline runs once `2.39` is added to the eos job's branch filter.

Part of #24163.