### PR TITLE
test: fix flaky RouteControllerTest.beforeAll timeout (probe on patch/2.41.8.2)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
@@ -75,6 +75,7 @@ import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockserver.client.MockServerClient;
 import org.postgresql.util.PGobject;
@@ -122,6 +123,10 @@ class RouteControllerTest extends DhisControllerIntegrationTest {
   }
 
   @BeforeAll
+  // Starting the Testcontainers upstream mock server pulls the Docker image on a cold runner,
+  // which can exceed the global 1m junit timeout and abort the whole class (flaky). Allow more
+  // time for container startup specifically for this lifecycle method.
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
   public static void beforeAll() {
     upstreamMockServerContainer =
         new GenericContainer<>("mockserver/mockserver")

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RouteControllerTest.java
@@ -129,7 +129,7 @@ class RouteControllerTest extends DhisControllerIntegrationTest {
   @Timeout(value = 5, unit = TimeUnit.MINUTES)
   public static void beforeAll() {
     upstreamMockServerContainer =
-        new GenericContainer<>("mockserver/mockserver")
+        new GenericContainer<>("mockserver/mockserver:5.15.0")
             .waitingFor(new HttpWaitStrategy().forStatusCode(404))
             .withExposedPorts(1080);
     upstreamMockServerContainer.start();


### PR DESCRIPTION
## Purpose
Fix the flaky `RouteControllerTest.beforeAll` failures seen on the 2.41.8.2 security backport (#24147). Not related to the security change.

## Root cause
`beforeAll` starts a Testcontainers `mockserver/mockserver` container as the upstream mock, with an **unpinned** image tag:
```java
new GenericContainer<>("mockserver/mockserver")
    .waitingFor(new HttpWaitStrategy().forStatusCode(404))
```
The `:latest` tag has drifted to **mockserver 7.0.0**, which returns **HTTP 502** at `/` instead of the `404` the wait strategy expects, so container startup never completes. On a fresh runner that pulls 7.0.0, the wait strategy spins and JUnit's global `1m` `beforeAll` timeout kills the whole class. That superficially looks like a slow image pull, but it is not: a runner with an older cached `:latest` (which still returns 404) passes, hence the flakiness.

Verified locally: `mockserver:5.15.0` → `GET /` returns **404** (wait strategy passes, all 16 tests run); `mockserver:7.0.0` (current `:latest`) → `GET /` returns **502** (`beforeAll` fails deterministically).

## Fix
Pin the image to `mockserver/mockserver:5.15.0`, matching what `master` already does. The `@Timeout(5, MINUTES)` on `beforeAll` is kept as defensive cover for genuinely slow cold pulls.

## Note
`EventHookControllerTest` uses the same unpinned Testcontainers-in-`beforeAll` pattern (#24158) and would want the same pin.

AI Assisted
