### PR TITLE
security backport: #22253 + #148 → 2.39 [DHIS2-20174]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
@@ -42,7 +42,14 @@ public interface SqlViewStore extends IdentifiableObjectStore<SqlView> {
 
   void dropViewTable(SqlView sqlView);
 
-  void populateSqlViewGrid(Grid grid, String sql);
+  /**
+   * Populates the given grid with the results of the given SQL query.
+   *
+   * @param grid the {@link Grid} to populate with the results of the sql query.
+   * @param sql the sql query to execute.
+   * @param args the args to bind to the query placeholders.
+   */
+  void populateSqlViewGrid(Grid grid, String sql, Object[] args);
 
   /**
    * Tests the given SQL for validity.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -235,7 +235,7 @@ public class DefaultSqlViewService implements SqlViewService {
     filter +=
         sqlHelper.whereAnd()
             + " "
-            + columnName
+            + statementBuilder.columnQuote(columnName)
             + " "
             + operatorWithPlaceHolderAndArg.getOperatorWithPlaceholder();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.sqlview;
 
+import static org.hisp.dhis.query.QueryUtils.parseStringValue;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USERNAME_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USER_ID_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.STANDARD_VARIABLES;
@@ -34,6 +35,8 @@ import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryParams;
 import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryValues;
 
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +53,8 @@ import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryUtils;
+import org.hisp.dhis.query.QueryUtils.OperatorWithPlaceHolderAndArg;
+import org.hisp.dhis.query.QueryUtils.PlaceholderQueryWithArgs;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.user.CurrentUserService;
@@ -166,12 +171,17 @@ public class DefaultSqlViewService implements SqlViewService {
 
     log.info(String.format("Retrieving data for SQL view: '%s'", sqlView.getUid()));
 
-    String sql =
+    PlaceholderQueryWithArgs placeholderQueryWithArgs =
         sqlView.isQuery()
             ? getSqlForQuery(sqlView, criteria, variables, filters, fields)
             : getSqlForView(sqlView, criteria, filters, fields);
 
-    sqlViewStore.populateSqlViewGrid(grid, sql);
+    sqlViewStore.populateSqlViewGrid(
+        grid,
+        placeholderQueryWithArgs.getPlaceholderQuery(),
+        placeholderQueryWithArgs.getArgs() == null
+            ? null
+            : placeholderQueryWithArgs.getArgs().toArray());
 
     return grid;
   }
@@ -183,39 +193,56 @@ public class DefaultSqlViewService implements SqlViewService {
     }
   }
 
-  private String parseFilters(List<String> filters, SqlHelper sqlHelper)
+  private PlaceholderQueryWithArgs parseFilters(List<String> filters, SqlHelper sqlHelper)
       throws QueryParserException {
-    String query = "";
+    StringBuilder query = new StringBuilder();
+    List<Object> queryArgs = new ArrayList<>();
 
-    for (String filter : filters) {
+    for (int i = 0; i < filters.size(); i++) {
+      String filter = filters.get(i);
       String[] split = filter.split(":");
 
       if (split.length == 3) {
         int index = split[0].length() + ":".length() + split[1].length() + ":".length();
-        query += getFilterQuery(sqlHelper, split[0], split[1], filter.substring(index));
+        OperatorWithPlaceHolderAndArg filterQuery =
+            getFilterQuery(sqlHelper, split[0], split[1], filter.substring(index));
+        query.append(filterQuery.getOperatorWithPlaceholder());
+
+        // this arg could be a collection, so need to add each (not the collection)
+        if (filterQuery.getArg() instanceof Collection<?>) {
+          Collection<?> collection = (Collection<?>) filterQuery.getArg();
+          queryArgs.addAll(collection);
+        } else {
+          queryArgs.add(filterQuery.getArg());
+        }
+      } else if (split.length == 2 && (split[1].equals("null") || split[1].equals("!null"))) {
+        query.append(
+            getFilterQuery(sqlHelper, split[0], split[1], null).getOperatorWithPlaceholder());
       } else {
         throw new QueryParserException("Invalid filter => " + filter);
       }
     }
 
-    return query;
+    return new PlaceholderQueryWithArgs(query.toString(), queryArgs);
   }
 
-  private String getFilterQuery(
+  private OperatorWithPlaceHolderAndArg getFilterQuery(
       SqlHelper sqlHelper, String columnName, String operator, String value) {
-    String query = "";
+    String filter = "";
+    OperatorWithPlaceHolderAndArg operatorWithPlaceHolderAndArg =
+        QueryUtils.parseFilterOperator(operator, value);
 
-    query +=
+    filter +=
         sqlHelper.whereAnd()
             + " "
             + columnName
             + " "
-            + QueryUtils.parseFilterOperator(operator, value);
+            + operatorWithPlaceHolderAndArg.getOperatorWithPlaceholder();
 
-    return query;
+    return new OperatorWithPlaceHolderAndArg(filter, operatorWithPlaceHolderAndArg.getArg());
   }
 
-  private String getSqlForQuery(
+  private PlaceholderQueryWithArgs getSqlForQuery(
       SqlView sqlView,
       Map<String, String> criteria,
       Map<String, String> variables,
@@ -227,6 +254,7 @@ public class DefaultSqlViewService implements SqlViewService {
 
     String sql = substituteQueryVariables(sqlView, variables);
 
+    List<Object> args = new ArrayList<>();
     if (hasCriteria || hasFilter) {
       sql = SqlViewUtils.removeQuerySeparator(sql);
 
@@ -236,17 +264,23 @@ public class DefaultSqlViewService implements SqlViewService {
       SqlHelper sqlHelper = new SqlHelper();
 
       if (hasCriteria) {
-        outerSql += getCriteriaSqlClause(criteria, sqlHelper);
+        PlaceholderQueryWithArgs placeholderQueryWithArgs =
+            getCriteriaSqlClause(criteria, sqlHelper);
+        outerSql += placeholderQueryWithArgs.getPlaceholderQuery();
+        args.addAll(placeholderQueryWithArgs.getArgs());
       }
 
       if (hasFilter) {
-        outerSql += parseFilters(filters, sqlHelper);
+        PlaceholderQueryWithArgs placeholderQueryWithArgs = parseFilters(filters, sqlHelper);
+        outerSql += placeholderQueryWithArgs.getPlaceholderQuery();
+        args.addAll(placeholderQueryWithArgs.getArgs());
+        return new PlaceholderQueryWithArgs(outerSql, args);
       }
 
-      sql = outerSql;
+      return new PlaceholderQueryWithArgs(outerSql, args);
     }
 
-    return sql;
+    return new PlaceholderQueryWithArgs(sql, null);
   }
 
   private String substituteQueryVariables(SqlView sqlView, Map<String, String> variables) {
@@ -266,7 +300,7 @@ public class DefaultSqlViewService implements SqlViewService {
     return sql;
   }
 
-  private String getSqlForView(
+  private PlaceholderQueryWithArgs getSqlForView(
       SqlView sqlView, Map<String, String> criteria, List<String> filters, List<String> fields) {
     String sql =
         "select "
@@ -279,39 +313,44 @@ public class DefaultSqlViewService implements SqlViewService {
 
     boolean hasFilter = filters != null && !filters.isEmpty();
 
+    List<Object> args = new ArrayList<>();
     if (hasCriteria || hasFilter) {
       SqlHelper sqlHelper = new SqlHelper();
 
       if (hasCriteria) {
-        sql += getCriteriaSqlClause(criteria, sqlHelper);
+        PlaceholderQueryWithArgs sqlQueryWithArgs = getCriteriaSqlClause(criteria, sqlHelper);
+        sql += sqlQueryWithArgs.getPlaceholderQuery();
+        args.addAll(sqlQueryWithArgs.getArgs());
       }
 
       if (hasFilter) {
-        sql += parseFilters(filters, sqlHelper);
+        PlaceholderQueryWithArgs sqlQueryWithArgs = parseFilters(filters, sqlHelper);
+        sql += sqlQueryWithArgs.getPlaceholderQuery();
+        args.addAll(sqlQueryWithArgs.getArgs());
       }
+      return new PlaceholderQueryWithArgs(sql, args);
     }
 
-    return sql;
+    return new PlaceholderQueryWithArgs(sql, null);
   }
 
-  private String getCriteriaSqlClause(Map<String, String> criteria, SqlHelper sqlHelper) {
-    String sql = "";
+  private PlaceholderQueryWithArgs getCriteriaSqlClause(
+      Map<String, String> criteria, SqlHelper sqlHelper) {
+    StringBuilder sql = new StringBuilder();
 
+    List<Object> args = new ArrayList<>();
     if (criteria != null && !criteria.isEmpty()) {
       sqlHelper = ObjectUtils.firstNonNull(sqlHelper, new SqlHelper());
 
-      for (String filter : criteria.keySet()) {
-        sql +=
-            sqlHelper.whereAnd()
-                + " "
-                + statementBuilder.columnQuote(filter)
-                + "='"
-                + criteria.get(filter)
-                + "' ";
+      for (Map.Entry<String, String> criterion : criteria.entrySet()) {
+        sql.append(sqlHelper.whereAnd())
+            .append(" ")
+            .append(statementBuilder.columnQuote(criterion.getKey()))
+            .append(" = ? ");
+        args.add(parseStringValue(criterion.getValue()));
       }
     }
-
-    return sql;
+    return new PlaceholderQueryWithArgs(sql.toString(), args);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
@@ -140,8 +140,8 @@ public class HibernateSqlViewStore extends HibernateIdentifiableObjectStore<SqlV
   }
 
   @Override
-  public void populateSqlViewGrid(Grid grid, String sql) {
-    SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet(sql);
+  public void populateSqlViewGrid(Grid grid, String sql, Object[] args) {
+    SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet(sql, args);
 
     int maxLimit = systemSettingManager.getIntSetting(SettingKey.SQL_VIEW_MAX_LIMIT);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerIntegrationTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.HttpStatus.CONFLICT;
+import static org.hisp.dhis.web.HttpStatus.CREATED;
+import static org.hisp.dhis.web.HttpStatus.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests the {@link SqlViewController} using (mocked) REST requests. Using Postgres DB to test
+ * actual views with criteria, filter & field queries.
+ *
+ * @author David Mackessy
+ */
+class SqlViewControllerIntegrationTest extends DhisControllerIntegrationTest {
+
+  private static final String QUERY_PATH = "/sqlViews/sqlViewUid1/data";
+  private static final String VIEW_PATH = "/sqlViews/sqlViewUid2/data";
+
+  @BeforeEach
+  void beforeEach() {
+    setupMetadataAndSqlViews();
+  }
+
+  @Test
+  void sqlInjectionFilterTest() {
+    HttpResponse response =
+        GET(
+            QUERY_PATH
+                + "?filter=name:ilike:\"test' AND CAST((SELECT password FROM userinfo WHERE username='admin') AS INTEGER) = 1 AND name ILIKE '\"");
+    assertEquals(0, response.content(OK).getObject("pager").getNumber("total").intValue());
+  }
+
+  @Test
+  void sqlInjectionFieldTest() {
+    HttpResponse response =
+        GET(
+            QUERY_PATH
+                + "?fields=*,(SELECT password FROM userinfo WHERE username='admin') AS admin_hash"
+                + "&filter=name:ilike:test");
+    assertTrue(
+        response
+            .content(CONFLICT)
+            .getObject("message")
+            .toString()
+            .contains("Query failed because of a syntax error"));
+  }
+
+  @Test
+  void filterCriteriaFieldsQueryTest() {
+    HttpResponse response =
+        GET(QUERY_PATH + "?fields=uid&filter=uid:ilike:uid&criteria=sort_order:2");
+    assertFilterResponse(response.content(OK), 2, Set.of("optionUidz3", "optionUidz2"));
+  }
+
+  @Test
+  void filterCriteriaFieldsViewTest() {
+    HttpResponse response =
+        GET(VIEW_PATH + "?fields=uid&filter=uid:ilike:uid&criteria=sort_order:2");
+    assertFilterResponse(response.content(OK), 2, Set.of("optionUidz3", "optionUidz2"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("sqlViewFilterQueries")
+  void queryFilterTest(String query, Set<String> expectedUids, int expectedNumResults) {
+    JsonResponse content = GET(query).content(OK);
+    assertFilterResponse(content, expectedNumResults, expectedUids);
+  }
+
+  @ParameterizedTest
+  @MethodSource("sqlViewFieldQueries")
+  void queryFieldsTest(
+      String query,
+      Set<String> expectedFields,
+      Set<String> expectedValues,
+      int expectedNumResults) {
+    JsonResponse content = GET(query).content(OK);
+    assertFieldsResponse(content, expectedNumResults, expectedFields, expectedValues);
+  }
+
+  @ParameterizedTest
+  @MethodSource("sqlViewCriteriaQueries")
+  void queryCriteriaTest(String query, Set<String> expectedValues, int expectedNumResults) {
+    JsonResponse content = GET(query).content(OK);
+    assertFilterResponse(content, expectedNumResults, expectedValues);
+  }
+
+  public static Stream<Arguments> sqlViewFilterQueries() {
+    return Stream.of(
+        // -------------
+        // QUERY TYPE
+        // -------------
+        Arguments.of(
+            QUERY_PATH, Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"), 4),
+
+        // single filter
+        Arguments.of(QUERY_PATH + "?filter=uid:eq:optionUidz2", Set.of("optionUidz2"), 1),
+        Arguments.of(QUERY_PATH + "?filter=uid:ieq:optionuidz2", Set.of("optionUidz2"), 1),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:!eq:optionUidz2",
+            Set.of("optionUidz1", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=sort_order:gt:1",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(QUERY_PATH + "?filter=sort_order:lt:2", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            QUERY_PATH + "?filter=sort_order:gte:2",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=sort_order:lte:2",
+            Set.of("optionUidz2", "optionUidz3", "optionUidz1"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:like:optionUid",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(QUERY_PATH + "?filter=uid:!like:optionUidz", Set.of("optionUid11"), 1),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:^like:optionUidz",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3"),
+            3),
+        Arguments.of(QUERY_PATH + "?filter=uid:!^like:optionUidz", Set.of("optionUid11"), 1),
+        Arguments.of(QUERY_PATH + "?filter=uid:$like:optionUidz1", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:!$like:optionUidz1",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:ilike:optionuid",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:!ilike:optionuidz2",
+            Set.of("optionUidz1", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:^ilike:optionuidz",
+            Set.of("optionUidz2", "optionUidz3", "optionUidz1"),
+            3),
+        Arguments.of(QUERY_PATH + "?filter=uid:!^ilike:optionuidz", Set.of("optionUid11"), 1),
+        Arguments.of(QUERY_PATH + "?filter=uid:$ilike:optionuidz", Set.of(), 0),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:!$ilike:optionuidz",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:in:[optionUidz2,optionUidz1]",
+            Set.of("optionUidz2", "optionUidz1"),
+            2),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:!in:[optionUidz2,optionUidz1]",
+            Set.of("optionUidz3", "optionUid11"),
+            2),
+        Arguments.of(
+            QUERY_PATH + "?filter=description:null",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(QUERY_PATH + "?filter=description:!null", Set.of("optionUidz1"), 1),
+
+        // multiple filters
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:like:optionUidz&filter=name:like:option",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3"),
+            3),
+        Arguments.of(
+            QUERY_PATH + "?filter=uid:in:[optionUidz2,optionUidz1]&filter=name:like:1",
+            Set.of("optionUidz1"),
+            1),
+
+        // -------------
+        // VIEW TYPE
+        // -------------
+        Arguments.of(
+            VIEW_PATH, Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"), 4),
+
+        // single filter
+        Arguments.of(VIEW_PATH + "?filter=uid:eq:optionUidz2", Set.of("optionUidz2"), 1),
+        Arguments.of(VIEW_PATH + "?filter=uid:ieq:optionuidz2", Set.of("optionUidz2"), 1),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:!eq:optionUidz2",
+            Set.of("optionUidz1", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=sort_order:gt:1",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(VIEW_PATH + "?filter=sort_order:lt:2", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            VIEW_PATH + "?filter=sort_order:gte:2",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=sort_order:lte:2",
+            Set.of("optionUidz2", "optionUidz3", "optionUidz1"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:like:optionUid",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(VIEW_PATH + "?filter=uid:!like:optionUidz", Set.of("optionUid11"), 1),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:^like:optionUidz",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3"),
+            3),
+        Arguments.of(VIEW_PATH + "?filter=uid:!^like:optionUidz", Set.of("optionUid11"), 1),
+        Arguments.of(VIEW_PATH + "?filter=uid:$like:optionUidz1", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:!$like:optionUidz1",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:ilike:optionuid",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:!ilike:optionuidz2",
+            Set.of("optionUidz1", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:^ilike:optionuidz",
+            Set.of("optionUidz2", "optionUidz3", "optionUidz1"),
+            3),
+        Arguments.of(VIEW_PATH + "?filter=uid:!^ilike:optionuidz", Set.of("optionUid11"), 1),
+        Arguments.of(VIEW_PATH + "?filter=uid:$ilike:optionuidz", Set.of(), 0),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:!$ilike:optionuidz",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3", "optionUid11"),
+            4),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:in:[optionUidz2,optionUidz1]",
+            Set.of("optionUidz2", "optionUidz1"),
+            2),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:!in:[optionUidz2,optionUidz1]",
+            Set.of("optionUidz3", "optionUid11"),
+            2),
+        Arguments.of(
+            VIEW_PATH + "?filter=description:null",
+            Set.of("optionUidz2", "optionUidz3", "optionUid11"),
+            3),
+        Arguments.of(VIEW_PATH + "?filter=description:!null", Set.of("optionUidz1"), 1),
+
+        // multiple filters
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:like:optionUidz&filter=name:like:option",
+            Set.of("optionUidz1", "optionUidz2", "optionUidz3"),
+            3),
+        Arguments.of(
+            VIEW_PATH + "?filter=uid:in:[optionUidz2,optionUidz1]&filter=name:like:1",
+            Set.of("optionUidz1"),
+            1));
+  }
+
+  /**
+   * Fields queries also contain a filter condition as views of type QUERY only apply the fields
+   * param when with a filter or criteria param
+   */
+  public static Stream<Arguments> sqlViewFieldQueries() {
+    return Stream.of(
+        // -------------
+        // QUERY TYPE
+        // -------------
+        Arguments.of(
+            QUERY_PATH + "?fields=*&filter=uid:ilike:uid",
+            Set.of("uid", "name", "description", "sort_order"),
+            Set.of("optionUidz1", "test option 1", "test description", "1"),
+            4),
+        Arguments.of(
+            QUERY_PATH + "?fields=uid&filter=uid:ilike:uid",
+            Set.of("uid"),
+            Set.of("optionUidz2"),
+            4),
+        Arguments.of(
+            QUERY_PATH + "?fields=name,description&filter=name:ilike:test",
+            Set.of("name", "description"),
+            Set.of("test option 3", ""),
+            4),
+
+        // -------------
+        // VIEW TYPE
+        // -------------
+        Arguments.of(
+            VIEW_PATH + "?fields=*&filter=uid:ilike:uid",
+            Set.of("uid", "name", "description", "sort_order"),
+            Set.of("optionUidz1", "test option 1", "test description", "1"),
+            4),
+        Arguments.of(
+            VIEW_PATH + "?fields=uid&filter=uid:ilike:uid",
+            Set.of("uid"),
+            Set.of("optionUidz2"),
+            4),
+        Arguments.of(
+            VIEW_PATH + "?fields=name,description&filter=name:ilike:test",
+            Set.of("name", "description"),
+            Set.of("test option 3", ""),
+            4));
+  }
+
+  public static Stream<Arguments> sqlViewCriteriaQueries() {
+    return Stream.of(
+        // -------------
+        // QUERY TYPE
+        // -------------
+        Arguments.of(QUERY_PATH + "?criteria=name:test option 1", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            QUERY_PATH + "?criteria=sort_order:2", Set.of("optionUidz2", "optionUidz3"), 2),
+        Arguments.of(
+            QUERY_PATH + "?criteria=sort_order:2&criteria=uid:optionUidz2",
+            Set.of("optionUidz2"),
+            1),
+
+        // -------------
+        // VIEW TYPE
+        // -------------
+        Arguments.of(QUERY_PATH + "?criteria=name:test option 1", Set.of("optionUidz1"), 1),
+        Arguments.of(
+            QUERY_PATH + "?criteria=sort_order:2", Set.of("optionUidz2", "optionUidz3"), 2),
+        Arguments.of(
+            QUERY_PATH + "?criteria=sort_order:2&criteria=uid:optionUidz2",
+            Set.of("optionUidz2"),
+            1));
+  }
+
+  private void assertFilterResponse(
+      JsonResponse content, int expectedSize, Set<String> expectedUids) {
+    assertEquals(expectedSize, content.getObject("pager").getNumber("total").intValue());
+
+    JsonArray rows = content.getObject("listGrid").getArray("rows");
+    for (int i = 0; i < rows.size(); i++) {
+      JsonList<JsonString> rowData = rows.get(i).asList(JsonString.class);
+      assertTrue(rowData.stream().anyMatch(row -> expectedUids.contains(row.string())));
+    }
+  }
+
+  private void assertFieldsResponse(
+      JsonResponse content,
+      int expectedSize,
+      Set<String> expectedFields,
+      Set<String> expectedValues) {
+    assertEquals(expectedSize, content.getObject("pager").getNumber("total").intValue());
+
+    JsonArray headers = content.getObject("listGrid").getArray("headers");
+    JsonArray rows = content.getObject("listGrid").getArray("rows");
+    for (int i = 0; i < headers.size(); i++) {
+      JsonObject header = headers.get(i).asObject();
+      assertTrue(expectedFields.contains(header.getString("column").string()));
+    }
+
+    assertTrue(
+        rows.asList(JsonString.class).stream()
+            .anyMatch(
+                row ->
+                    expectedValues.containsAll(
+                        row.asList(JsonString.class).stream()
+                            .map(JsonString::string)
+                            .collect(Collectors.toSet()))));
+  }
+
+  void setupMetadataAndSqlViews() {
+    POST("/metadata?async=false", metadata()).content(OK);
+    POST("/sqlViews/", sqlQueryView()).content(CREATED);
+    POST("/sqlViews/", sqlView()).content(CREATED);
+    POST("/sqlViews/sqlViewUid2/execute").content(CREATED);
+  }
+
+  private String sqlQueryView() {
+    return "{\n"
+        + "    \"id\": \"sqlViewUid1\",\n"
+        + "    \"sqlQuery\": \"SELECT uid, name, description, sort_order FROM optionvalue\",\n"
+        + "    \"type\": \"QUERY\",\n"
+        + "    \"name\": \"test-sql-view1\",\n"
+        + "    \"cacheStrategy\": \"NO_CACHE\"\n"
+        + "}";
+  }
+
+  private String sqlView() {
+    return "{\n"
+        + "    \"id\": \"sqlViewUid2\",\n"
+        + "    \"sqlQuery\": \"SELECT uid, name, description, sort_order FROM optionvalue\",\n"
+        + "    \"type\": \"VIEW\",\n"
+        + "    \"name\": \"test-sql-view2\",\n"
+        + "    \"cacheStrategy\": \"NO_CACHE\"\n"
+        + "}";
+  }
+
+  private String metadata() {
+    return "{\n"
+        + "    \"options\": [\n"
+        + "        {\n"
+        + "            \"id\": \"optionUidz1\",\n"
+        + "            \"name\": \"test option 1\",\n"
+        + "            \"code\": \"test option 1\",\n"
+        + "            \"sortOrder\": 1,\n"
+        + "            \"description\": \"test description\"\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"id\": \"optionUidz2\",\n"
+        + "            \"name\": \"test option 2\",\n"
+        + "            \"code\": \"test option 2\",\n"
+        + "            \"sortOrder\": 2\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"id\": \"optionUidz3\",\n"
+        + "            \"name\": \"test option 3\",\n"
+        + "            \"code\": \"test option 3\",\n"
+        + "            \"sortOrder\": 2\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"id\": \"optionUid11\",\n"
+        + "            \"name\": \"test option 11\",\n"
+        + "            \"code\": \"test option 11\",\n"
+        + "            \"sortOrder\": 11\n"
+        + "        }\n"
+        + "    ]\n"
+        + "}";
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -110,7 +110,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(
@@ -134,7 +134,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(
@@ -158,7 +158,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(
@@ -180,7 +180,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(
@@ -202,13 +202,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> paramFields = contextService.getParameterValues("fields");
-    // handle comma-separated fields
-    List<String> fields =
-        paramFields.stream()
-            .map(s -> Arrays.asList(s.split(",")))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(
@@ -262,6 +256,14 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     return ok("Materialized view refreshed");
   }
 
+  private List<String> getFields() {
+    // handle comma-separated fields so each field is quoted individually downstream
+    return Lists.newArrayList(contextService.getParameterValues("fields")).stream()
+        .map(s -> Arrays.asList(s.split(",")))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
   private SqlView validateView(String uid) throws WebMessageException {
     SqlView sqlView = sqlViewService.getSqlViewByUid(uid);
 
@@ -274,7 +276,7 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
 
   private GridResponse buildResponse(SqlView sqlView, SqlViewQuery query) {
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> fields = getFields();
 
     Grid grid =
         sqlViewService.getSqlViewGrid(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -34,8 +34,11 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridResponse;
@@ -199,7 +202,13 @@ public class SqlViewController extends AbstractCrudController<SqlView> {
     SqlView sqlView = validateView(uid);
 
     List<String> filters = Lists.newArrayList(contextService.getParameterValues("filter"));
-    List<String> fields = Lists.newArrayList(contextService.getParameterValues("fields"));
+    List<String> paramFields = contextService.getParameterValues("fields");
+    // handle comma-separated fields
+    List<String> fields =
+        paramFields.stream()
+            .map(s -> Arrays.asList(s.split(",")))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
 
     Grid grid =
         sqlViewService.getSqlViewGrid(


### PR DESCRIPTION
Backports the full SQL View injection fix to the EOS **2.39** release, closing **both** injection slots in `DefaultSqlViewService.getFilterQuery`:

- **#22253** (DHIS2-20174) — value slot: parameter binding (`?` placeholders + bound args) and identifier quoting of fields/criteria.
- **#148** — column-name slot: `statementBuilder.columnQuote(columnName)`.

#22253 was never backported to 2.37–2.39 (already EOS at the time), so these branches were injectable on both the value slot and the column-name slot. This restores parity with 2.40+.

Includes `SqlViewControllerIntegrationTest` (value + field injection coverage) plus the `QueryUtilsTest` parameter-binding assertions.

Supersedes **#24149** (#148 only). GPG-signed.

AI Assisted. Refs DHIS2-20174, GHSA-pwmg-mvjw-4m23.
