### PR TITLE
security backport: #22253 + #148 → 2.37 [DHIS2-20174]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
@@ -44,7 +44,7 @@ public interface SqlViewStore
 
     void dropViewTable( SqlView sqlView );
 
-    void populateSqlViewGrid( Grid grid, String sql );
+    void populateSqlViewGrid( Grid grid, String sql, Object[] args );
 
     /**
      * Tests the given SQL for validity.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -223,7 +223,8 @@ public class DefaultSqlViewService
                     filter.substring( index ) );
                 query.append( filterQuery.getOperatorWithPlaceholder() );
 
-                // this arg could be a collection, so need to add each (not the collection)
+                // this arg could be a collection, so need to add each (not the
+                // collection)
                 if ( filterQuery.getArg() instanceof Collection<?> )
                 {
                     Collection<?> collection = (Collection<?>) filterQuery.getArg();

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -27,12 +27,15 @@
  */
 package org.hisp.dhis.sqlview;
 
+import static org.hisp.dhis.query.QueryUtils.parseStringValue;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USERNAME_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.CURRENT_USER_ID_VARIABLE;
 import static org.hisp.dhis.sqlview.SqlView.STANDARD_VARIABLES;
 import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryParams;
 import static org.hisp.dhis.sqlview.SqlView.getInvalidQueryValues;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +55,8 @@ import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryUtils;
+import org.hisp.dhis.query.QueryUtils.OperatorWithPlaceHolderAndArg;
+import org.hisp.dhis.query.QueryUtils.PlaceholderQueryWithArgs;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.user.CurrentUserService;
@@ -181,10 +186,12 @@ public class DefaultSqlViewService
 
         log.info( String.format( "Retrieving data for SQL view: '%s'", sqlView.getUid() ) );
 
-        String sql = sqlView.isQuery() ? getSqlForQuery( sqlView, criteria, variables, filters, fields )
+        PlaceholderQueryWithArgs placeholderQueryWithArgs = sqlView.isQuery()
+            ? getSqlForQuery( sqlView, criteria, variables, filters, fields )
             : getSqlForView( sqlView, criteria, filters, fields );
 
-        sqlViewStore.populateSqlViewGrid( grid, sql );
+        sqlViewStore.populateSqlViewGrid( grid, placeholderQueryWithArgs.getPlaceholderQuery(),
+            placeholderQueryWithArgs.getArgs() == null ? null : placeholderQueryWithArgs.getArgs().toArray() );
 
         return grid;
     }
@@ -198,19 +205,38 @@ public class DefaultSqlViewService
         }
     }
 
-    private String parseFilters( List<String> filters, SqlHelper sqlHelper )
+    private PlaceholderQueryWithArgs parseFilters( List<String> filters, SqlHelper sqlHelper )
         throws QueryParserException
     {
-        String query = StringUtils.EMPTY;
+        StringBuilder query = new StringBuilder();
+        List<Object> queryArgs = new ArrayList<>();
 
-        for ( String filter : filters )
+        for ( int i = 0; i < filters.size(); i++ )
         {
+            String filter = filters.get( i );
             String[] split = filter.split( ":" );
 
             if ( split.length == 3 )
             {
                 int index = split[0].length() + ":".length() + split[1].length() + ":".length();
-                query += getFilterQuery( sqlHelper, split[0], split[1], filter.substring( index ) );
+                OperatorWithPlaceHolderAndArg filterQuery = getFilterQuery( sqlHelper, split[0], split[1],
+                    filter.substring( index ) );
+                query.append( filterQuery.getOperatorWithPlaceholder() );
+
+                // this arg could be a collection, so need to add each (not the collection)
+                if ( filterQuery.getArg() instanceof Collection<?> )
+                {
+                    Collection<?> collection = (Collection<?>) filterQuery.getArg();
+                    queryArgs.addAll( collection );
+                }
+                else
+                {
+                    queryArgs.add( filterQuery.getArg() );
+                }
+            }
+            else if ( split.length == 2 && (split[1].equals( "null" ) || split[1].equals( "!null" )) )
+            {
+                query.append( getFilterQuery( sqlHelper, split[0], split[1], null ).getOperatorWithPlaceholder() );
             }
             else
             {
@@ -218,20 +244,24 @@ public class DefaultSqlViewService
             }
         }
 
-        return query;
+        return new PlaceholderQueryWithArgs( query.toString(), queryArgs );
     }
 
-    private String getFilterQuery( SqlHelper sqlHelper, String columnName, String operator, String value )
+    private OperatorWithPlaceHolderAndArg getFilterQuery( SqlHelper sqlHelper, String columnName, String operator,
+        String value )
     {
-        String query = StringUtils.EMPTY;
+        String filter = StringUtils.EMPTY;
+        OperatorWithPlaceHolderAndArg operatorWithPlaceHolderAndArg = QueryUtils.parseFilterOperator( operator,
+            value );
 
-        query += sqlHelper.whereAnd() + " " + columnName + " " + QueryUtils.parseFilterOperator( operator, value );
+        filter += sqlHelper.whereAnd() + " " + columnName + " "
+            + operatorWithPlaceHolderAndArg.getOperatorWithPlaceholder();
 
-        return query;
+        return new OperatorWithPlaceHolderAndArg( filter, operatorWithPlaceHolderAndArg.getArg() );
     }
 
-    private String getSqlForQuery( SqlView sqlView, Map<String, String> criteria, Map<String, String> variables,
-        List<String> filters, List<String> fields )
+    private PlaceholderQueryWithArgs getSqlForQuery( SqlView sqlView, Map<String, String> criteria,
+        Map<String, String> variables, List<String> filters, List<String> fields )
     {
         boolean hasCriteria = criteria != null && !criteria.isEmpty();
 
@@ -239,6 +269,7 @@ public class DefaultSqlViewService
 
         String sql = substituteQueryVariables( sqlView, variables );
 
+        List<Object> args = new ArrayList<>();
         if ( hasCriteria || hasFilter )
         {
             sql = SqlViewUtils.removeQuerySeparator( sql );
@@ -249,18 +280,23 @@ public class DefaultSqlViewService
 
             if ( hasCriteria )
             {
-                outerSql += getCriteriaSqlClause( criteria, sqlHelper );
+                PlaceholderQueryWithArgs placeholderQueryWithArgs = getCriteriaSqlClause( criteria, sqlHelper );
+                outerSql += placeholderQueryWithArgs.getPlaceholderQuery();
+                args.addAll( placeholderQueryWithArgs.getArgs() );
             }
 
             if ( hasFilter )
             {
-                outerSql += parseFilters( filters, sqlHelper );
+                PlaceholderQueryWithArgs placeholderQueryWithArgs = parseFilters( filters, sqlHelper );
+                outerSql += placeholderQueryWithArgs.getPlaceholderQuery();
+                args.addAll( placeholderQueryWithArgs.getArgs() );
+                return new PlaceholderQueryWithArgs( outerSql, args );
             }
 
-            sql = outerSql;
+            return new PlaceholderQueryWithArgs( outerSql, args );
         }
 
-        return sql;
+        return new PlaceholderQueryWithArgs( sql, null );
     }
 
     private String substituteQueryVariables( SqlView sqlView, Map<String, String> variables )
@@ -279,8 +315,8 @@ public class DefaultSqlViewService
         return sql;
     }
 
-    private String getSqlForView( SqlView sqlView, Map<String, String> criteria, List<String> filters,
-        List<String> fields )
+    private PlaceholderQueryWithArgs getSqlForView( SqlView sqlView, Map<String, String> criteria,
+        List<String> filters, List<String> fields )
     {
         String sql = "select " + QueryUtils.parseSelectFields( fields ) + " from "
             + statementBuilder.columnQuote( sqlView.getViewName() ) + " ";
@@ -289,40 +325,47 @@ public class DefaultSqlViewService
 
         boolean hasFilter = filters != null && !filters.isEmpty();
 
+        List<Object> args = new ArrayList<>();
         if ( hasCriteria || hasFilter )
         {
             SqlHelper sqlHelper = new SqlHelper();
 
             if ( hasCriteria )
             {
-                sql += getCriteriaSqlClause( criteria, sqlHelper );
+                PlaceholderQueryWithArgs sqlQueryWithArgs = getCriteriaSqlClause( criteria, sqlHelper );
+                sql += sqlQueryWithArgs.getPlaceholderQuery();
+                args.addAll( sqlQueryWithArgs.getArgs() );
             }
 
             if ( hasFilter )
             {
-                sql += parseFilters( filters, sqlHelper );
+                PlaceholderQueryWithArgs sqlQueryWithArgs = parseFilters( filters, sqlHelper );
+                sql += sqlQueryWithArgs.getPlaceholderQuery();
+                args.addAll( sqlQueryWithArgs.getArgs() );
             }
+            return new PlaceholderQueryWithArgs( sql, args );
         }
 
-        return sql;
+        return new PlaceholderQueryWithArgs( sql, null );
     }
 
-    private String getCriteriaSqlClause( Map<String, String> criteria, SqlHelper sqlHelper )
+    private PlaceholderQueryWithArgs getCriteriaSqlClause( Map<String, String> criteria, SqlHelper sqlHelper )
     {
-        String sql = StringUtils.EMPTY;
+        StringBuilder sql = new StringBuilder();
 
+        List<Object> args = new ArrayList<>();
         if ( criteria != null && !criteria.isEmpty() )
         {
             sqlHelper = ObjectUtils.firstNonNull( sqlHelper, new SqlHelper() );
 
-            for ( String filter : criteria.keySet() )
+            for ( Map.Entry<String, String> criterion : criteria.entrySet() )
             {
-                sql += sqlHelper.whereAnd() + " " + statementBuilder.columnQuote( filter ) + "='"
-                    + criteria.get( filter ) + "' ";
+                sql.append( sqlHelper.whereAnd() ).append( " " )
+                    .append( statementBuilder.columnQuote( criterion.getKey() ) ).append( " = ? " );
+                args.add( parseStringValue( criterion.getValue() ) );
             }
         }
-
-        return sql;
+        return new PlaceholderQueryWithArgs( sql.toString(), args );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -254,7 +254,7 @@ public class DefaultSqlViewService
         OperatorWithPlaceHolderAndArg operatorWithPlaceHolderAndArg = QueryUtils.parseFilterOperator( operator,
             value );
 
-        filter += sqlHelper.whereAnd() + " " + columnName + " "
+        filter += sqlHelper.whereAnd() + " " + statementBuilder.columnQuote( columnName ) + " "
             + operatorWithPlaceHolderAndArg.getOperatorWithPlaceholder();
 
         return new OperatorWithPlaceHolderAndArg( filter, operatorWithPlaceHolderAndArg.getArg() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -41,6 +41,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.TypedQuery;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -227,7 +228,8 @@ public final class QueryUtils
     }
 
     /**
-     * Parses the provided string value to return either null, a number or a string value
+     * Parses the provided string value to return either null, a number or a
+     * string value
      *
      * @param value string value to parse
      * @return null,number or string
@@ -566,7 +568,8 @@ public final class QueryUtils
     @AllArgsConstructor
     public static class OperatorWithPlaceHolderAndArg
     {
-        // operatorWithPlaceholder SQL operator with a '?' placeholder (e.g. 'like ?', '> ?')
+        // operatorWithPlaceholder SQL operator with a '?' placeholder (e.g.
+        // 'like ?', '> ?')
         private String operatorWithPlaceholder;
 
         // the arg to be supplied to the placeholder

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -37,14 +37,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.TypedQuery;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
@@ -223,6 +227,33 @@ public final class QueryUtils
     }
 
     /**
+     * Parses the provided string value to return either null, a number or a string value
+     *
+     * @param value string value to parse
+     * @return null,number or string
+     */
+    @CheckForNull
+    public static Object parseStringValue( String value )
+    {
+        if ( value == null || StringUtils.isEmpty( value ) )
+        {
+            return null;
+        }
+        if ( NumberUtils.isNumber( value ) )
+        {
+            try
+            {
+                return NumberUtils.createNumber( value );
+            }
+            catch ( NumberFormatException e )
+            {
+                throw new QueryParserException( String.format( "Could not parse number from value: %s", value ) );
+            }
+        }
+        return value;
+    }
+
+    /**
      * Convert a List of select fields into a string as in SQL select query.
      * <p>
      * If input is null, return "*" means the query will select all fields.
@@ -236,19 +267,24 @@ public final class QueryUtils
         {
             return " * ";
         }
-        else
+        StringBuilder str = new StringBuilder( StringUtils.EMPTY );
+        for ( int i = 0; i < fields.size(); i++ )
         {
-            String str = StringUtils.EMPTY;
-            for ( int i = 0; i < fields.size(); i++ )
+            String field = fields.get( i );
+            if ( field.equals( "*" ) )
             {
-                str += fields.get( i );
-                if ( i < fields.size() - 1 )
-                {
-                    str += ",";
-                }
+                str.append( "*" );
             }
-            return str;
+            else
+            {
+                str.append( SqlUtils.quote( field ) );
+            }
+            if ( i < fields.size() - 1 )
+            {
+                str.append( "," );
+            }
         }
+        return str.toString();
     }
 
     /**
@@ -293,6 +329,39 @@ public final class QueryUtils
     }
 
     /**
+     * Converts a String with JSON format [x,y,z] into a list of Objects
+     *
+     * @param value a string contains a collection with JSON format [x,y,z].
+     * @return as a list of objects e.g. List.of(x,y,z)
+     */
+    public static List<Object> convertToCollectionArgs( String value )
+    {
+        if ( StringUtils.isEmpty( value ) )
+        {
+            throw new QueryParserException( "Value is null" );
+        }
+
+        if ( !value.startsWith( "[" ) || !value.endsWith( "]" ) )
+        {
+            throw new QueryParserException( "Invalid query value" );
+        }
+
+        String[] split = value.substring( 1, value.length() - 1 ).split( "," );
+        List<String> items = Lists.newArrayList( split );
+        List<Object> args = new ArrayList<>();
+
+        for ( String s : items )
+        {
+            Object item = parseStringValue( s );
+            if ( item != null )
+            {
+                args.add( item );
+            }
+        }
+        return args;
+    }
+
+    /**
      * Converts a filter operator into an SQL operator.
      * <p>
      * Example: {@code parseFilterOperator('eq', 5)} will return "=5".
@@ -301,7 +370,7 @@ public final class QueryUtils
      * @param value value of the current SQL query condition.
      * @return a string contains an SQL expression with operator and value.
      */
-    public static String parseFilterOperator( String operator, String value )
+    public static OperatorWithPlaceHolderAndArg parseFilterOperator( String operator, String value )
     {
 
         if ( StringUtils.isEmpty( operator ) )
@@ -312,113 +381,65 @@ public final class QueryUtils
         switch ( operator )
         {
         case "eq":
-        {
-            return "= " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " = ? ", parseStringValue( value ) );
+        case "ieq":
+            return new OperatorWithPlaceHolderAndArg( " ilike ? ", value );
         case "!eq":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
         case "ne":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
         case "neq":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " != ? ", parseStringValue( value ) );
         case "gt":
-        {
-            return "> " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " > ? ", parseStringValue( value ) );
         case "lt":
-        {
-            return "< " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " < ? ", parseStringValue( value ) );
         case "gte":
-        {
-            return ">= " + QueryUtils.parseValue( value );
-        }
         case "ge":
-        {
-            return ">= " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " >= ? ", parseStringValue( value ) );
         case "lte":
-        {
-            return "<= " + QueryUtils.parseValue( value );
-        }
         case "le":
-        {
-            return "<= " + QueryUtils.parseValue( value );
-        }
+            return new OperatorWithPlaceHolderAndArg( " <= ? ", parseStringValue( value ) );
         case "like":
-        {
-            return "like '%" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " like ? ", "%" + value + "%" );
         case "!like":
-        {
-            return "not like '%" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not like ? ", "%" + value + "%" );
         case "^like":
-        {
-            return " like '" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " like ? ", value + "%" );
         case "!^like":
-        {
-            return " not like '" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not like ? ", value + "%" );
         case "$like":
-        {
-            return " like '%" + value + "'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " like ? ", "%" + value );
         case "!$like":
-        {
-            return " not like '%" + value + "'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not like ? ", "%" + value );
         case "ilike":
-        {
-            return " ilike '%" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " ilike ? ", "%" + value + "%" );
         case "!ilike":
-        {
-            return " not ilike '%" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not ilike ? ", "%" + value + "%" );
         case "^ilike":
-        {
-            return " ilike '" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " ilike ? ", value + "%" );
         case "!^ilike":
-        {
-            return " not ilike '" + value + "%'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not ilike ? ", value + "%" );
         case "$ilike":
-        {
-            return " ilike '%" + value + "'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " ilike ? ", "%" + value );
         case "!$ilike":
-        {
-            return " not ilike '%" + value + "'";
-        }
+            return new OperatorWithPlaceHolderAndArg( " not ilike ? ", "%" + value );
         case "in":
         {
-            return "in " + QueryUtils.convertCollectionValue( value );
+            List<Object> objects = convertToCollectionArgs( value );
+            return new OperatorWithPlaceHolderAndArg(
+                " in (" + String.join( ",", Collections.nCopies( objects.size(), "?" ) ) + ") ", objects );
         }
         case "!in":
         {
-            return " not in " + QueryUtils.convertCollectionValue( value );
+            List<Object> objects = convertToCollectionArgs( value );
+            return new OperatorWithPlaceHolderAndArg(
+                " not in (" + String.join( ",", Collections.nCopies( objects.size(), "?" ) ) + ") ", objects );
         }
         case "null":
-        {
-            return "is null";
-        }
+            return new OperatorWithPlaceHolderAndArg( "is null ", null );
         case "!null":
-        {
-            return "is not null";
-        }
+            return new OperatorWithPlaceHolderAndArg( "is not null ", null );
         default:
-        {
             throw new QueryParserException( "`" + operator + "` is not a valid operator." );
-        }
         }
     }
 
@@ -528,5 +549,27 @@ public final class QueryUtils
         }
 
         return list.get( 0 );
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class PlaceholderQueryWithArgs
+    {
+        // placeholderQuery SQL query with '?' placeholders for args
+        private String placeholderQuery;
+
+        // the args to be supplied to the placeholders
+        private List<Object> args;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class OperatorWithPlaceHolderAndArg
+    {
+        // operatorWithPlaceholder SQL operator with a '?' placeholder (e.g. 'like ?', '> ?')
+        private String operatorWithPlaceholder;
+
+        // the arg to be supplied to the placeholder
+        private Object arg;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
@@ -135,9 +135,9 @@ public class HibernateSqlViewStore
     }
 
     @Override
-    public void populateSqlViewGrid( Grid grid, String sql )
+    public void populateSqlViewGrid( Grid grid, String sql, Object[] args )
     {
-        SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet( sql );
+        SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet( sql, args );
 
         int maxLimit = (Integer) systemSettingManager.getSystemSetting( SettingKey.SQL_VIEW_MAX_LIMIT );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
@@ -178,7 +178,7 @@ public class QueryUtilsTest
         fields.add( "ABC" );
         fields.add( "DEF" );
 
-        assertEquals( "ABC,DEF", QueryUtils.parseSelectFields( fields ) );
+        assertEquals( "\"ABC\",\"DEF\"", QueryUtils.parseSelectFields( fields ) );
     }
 
     @Test
@@ -198,19 +198,28 @@ public class QueryUtilsTest
     @Test
     public void testParseFilterOperator()
     {
-        assertEquals( "= 5", QueryUtils.parseFilterOperator( "eq", "5" ) );
+        assertOperator( " = ? ", 5, QueryUtils.parseFilterOperator( "eq", "5" ) );
 
-        assertEquals( "= 'ABC'", QueryUtils.parseFilterOperator( "eq", "ABC" ) );
+        assertOperator( " = ? ", "ABC", QueryUtils.parseFilterOperator( "eq", "ABC" ) );
 
-        assertEquals( "like '%abc%'", QueryUtils.parseFilterOperator( "like", "abc" ) );
+        assertOperator( " ilike ? ", "abc", QueryUtils.parseFilterOperator( "ieq", "abc" ) );
 
-        assertEquals( " like '%abc'", QueryUtils.parseFilterOperator( "$like", "abc" ) );
+        assertOperator( " like ? ", "%abc%", QueryUtils.parseFilterOperator( "like", "abc" ) );
 
-        assertEquals( "in ('a','b','c')", QueryUtils.parseFilterOperator( "in", "[a,b,c]" ) );
+        assertOperator( " like ? ", "%abc", QueryUtils.parseFilterOperator( "$like", "abc" ) );
 
-        assertEquals( "in (1,2,3)", QueryUtils.parseFilterOperator( "in", "[1,2,3]" ) );
+        assertOperator( " in (?,?,?) ", List.of( "a", "b", "c" ), QueryUtils.parseFilterOperator( "in", "[a,b,c]" ) );
 
-        assertEquals( "is not null", QueryUtils.parseFilterOperator( "!null", null ) );
+        assertOperator( " in (?,?,?) ", List.of( 1, 2, 3 ), QueryUtils.parseFilterOperator( "in", "[1,2,3]" ) );
+
+        assertOperator( "is not null ", null, QueryUtils.parseFilterOperator( "!null", null ) );
+    }
+
+    private void assertOperator( String expectedOperator, Object expectedArg,
+        QueryUtils.OperatorWithPlaceHolderAndArg actual )
+    {
+        assertEquals( expectedOperator, actual.getOperatorWithPlaceholder() );
+        assertEquals( expectedArg, actual.getArg() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -261,7 +261,8 @@ public class SqlViewController
 
     private List<String> getFields()
     {
-        // handle comma-separated fields so each field is quoted individually downstream
+        // handle comma-separated fields so each field is quoted individually
+        // downstream
         return Lists.newArrayList( contextService.getParameterValues( "fields" ) ).stream()
             .map( s -> Arrays.asList( s.split( "," ) ) )
             .flatMap( Collection::stream )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -33,8 +33,11 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -116,7 +119,7 @@ public class SqlViewController
         SqlView sqlView = validateView( uid );
 
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService.getSqlViewGrid( sqlView, SqlView.getCriteria( criteria ), SqlView.getCriteria( var ),
             filters, fields );
@@ -138,7 +141,7 @@ public class SqlViewController
         SqlView sqlView = validateView( uid );
 
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService.getSqlViewGrid( sqlView, SqlView.getCriteria( criteria ), SqlView.getCriteria( var ),
             filters, fields );
@@ -160,7 +163,7 @@ public class SqlViewController
         SqlView sqlView = validateView( uid );
 
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService
             .getSqlViewGrid( sqlView, SqlView.getCriteria( criteria ), SqlView.getCriteria( var ), filters, fields );
@@ -179,7 +182,7 @@ public class SqlViewController
         SqlView sqlView = validateView( uid );
 
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService
             .getSqlViewGrid( sqlView, SqlView.getCriteria( criteria ), SqlView.getCriteria( var ), filters, fields );
@@ -198,7 +201,7 @@ public class SqlViewController
         SqlView sqlView = validateView( uid );
 
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService.getSqlViewGrid( sqlView, SqlView.getCriteria( criteria ), SqlView.getCriteria( var ),
             filters, fields );
@@ -256,6 +259,15 @@ public class SqlViewController
         return ok( "Materialized view refreshed" );
     }
 
+    private List<String> getFields()
+    {
+        // handle comma-separated fields so each field is quoted individually downstream
+        return Lists.newArrayList( contextService.getParameterValues( "fields" ) ).stream()
+            .map( s -> Arrays.asList( s.split( "," ) ) )
+            .flatMap( Collection::stream )
+            .collect( Collectors.toList() );
+    }
+
     private SqlView validateView( String uid )
         throws WebMessageException
     {
@@ -272,7 +284,7 @@ public class SqlViewController
     private GridResponse buildResponse( SqlView sqlView, SqlViewQuery query )
     {
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
+        List<String> fields = getFields();
 
         Grid grid = sqlViewService.getSqlViewGrid( sqlView, SqlView.getCriteria( query.getCriteria() ),
             SqlView.getCriteria( query.getVar() ), filters, fields );


### PR DESCRIPTION
Backports the full SQL View injection fix to the EOS **2.37** release, closing **both** injection slots in `DefaultSqlViewService.getFilterQuery`:

- **#22253** (DHIS2-20174) — value slot: parameter binding (`?` placeholders + bound args) and identifier quoting of fields/criteria.
- **#148** — column-name slot: `statementBuilder.columnQuote(columnName)`.

#22253 was never backported to 2.37–2.39 (already EOS at the time), so these branches were injectable on both the value slot and the column-name slot. This restores parity with 2.40+. Adapted to 2.37's older code (pre-`TransactionMode`, old Google-Java-Format, JUnit 4).

Value-side parameterization is covered by `QueryUtilsTest`. The `SqlViewControllerIntegrationTest` from #22253 targets newer test infrastructure / a renamed module not present on 2.37, so it is omitted here (as in the original #148-only backport); 2.39 carries it.

Supersedes **#24151** (#148 only). GPG-signed.

AI Assisted. Refs DHIS2-20174, GHSA-pwmg-mvjw-4m23.
