### PR TITLE
fix: compress audit log archives on rollover [DHIS2-21620]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
@@ -161,7 +161,7 @@ public class Log4JLogConfigInitializer implements LogConfigInitializer {
         RollingFileAppender.newBuilder()
             .withFileName(file)
             .setName("appender_" + file)
-            .withFilePattern(file + ".%i")
+            .withFilePattern(file + ".%i.gz")
             .setLayout(PATTERN_LAYOUT)
             .withPolicy(
                 CronTriggeringPolicy.createPolicy(getLogConfiguration(), "true", "0 0 0 * * ?"))


### PR DESCRIPTION
## Summary

The `dhis-audit.log` rolling appender in `Log4JLogConfigInitializer` is configured with `BEST_COMPRESSION` but its `filePattern` was `<file>.%i` — which has **no compression suffix**. In Log4j2, archive compression is triggered *solely* by the `filePattern` suffix (`.gz`/`.zip`); `compressionLevel` only selects the level when such a suffix is present.

As a result the configured compression never ran, and combined with `withFileIndex("nomax")` (unbounded retention) the audit archives accumulated **uncompressed and unbounded**. On a production instance this filled the log directory to **315 GB**. Every default install is affected; it stays hidden only where operators have added an external cleanup job.

## Fix

Add the `.gz` suffix to the audit appender's file pattern so the already-configured `BEST_COMPRESSION` takes effect:

```diff
-            .withFilePattern(file + ".%i")
+            .withFilePattern(file + ".%i.gz")
```

Each midnight rollover now produces a gzip-compressed archive (e.g. `dhis-audit.log.1.gz`).

## Scope / notes

- Scoped to the audit appender, which is the actual bug (it's the one that explicitly configures compression). The size-based appender (`getRollingFileAppender`) shares the same `.%i` pattern and is also uncompressed, but it's bounded by `logging.file.max_archives`, so its impact is far smaller — left as an optional follow-up.
- Unbounded `nomax` retention is left as-is, as "never lose audit history" is plausibly intentional; bounded retention is a separate decision.
- Verified against log4j-core 2.25.4. Module compiles clean.

Jira: [DHIS2-21620](https://dhis2.atlassian.net/browse/DHIS2-21620)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DHIS2-21620]: https://dhis2.atlassian.net/browse/DHIS2-21620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ