### PR TITLE
fix: compile SQL view backport test under JDK 8 [2.37]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
@@ -208,9 +208,10 @@ public class QueryUtilsTest
 
         assertOperator( " like ? ", "%abc", QueryUtils.parseFilterOperator( "$like", "abc" ) );
 
-        assertOperator( " in (?,?,?) ", List.of( "a", "b", "c" ), QueryUtils.parseFilterOperator( "in", "[a,b,c]" ) );
+        assertOperator( " in (?,?,?) ", Arrays.asList( "a", "b", "c" ),
+            QueryUtils.parseFilterOperator( "in", "[a,b,c]" ) );
 
-        assertOperator( " in (?,?,?) ", List.of( 1, 2, 3 ), QueryUtils.parseFilterOperator( "in", "[1,2,3]" ) );
+        assertOperator( " in (?,?,?) ", Arrays.asList( 1, 2, 3 ), QueryUtils.parseFilterOperator( "in", "[1,2,3]" ) );
 
         assertOperator( "is not null ", null, QueryUtils.parseFilterOperator( "!null", null ) );
     }


### PR DESCRIPTION
## What

PR #24174 backported the SQL View injection fix to **2.37**, but `QueryUtilsTest` used `List.of(...)`, a Java 9+ API. It compiles under the JDK 11 GitHub Actions CI, yet the EOS/stable **release build runs on JDK 8** (`jenkinsfiles/eos`, `ec2-jdk8`, `mvn clean install -P jdk8,-default`) and compiles test sources, so `List.of` fails to resolve and the release no longer builds.

## Fix

Replace `List.of(...)` with `Arrays.asList(...)` (already imported in the test). The values feed an element-wise `assertEquals`, so the lists compare equal element-for-element and behaviour is unchanged.

## Verification

- **JDK 8** (Liberica 1.8.0_472): `dhis-service-core` test sources compile and `QueryUtilsTest#testParseFilterOperator` passes (`Tests run: 1, Failures: 0`).
- **JDK 8**: full `dhis-web-api -am` main build (59 modules) green, covering the other backported files (`DefaultSqlViewService`, `SqlViewController`, `HibernateSqlViewStore`, `QueryUtils`, `SqlViewStore`).
- **JDK 11**: `speedy-spotless:check` clean (matches `check-formatting`).

AI Assisted. Refs DHIS2-20174.
