### PR TITLE
DHIS2-21617 Always commit new periods when mixing transactions

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -117,6 +117,24 @@ public interface PeriodStore {
    */
   Period reloadForceAddPeriod(Period period);
 
+  /**
+   * Like {@link #reloadForceAddPeriod(Period)} but, when the period has to be created, persists the
+   * iso&rarr;PK mapping in its <em>own</em> session and commits it immediately, independently of any
+   * transaction active on the calling thread.
+   *
+   * <p>This is required by importers (complete data set registrations, data value sets) that
+   * reference the period through a <em>separate</em> JDBC connection: the {@code quick} BatchHandler
+   * inserts with autoCommit on its own pooled connection and therefore cannot see a period that
+   * only lives in the caller's still-open transaction. Without an immediate commit the dependent
+   * insert fails with a foreign key violation while the import still reports success (see
+   * DHIS2-7539, DHIS2-21617). Periods are an append-only iso&rarr;PK mapping, so committing them
+   * even when the surrounding transaction later rolls back is safe.
+   *
+   * @param period the Period.
+   * @return the persisted Period.
+   */
+  Period reloadForceAddPeriodInNewTransaction(Period period);
+
   // -------------------------------------------------------------------------
   // PeriodType
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -122,13 +122,13 @@ public interface PeriodStore {
    * iso&rarr;PK mapping in its <em>own</em> session and commits it immediately, independently of
    * any transaction active on the calling thread.
    *
-   * <p>This is required by importers (complete data set registrations, data value sets) that
-   * reference the period through a <em>separate</em> JDBC connection: the {@code quick}
-   * BatchHandler inserts with autoCommit on its own pooled connection and therefore cannot see a
-   * period that only lives in the caller's still-open transaction. Without an immediate commit the
-   * dependent insert fails with a foreign key violation while the import still reports success (see
-   * DHIS2-7539, DHIS2-21617). Periods are an append-only iso&rarr;PK mapping, so committing them
-   * even when the surrounding transaction later rolls back is safe.
+   * <p>This is required by the complete data set registration import, which references the period
+   * through a <em>separate</em> JDBC connection: the {@code quick} BatchHandler inserts with
+   * autoCommit on its own pooled connection and therefore cannot see a period that only lives in
+   * the caller's still-open transaction. Without an immediate commit the dependent insert fails
+   * with a foreign key violation while the import still reports success (see DHIS2-7539,
+   * DHIS2-21617). Periods are an append-only iso&rarr;PK mapping, so committing them even when the
+   * surrounding transaction later rolls back is safe.
    *
    * @param period the Period.
    * @return the persisted Period.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -119,14 +119,14 @@ public interface PeriodStore {
 
   /**
    * Like {@link #reloadForceAddPeriod(Period)} but, when the period has to be created, persists the
-   * iso&rarr;PK mapping in its <em>own</em> session and commits it immediately, independently of any
-   * transaction active on the calling thread.
+   * iso&rarr;PK mapping in its <em>own</em> session and commits it immediately, independently of
+   * any transaction active on the calling thread.
    *
    * <p>This is required by importers (complete data set registrations, data value sets) that
-   * reference the period through a <em>separate</em> JDBC connection: the {@code quick} BatchHandler
-   * inserts with autoCommit on its own pooled connection and therefore cannot see a period that
-   * only lives in the caller's still-open transaction. Without an immediate commit the dependent
-   * insert fails with a foreign key violation while the import still reports success (see
+   * reference the period through a <em>separate</em> JDBC connection: the {@code quick}
+   * BatchHandler inserts with autoCommit on its own pooled connection and therefore cannot see a
+   * period that only lives in the caller's still-open transaction. Without an immediate commit the
+   * dependent insert fails with a foreign key violation while the import still reports success (see
    * DHIS2-7539, DHIS2-21617). Periods are an append-only iso&rarr;PK mapping, so committing them
    * even when the surrounding transaction later rolls back is safe.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -175,10 +175,10 @@ public class DefaultPeriodService implements PeriodService {
    *
    * <p>Unlike {@link #reloadIsoPeriod(String)}, the period is committed in its own transaction even
    * when the caller is already inside an active read-write transaction (e.g. the
-   * {@code @Transactional} async complete data set registration / data value set import). This is
-   * required so the {@code quick} BatchHandler, which inserts on its own separate autoCommit
-   * connection, can see the freshly created period; otherwise the dependent insert fails with a
-   * foreign key violation while the import still reports success (DHIS2-21617).
+   * {@code @Transactional} complete data set registration import). This is required so the {@code
+   * quick} BatchHandler, which inserts on its own separate autoCommit connection, can see the
+   * freshly created period; otherwise the dependent insert fails with a foreign key violation while
+   * the import still reports success (DHIS2-21617).
    */
   @Override
   @IndirectTransactional

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -172,11 +172,18 @@ public class DefaultPeriodService implements PeriodService {
    * Fix issue DHIS2-7539 If period doesn't exist in cache and database. Need to add and sync with
    * database right away in a separate session/transaction. Otherwise will get foreign key
    * constraint error in subsequence calls of batch.flush()
+   *
+   * <p>Unlike {@link #reloadIsoPeriod(String)}, the period is committed in its own transaction even
+   * when the caller is already inside an active read-write transaction (e.g. the {@code
+   * @Transactional} async complete data set registration / data value set import). This is required
+   * so the {@code quick} BatchHandler, which inserts on its own separate autoCommit connection, can
+   * see the freshly created period; otherwise the dependent insert fails with a foreign key
+   * violation while the import still reports success (DHIS2-21617).
    */
   @Override
   @IndirectTransactional
   public Period reloadIsoPeriodInStatelessSession(String isoPeriod) {
-    return reloadPeriod(Period.of(isoPeriod));
+    return periodStore.reloadForceAddPeriodInNewTransaction(Period.of(isoPeriod));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -174,11 +174,11 @@ public class DefaultPeriodService implements PeriodService {
    * constraint error in subsequence calls of batch.flush()
    *
    * <p>Unlike {@link #reloadIsoPeriod(String)}, the period is committed in its own transaction even
-   * when the caller is already inside an active read-write transaction (e.g. the {@code
-   * @Transactional} async complete data set registration / data value set import). This is required
-   * so the {@code quick} BatchHandler, which inserts on its own separate autoCommit connection, can
-   * see the freshly created period; otherwise the dependent insert fails with a foreign key
-   * violation while the import still reports success (DHIS2-21617).
+   * when the caller is already inside an active read-write transaction (e.g. the
+   * {@code @Transactional} async complete data set registration / data value set import). This is
+   * required so the {@code quick} BatchHandler, which inserts on its own separate autoCommit
+   * connection, can see the freshly created period; otherwise the dependent insert fails with a
+   * foreign key violation while the import still reports success (DHIS2-21617).
    */
   @Override
   @IndirectTransactional

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -120,24 +120,22 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         VALUES (nextval('hibernate_sequence'),
           (SELECT periodtypeid FROM periodtype WHERE name = :type), :start, :end, :iso)""";
     String isoDate = period.getIsoDate();
-    Object id =
-        runAutoJoinTransaction(
-            session -> {
-              Object pk =
-                  getSingleResult(session.createNativeQuery(sql1).setParameter("iso", isoDate));
-              if (pk != null) {
-                return pk;
-              }
-              session
-                  .createNativeQuery(sql2)
-                  .setParameter("type", period.getPeriodType().getName())
-                  .setParameter("start", period.getStartDate())
-                  .setParameter("end", period.getEndDate())
-                  .setParameter("iso", isoDate)
-                  .executeUpdate();
-              return session.createNativeQuery("SELECT lastval()").uniqueResult();
-            },
-            forceNewTransaction);
+    Function<StatelessSession, Object> upsert =
+        session -> {
+          Object pk = getSingleResult(session.createNativeQuery(sql1).setParameter("iso", isoDate));
+          if (pk != null) {
+            return pk;
+          }
+          session
+              .createNativeQuery(sql2)
+              .setParameter("type", period.getPeriodType().getName())
+              .setParameter("start", period.getStartDate())
+              .setParameter("end", period.getEndDate())
+              .setParameter("iso", isoDate)
+              .executeUpdate();
+          return session.createNativeQuery("SELECT lastval()").uniqueResult();
+        };
+    Object id = forceNewTransaction ? runInNewTransaction(upsert) : runAutoJoinTransaction(upsert);
     if (id instanceof Number n) {
       long periodId = n.longValue();
       periodIdByIsoPeriod.putIfAbsent(isoDate, periodId);
@@ -274,8 +272,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               }
               session.createNativeQuery(sql2).setParameter("name", name).executeUpdate();
               return session.createNativeQuery("SELECT lastval()").uniqueResult();
-            },
-            false);
+            });
     if (id instanceof Number n) {
       int periodTypeId = n.intValue();
       periodType.setId(periodTypeId);
@@ -300,8 +297,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
                 .createNativeQuery(sql)
                 .setParameter("name", name)
                 .setParameter("label", label)
-                .executeUpdate(),
-        false);
+                .executeUpdate());
   }
 
   @Override
@@ -319,33 +315,42 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         .uniqueResult();
   }
 
-  private <R> R runAutoJoinTransaction(
-      Function<StatelessSession, R> query, boolean forceNewTransaction) {
+  /**
+   * Persists the implicit period/period-type mapping, joining the caller's active read-write
+   * transaction when there is one (so the mapping is visible within - and rolls back with - that
+   * transaction), and otherwise committing it in a new, independent transaction. This is the right
+   * behaviour for ordinary period creation, where the caller persists everything it references on
+   * the same transaction-bound connection. Callers that must commit the mapping immediately even
+   * inside an active transaction use {@link #runInNewTransaction} directly.
+   */
+  private <R> R runAutoJoinTransaction(Function<StatelessSession, R> query) {
     boolean active = TransactionSynchronizationManager.isActualTransactionActive();
     boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
 
-    if (!forceNewTransaction && active && !readOnly) {
-      // Join the caller's active read-write transaction (no independent commit) by borrowing its
-      // transaction-bound connection. The implicit period/period-type mapping is then visible
-      // within - and rolls back with - that transaction. This is the right behaviour for ordinary
-      // period creation, where the caller persists everything it references on the same
-      // transaction-bound connection.
+    if (active && !readOnly) {
+      // Join the caller's active read-write transaction by borrowing its transaction-bound
+      // connection, so the implicit mapping is visible within - and rolls back with - it.
       Connection borrowedConnection = DataSourceUtils.getConnection(dataSource);
       StatelessSession session =
           getSession().getSessionFactory().openStatelessSession(borrowedConnection);
       return query.apply(session);
     }
 
-    // Run in - and commit - a new, independent transaction. Reached either when there is no active
-    // read-write transaction, or when the caller explicitly requires the mapping to be committed
-    // right away (forceNewTransaction). The latter is needed by importers that reference the
-    // freshly created period through a SEPARATE JDBC connection (the `quick` BatchHandler, which
-    // inserts with autoCommit on its own pooled connection): a period that only lives in the
-    // caller's still-open transaction is invisible to that connection, so the dependent insert
-    // fails with a foreign key violation while the import still reports success (DHIS2-7539,
-    // DHIS2-21617). Committing here makes the period visible to every connection immediately;
-    // periods are an append-only iso -> PK mapping, so committing them even when an outer
-    // transaction later rolls back is safe.
+    return runInNewTransaction(query);
+  }
+
+  /**
+   * Runs the query in - and commits - its own session/transaction, independently of any transaction
+   * active on the calling thread. Required by the complete data set registration import, which
+   * references the freshly created period through a SEPARATE JDBC connection (the {@code quick}
+   * BatchHandler, which inserts with autoCommit on its own pooled connection): a period that only
+   * lives in the caller's still-open transaction is invisible to that connection, so the dependent
+   * insert fails with a foreign key violation while the import still reports success (DHIS2-7539,
+   * DHIS2-21617). Committing here makes the period visible to every connection immediately; periods
+   * are an append-only iso -> PK mapping, so committing them even when an outer transaction later
+   * rolls back is safe.
+   */
+  private <R> R runInNewTransaction(Function<StatelessSession, R> query) {
     StatelessSession session = getSession().getSessionFactory().openStatelessSession();
 
     Transaction transaction = null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -109,10 +109,17 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
    */
   @Override
   public void save(Period period) {
-    save(period, false);
+    // Default path: join the caller's active read-write transaction when there is one (so the
+    // mapping is visible within - and rolls back with - it), otherwise run in its own transaction.
+    applyPeriodId(period, runAutoJoinTransaction(upsertPeriod(period)));
   }
 
-  private void save(Period period, boolean forceNewTransaction) {
+  /**
+   * The load-or-create upsert for a period, as a unit of work that can be run in any stateless
+   * session. Returns the existing primary key when the iso period is already present, otherwise
+   * inserts it and returns the new primary key.
+   */
+  private Function<StatelessSession, Object> upsertPeriod(Period period) {
     String sql1 = "SELECT periodid FROM period WHERE iso = :iso";
     String sql2 =
         """
@@ -120,25 +127,27 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         VALUES (nextval('hibernate_sequence'),
           (SELECT periodtypeid FROM periodtype WHERE name = :type), :start, :end, :iso)""";
     String isoDate = period.getIsoDate();
-    Function<StatelessSession, Object> upsert =
-        session -> {
-          Object pk = getSingleResult(session.createNativeQuery(sql1).setParameter("iso", isoDate));
-          if (pk != null) {
-            return pk;
-          }
-          session
-              .createNativeQuery(sql2)
-              .setParameter("type", period.getPeriodType().getName())
-              .setParameter("start", period.getStartDate())
-              .setParameter("end", period.getEndDate())
-              .setParameter("iso", isoDate)
-              .executeUpdate();
-          return session.createNativeQuery("SELECT lastval()").uniqueResult();
-        };
-    Object id = forceNewTransaction ? runInNewTransaction(upsert) : runAutoJoinTransaction(upsert);
+    return session -> {
+      Object pk = getSingleResult(session.createNativeQuery(sql1).setParameter("iso", isoDate));
+      if (pk != null) {
+        return pk;
+      }
+      session
+          .createNativeQuery(sql2)
+          .setParameter("type", period.getPeriodType().getName())
+          .setParameter("start", period.getStartDate())
+          .setParameter("end", period.getEndDate())
+          .setParameter("iso", isoDate)
+          .executeUpdate();
+      return session.createNativeQuery("SELECT lastval()").uniqueResult();
+    };
+  }
+
+  /** Caches and links the resolved primary key onto the transient period instance. */
+  private void applyPeriodId(Period period, Object id) {
     if (id instanceof Number n) {
       long periodId = n.longValue();
-      periodIdByIsoPeriod.putIfAbsent(isoDate, periodId);
+      periodIdByIsoPeriod.putIfAbsent(period.getIsoDate(), periodId);
       period.setId(periodId);
     }
   }
@@ -245,7 +254,9 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
 
   @Override
   public Period reloadForceAddPeriodInNewTransaction(Period period) {
-    save(period, true);
+    // Immediate-commit path: always commit in its own transaction so a separate connection (the
+    // quick BatchHandler) can see the period - see runInNewTransaction (DHIS2-7539, DHIS2-21617).
+    applyPeriodId(period, runInNewTransaction(upsertPeriod(period)));
     return period;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.period.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.sql.Connection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
@@ -48,7 +50,9 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.RelativePeriods;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Persistence for {@link Period} and {@link PeriodType}.
@@ -74,11 +78,15 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
 
   private final Map<String, Long> periodIdByIsoPeriod = new ConcurrentHashMap<>();
 
+  private final DataSource dataSource;
+
   public HibernatePeriodStore(
       EntityManager entityManager,
+      DataSource dataSource,
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher) {
     super(entityManager, jdbcTemplate, publisher, Period.class, false);
+    this.dataSource = dataSource;
   }
 
   @Override
@@ -101,6 +109,10 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
    */
   @Override
   public void save(Period period) {
+    save(period, false);
+  }
+
+  private void save(Period period, boolean forceNewTransaction) {
     String sql1 = "SELECT periodid FROM period WHERE iso = :iso";
     String sql2 =
         """
@@ -124,7 +136,8 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
                   .setParameter("iso", isoDate)
                   .executeUpdate();
               return session.createNativeQuery("SELECT lastval()").uniqueResult();
-            });
+            },
+            forceNewTransaction);
     if (id instanceof Number n) {
       long periodId = n.longValue();
       periodIdByIsoPeriod.putIfAbsent(isoDate, periodId);
@@ -232,6 +245,12 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
     return period;
   }
 
+  @Override
+  public Period reloadForceAddPeriodInNewTransaction(Period period) {
+    save(period, true);
+    return period;
+  }
+
   // -------------------------------------------------------------------------
   // PeriodType (do not use generic store which is linked to Period)
   // -------------------------------------------------------------------------
@@ -255,7 +274,8 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               }
               session.createNativeQuery(sql2).setParameter("name", name).executeUpdate();
               return session.createNativeQuery("SELECT lastval()").uniqueResult();
-            });
+            },
+            false);
     if (id instanceof Number n) {
       int periodTypeId = n.intValue();
       periodType.setId(periodTypeId);
@@ -280,7 +300,8 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
                 .createNativeQuery(sql)
                 .setParameter("name", name)
                 .setParameter("label", label)
-                .executeUpdate());
+                .executeUpdate(),
+        false);
   }
 
   @Override
@@ -298,18 +319,33 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         .uniqueResult();
   }
 
-  private <R> R runAutoJoinTransaction(Function<StatelessSession, R> query) {
-    // The implicit period/period-type mapping (iso/name -> PK) must be persisted and committed
-    // "right away" in its own session/transaction, independently of any transaction that is
-    // active on the calling thread (see DHIS2-7539, DHIS2-21617). Callers such as the complete
-    // data set registration and data value set importers reference the freshly created period
-    // through a SEPARATE JDBC connection (the `quick` BatchHandler, which inserts with autoCommit
-    // on its own pooled connection). If the period were only inserted into the caller's still-open
-    // transaction, that separate connection cannot see it and the dependent insert fails with a
-    // foreign key violation - so the registrations/values are silently not persisted even though
-    // the import reports success. Always committing here makes the period visible to every
-    // connection immediately; periods are an append-only id mapping, so committing them even when
-    // an outer transaction later rolls back is safe.
+  private <R> R runAutoJoinTransaction(
+      Function<StatelessSession, R> query, boolean forceNewTransaction) {
+    boolean active = TransactionSynchronizationManager.isActualTransactionActive();
+    boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+    if (!forceNewTransaction && active && !readOnly) {
+      // Join the caller's active read-write transaction (no independent commit) by borrowing its
+      // transaction-bound connection. The implicit period/period-type mapping is then visible
+      // within - and rolls back with - that transaction. This is the right behaviour for ordinary
+      // period creation, where the caller persists everything it references on the same
+      // transaction-bound connection.
+      Connection borrowedConnection = DataSourceUtils.getConnection(dataSource);
+      StatelessSession session =
+          getSession().getSessionFactory().openStatelessSession(borrowedConnection);
+      return query.apply(session);
+    }
+
+    // Run in - and commit - a new, independent transaction. Reached either when there is no active
+    // read-write transaction, or when the caller explicitly requires the mapping to be committed
+    // right away (forceNewTransaction). The latter is needed by importers that reference the
+    // freshly created period through a SEPARATE JDBC connection (the `quick` BatchHandler, which
+    // inserts with autoCommit on its own pooled connection): a period that only lives in the
+    // caller's still-open transaction is invisible to that connection, so the dependent insert
+    // fails with a foreign key violation while the import still reports success (DHIS2-7539,
+    // DHIS2-21617). Committing here makes the period visible to every connection immediately;
+    // periods are an append-only iso -> PK mapping, so committing them even when an outer
+    // transaction later rolls back is safe.
     StatelessSession session = getSession().getSessionFactory().openStatelessSession();
 
     Transaction transaction = null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -111,7 +111,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
   public void save(Period period) {
     // Default path: join the caller's active read-write transaction when there is one (so the
     // mapping is visible within - and rolls back with - it), otherwise run in its own transaction.
-    applyPeriodId(period, runAutoJoinTransaction(upsertPeriod(period)));
+    applyPeriodId(period, runInTransaction(upsertPeriod(period)));
   }
 
   /**
@@ -274,7 +274,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         INSERT INTO periodtype (periodtypeid, name)
         VALUES (nextval('hibernate_sequence'), :name)""";
     Object id =
-        runAutoJoinTransaction(
+        runInTransaction(
             session -> {
               Object pk =
                   getSingleResult(session.createNativeQuery(sql1).setParameter("name", name));
@@ -302,7 +302,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         UPDATE periodtype SET label = :label
         WHERE name = :name""";
 
-    runAutoJoinTransaction(
+    runInTransaction(
         session ->
             session
                 .createNativeQuery(sql)
@@ -327,27 +327,42 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
   }
 
   /**
-   * Persists the implicit period/period-type mapping, joining the caller's active read-write
-   * transaction when there is one (so the mapping is visible within - and rolls back with - that
-   * transaction), and otherwise committing it in a new, independent transaction. This is the right
-   * behaviour for ordinary period creation, where the caller persists everything it references on
-   * the same transaction-bound connection. Callers that must commit the mapping immediately even
-   * inside an active transaction use {@link #runInNewTransaction} directly.
+   * The single place that decides how an implicit period/period-type mapping is persisted: it joins
+   * the caller's active read-write transaction when there is one (so the mapping is visible within
+   * - and rolls back with - that transaction), and otherwise commits it in a new, independent
+   * transaction. This is the right behaviour for ordinary period creation, where the caller may or
+   * may not already be inside a transaction (e.g. a controller calling {@code reloadPeriod}
+   * directly). Callers that must commit the mapping immediately even inside an active transaction
+   * use {@link #runInNewTransaction} directly.
    */
-  private <R> R runAutoJoinTransaction(Function<StatelessSession, R> query) {
-    boolean active = TransactionSynchronizationManager.isActualTransactionActive();
-    boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+  private <R> R runInTransaction(Function<StatelessSession, R> query) {
+    return isActiveReadWriteTransaction()
+        ? joinActiveTransaction(query)
+        : runInNewTransaction(query);
+  }
 
-    if (active && !readOnly) {
-      // Join the caller's active read-write transaction by borrowing its transaction-bound
-      // connection, so the implicit mapping is visible within - and rolls back with - it.
-      Connection borrowedConnection = DataSourceUtils.getConnection(dataSource);
-      StatelessSession session =
-          getSession().getSessionFactory().openStatelessSession(borrowedConnection);
-      return query.apply(session);
+  private boolean isActiveReadWriteTransaction() {
+    return TransactionSynchronizationManager.isActualTransactionActive()
+        && !TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+  }
+
+  /**
+   * Joins the caller's active read-write transaction by borrowing its transaction-bound connection,
+   * so the mapping is visible within - and rolls back with - it. The active read-write transaction
+   * is a hard precondition: this method never opens one of its own, so it throws if there is none
+   * (the {@link #runInTransaction} dispatcher is the only place that decides join-vs-new; this
+   * guard protects any other/future caller from silently running outside a transaction).
+   */
+  private <R> R joinActiveTransaction(Function<StatelessSession, R> query) {
+    if (!isActiveReadWriteTransaction()) {
+      throw new IllegalStateException(
+          "joinActiveTransaction requires an active read-write transaction; "
+              + "use runInTransaction or runInNewTransaction when none is guaranteed");
     }
-
-    return runInNewTransaction(query);
+    Connection borrowedConnection = DataSourceUtils.getConnection(dataSource);
+    StatelessSession session =
+        getSession().getSessionFactory().openStatelessSession(borrowedConnection);
+    return query.apply(session);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -30,7 +30,6 @@
 package org.hisp.dhis.period.hibernate;
 
 import jakarta.persistence.EntityManager;
-import java.sql.Connection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
@@ -50,9 +48,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.RelativePeriods;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Persistence for {@link Period} and {@link PeriodType}.
@@ -78,15 +74,11 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
 
   private final Map<String, Long> periodIdByIsoPeriod = new ConcurrentHashMap<>();
 
-  private final DataSource dataSource;
-
   public HibernatePeriodStore(
       EntityManager entityManager,
-      DataSource dataSource,
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher) {
     super(entityManager, jdbcTemplate, publisher, Period.class, false);
-    this.dataSource = dataSource;
   }
 
   @Override
@@ -307,18 +299,17 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
   }
 
   private <R> R runAutoJoinTransaction(Function<StatelessSession, R> query) {
-    boolean active = TransactionSynchronizationManager.isActualTransactionActive();
-    boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
-
-    if (active && !readOnly) {
-      // run in existing TX (for visibility)
-      Connection borrowedConnection = DataSourceUtils.getConnection(dataSource);
-      StatelessSession session =
-          getSession().getSessionFactory().openStatelessSession(borrowedConnection);
-      return query.apply(session);
-    }
-
-    // run in new TX
+    // The implicit period/period-type mapping (iso/name -> PK) must be persisted and committed
+    // "right away" in its own session/transaction, independently of any transaction that is
+    // active on the calling thread (see DHIS2-7539, DHIS2-21617). Callers such as the complete
+    // data set registration and data value set importers reference the freshly created period
+    // through a SEPARATE JDBC connection (the `quick` BatchHandler, which inserts with autoCommit
+    // on its own pooled connection). If the period were only inserted into the caller's still-open
+    // transaction, that separate connection cannot see it and the dependent insert fails with a
+    // foreign key violation - so the registrations/values are silently not persisted even though
+    // the import reports success. Always committing here makes the period visible to every
+    // connection immediately; periods are an append-only id mapping, so committing them even when
+    // an outer transaction later rolls back is safe.
     StatelessSession session = getSession().getSessionFactory().openStatelessSession();
 
     Transaction transaction = null;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataset.CompleteDataSetRegistration;
+import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.PeriodTypeEnum;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Regression test for DHIS2-21617.
+ *
+ * <p>Importing complete data set registrations for a period that does not yet exist in the database
+ * must create the period and durably persist the registrations. The registrations are written by
+ * the {@code quick} BatchHandler on its own pooled JDBC connection (autoCommit), so the
+ * newly-created period must be committed in a separate transaction (see {@link
+ * org.hisp.dhis.period.hibernate.HibernatePeriodStore}); otherwise the registration insert hits a
+ * foreign key violation / is not persisted while the import still reports success.
+ *
+ * @author Claude
+ */
+class CompleteDataSetRegistrationImportNewPeriodTest extends PostgresIntegrationTestBase {
+
+  @Autowired private CompleteDataSetRegistrationExchangeService exchangeService;
+
+  @Autowired private CompleteDataSetRegistrationService registrationService;
+
+  @Autowired private PeriodService periodService;
+
+  @Autowired private IdentifiableObjectManager idObjectManager;
+
+  @Autowired private CategoryService categoryService;
+
+  private DataSet dataSetA;
+
+  private OrganisationUnit orgUnitA;
+
+  private CategoryOptionCombo defaultAoc;
+
+  /** A future period that is intentionally NOT added to the database during setup. */
+  private static final String NEW_PERIOD_ISO = "209901";
+
+  @BeforeEach
+  void setUp() {
+    PeriodType monthly = PeriodType.getPeriodType(PeriodTypeEnum.MONTHLY);
+
+    orgUnitA = createOrganisationUnit('A');
+    idObjectManager.save(orgUnitA);
+
+    dataSetA = createDataSet('A', monthly);
+    dataSetA.addOrganisationUnit(orgUnitA);
+    idObjectManager.save(dataSetA);
+
+    defaultAoc = categoryService.getDefaultCategoryOptionCombo();
+
+    User user = createAndAddUser(true, "cdsruser", orgUnitA, "ALL");
+    injectSecurityContextUser(user);
+  }
+
+  @Test
+  void testImportRegistrationForNonExistingPeriodIsPersisted() {
+    // Guard: the period must not exist yet, so the import is forced to create it.
+    assertNull(
+        periodService.getPeriod(NEW_PERIOD_ISO),
+        "Test pre-condition: period " + NEW_PERIOD_ISO + " must not exist before the import");
+
+    String json =
+        """
+        {
+          "completeDataSetRegistrations": [
+            {
+              "dataSet": "%s",
+              "period": "%s",
+              "organisationUnit": "%s",
+              "attributeOptionCombo": "%s",
+              "completed": true
+            }
+          ]
+        }"""
+            .formatted(
+                dataSetA.getUid(), NEW_PERIOD_ISO, orgUnitA.getUid(), defaultAoc.getUid());
+
+    ImportSummary summary =
+        exchangeService.saveCompleteDataSetRegistrationsJson(
+            new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)),
+            new ImportOptions());
+
+    assertEquals(
+        ImportStatus.SUCCESS,
+        summary.getStatus(),
+        "Import should succeed, conflicts: " + summary.getConflicts());
+    assertEquals(1, summary.getImportCount().getImported(), "One registration should be imported");
+
+    // The registration must be durably persisted (this is the actual DHIS2-21617 failure).
+    List<CompleteDataSetRegistration> all = registrationService.getAllCompleteDataSetRegistrations();
+    assertEquals(
+        1, all.size(), "The imported registration must be persisted in completedatasetregistration");
+
+    // The period must have been created as part of the import.
+    assertTrue(
+        periodService.getPeriod(NEW_PERIOD_ISO) != null,
+        "The previously non-existing period should have been created and persisted");
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
@@ -65,6 +65,11 @@ import org.springframework.beans.factory.annotation.Autowired;
  * org.hisp.dhis.period.hibernate.HibernatePeriodStore}); otherwise the registration insert hits a
  * foreign key violation / is not persisted while the import still reports success.
  *
+ * <p>The bug is reproduced through the <em>synchronous</em> {@code
+ * saveCompleteDataSetRegistrationsJson} entry point rather than the async job path: the defect is
+ * transactional, not async, so the synchronous path exercises it deterministically (no scheduler
+ * involved) while running the same import/BatchHandler code.
+ *
  * @author Claude
  */
 class CompleteDataSetRegistrationImportNewPeriodTest extends PostgresIntegrationTestBase {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/dataset/CompleteDataSetRegistrationImportNewPeriodTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -46,7 +46,6 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.PeriodTypeEnum;
@@ -126,13 +125,11 @@ class CompleteDataSetRegistrationImportNewPeriodTest extends PostgresIntegration
             }
           ]
         }"""
-            .formatted(
-                dataSetA.getUid(), NEW_PERIOD_ISO, orgUnitA.getUid(), defaultAoc.getUid());
+            .formatted(dataSetA.getUid(), NEW_PERIOD_ISO, orgUnitA.getUid(), defaultAoc.getUid());
 
     ImportSummary summary =
         exchangeService.saveCompleteDataSetRegistrationsJson(
-            new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)),
-            new ImportOptions());
+            new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), new ImportOptions());
 
     assertEquals(
         ImportStatus.SUCCESS,
@@ -141,9 +138,12 @@ class CompleteDataSetRegistrationImportNewPeriodTest extends PostgresIntegration
     assertEquals(1, summary.getImportCount().getImported(), "One registration should be imported");
 
     // The registration must be durably persisted (this is the actual DHIS2-21617 failure).
-    List<CompleteDataSetRegistration> all = registrationService.getAllCompleteDataSetRegistrations();
+    List<CompleteDataSetRegistration> all =
+        registrationService.getAllCompleteDataSetRegistrations();
     assertEquals(
-        1, all.size(), "The imported registration must be persisted in completedatasetregistration");
+        1,
+        all.size(),
+        "The imported registration must be persisted in completedatasetregistration");
 
     // The period must have been created as part of the import.
     assertTrue(


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-21617

TL;DR:
BatchHandler cannot see uncommitted periods, and silently fails due to foreign key constraint, falsely reporting rows as added.

This fix now always commits periods immediately in a new session for the batchhandler flow, while keeping the old logic in other cases (Otherwise this would break a few tests).


Fixed by Claude, see here for in-depth description: https://github.com/stian-sandvold/dhis2-core/pull/2