### PR TITLE
fix: enrollment analytics PI filters by resolving CTE placeholders before SQL exec [DHIS2-21628]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -786,7 +786,10 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   @Transactional(readOnly = true, propagation = REQUIRES_NEW)
   public Grid getAggregatedEventData(EventQueryParams passedParams, Grid grid, int maxLimit) {
     EventQueryParams params = piDisagInfoInitializer.getParamsWithDisaggregationInfo(passedParams);
-    AggregateClause aggregateClause = getAggregateClause(params);
+    Optional<ProgramIndicatorCteSql> programIndicatorCte = getProgramIndicatorCteSql(params);
+    AggregateClause aggregateClause =
+        getAggregateClause(
+            params, programIndicatorCte.map(ProgramIndicatorCteSql::valueColumn).orElse(null));
     List<String> columns =
         union(getSelectColumns(params, true), piDisagQueryGenerator.getCocSelectColumns(params));
 
@@ -803,6 +806,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     // ---------------------------------------------------------------------
 
     sql += getFromClause(params);
+    sql += programIndicatorCte.map(ProgramIndicatorCteSql::joinClause).orElse("");
 
     String whereClause = getWhereClause(params);
     sql += whereClause;
@@ -833,6 +837,10 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       sql += LIMIT + " " + params.getLimit();
     } else if (maxLimit > 0) {
       sql += LIMIT + " " + (maxLimit + 1);
+    }
+
+    if (programIndicatorCte.isPresent()) {
+      sql = programIndicatorCte.get().withClause() + sql;
     }
 
     // ---------------------------------------------------------------------
@@ -950,6 +958,22 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    * @return an {@link AggregateClause} containing the SQL and metadata
    */
   protected AggregateClause getAggregateClause(EventQueryParams params) {
+    return getAggregateClause(params, null);
+  }
+
+  /**
+   * Returns the aggregate clause based on value dimension and output type. When {@code
+   * programIndicatorValueColumn} is given, a program indicator dimension is aggregated over that
+   * column (the per-enrollment value of the joined program indicator CTE) instead of inlining the
+   * program indicator expression SQL.
+   *
+   * @param params the {@link EventQueryParams}.
+   * @param programIndicatorValueColumn the column holding the per-enrollment program indicator
+   *     value, or null when no program indicator CTE is joined.
+   * @return an {@link AggregateClause} containing the SQL and metadata
+   */
+  private AggregateClause getAggregateClause(
+      EventQueryParams params, String programIndicatorValueColumn) {
     // TODO include output type if aggregation type is count
 
     // If no aggregation type is set for this event data item and no override aggregation type is
@@ -979,12 +1003,14 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       return AggregateClause.of(sql, aggregationType, expression);
     } else if (params.hasProgramIndicatorDimension()) {
       String expression =
-          programIndicatorService.getAnalyticsSql(
-              params.getProgramIndicator().getExpression(),
-              NUMERIC,
-              params.getProgramIndicator(),
-              params.getEarliestStartDate(),
-              params.getLatestEndDate());
+          programIndicatorValueColumn != null
+              ? programIndicatorValueColumn
+              : programIndicatorService.getAnalyticsSql(
+                  params.getProgramIndicator().getExpression(),
+                  NUMERIC,
+                  params.getProgramIndicator(),
+                  params.getEarliestStartDate(),
+                  params.getLatestEndDate());
       String sql = function + "(" + expression + ")";
       return AggregateClause.of(sql, aggregationType, expression);
     } else {
@@ -1015,6 +1041,53 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         }
       }
     }
+  }
+
+  /**
+   * SQL fragments for joining a program indicator CTE into an aggregate query: the {@code with}
+   * clause defining the CTEs, the inner join of the main program indicator CTE on enrollment, and
+   * the column holding the per-enrollment program indicator value.
+   */
+  protected record ProgramIndicatorCteSql(
+      String withClause, String joinClause, String valueColumn) {}
+
+  /**
+   * Builds the CTE definitions for an enrollment program indicator dimension. The program indicator
+   * expression and filter are processed by the placeholder-to-CTE pipeline, so stage element,
+   * variable and d2 function references become CTE references instead of placeholder tokens. The
+   * returned inner join applies the program indicator filter semantics: enrollments not satisfying
+   * the filter have no row in the program indicator CTE.
+   *
+   * @param params the {@link EventQueryParams}.
+   * @return the SQL fragments, or empty when the query has no enrollment program indicator
+   *     dimension.
+   */
+  protected Optional<ProgramIndicatorCteSql> getProgramIndicatorCteSql(EventQueryParams params) {
+    if (!params.hasEnrollmentProgramIndicatorDimension()) {
+      return Optional.empty();
+    }
+    ProgramIndicator programIndicator = params.getProgramIndicator();
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    programIndicatorSubqueryBuilder.addCte(
+        programIndicator,
+        getAnalyticsType(),
+        params.getEarliestStartDate(),
+        params.getLatestEndDate(),
+        cteContext);
+    CteDefinition definition = cteContext.getDefinitionByItemUid(programIndicator.getUid());
+    String alias = definition.getAlias();
+    String withClause =
+        cteContext.getAliasAndDefinitionSqlMap().entrySet().stream()
+            .map(entry -> entry.getKey() + " as (" + entry.getValue().cteDefinitionSql() + ")")
+            .collect(Collectors.joining(", ", "with ", " "));
+    String joinClause =
+        "inner join %s %s on %s.enrollment = %s.enrollment "
+            .formatted(programIndicator.getUid(), alias, alias, ANALYTICS_TBL_ALIAS);
+    String valueColumn =
+        definition.isRequiresCoalesce()
+            ? "coalesce(%s.value, 0)".formatted(alias)
+            : "%s.value".formatted(alias);
+    return Optional.of(new ProgramIndicatorCteSql(withClause, joinClause, valueColumn));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.analytics.event.data;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
-import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.common.CteDefinition.ENROLLMENT_AGGR_BASE;
 import static org.hisp.dhis.analytics.event.data.EnrollmentQueryHelper.getHeaderColumns;
 import static org.hisp.dhis.analytics.event.data.OrgUnitTableJoiner.joinOrgUnitTables;
@@ -99,7 +98,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueStatus;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.commons.util.ExpressionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -332,12 +330,18 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
   @Override
   public long getEnrollmentCount(EventQueryParams params) {
+    Optional<ProgramIndicatorCteSql> programIndicatorCte = getProgramIndicatorCteSql(params);
     String sql = "select count(pi) ";
 
     sql += getFromClause(params);
+    sql += programIndicatorCte.map(ProgramIndicatorCteSql::joinClause).orElse("");
 
     sql += getWhereClause(params);
     sql += addFiltersToWhereClause(params);
+
+    if (programIndicatorCte.isPresent()) {
+      sql = programIndicatorCte.get().withClause() + sql;
+    }
 
     long count = 0;
 
@@ -509,24 +513,6 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
     if (params.hasProgramStage()) {
       sql += "and ps = '" + params.getProgramStage().getUid() + "' ";
-    }
-
-    // ---------------------------------------------------------------------
-    // Filter expression
-    // ---------------------------------------------------------------------
-
-    if (params.hasProgramIndicatorDimension() && params.getProgramIndicator().hasFilter()) {
-      String filter =
-          programIndicatorService.getAnalyticsSqlAllowingNulls(
-              params.getProgramIndicator().getFilter(),
-              BOOLEAN,
-              params.getProgramIndicator(),
-              params.getEarliestStartDate(),
-              params.getLatestEndDate());
-
-      String sqlFilter = ExpressionUtils.asSql(filter);
-
-      sql += "and (" + sqlFilter + ") ";
     }
 
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -32,7 +32,9 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.analytics.table.EventAnalyticsColumnName.EVENT_STATUS_COLUMN_NAME;
@@ -53,6 +55,7 @@ import static org.hisp.dhis.test.TestBase.getDate;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +65,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -90,6 +94,7 @@ import org.hisp.dhis.db.sql.DorisAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.external.conf.DefaultDhisConfigurationProvider;
 import org.hisp.dhis.period.PeriodDimension;
+import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -166,6 +171,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     when(systemSettings.getOrgUnitCentroidsInEventsAnalytics()).thenReturn(false);
     when(config.getPropertyOrDefault(ANALYTICS_DATABASE, "")).thenReturn("postgresql");
     when(rowSet.getMetaData()).thenReturn(rowSetMetaData);
+    when(piDisagInfoInitializer.getParamsWithDisaggregationInfo(any(EventQueryParams.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
     // Mock stage.ou CTE context for stage OU dimension tests
     when(organisationUnitResolver.buildStageOuCteContext(any(), any()))
         .thenReturn(
@@ -1371,5 +1378,227 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
       index += search.length();
     }
     return count;
+  }
+
+  // -------------------------------------------------------------------------
+  // Program indicator placeholder resolution in aggregate queries
+  // (classic /api/analytics path: getAggregatedEventData / getEnrollmentCount)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void verifyAggregatedEventDataResolvesPsdePlaceholderInPiFilter() {
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "V{enrollment_count}",
+            "A{w75KJ2mc4zz} == 'PIPPO' && #{%s.%s} == 'hello'"
+                .formatted(programStage.getUid(), dataElementA.getUid()));
+    stubPiExpressionSql(pi, "enrollment");
+    stubPiFilterSql(pi, "\"w75KJ2mc4zz\" = 'PIPPO' and " + psdePlaceholder(pi) + " = 'hello'");
+
+    subject.getAggregatedEventData(
+        createAggregatePiParams(pi, AggregationType.COUNT), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString(pi.getUid() + " as ("));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+    assertThat(generatedSql, containsString(".enrollment = ax.enrollment"));
+  }
+
+  @Test
+  void verifyEnrollmentCountResolvesPsdePlaceholderInPiFilter() {
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "V{enrollment_count}",
+            "#{%s.%s} == 'hello'".formatted(programStage.getUid(), dataElementA.getUid()));
+    stubPiExpressionSql(pi, "enrollment");
+    stubPiFilterSql(pi, psdePlaceholder(pi) + " = 'hello'");
+
+    subject.getEnrollmentCount(createAggregatePiParams(pi, AggregationType.COUNT));
+    verify(jdbcTemplate).queryForObject(sql.capture(), eq(Long.class));
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+    assertThat(generatedSql, containsString(".enrollment = ax.enrollment"));
+  }
+
+  @Test
+  void verifyAggregatedEventDataResolvesPsdePlaceholderInPiExpression() {
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "#{%s.%s}".formatted(programStage.getUid(), dataElementA.getUid()), null);
+    stubPiExpressionSql(pi, psdePlaceholder(pi));
+
+    subject.getAggregatedEventData(
+        createAggregatePiParams(pi, AggregationType.SUM), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+    assertThat(generatedSql, containsString("sum("));
+  }
+
+  @Test
+  void verifyAggregatedEventDataResolvesVariablePlaceholderInPiFilter() {
+    // d2:daysBetween keeps the V{...} reference out of the simple-filter analyzer, so the
+    // variable placeholder must be resolved by the complex-filter processing chain
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "V{enrollment_count}", "d2:daysBetween(V{enrollment_date}, V{event_date}) > 7");
+    stubPiExpressionSql(pi, "enrollment");
+    stubPiFilterSql(
+        pi, "(cast(" + variablePlaceholder(pi) + " as date) - cast(enrollmentdate as date)) > 7");
+
+    subject.getAggregatedEventData(
+        createAggregatePiParams(pi, AggregationType.COUNT), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+  }
+
+  @Test
+  void verifyAggregatedEventDataResolvesD2FunctionPlaceholderInPiFilter() {
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "V{enrollment_count}",
+            "d2:countIfValue(#{%s.%s}, 10) > 0"
+                .formatted(programStage.getUid(), dataElementA.getUid()));
+    stubPiExpressionSql(pi, "enrollment");
+    stubPiFilterSql(pi, d2FunctionPlaceholder(pi) + " > 0");
+
+    subject.getAggregatedEventData(
+        createAggregatePiParams(pi, AggregationType.COUNT), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+  }
+
+  @Test
+  void verifyAggregatedEventDataResolvesMixedPlaceholdersInPiFilter() {
+    ProgramIndicator pi =
+        createEnrollmentProgramIndicator(
+            "V{enrollment_count}",
+            "A{w75KJ2mc4zz} == 'PIPPO' && #{%s.%s} == 'hello' && (V{event_date} > '2021-01-01' || A{w75KJ2mc4zz} == 'x')"
+                .formatted(programStage.getUid(), dataElementA.getUid()));
+    stubPiExpressionSql(pi, "enrollment");
+    stubPiFilterSql(
+        pi,
+        "\"w75KJ2mc4zz\" = 'PIPPO' and "
+            + psdePlaceholder(pi)
+            + " = 'hello' and ("
+            + variablePlaceholder(pi)
+            + " > '2021-01-01' or \"w75KJ2mc4zz\" = 'x')");
+
+    subject.getAggregatedEventData(
+        createAggregatePiParams(pi, AggregationType.COUNT), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertNoCtePlaceholders(generatedSql);
+    assertThat(generatedSql, startsWith("with "));
+    assertThat(generatedSql, containsString("inner join " + pi.getUid()));
+  }
+
+  @Test
+  void verifyAggregatedEventDataWithoutProgramIndicatorHasNoCtes() {
+    subject.getAggregatedEventData(
+        createRequestParams(programStage, ValueType.INTEGER), new ListGrid(), 200000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = sql.getValue();
+    assertThat(generatedSql, not(startsWith("with ")));
+    assertThat(generatedSql, not(containsString("inner join")));
+  }
+
+  private ProgramIndicator createEnrollmentProgramIndicator(String expression, String filter) {
+    return createProgramIndicator('X', AnalyticsType.ENROLLMENT, programA, expression, filter);
+  }
+
+  private EventQueryParams createAggregatePiParams(
+      ProgramIndicator pi, AggregationType aggregationType) {
+    return new EventQueryParams.Builder(createRequestParams())
+        .withProgramIndicator(pi)
+        .withAggregationType(AnalyticsAggregationType.fromAggregationType(aggregationType))
+        .build();
+  }
+
+  private String psdePlaceholder(ProgramIndicator pi) {
+    return "__PSDE_CTE_PLACEHOLDER__(psUid='%s', deUid='%s', offset='0', boundaryHash='noboundaries', piUid='%s')"
+        .formatted(programStage.getUid(), dataElementA.getUid(), pi.getUid());
+  }
+
+  private String variablePlaceholder(ProgramIndicator pi) {
+    return "FUNC_CTE_VAR( type='vEventDate', column='occurreddate', piUid='%s', psUid='null', offset='0')"
+        .formatted(pi.getUid());
+  }
+
+  private String d2FunctionPlaceholder(ProgramIndicator pi) {
+    return "__D2FUNC__(func='countIfValue', ps='%s', de='%s', argType='val64', arg64='MTA=', hash='noboundaries', pi='%s')__"
+        .formatted(programStage.getUid(), dataElementA.getUid(), pi.getUid());
+  }
+
+  private void stubPiExpressionSql(ProgramIndicator pi, String rawExpressionSql) {
+    when(programIndicatorService.getAnalyticsSql(
+            eq(pi.getExpression()), eq(NUMERIC), eq(pi), any(), any()))
+        .thenReturn(rawExpressionSql);
+    when(programIndicatorService.getAnalyticsSql(
+            eq(pi.getExpression()), eq(NUMERIC), eq(pi), any(), any(), anyString()))
+        .thenReturn(rawExpressionSql);
+  }
+
+  private void stubPiFilterSql(ProgramIndicator pi, String rawFilterSql) {
+    // The filter analyzer may strip simple V{...} comparisons from the filter text before
+    // asking the service for SQL, so match any expression string for this PI.
+    when(programIndicatorService.getAnalyticsSqlAllowingNulls(
+            anyString(), eq(BOOLEAN), eq(pi), any(), any()))
+        .thenReturn(rawFilterSql);
+    when(programIndicatorService.getAnalyticsSqlAllowingNulls(
+            anyString(), eq(BOOLEAN), eq(pi), any(), any(), anyString()))
+        .thenReturn(rawFilterSql);
+  }
+
+  private void assertNoCtePlaceholders(String generatedSql) {
+    assertThat(generatedSql, not(containsString("__PSDE_CTE_PLACEHOLDER__")));
+    assertThat(generatedSql, not(containsString("FUNC_CTE_VAR(")));
+    assertThat(generatedSql, not(containsString("__D2FUNC__")));
+    assertJoinTargetsAreDefinedCtes(generatedSql);
+  }
+
+  /**
+   * Every inner/left join target that is not an analytics table must be defined as a CTE in the
+   * with clause, otherwise the query fails at runtime with "relation does not exist".
+   */
+  private void assertJoinTargetsAreDefinedCtes(String generatedSql) {
+    java.util.Set<String> definedCtes =
+        java.util.regex.Pattern.compile("([A-Za-z0-9_]+)\\s+as\\s*\\(")
+            .matcher(generatedSql)
+            .results()
+            .map(r -> r.group(1))
+            .collect(java.util.stream.Collectors.toSet());
+    java.util.regex.Matcher joins =
+        java.util.regex.Pattern.compile("(?:inner|left)\\s+join\\s+([A-Za-z0-9_]+)")
+            .matcher(generatedSql);
+    while (joins.find()) {
+      String target = joins.group(1);
+      if (target.startsWith("analytics_")) {
+        continue;
+      }
+      assertThat(
+          "join target '" + target + "' must be defined as a CTE in: " + generatedSql,
+          definedCtes.contains(target),
+          is(true));
+    }
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
 import org.hisp.dhis.test.e2e.actions.RestApiActions;
+import org.hisp.dhis.test.e2e.dependsOn.DependsOn;
+import org.hisp.dhis.test.e2e.dependsOn.Resource;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
@@ -1082,5 +1084,58 @@ public class AnalyticsQueryDv16AutoTest extends AnalyticsApiTest {
             Map.entry("factor", ""),
             Map.entry("multiplier", ""),
             Map.entry("divisor", "")));
+  }
+
+  @Test
+  @DependsOn(
+      files = {"pi-with-program-stage-in-filter.json"},
+      delete = true)
+  public void enrollmentProgramIndicatorsWithStageElementFilters(List<Resource> resource)
+      throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    String piUid = resource.get(0).uid();
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=pe:LAST_12_MONTHS,ou:USER_ORGUNIT")
+            .add("skipData=false")
+            .add("includeNumDen=false")
+            .add("displayProperty=NAME")
+            .add("skipMeta=true")
+            .add("dimension=dx:" + piUid)
+            .add("relativePeriodDate=2024-01-01");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        1,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // metaData not found or is empty in response, skipping assertion.
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("dx", piUid, "value", "1.0"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
@@ -211,6 +211,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "enrollmentProgramIndicatorsWithStageElementFilters",
+      "query": "/api/analytics.json?dimension=dx:x8f2Dq4jI3H&filter=pe:LAST_12_MONTHS&filter=ou:USER_ORGUNIT&displayProperty=NAME&skipMeta=true&skipData=false&includeNumDen=false&relativePeriodDate=2024-01-01",
+      "version": {
+        "min": 43
+      }
     }
   ]
 }

--- a/dhis-2/dhis-test-e2e/src/test/resources/dependencies/pi-with-program-stage-in-filter.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/dependencies/pi-with-program-stage-in-filter.json
@@ -1,0 +1,15 @@
+{
+  "type": "program_indicator",
+  "code": "PI_PROGRAM_STAGE_IN_FILTER",
+  "aggregationType":"COUNT",
+  "expression":"V{enrollment_count}",
+  "filter":"A{w75KJ2mc4zz} == 'Evelyn' && #{ZzYYXq4fJie.OuJ6sgPyAbC} == 'High blood pressure.' && (#{A03MvHHogjR.a3kGcGDCuk6} == 34)",
+  "name":"PI_WITH_PROGRAM_STAGE_IN_FILTER",
+  "analyticsType":"ENROLLMENT",
+  "shortName":"PI_PROGRAM_STAGE_IN_FILTER",
+  "program":{
+    "id":"IpHINAT79UW"
+  },
+  "analyticsPeriodBoundaries": [],
+  "legendSets": []
+}


### PR DESCRIPTION
## Summary

This PR fixes enrollment analytics aggregate/count queries where an enrollment program indicator filter references event-stage data, such as `#{programStage.dataElement}`.

The affected path was rendering the program indicator filter outside the program indicator CTE pipeline and appending it directly to the outer enrollment `WHERE` clause. 

For enrollment program indicators, event-stage references are represented as internal CTE placeholders so they can be resolved without Doris-incompatible correlated subqueries. Because the raw outer `WHERE` path did not process those placeholders, generated SQL could contain unresolved tokens like `__PSDE_CTE_PLACEHOLDER__(...)`.

### Fix

- Builds enrollment program indicator dimensions through the existing program indicator CTE pipeline in aggregate/count queries.
- Joins the generated program indicator CTE into the outer enrollment query.
- Aggregates over the resolved program indicator CTE value column instead of inlining expression with placeholder.
- Add tests and e2e test
