### PR TITLE
fix: Harmonize db sequences for tracker [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/SingleEvent.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/SingleEvent.hbm.xml
@@ -8,7 +8,7 @@
 
     <id name="id" column="eventid">
       <generator class="sequence">
-        <param name="sequence_name">programstageinstance_sequence</param>
+        <param name="sequence_name">singleevent_sequence</param>
       </generator>
     </id>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
@@ -13,7 +13,9 @@
              longer touches relationships via Hibernate. -->
 
         <id name="id" column="relationshipid">
-            <generator class="native"/>
+            <generator class="sequence">
+                <param name="sequence_name">relationship_sequence</param>
+            </generator>
         </id>
 
         &identifiableProperties;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
@@ -12,7 +12,9 @@
              items via Hibernate. -->
 
         <id name="id" column="relationshipitemid">
-            <generator class="native" />
+            <generator class="sequence">
+                <param name="sequence_name">relationshipitem_sequence</param>
+            </generator>
         </id>
 
         <many-to-one name="relationship" class="org.hisp.dhis.tracker.model.Relationship"

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_12__rename_tracker_sequences_to_match_table_names.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_12__rename_tracker_sequences_to_match_table_names.sql
@@ -1,0 +1,22 @@
+-- DHIS2-21378: align tracker sequence names with the current table names and give
+-- relationship/relationshipitem their own sequences instead of the shared hibernate_sequence.
+
+-- Tables were renamed long ago (trackedentityinstance -> trackedentity,
+-- programinstance -> enrollment) but the sequences kept the legacy names.
+alter sequence if exists trackedentityinstance_sequence rename to trackedentity_sequence;
+alter sequence if exists programinstance_sequence rename to enrollment_sequence;
+
+-- After the event table split (V2_43_21) the SingleEvent Hibernate mapping kept drawing ids
+-- from the legacy programstageinstance_sequence while the JDBC import path used the canonical
+-- singleevent_sequence, so the two counters diverged. Resync the canonical sequence to the
+-- table's max id and drop the legacy sequence.
+select setval('singleevent_sequence', coalesce(max(eventid), 1)) from singleevent;
+drop sequence if exists programstageinstance_sequence;
+
+-- relationship and relationshipitem drew ids from the shared, global hibernate_sequence
+-- (<generator class="native"/>). Give them dedicated sequences, seeded from the current max ids.
+create sequence if not exists relationship_sequence;
+select setval('relationship_sequence', coalesce(max(relationshipid), 1)) from relationship;
+
+create sequence if not exists relationshipitem_sequence;
+select setval('relationshipitem_sequence', coalesce(max(relationshipitemid), 1)) from relationshipitem;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.annotations.QueryHints;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.SoftDeletableEntity;
 import org.hisp.dhis.common.SortDirection;
@@ -85,7 +84,12 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher,
       AclService aclService) {
-    super(entityManager, jdbcTemplate, publisher, Relationship.class, aclService, true);
+    // cacheable=false: every query space this store reads (relationship, relationshipitem,
+    // trackedentity, enrollment, trackerevent, singleevent) is written via raw JDBC in the
+    // importer, which bypasses Hibernate's query-cache invalidation -- cached results would go
+    // stale across imports (e.g. an empty duplicate-check result would silently disable
+    // duplicate detection).
+    super(entityManager, jdbcTemplate, publisher, Relationship.class, aclService, false);
   }
 
   public Optional<TrackedEntity> findTrackedEntity(UID trackedEntity, boolean includeDeleted) {
@@ -176,14 +180,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
         or (r.invertedKey in (:keys) and r.relationshipType.bidirectional = true))""";
     List<String> relationshipKeysAsString =
         relationshipKeys.stream().map(RelationshipKey::asString).toList();
-    // Query cache must be off here: the tracker importer writes relationships through JDBC, which
-    // bypasses Hibernate's query-cache invalidation. Leaving the cache on would let an earlier
-    // empty result for a key linger across imports and silently disable duplicate detection.
-    return getQuery(hql, Relationship.class)
-        .setParameter("keys", relationshipKeysAsString)
-        .setCacheable(false)
-        .setHint(QueryHints.CACHEABLE, false)
-        .list();
+    return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString).list();
   }
 
   public List<RelationshipItem> getRelationshipItemsByTrackedEntity(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -72,7 +72,7 @@ public class EnrollmentPersister
 
   @Override
   protected String sequenceName() {
-    return "programinstance_sequence";
+    return "enrollment_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -71,13 +71,12 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * <ul>
  *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
  *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       trackedentityinstance_sequence} in one round-trip.
+ *       trackedentity_sequence} in one round-trip.
  *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
  *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
  *       update branch.
  *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
- *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       programinstance_sequence}.
+ *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code enrollment_sequence}.
  *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
  *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
  *   <li>TrackerEvent inserts are flushed via a multi-row JDBC INSERT against {@code trackerevent}
@@ -97,9 +96,9 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT
  *       into {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code
  *       relationship} to set the from/to FKs. The three-step shape breaks the circular FK between
- *       the two tables, which is not deferrable in the live schema. Both tables use the shared
- *       {@code hibernate_sequence}. Relationship is INSERT-only -- the persister rejects UPDATE
- *       strategy upstream.
+ *       the two tables, which is not deferrable in the live schema. Ids come from {@code
+ *       relationship_sequence} and {@code relationshipitem_sequence}. Relationship is INSERT-only
+ *       -- the persister rejects UPDATE strategy upstream.
  *   <li>TrackedEntityAttributeValues are flushed via JDBC against {@code
  *       trackedentityattributevalue} -- a multi-row INSERT, a single unnest UPDATE keyed on the
  *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single
@@ -384,9 +383,8 @@ class EntityWriteBatch {
   private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
   // Relationship is INSERT-only in tracker imports (RelationshipPersister.convert returns null on
-  // UPDATE strategy). Both relationship and relationshipitem use `hibernate_sequence` (no
-  // dedicated sequence was provisioned in any Flyway migration -- the hbm.xml `<generator
-  // class="native"/>` resolves to the shared global counter).
+  // UPDATE strategy). Relationship ids come from `relationship_sequence`, item ids from
+  // `relationshipitem_sequence`.
   //
   // The two tables form a circular FK (relationship.from/to_relationshipitemid <->
   // relationshipitem.relationshipid) with non-deferrable constraints. We break the cycle by
@@ -1409,7 +1407,7 @@ class EntityWriteBatch {
 
   /**
    * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
-   * we allocate {@code 2 * relationships.size()} ids from {@code hibernate_sequence} in one
+   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
    * round-trip, assign them to the in-memory items (so the subsequent unnest UPDATE can read them
    * back), then flatten the from/to items into a single multi-row INSERT.
    */
@@ -1417,11 +1415,11 @@ class EntityWriteBatch {
     if (relationshipInserts.isEmpty()) {
       return;
     }
-    long[] itemIds = allocateIds(conn, "hibernate_sequence", 2 * relationshipInserts.size());
+    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * relationshipInserts.size());
     int cursor = 0;
     for (Relationship r : relationshipInserts) {
-      r.getFrom().setId((int) itemIds[cursor++]);
-      r.getTo().setId((int) itemIds[cursor++]);
+      r.getFrom().setId(itemIds[cursor++]);
+      r.getTo().setId(itemIds[cursor++]);
     }
 
     // Flatten (from + to) per relationship into a single list to drive one multi-row INSERT.
@@ -1501,8 +1499,8 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         Relationship r = chunk.get(i);
         ids[i] = r.getId();
-        fromIds[i] = (long) r.getFrom().getId();
-        toIds[i] = (long) r.getTo().getId();
+        fromIds[i] = r.getFrom().getId();
+        toIds[i] = r.getTo().getId();
       }
 
       try (PreparedStatement ps = conn.prepareStatement(RELATIONSHIP_UPDATE_FROM_TO_SQL)) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -1418,8 +1418,8 @@ class EntityWriteBatch {
     long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * relationshipInserts.size());
     int cursor = 0;
     for (Relationship r : relationshipInserts) {
-      r.getFrom().setId(itemIds[cursor++]);
-      r.getTo().setId(itemIds[cursor++]);
+      r.getFrom().setId((int) itemIds[cursor++]);
+      r.getTo().setId((int) itemIds[cursor++]);
     }
 
     // Flatten (from + to) per relationship into a single list to drive one multi-row INSERT.
@@ -1499,8 +1499,8 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         Relationship r = chunk.get(i);
         ids[i] = r.getId();
-        fromIds[i] = r.getFrom().getId();
-        toIds[i] = r.getTo().getId();
+        fromIds[i] = (long) r.getFrom().getId();
+        toIds[i] = (long) r.getTo().getId();
       }
 
       try (PreparedStatement ps = conn.prepareStatement(RELATIONSHIP_UPDATE_FROM_TO_SQL)) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -63,12 +63,9 @@ public class RelationshipPersister
 
   @Override
   protected String sequenceName() {
-    // Shared with every other entity that uses Hibernate's `<generator class="native"/>`. No
-    // dedicated relationship_sequence was provisioned in any Flyway migration. The 2
-    // RelationshipItem
-    // ids per Relationship are allocated separately inside
-    // EntityWriteBatch.insertRelationshipItems.
-    return "hibernate_sequence";
+    // The 2 RelationshipItem ids per Relationship are allocated separately from
+    // relationshipitem_sequence inside EntityWriteBatch.insertRelationshipItems.
+    return "relationship_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -64,7 +64,7 @@ public class TrackedEntityPersister
 
   @Override
   protected String sequenceName() {
-    return "trackedentityinstance_sequence";
+    return "trackedentity_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
@@ -92,10 +92,10 @@ public class Enrollment extends BaseTrackerObject
 
   @Id
   @Column(name = "enrollmentid")
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "programinstance_sequence")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "enrollment_sequence")
   @SequenceGenerator(
-      name = "programinstance_sequence",
-      sequenceName = "programinstance_sequence",
+      name = "enrollment_sequence",
+      sequenceName = "enrollment_sequence",
       allocationSize = 1)
   private long id;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/RelationshipItem.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/RelationshipItem.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.common.EmbeddedObject;
 @Getter
 @NoArgsConstructor
 public class RelationshipItem implements EmbeddedObject {
-  private long id;
+  private int id;
 
   private Relationship relationship;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/RelationshipItem.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/RelationshipItem.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.common.EmbeddedObject;
 @Getter
 @NoArgsConstructor
 public class RelationshipItem implements EmbeddedObject {
-  private int id;
+  private long id;
 
   private Relationship relationship;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
@@ -86,9 +86,12 @@ public class TrackedEntity extends BaseTrackerObject
     implements IdentifiableObject, SoftDeletableEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
-  @SequenceGenerator(sequenceName = "trackedentityinstance_sequence")
   @Column(name = "trackedentityid")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trackedentity_sequence")
+  @SequenceGenerator(
+      name = "trackedentity_sequence",
+      sequenceName = "trackedentity_sequence",
+      allocationSize = 1)
   private long id;
 
   private boolean deleted = false;


### PR DESCRIPTION
## Summary

Aligns tracker database sequence names with their table names and gives `relationship`/`relationshipitem` dedicated sequences instead of the shared global `hibernate_sequence` [DHIS2-21378]. This also fixes a real divergence introduced by the event table split: the SingleEvent Hibernate mapping kept drawing ids from the legacy `programstageinstance_sequence` while the JDBC import path used `singleevent_sequence`, so the two counters drifted apart.

## Changes

- **Migration** `V2_44_12__rename_tracker_sequences_to_match_table_names.sql`: renames `trackedentityinstance_sequence` → `trackedentity_sequence` and `programinstance_sequence` → `enrollment_sequence`; resyncs `singleevent_sequence` to the table's max id and drops the legacy `programstageinstance_sequence`; creates dedicated `relationship_sequence` and `relationshipitem_sequence` seeded from the current max ids. All `setval` calls use `coalesce(max(...), 1)` so empty tables are seeded explicitly.
- **Hibernate mappings**: `SingleEvent.hbm.xml` now draws from `singleevent_sequence`; `Relationship.hbm.xml` and `RelationshipItem.hbm.xml` switch from `<generator class="native"/>` (the shared `hibernate_sequence`) to their dedicated sequences.
- **JPA annotations**: `TrackedEntity.java` and `Enrollment.java` reference the renamed sequences. `TrackedEntity` now declares an explicit generator name and `allocationSize = 1`, matching `Enrollment`, so the JPA default of 50 can never collide with the JDBC importer's plain-`nextval` allocation if a Hibernate persist path is ever added.
- **Persisters**: `TrackedEntityPersister`, `EnrollmentPersister`, and `RelationshipPersister` allocate ids from the renamed/new sequences; `EntityWriteBatch` allocates relationship item ids from `relationshipitem_sequence` instead of `hibernate_sequence`.
- **`HibernateRelationshipStore`**: disables the Hibernate query cache for the whole store (constructor `cacheable=false`) instead of per-query hints. Every query space this store reads is written via raw JDBC in the importer, which bypasses query-cache invalidation — cached results would go stale across imports (e.g. an empty duplicate-check result would silently disable duplicate detection). This brings the store in line with all other tracker stores, which already pass `cacheable=false`.

## Next Steps

**Done**
- ✅ TEAV JDBC insert/update (#24098)
- ✅ Persistence layer refactor in tracker importer (#24197)
- ✅ Sequence harmonization and dedicated relationship sequences (this PR)

**To do**
- ⬜ `EntityWriteBatch` refactor

[DHIS2-21378]: https://dhis2.atlassian.net/browse/DHIS2-21378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ