### PR TITLE
chore: Deprecate old analytics resource tables

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_12__deprecate_old_analytics_tables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_12__deprecate_old_analytics_tables.sql
@@ -1,0 +1,39 @@
+-- It relates to https://dhis2.atlassian.net/browse/DHIS2-21273
+-- Rename/deprecated old analytics resource tables, so it fails fast if someone is still pointing to them.
+
+do $$
+declare
+tbl text;
+    new_name text;
+begin
+for tbl in
+    	-- List of possible analytics resource tables.
+select unnest(array[
+                  '_categoryoptioncomboname',
+              '_categorystructure',
+              '_dataelementcategoryoptioncombo',
+              '_dataelementgroupsetstructure',
+              '_dataelementstructure',
+              '_datasetorganisationunitcategory',
+              '_dateperiodstructure',
+              '_indicatorgroupsetstructure',
+              '_organisationunitgroupsetstructure',
+              '_orgunitstructure',
+              '_periodstructure',
+              '_relationship'
+                  ])
+           loop
+       -- Build the new name by replacing the leading underscore with "_deprecated".
+    new_name := '_deprecated_' || substr(tbl, 2);
+
+-- Only rename/deprecate if the table actually exists.
+if exists (
+            select 1
+            from pg_tables
+            where schemaname = 'public'
+              and tablename = tbl
+        ) then
+            execute format('alter table public.%I rename to %I;', tbl, new_name);
+end if;
+end loop;
+end $$;


### PR DESCRIPTION
In release 41, the analytics tables were renamed.

When a user upgrades to 41, the analytics resource tables (which use the original names) remain in place even after a full analytics export.

This causes confusion and issues for users that have scripts or SQL statements using the original names. They will still work on top of previous data that are never updated, and it might not be noticed.

Also, DBAs might find strange we have such “duplications” from the database perspective.

This migration will rename/deprecate the existing analytics resource tables. In this way, we can avoid such situations.