### PR TITLE
chore(deps): bump micrometer to 1.17.0 and align prometheus-metrics-model to 1.7.0

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -214,8 +214,8 @@
 
     <!-- Monitoring -->
     <micrometer-spring-legacy.version>1.3.20</micrometer-spring-legacy.version>
-    <micrometer.version>1.16.5</micrometer.version>
-    <prometheus-metrics-model.version>1.4.3</prometheus-metrics-model.version>
+    <micrometer.version>1.17.0</micrometer.version>
+    <prometheus-metrics-model.version>1.7.0</prometheus-metrics-model.version>
 
     <!-- Logging -->
     <log4j.version>2.26.0</log4j.version>


### PR DESCRIPTION
  ## What

  Bumps `micrometer.version` 1.16.5 → 1.17.0 **and** `prometheus-metrics-model.version` 1.4.3 → 1.7.0 together. Supersedes the version-only dependabot PR #24180.

  ## Why both properties move together

  `micrometer-registry-prometheus` pulls the `io.prometheus` client_java train transitively, but we pin `prometheus-metrics-model` separately in `dependencyManagement`. The two have to stay on the same train:

  | micrometer-registry-prometheus | pulls prometheus-metrics-core |
  |---|---|
  | 1.16.5 | 1.4.3 |
  | **1.17.0** | **1.7.0** |

  If only `micrometer.version` moves, `prometheus-metrics-model` stays at 1.4.3 and drags `prometheus-metrics-config` down to 1.4.3, while `prometheus-metrics-exposition-formats` resolves to 1.7.0. At scrape time that mismatch throws:

  `java.lang.NoSuchMethodError: io.prometheus.metrics.config.PrometheusProperties.getOpenMetrics2Properties()`

  → `GET /api/metrics` returns HTTP 500. Same failure mode as the 1.16.5 alignment in #24043, just a wider gap (the prometheus train jumps three minors, 1.4.3 → 1.7.0).

  Bumping `prometheus-metrics-model` to 1.7.0 keeps the whole `io.prometheus` train aligned (model = core = config = exposition-formats = 1.7.0). It's the only `io.prometheus` version pin we set, and `dhis-support-system` declares it without a version
  (relies on the managed pin), so aligning the pin is the minimal correct fix.

  ## Verification

  Reproduced both states against the registry/scrape wiring (`PrometheusMeterRegistry` + the JVM/system meter binders, then `scrape()`):

  - micrometer 1.17.0 + model **1.4.3** → `NoSuchMethodError getOpenMetrics2Properties()` (scrape dead)
  - micrometer 1.17.0 + model **1.7.0** → scrape renders cleanly (JVM + custom metrics present)

  `MetricsEndpointTest` / the `api-test` job is the authoritative check here.

  ## Notes

  - Not CVE-driven; OSV clean for the bumped artifacts either direction.
  - `micrometer-registry-prometheus-simpleclient` still ships at 1.17.0, so the `TextFormat` usage in `PrometheusScrapeEndpointController` is unaffected.
  - 2.42 / 2.43 have their own dependabot PRs (#24184 / #24182) and need the same alignment — 2.43 starts from 1.15.4 and should have its `prometheus-metrics-model` pin checked too.