### PR TITLE
refactor: Split EntityWriteBatch into per-entity writers [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
@@ -9,7 +9,9 @@
   <class name="org.hisp.dhis.note.Note" table="note">
 
     <id name="id" column="noteid">
-      <generator class="native" />
+      <generator class="sequence">
+        <param name="sequence_name">note_sequence</param>
+      </generator>
     </id>
 
     <property name="uid" column="uid" unique="true" not-null="true" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityProgramOwner.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityProgramOwner.hbm.xml
@@ -8,7 +8,9 @@
     table="trackedentityprogramowner">
 
     <id name="id" column="trackedentityprogramownerid">
-      <generator class="native" />
+      <generator class="sequence">
+        <param name="sequence_name">trackedentityprogramowner_sequence</param>
+      </generator>
     </id>
 
     <many-to-one name="trackedEntity" class="org.hisp.dhis.tracker.model.TrackedEntity"

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_14__add_trackedentityprogramowner_sequence.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_14__add_trackedentityprogramowner_sequence.sql
@@ -1,0 +1,7 @@
+-- DHIS2-21378: give trackedentityprogramowner its own sequence instead of the shared global
+-- hibernate_sequence. The table drew ids from hibernate_sequence (<generator class="native"/>);
+-- both the JDBC tracker-import write path (TrackedEntityProgramOwnerWriter) and the remaining
+-- Hibernate paths (ownership create-or-update and transfer) now use this dedicated sequence.
+-- Seed it from the current max id so the first nextval is above all existing rows.
+create sequence if not exists trackedentityprogramowner_sequence;
+select setval('trackedentityprogramowner_sequence', coalesce(max(trackedentityprogramownerid), 1)) from trackedentityprogramowner;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityCacheTest.java
@@ -206,6 +206,8 @@ class TrackedEntityCacheTest extends PostgresIntegrationTestBase {
             TrackerImportParams.builder().importStrategy(TrackerImportStrategy.CREATE).build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build()));
 
+    clearSession();
+
     // The cache is empty again, but this time, the owner should be found in the DB, so the user has
     // access to the te-program combination
     assertTrue(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackedEntityProgramOwnerService.java
@@ -62,6 +62,11 @@ public class DefaultTrackedEntityProgramOwnerService implements TrackedEntityPro
         buildTrackedEntityProgramOwner(trackedEntity, program, orgUnit));
   }
 
+  @Override
+  public void invalidateOwnershipCache(TrackedEntity trackedEntity, Program program) {
+    trackedEntityProgramOwnerStore.invalidateOwnershipCache(trackedEntity, program);
+  }
+
   private TrackedEntityProgramOwner buildTrackedEntityProgramOwner(
       TrackedEntity trackedEntity, Program program, OrganisationUnit ou) {
     TrackedEntityProgramOwner teProgramOwner =

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
@@ -111,16 +111,19 @@ public class HibernateTrackedEntityProgramOwnerStore
   @Override
   public void save(@Nonnull TrackedEntityProgramOwner trackedEntityProgramOwner) {
     super.save(trackedEntityProgramOwner);
-    ownerCache.invalidate(
-        getOwnershipCacheKey(
-            trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram()));
+    invalidateOwnershipCache(
+        trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram());
   }
 
   @Override
   public void update(@Nonnull TrackedEntityProgramOwner trackedEntityProgramOwner) {
     super.update(trackedEntityProgramOwner);
-    ownerCache.invalidate(
-        getOwnershipCacheKey(
-            trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram()));
+    invalidateOwnershipCache(
+        trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram());
+  }
+
+  @Override
+  public void invalidateOwnershipCache(TrackedEntity te, Program program) {
+    ownerCache.invalidate(getOwnershipCacheKey(te, program));
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerService.java
@@ -72,4 +72,11 @@ public interface TrackedEntityProgramOwnerService {
    */
   void createTrackedEntityProgramOwner(
       TrackedEntity trackedEntity, Program program, OrganisationUnit orgUnit);
+
+  /**
+   * Invalidates the cached ownership org unit for the te-program combination. Used by write paths
+   * that persist ownership without going through this service's {@code create*} methods (e.g. the
+   * JDBC tracker-import write batch in {@code EntityWriteBatch}).
+   */
+  void invalidateOwnershipCache(TrackedEntity trackedEntity, Program program);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerStore.java
@@ -47,4 +47,11 @@ public interface TrackedEntityProgramOwnerStore extends GenericStore<TrackedEnti
   TrackedEntityProgramOwner getTrackedEntityProgramOwner(TrackedEntity te, Program program);
 
   List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits(Set<Long> teIds);
+
+  /**
+   * Invalidates the cached ownership org unit for the te-program combination. Used by write paths
+   * that persist ownership outside this store (e.g. the JDBC tracker-import write batch) and so do
+   * not go through {@link #save} / {@link #update}, which invalidate the cache themselves.
+   */
+  void invalidateOwnershipCache(TrackedEntity te, Program program);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -164,7 +164,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             if (preAllocatedIds != null) {
               assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
             }
-            persistOwnership(bundle, trackerDto, convertedDto);
+            persistOwnership(bundle, trackerDto, convertedDto, batch);
             stageInsert(convertedDto, batch);
             updateDataValues(
                 bundle.getPreheat(),
@@ -335,16 +335,15 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /**
    * Persists ownership records for the given entity. The only non-trivial implementation
-   * (enrollments creating a {@link org.hisp.dhis.tracker.model.TrackedEntityProgramOwner}) still
-   * goes through a Hibernate {@code save()} that is never flushed per entity -- a per-entity
-   * session flush would dirty-check the whole preheat-populated persistence context, which is the
-   * overhead the JDBC write path removed. Consequence: a constraint violation on the owner row
-   * (only reachable via a concurrent import racing on the {@code trackedentityid + programid}
-   * unique key) surfaces at transaction commit, outside the per-entity try/catch in {@link
-   * #persist}, so in non-atomic mode stats can report the enrollment as created while the commit
-   * then fails.
+   * (enrollments creating a {@link org.hisp.dhis.tracker.model.TrackedEntityProgramOwner}) stages
+   * the owner row into {@code batch} for a single batched multi-row INSERT at flush, alongside the
+   * other entity writes. Staging within the per-entity try/catch means a rollback also drops the
+   * staged owner, and the {@code trackedentityid + programid} unique-key violation (only reachable
+   * via a concurrent import racing on the same key) now surfaces at the batch flush rather than at
+   * transaction commit.
    */
-  protected abstract void persistOwnership(TrackerBundle bundle, T trackerDto, V entity);
+  protected abstract void persistOwnership(
+      TrackerBundle bundle, T trackerDto, V entity, EntityWriteBatch batch);
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -80,12 +80,8 @@ import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
-import org.hisp.dhis.tracker.model.Enrollment;
-import org.hisp.dhis.tracker.model.Relationship;
-import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.model.TrackerEvent;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.jdbc.datasource.DataSourceUtils;
@@ -297,58 +293,25 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     return allocateIds(conn, sequenceName, createCount);
   }
 
-  private void assignId(V convertedDto, long id) {
-    if (convertedDto instanceof TrackedEntity te) {
-      te.setId(id);
-    } else if (convertedDto instanceof Enrollment e) {
-      e.setId(id);
-    } else if (convertedDto instanceof TrackerEvent ev) {
-      ev.setId(id);
-    } else if (convertedDto instanceof SingleEvent sev) {
-      sev.setId(id);
-    } else if (convertedDto instanceof Relationship r) {
-      r.setId(id);
-    } else {
-      throw new IllegalStateException(
-          "Pre-allocated id assignment not implemented for "
-              + convertedDto.getClass().getName()
-              + " -- sequenceName() returned non-null but assignId does not handle this type.");
-    }
-  }
+  /**
+   * Assigns a pre-allocated id to a new entity. Implemented by each concrete persister against its
+   * statically-known entity type {@code V}; only invoked when {@link #sequenceName()} is non-null.
+   */
+  protected abstract void assignId(V convertedDto, long id);
 
-  private void stageInsert(V convertedDto, EntityWriteBatch batch) {
-    if (convertedDto instanceof TrackedEntity te) {
-      batch.stageInsert(te);
-    } else if (convertedDto instanceof Enrollment e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof TrackerEvent e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof SingleEvent e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof Relationship r) {
-      batch.stageInsert(r);
-    } else {
-      throw new IllegalArgumentException(
-          "Unsupported entity type: " + convertedDto.getClass().getName());
-    }
-  }
+  /**
+   * Stages a new entity for insertion in the batch. Implemented by each concrete persister against
+   * its statically-known entity type {@code V}, so the correct {@link EntityWriteBatch} overload is
+   * selected at compile time rather than by runtime type dispatch.
+   */
+  protected abstract void stageInsert(V convertedDto, EntityWriteBatch batch);
 
-  // Relationships are not updated -- the persister branch above ignores update payloads before
-  // this is called -- so no Relationship case is needed here.
-  private void stageUpdate(V convertedDto, EntityWriteBatch batch) {
-    if (convertedDto instanceof TrackedEntity te) {
-      batch.stageUpdate(te);
-    } else if (convertedDto instanceof Enrollment e) {
-      batch.stageUpdate(e);
-    } else if (convertedDto instanceof TrackerEvent e) {
-      batch.stageUpdate(e);
-    } else if (convertedDto instanceof SingleEvent e) {
-      batch.stageUpdate(e);
-    } else {
-      throw new IllegalArgumentException(
-          "Unsupported entity type for update: " + convertedDto.getClass().getName());
-    }
-  }
+  /**
+   * Stages an existing entity for update in the batch. {@link RelationshipPersister} throws, as
+   * relationships are never updated -- the persister branch in {@link #persist} ignores update
+   * payloads before this is called.
+   */
+  protected abstract void stageUpdate(V convertedDto, EntityWriteBatch batch);
 
   // // // // // // // //
   // // // // // // // //

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -49,6 +49,8 @@ import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -172,7 +174,8 @@ public class EnrollmentPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
-      Enrollment entity) {
+      Enrollment entity,
+      EntityWriteBatch batch) {
     if ((bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
         || bundle
                 .getPreheat()
@@ -180,8 +183,20 @@ public class EnrollmentPersister
                 .get(entity.getTrackedEntity().getUID())
                 .get(entity.getProgram().getUid())
             == null)) {
-      trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
-          entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
+      // Mirrors DefaultTrackedEntityProgramOwnerService.createTrackedEntityProgramOwner, but stages
+      // the row into the write batch instead of a per-enrollment Hibernate save (see
+      // AbstractTrackerPersister#persistOwnership and TrackedEntityProgramOwnerWriter).
+      TrackedEntityProgramOwner owner =
+          new TrackedEntityProgramOwner(
+              entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
+      owner.updateDates();
+      owner.setCreatedBy(CurrentUserUtil.getCurrentUsername());
+      batch.stageOwnershipInsert(owner);
+      // The store's save()/update() invalidate the program-owner cache; since we bypass the store,
+      // invalidate it here so a stale "no owner / registering org unit" entry cached before this
+      // import does not survive the newly created ownership.
+      trackedEntityProgramOwnerService.invalidateOwnershipCache(
+          entity.getTrackedEntity(), entity.getProgram());
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -76,6 +76,21 @@ public class EnrollmentPersister
   }
 
   @Override
+  protected void assignId(Enrollment entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(Enrollment entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(Enrollment entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updateAttributes(
       Connection connection,
       TrackerPreheat preheat,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.Enrollment;
+
+/**
+ * Flushes staged {@link Enrollment} writes: a multi-row JDBC INSERT against {@code enrollment} (ids
+ * pre-allocated from {@code enrollment_sequence}), a single unnest UPDATE, and a cascade insert of
+ * any new notes into {@code note} + {@code enrollment_notes}.
+ */
+final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
+
+  private static final String INSERT_PREFIX =
+      "insert into enrollment ("
+          + "enrollmentid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " enrollmentdate, occurreddate, completeddate, completedby,"
+          + " status, followup, deleted,"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
+          + " geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch. Insert-
+  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths (deleted)
+  // are deliberately excluded. status, completeddate, completedby are included even though the
+  // mapper only touches them on a status change -- writing the unchanged values back is a no-op
+  // against the existing row.
+  private static final String UPDATE_SQL =
+      "update enrollment e set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " trackedentityid = v.trackedentityid,"
+          + " programid = v.programid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " enrollmentdate = v.enrollmentdate,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " status = v.status,"
+          + " followup = v.followup,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::timestamptz[]) as enrollmentdate,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::boolean[]) as followup,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where e.enrollmentid = v.enrollmentid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("enrollment_notes", "enrollmentid");
+
+  EnrollmentWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, Enrollment::getId, Enrollment::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (Enrollment e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "Enrollment "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, e.getStatus().name());
+    if (e.getFollowup() != null) {
+      ps.setBoolean(p++, e.getFollowup());
+    } else {
+      ps.setNull(p++, Types.BOOLEAN);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    ps.setLong(p++, e.getTrackedEntity().getId());
+    ps.setLong(p++, e.getProgram().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] trackedEntityIds = new Long[n];
+          Long[] programIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] enrollmentDate = new String[n];
+          String[] occurredDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          String[] status = new String[n];
+          Boolean[] followup = new Boolean[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            Enrollment e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            trackedEntityIds[i] = e.getTrackedEntity().getId();
+            programIds[i] = e.getProgram().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            enrollmentDate[i] = toTimestamptz(e.getEnrollmentDate());
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            status[i] = e.getStatus().name();
+            followup[i] = e.getFollowup();
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(7, conn.createArrayOf("bigint", programIds));
+            ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(10, conn.createArrayOf("text", enrollmentDate));
+            ps.setArray(11, conn.createArrayOf("text", occurredDate));
+            ps.setArray(12, conn.createArrayOf("text", completedDate));
+            ps.setArray(13, conn.createArrayOf("text", completedBy));
+            ps.setArray(14, conn.createArrayOf("text", status));
+            ps.setArray(15, conn.createArrayOf("boolean", followup));
+            ps.setArray(16, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.tracker.model.Relationship;
 import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
 import org.hisp.dhis.tracker.model.TrackerEvent;
 
 /**
@@ -99,6 +100,8 @@ class EntityWriteBatch {
   private final TrackerEventWriter trackerEventWriter;
   private final SingleEventWriter singleEventWriter;
   private final RelationshipWriter relationshipWriter = new RelationshipWriter();
+  private final TrackedEntityProgramOwnerWriter ownershipWriter =
+      new TrackedEntityProgramOwnerWriter();
   private final TeavWriter teavWriter = new TeavWriter();
 
   EntityWriteBatch(ObjectMapper objectMapper) {
@@ -147,6 +150,14 @@ class EntityWriteBatch {
     relationshipWriter.stageInsert(relationship);
   }
 
+  /**
+   * Stages a program-ownership row for a newly created enrollment. INSERT-only; {@link
+   * EnrollmentPersister} guards against duplicates before staging.
+   */
+  void stageOwnershipInsert(TrackedEntityProgramOwner owner) {
+    ownershipWriter.stageInsert(owner);
+  }
+
   void stageTeavInsert(TrackedEntityAttributeValue value) {
     teavWriter.stageInsert(value);
   }
@@ -183,6 +194,7 @@ class EntityWriteBatch {
         trackerEventWriter.mark(),
         singleEventWriter.mark(),
         relationshipWriter.mark(),
+        ownershipWriter.mark(),
         teavWriter.mark());
   }
 
@@ -192,6 +204,7 @@ class EntityWriteBatch {
     trackerEventWriter.rollbackTo(mark.trackerEvent());
     singleEventWriter.rollbackTo(mark.singleEvent());
     relationshipWriter.rollbackTo(mark.relationshipInserts());
+    ownershipWriter.rollbackTo(mark.ownershipInserts());
     teavWriter.rollbackTo(mark.teav());
   }
 
@@ -202,8 +215,10 @@ class EntityWriteBatch {
    * bypass the Hibernate persistence context and audit listeners -- see the class javadoc for the
    * scope of that trade-off.
    *
-   * <p>Writers run in FK-safe order: TrackedEntity -> Enrollment -> TrackerEvent -> SingleEvent ->
-   * Relationship -> TEAV. Each writer applies its own inserts before updates before notes.
+   * <p>Writers run in FK-safe order: TrackedEntity -> Enrollment -> program ownership ->
+   * TrackerEvent -> SingleEvent -> Relationship -> TEAV. Each writer applies its own inserts before
+   * updates before notes. Program ownership is flushed after Enrollment (it references the tracked
+   * entity, program and org unit, all already present).
    */
   void flush(Connection conn) throws SQLException {
     if (isEmpty()) {
@@ -212,6 +227,7 @@ class EntityWriteBatch {
 
     trackedEntityWriter.flush(conn);
     enrollmentWriter.flush(conn);
+    ownershipWriter.flush(conn);
     trackerEventWriter.flush(conn);
     singleEventWriter.flush(conn);
     relationshipWriter.flush(conn);
@@ -219,6 +235,7 @@ class EntityWriteBatch {
 
     trackedEntityWriter.clear();
     enrollmentWriter.clear();
+    ownershipWriter.clear();
     trackerEventWriter.clear();
     singleEventWriter.clear();
     relationshipWriter.clear();
@@ -228,6 +245,7 @@ class EntityWriteBatch {
   private boolean isEmpty() {
     return trackedEntityWriter.isEmpty()
         && enrollmentWriter.isEmpty()
+        && ownershipWriter.isEmpty()
         && trackerEventWriter.isEmpty()
         && singleEventWriter.isEmpty()
         && relationshipWriter.isEmpty()
@@ -240,5 +258,6 @@ class EntityWriteBatch {
       UpsertTableWriter.Mark trackerEvent,
       UpsertTableWriter.Mark singleEvent,
       int relationshipInserts,
+      int ownershipInserts,
       TeavWriter.Mark teav) {}
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -29,33 +29,12 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
-import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
-import org.hisp.dhis.note.Note;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
-import org.hisp.dhis.tracker.model.RelationshipItem;
 import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
@@ -66,44 +45,24 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
  * per-entity error isolation in non-atomic mode.
  *
- * <p>Scope:
+ * <p>This class is a thin composite: the per-table SQL, binding and flush mechanics live in the
+ * dedicated {@code *Writer} classes ({@link TrackedEntityWriter}, {@link EnrollmentWriter}, {@link
+ * TrackerEventWriter}, {@link SingleEventWriter}, {@link RelationshipWriter}, {@link TeavWriter}),
+ * with shared helpers in {@link JdbcBatchSupport} and the notes cascade in {@link
+ * NoteCascadeWriter}. This class owns only the staging delegation, the composite mark/rollback and
+ * the FK-safe flush order. Scope of each writer:
  *
  * <ul>
- *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
- *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       trackedentity_sequence} in one round-trip.
- *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
- *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
- *       update branch.
- *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
- *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code enrollment_sequence}.
- *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
- *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
- *   <li>TrackerEvent inserts are flushed via a multi-row JDBC INSERT against {@code trackerevent}
- *       -- ids are pre-allocated from {@code trackerevent_sequence}. The {@code eventdatavalues}
- *       jsonb column is serialized as a JSON object keyed by dataElement uid, matching {@code
- *       JsonEventDataValueSetBinaryType}.
- *   <li>TrackerEvent updates are flushed via a JDBC unnest UPDATE against {@code trackerevent}.
- *   <li>SingleEvent inserts / updates use the same shape as TrackerEvent but write to {@code
- *       singleevent} (no {@code enrollmentid}, no {@code scheduleddate}); ids are pre-allocated
- *       from {@code singleevent_sequence}.
- *   <li>Any new {@code note}s on inserted or updated enrollments / tracker events / single events
- *       are cascade-inserted in further multi-row INSERTs (into {@code note} plus the matching
- *       {@code enrollment_notes} / {@code trackerevent_notes} / {@code singleevent_notes} join),
- *       replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on
- *       UPDATE.
- *   <li>Relationship inserts are flushed via three JDBC statements -- a multi-row INSERT into
- *       {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT
- *       into {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code
- *       relationship} to set the from/to FKs. The three-step shape breaks the circular FK between
- *       the two tables, which is not deferrable in the live schema. Ids come from {@code
- *       relationship_sequence} and {@code relationshipitem_sequence}. Relationship is INSERT-only
- *       -- the persister rejects UPDATE strategy upstream.
- *   <li>TrackedEntityAttributeValues are flushed via JDBC against {@code
- *       trackedentityattributevalue} -- a multi-row INSERT, a single unnest UPDATE keyed on the
- *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single
- *       unnest DELETE on the same key. Confidential attributes and the {@code encryptedvalue}
- *       column were removed in DHIS2-21518, so the value is written as plain text in {@code value}.
+ *   <li>TrackedEntity -- multi-row INSERT + unnest UPDATE on {@code trackedentity} ({@code
+ *       trackedentity_sequence}).
+ *   <li>Enrollment -- multi-row INSERT + unnest UPDATE on {@code enrollment} ({@code
+ *       enrollment_sequence}) plus the notes cascade.
+ *   <li>TrackerEvent / SingleEvent -- multi-row INSERT + unnest UPDATE on {@code trackerevent} /
+ *       {@code singleevent} ({@code eventdatavalues} jsonb keyed by dataElement uid) plus notes.
+ *   <li>Relationship -- INSERT-only three-step (parent INSERT with NULL from/to, item INSERT,
+ *       unnest UPDATE to set the from/to FKs) breaking the circular, non-deferrable FK.
+ *   <li>TrackedEntityAttributeValue -- multi-row INSERT, unnest UPDATE and unnest DELETE on the
+ *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK.
  * </ul>
  *
  * <p>All reads and writes in the import path go through JDBC, bypassing the Hibernate persistence
@@ -125,9 +84,9 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * </ul>
  *
  * <p>Top-level entities are flushed before TEAVs so that ids are set and rows are present in the DB
- * before any TEAV that references them. Within top-level entities the order (TE inserts, TE
- * updates, Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order
- * enforced by {@code DefaultTrackerBundleService.commit()} and is FK-safe.
+ * before any TEAV that references them. Within top-level entities the order (TrackedEntity,
+ * Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order enforced by
+ * {@code DefaultTrackerBundleService.commit()} and is FK-safe.
  *
  * <p>Each {@link AbstractTrackerPersister#persist} call creates its own batch, so in practice only
  * one top-level entity type list is populated per batch (the persister's own type) alongside any
@@ -135,409 +94,77 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  */
 class EntityWriteBatch {
 
-  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
-  private static final int BATCH_SIZE = 128;
-
-  private static final int TRACKED_ENTITY_SRID = 4326;
-
-  private static final String TRACKED_ENTITY_INSERT_PREFIX =
-      "insert into trackedentity ("
-          + "trackedentityid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " inactive, deleted, lastsynchronized, potentialduplicate,"
-          + " organisationunitid, trackedentitytypeid,"
-          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
-
-  private static final String TRACKED_ENTITY_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "), ?::jsonb, ?::jsonb)";
-
-  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch (see lines 90-104). Insert-
-  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths
-  // (deleted, lastsynchronized -- the latter is bulk-updated by
-  // DefaultTrackerBundleService.postCommit) are deliberately excluded.
-  private static final String TRACKED_ENTITY_UPDATE_SQL =
-      "update trackedentity te set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " organisationunitid = v.organisationunitid,"
-          + " trackedentitytypeid = v.trackedentitytypeid,"
-          + " potentialduplicate = v.potentialduplicate,"
-          + " inactive = v.inactive,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as trackedentitytypeid,"
-          + " unnest(?::boolean[]) as potentialduplicate,"
-          + " unnest(?::boolean[]) as inactive,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where te.trackedentityid = v.trackedentityid";
-
-  private static final String ENROLLMENT_INSERT_PREFIX =
-      "insert into enrollment ("
-          + "enrollmentid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " enrollmentdate, occurreddate, completeddate, completedby,"
-          + " status, followup, deleted,"
-          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
-          + " geometry) values ";
-
-  private static final String ENROLLMENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch (see
-  // lines 124-180). Insert-only columns (uid, created, createdbyuserinfo) and columns owned by
-  // other code paths (deleted) are deliberately excluded. status, completeddate, completedby are
-  // included even though the mapper only touches them on a status change -- writing the unchanged
-  // values back is a no-op against the existing row.
-  private static final String ENROLLMENT_UPDATE_SQL =
-      "update enrollment e set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " trackedentityid = v.trackedentityid,"
-          + " programid = v.programid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " enrollmentdate = v.enrollmentdate,"
-          + " occurreddate = v.occurreddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " status = v.status,"
-          + " followup = v.followup,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as enrollmentid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as programid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::timestamptz[]) as enrollmentdate,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::boolean[]) as followup,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where e.enrollmentid = v.enrollmentid";
-
-  private static final String TRACKER_EVENT_INSERT_PREFIX =
-      "insert into trackerevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, scheduleddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
-          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String TRACKER_EVENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch
-  // (see TrackerObjectsMapper.java:199-251). Insert-only columns (uid, created,
-  // createdbyuserinfo, deleted) and columns owned by other code paths (lastsynchronized) are
-  // excluded.
-  private static final String TRACKER_EVENT_UPDATE_SQL =
-      "update trackerevent ev set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " enrollmentid = v.enrollmentid,"
-          + " programstageid = v.programstageid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " status = v.status,"
-          + " occurreddate = v.occurreddate,"
-          + " scheduleddate = v.scheduleddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " assigneduserid = v.assigneduserid,"
-          + " eventdatavalues = v.eventdatavalues::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as eventid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as enrollmentid,"
-          + " unnest(?::bigint[]) as programstageid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as scheduleddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::bigint[]) as assigneduserid,"
-          + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where ev.eventid = v.eventid";
-
-  // Cascade-INSERT targets for entities that carry notes (Enrollment, TrackerEvent). See
-  // Enrollment.java:192-199 and TrackerEvent.hbm.xml:65-70.
-  private static final String NOTE_INSERT_PREFIX =
-      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
-  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
-
-  private static final String ENROLLMENT_NOTES_INSERT_PREFIX =
-      "insert into enrollment_notes (enrollmentid, noteid, sort_order) values ";
-  private static final String ENROLLMENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  private static final String TRACKER_EVENT_NOTES_INSERT_PREFIX =
-      "insert into trackerevent_notes (eventid, noteid, sort_order) values ";
-  private static final String TRACKER_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  // SingleEvent mirrors TrackerEvent without enrollmentid (single events aren't tied to an
-  // enrollment) and without scheduleddate. Sequence is singleevent_sequence per
-  // V2_43_21__split_event_table.sql.
-  private static final String SINGLE_EVENT_INSERT_PREFIX =
-      "insert into singleevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
-          + " programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String SINGLE_EVENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch (see
-  // TrackerObjectsMapper.java:270-322). Insert-only columns (uid, created, createdbyuserinfo,
-  // deleted) and columns owned by other code paths (lastsynchronized) are excluded.
-  private static final String SINGLE_EVENT_UPDATE_SQL =
-      "update singleevent ev set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " programstageid = v.programstageid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " status = v.status,"
-          + " occurreddate = v.occurreddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " assigneduserid = v.assigneduserid,"
-          + " eventdatavalues = v.eventdatavalues::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as eventid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as programstageid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::bigint[]) as assigneduserid,"
-          + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where ev.eventid = v.eventid";
-
-  private static final String SINGLE_EVENT_NOTES_INSERT_PREFIX =
-      "insert into singleevent_notes (eventid, noteid, sort_order) values ";
-  private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  // Relationship is INSERT-only in tracker imports (RelationshipPersister.convert returns null on
-  // UPDATE strategy). Relationship ids come from `relationship_sequence`, item ids from
-  // `relationshipitem_sequence`.
-  //
-  // The two tables form a circular FK (relationship.from/to_relationshipitemid <->
-  // relationshipitem.relationshipid) with non-deferrable constraints. We break the cycle by
-  // inserting the relationship row first with from/to as NULL, then the items pointing at the
-  // pre-allocated relationshipid, then an unnest UPDATE to set the from/to FKs.
-  private static final String RELATIONSHIP_INSERT_PREFIX =
-      "insert into relationship ("
-          + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
-          + " style, relationshiptypeid,"
-          + " from_relationshipitemid, to_relationshipitemid,"
-          + " key, inverted_key, deleted, createdatclient) values ";
-
-  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
-  // updateRelationshipFromTo after the items are inserted.
-  private static final String RELATIONSHIP_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
-
-  private static final String RELATIONSHIP_ITEM_INSERT_PREFIX =
-      "insert into relationshipitem ("
-          + "relationshipitemid, relationshipid,"
-          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
-  private static final String RELATIONSHIP_ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
-
-  private static final String RELATIONSHIP_UPDATE_FROM_TO_SQL =
-      "update relationship r set"
-          + " from_relationshipitemid = v.from_id,"
-          + " to_relationshipitemid = v.to_id"
-          + " from ( select"
-          + " unnest(?::bigint[]) as relationshipid,"
-          + " unnest(?::bigint[]) as from_id,"
-          + " unnest(?::bigint[]) as to_id"
-          + " ) v where r.relationshipid = v.relationshipid";
-
-  // TrackedEntityAttributeValue has a composite PK (trackedentityid, trackedentityattributeid) and
-  // no sequence, so no id pre-allocation is needed. Confidential attributes (and the encrypted
-  // value column) were removed in DHIS2-21518, so the value is stored as plain text in `value`.
-  private static final String TEAV_INSERT_PREFIX =
-      "insert into trackedentityattributevalue ("
-          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
-          + " value, updatedby) values ";
-  private static final String TEAV_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
-
-  // `created` is insert-only and deliberately excluded from the UPDATE column set.
-  private static final String TEAV_UPDATE_SQL =
-      "update trackedentityattributevalue teav set"
-          + " lastupdated = v.lastupdated,"
-          + " value = v.value,"
-          + " updatedby = v.updatedby"
-          + " from ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as trackedentityattributeid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::text[]) as value,"
-          + " unnest(?::text[]) as updatedby"
-          + " ) v where teav.trackedentityid = v.trackedentityid"
-          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
-
-  // Unnest DELETE on the composite key, mirroring the unnest UPDATE shape rather than the plan's
-  // IN (VALUES ...) form, to stay consistent with the other batch statements and avoid dynamic SQL.
-  private static final String TEAV_DELETE_SQL =
-      "delete from trackedentityattributevalue teav"
-          + " using ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as trackedentityattributeid"
-          + " ) v where teav.trackedentityid = v.trackedentityid"
-          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
-
-  private final ObjectMapper objectMapper;
-
-  private final List<TrackedEntity> teInserts = new ArrayList<>();
-  private final List<TrackedEntity> teUpdates = new ArrayList<>();
-
-  private final List<Enrollment> enrollmentInserts = new ArrayList<>();
-  private final List<Enrollment> enrollmentUpdates = new ArrayList<>();
-
-  private final List<TrackerEvent> trackerEventInserts = new ArrayList<>();
-  private final List<TrackerEvent> trackerEventUpdates = new ArrayList<>();
-
-  private final List<SingleEvent> singleEventInserts = new ArrayList<>();
-  private final List<SingleEvent> singleEventUpdates = new ArrayList<>();
-
-  private final List<Relationship> relationshipInserts = new ArrayList<>();
-
-  private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
-  private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
-  private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+  private final TrackedEntityWriter trackedEntityWriter;
+  private final EnrollmentWriter enrollmentWriter;
+  private final TrackerEventWriter trackerEventWriter;
+  private final SingleEventWriter singleEventWriter;
+  private final RelationshipWriter relationshipWriter = new RelationshipWriter();
+  private final TeavWriter teavWriter = new TeavWriter();
 
   EntityWriteBatch(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+    this.trackedEntityWriter = new TrackedEntityWriter(objectMapper);
+    this.enrollmentWriter = new EnrollmentWriter(objectMapper);
+    this.trackerEventWriter = new TrackerEventWriter(objectMapper);
+    this.singleEventWriter = new SingleEventWriter(objectMapper);
   }
 
   void stageInsert(TrackedEntity trackedEntity) {
-    teInserts.add(trackedEntity);
+    trackedEntityWriter.stageInsert(trackedEntity);
   }
 
   void stageUpdate(TrackedEntity trackedEntity) {
-    teUpdates.add(trackedEntity);
+    trackedEntityWriter.stageUpdate(trackedEntity);
   }
 
   void stageInsert(Enrollment enrollment) {
-    enrollmentInserts.add(enrollment);
+    enrollmentWriter.stageInsert(enrollment);
   }
 
   void stageUpdate(Enrollment enrollment) {
-    enrollmentUpdates.add(enrollment);
+    enrollmentWriter.stageUpdate(enrollment);
   }
 
   void stageInsert(TrackerEvent event) {
-    trackerEventInserts.add(event);
+    trackerEventWriter.stageInsert(event);
   }
 
   void stageUpdate(TrackerEvent event) {
-    trackerEventUpdates.add(event);
+    trackerEventWriter.stageUpdate(event);
   }
 
   void stageInsert(SingleEvent event) {
-    singleEventInserts.add(event);
+    singleEventWriter.stageInsert(event);
   }
 
   void stageUpdate(SingleEvent event) {
-    singleEventUpdates.add(event);
+    singleEventWriter.stageUpdate(event);
   }
 
   /**
    * Relationships are never updated -- {@link AbstractTrackerPersister} ignores update payloads.
    */
   void stageInsert(Relationship relationship) {
-    relationshipInserts.add(relationship);
+    relationshipWriter.stageInsert(relationship);
   }
 
   void stageTeavInsert(TrackedEntityAttributeValue value) {
-    teavInserts.add(value);
+    teavWriter.stageInsert(value);
   }
 
   void stageTeavUpdate(TrackedEntityAttributeValue value) {
-    teavUpdates.add(value);
+    teavWriter.stageUpdate(value);
   }
 
   void stageTeavDelete(TrackedEntityAttributeValue value) {
-    teavDeletes.add(value);
+    teavWriter.stageDelete(value);
   }
 
   /**
-   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
-   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
-   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
-   * each carrying the same attribute value -- so it can fold the second occurrence into the first
-   * staged instance instead of staging a second INSERT for the same composite key, which would
-   * violate the primary key at flush.
+   * TEAVs already staged for insert or update against the given TrackedEntity. See {@link
+   * TeavWriter#stagedFor}.
    */
   Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
-    return Stream.concat(teavInserts.stream(), teavUpdates.stream())
-        .filter(v -> v.getTrackedEntity() == trackedEntity);
+    return teavWriter.stagedFor(trackedEntity);
   }
 
   /**
@@ -546,32 +173,26 @@ class EntityWriteBatch {
    * empty for a fresh insert.
    */
   boolean isStagedAsInsert(TrackedEntity trackedEntity) {
-    return teInserts.contains(trackedEntity);
+    return trackedEntityWriter.isStagedAsInsert(trackedEntity);
   }
 
   Mark mark() {
     return new Mark(
-        new Mark.EntityCounts(teInserts.size(), teUpdates.size()),
-        new Mark.EntityCounts(enrollmentInserts.size(), enrollmentUpdates.size()),
-        new Mark.EntityCounts(trackerEventInserts.size(), trackerEventUpdates.size()),
-        new Mark.EntityCounts(singleEventInserts.size(), singleEventUpdates.size()),
-        relationshipInserts.size(),
-        new Mark.TeavCounts(teavInserts.size(), teavUpdates.size(), teavDeletes.size()));
+        trackedEntityWriter.mark(),
+        enrollmentWriter.mark(),
+        trackerEventWriter.mark(),
+        singleEventWriter.mark(),
+        relationshipWriter.mark(),
+        teavWriter.mark());
   }
 
   void rollbackTo(Mark mark) {
-    truncate(teInserts, mark.te().inserts());
-    truncate(teUpdates, mark.te().updates());
-    truncate(enrollmentInserts, mark.enrollment().inserts());
-    truncate(enrollmentUpdates, mark.enrollment().updates());
-    truncate(trackerEventInserts, mark.trackerEvent().inserts());
-    truncate(trackerEventUpdates, mark.trackerEvent().updates());
-    truncate(singleEventInserts, mark.singleEvent().inserts());
-    truncate(singleEventUpdates, mark.singleEvent().updates());
-    truncate(relationshipInserts, mark.relationshipInserts());
-    truncate(teavInserts, mark.teav().inserts());
-    truncate(teavUpdates, mark.teav().updates());
-    truncate(teavDeletes, mark.teav().deletes());
+    trackedEntityWriter.rollbackTo(mark.te());
+    enrollmentWriter.rollbackTo(mark.enrollment());
+    trackerEventWriter.rollbackTo(mark.trackerEvent());
+    singleEventWriter.rollbackTo(mark.singleEvent());
+    relationshipWriter.rollbackTo(mark.relationshipInserts());
+    teavWriter.rollbackTo(mark.teav());
   }
 
   /**
@@ -580,1188 +201,44 @@ class EntityWriteBatch {
    * Spring-managed transaction so the JDBC statements execute under the same commit. The writes
    * bypass the Hibernate persistence context and audit listeners -- see the class javadoc for the
    * scope of that trade-off.
+   *
+   * <p>Writers run in FK-safe order: TrackedEntity -> Enrollment -> TrackerEvent -> SingleEvent ->
+   * Relationship -> TEAV. Each writer applies its own inserts before updates before notes.
    */
   void flush(Connection conn) throws SQLException {
     if (isEmpty()) {
       return;
     }
 
-    insertTrackedEntities(conn);
-    updateTrackedEntities(conn);
-    insertEnrollments(conn);
-    updateEnrollments(conn);
-    insertEnrollmentNotes(conn);
-    insertTrackerEvents(conn);
-    updateTrackerEvents(conn);
-    insertTrackerEventNotes(conn);
-    insertSingleEvents(conn);
-    updateSingleEvents(conn);
-    insertSingleEventNotes(conn);
-    insertRelationships(conn);
-    insertRelationshipItems(conn);
-    updateRelationshipFromTo(conn);
-
-    insertTeavs(conn);
-    updateTeavs(conn);
-    deleteTeavs(conn);
-
-    teInserts.clear();
-    teUpdates.clear();
-    enrollmentInserts.clear();
-    enrollmentUpdates.clear();
-    trackerEventInserts.clear();
-    trackerEventUpdates.clear();
-    singleEventInserts.clear();
-    singleEventUpdates.clear();
-    relationshipInserts.clear();
-    teavInserts.clear();
-    teavUpdates.clear();
-    teavDeletes.clear();
-  }
-
-  private void updateTrackedEntities(Connection conn) throws SQLException {
-    if (teUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teUpdates.size());
-      List<TrackedEntity> chunk = teUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] trackedEntityTypeIds = new Long[n];
-      Boolean[] potentialDuplicate = new Boolean[n];
-      Boolean[] inactive = new Boolean[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackedEntity te = chunk.get(i);
-        ids[i] = te.getId();
-        lastUpdated[i] = toTimestamptz(te.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(te.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(te.getLastUpdatedAtClient());
-        organisationUnitIds[i] = te.getOrganisationUnit().getId();
-        trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
-        potentialDuplicate[i] = te.isPotentialDuplicate();
-        inactive[i] = te.isInactive();
-        lastUpdatedByUserInfo[i] = toJson(te.getLastUpdatedByUserInfo());
-        geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TRACKED_ENTITY_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
-        ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
-        ps.setArray(8, conn.createArrayOf("boolean", inactive));
-        ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(10, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTrackedEntities(Connection conn) throws SQLException {
-    if (teInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teInserts.size());
-      List<TrackedEntity> chunk = teInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKED_ENTITY_INSERT_PREFIX, TRACKED_ENTITY_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackedEntity te : chunk) {
-          p = bindTrackedEntityRow(ps, p, te);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindTrackedEntityRow(PreparedStatement ps, int p, TrackedEntity te)
-      throws SQLException {
-    if (te.getId() == 0) {
-      throw new SQLException(
-          "TrackedEntity "
-              + te.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, te.getId());
-    ps.setString(p++, te.getUid());
-    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
-    setNullableTimestamp(ps, p++, te.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
-    ps.setBoolean(p++, te.isInactive());
-    ps.setBoolean(p++, te.isDeleted());
-    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
-    ps.setBoolean(p++, te.isPotentialDuplicate());
-    ps.setLong(p++, te.getOrganisationUnit().getId());
-    ps.setLong(p++, te.getTrackedEntityType().getId());
-    if (te.getGeometry() != null) {
-      ps.setString(p++, te.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, toJson(te.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(te.getLastUpdatedByUserInfo()));
-    return p;
-  }
-
-  private void insertEnrollments(Connection conn) throws SQLException {
-    if (enrollmentInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < enrollmentInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, enrollmentInserts.size());
-      List<Enrollment> chunk = enrollmentInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(ENROLLMENT_INSERT_PREFIX, ENROLLMENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (Enrollment e : chunk) {
-          p = bindEnrollmentRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindEnrollmentRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "Enrollment "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, e.getStatus().name());
-    if (e.getFollowup() != null) {
-      ps.setBoolean(p++, e.getFollowup());
-    } else {
-      ps.setNull(p++, Types.BOOLEAN);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    ps.setLong(p++, e.getTrackedEntity().getId());
-    ps.setLong(p++, e.getProgram().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateEnrollments(Connection conn) throws SQLException {
-    if (enrollmentUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < enrollmentUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, enrollmentUpdates.size());
-      List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] trackedEntityIds = new Long[n];
-      Long[] programIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] enrollmentDate = new String[n];
-      String[] occurredDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      String[] status = new String[n];
-      Boolean[] followup = new Boolean[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        Enrollment e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        trackedEntityIds[i] = e.getTrackedEntity().getId();
-        programIds[i] = e.getProgram().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        enrollmentDate[i] = toTimestamptz(e.getEnrollmentDate());
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        status[i] = e.getStatus().name();
-        followup[i] = e.getFollowup();
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(ENROLLMENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(7, conn.createArrayOf("bigint", programIds));
-        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(10, conn.createArrayOf("text", enrollmentDate));
-        ps.setArray(11, conn.createArrayOf("text", occurredDate));
-        ps.setArray(12, conn.createArrayOf("text", completedDate));
-        ps.setArray(13, conn.createArrayOf("text", completedBy));
-        ps.setArray(14, conn.createArrayOf("text", status));
-        ps.setArray(15, conn.createArrayOf("boolean", followup));
-        ps.setArray(16, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTrackerEvents(Connection conn) throws SQLException {
-    if (trackerEventInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < trackerEventInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, trackerEventInserts.size());
-      List<TrackerEvent> chunk = trackerEventInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKER_EVENT_INSERT_PREFIX, TRACKER_EVENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackerEvent e : chunk) {
-          p = bindTrackerEventRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindTrackerEventRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "TrackerEvent "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getScheduledDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getEnrollment().getId());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateTrackerEvents(Connection conn) throws SQLException {
-    if (trackerEventUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < trackerEventUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, trackerEventUpdates.size());
-      List<TrackerEvent> chunk = trackerEventUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] enrollmentIds = new Long[n];
-      Long[] programStageIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] status = new String[n];
-      String[] occurredDate = new String[n];
-      String[] scheduledDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      Long[] assignedUserIds = new Long[n];
-      String[] eventDataValues = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackerEvent e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        enrollmentIds[i] = e.getEnrollment().getId();
-        programStageIds[i] = e.getProgramStage().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        scheduledDate[i] = toTimestamptz(e.getScheduledDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
-        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TRACKER_EVENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
-        ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
-        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(10, conn.createArrayOf("text", status));
-        ps.setArray(11, conn.createArrayOf("text", occurredDate));
-        ps.setArray(12, conn.createArrayOf("text", scheduledDate));
-        ps.setArray(13, conn.createArrayOf("text", completedDate));
-        ps.setArray(14, conn.createArrayOf("text", completedBy));
-        ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
-        ps.setArray(16, conn.createArrayOf("text", eventDataValues));
-        ps.setArray(17, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Shared shape between {@code enrollment_notes} and {@code trackerevent_notes} cascade rows. */
-  private interface NoteToInsert {
-    Note note();
-  }
-
-  /**
-   * Cascade-insert any notes attached to enrollments that were just inserted by {@link
-   * #insertEnrollments} or appended to existing enrollments by {@link #updateEnrollments}. Mirrors
-   * what Hibernate did via {@code @OneToMany(cascade=ALL)} on {@code Enrollment.notes} (see {@code
-   * Enrollment.java:192-199}): allocate ids for the new {@code note} rows from {@code
-   * note_sequence}, insert the {@code note} rows, then insert the join rows in {@code
-   * enrollment_notes} with {@code sort_order} taken from the list position (1-based, per
-   * {@code @ListIndexBase(1)}). On INSERT every Note is new; on UPDATE only Notes with {@code id ==
-   * 0} are new (existing ones were loaded by the preheat).
-   */
-  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertEnrollmentNotes(Connection conn) throws SQLException {
-    List<EnrollmentNoteToInsert> newNotes = collectNewEnrollmentNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertEnrollmentNotesJoinRows(conn, newNotes);
-  }
-
-  /**
-   * For each enrollment being inserted or updated, collect the {@link Note}s that are new (no DB
-   * id) along with their 1-based sort order, which is the position in the {@code getNotes()} list.
-   * For inserts every note is new; for updates the preheat-loaded list already contains existing
-   * notes with non-zero ids, so we skip those.
-   */
-  private List<EnrollmentNoteToInsert> collectNewEnrollmentNotes() {
-    List<EnrollmentNoteToInsert> newNotes = new ArrayList<>();
-    collectNewNotesFrom(enrollmentInserts, newNotes);
-    collectNewNotesFrom(enrollmentUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewNotesFrom(
-      List<Enrollment> enrollments, List<EnrollmentNoteToInsert> out) {
-    for (Enrollment e : enrollments) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new EnrollmentNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertNoteRows(Connection conn, List<? extends NoteToInsert> newNotes)
-      throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<? extends NoteToInsert> chunk = newNotes.subList(from, to);
-      String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (NoteToInsert item : chunk) {
-          Note n = item.note();
-          ps.setLong(p++, n.getId());
-          ps.setString(p++, n.getUid());
-          ps.setTimestamp(p++, toTimestamp(n.getCreated()));
-          if (n.getLastUpdatedBy() != null) {
-            ps.setLong(p++, n.getLastUpdatedBy().getId());
-          } else {
-            ps.setNull(p++, Types.BIGINT);
-          }
-          if (n.getNoteText() != null) {
-            ps.setString(p++, n.getNoteText());
-          } else {
-            ps.setNull(p++, Types.VARCHAR);
-          }
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertEnrollmentNotesJoinRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
-      throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              ENROLLMENT_NOTES_INSERT_PREFIX, ENROLLMENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (EnrollmentNoteToInsert item : chunk) {
-          ps.setLong(p++, item.enrollmentId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code trackerevent_notes} join table. */
-  private record TrackerEventNoteToInsert(long eventId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertTrackerEventNotes(Connection conn) throws SQLException {
-    List<TrackerEventNoteToInsert> newNotes = collectNewTrackerEventNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertTrackerEventNotesJoinRows(conn, newNotes);
-  }
-
-  private List<TrackerEventNoteToInsert> collectNewTrackerEventNotes() {
-    List<TrackerEventNoteToInsert> newNotes = new ArrayList<>();
-    collectNewTrackerEventNotesFrom(trackerEventInserts, newNotes);
-    collectNewTrackerEventNotesFrom(trackerEventUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewTrackerEventNotesFrom(
-      List<TrackerEvent> events, List<TrackerEventNoteToInsert> out) {
-    for (TrackerEvent e : events) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new TrackerEventNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertTrackerEventNotesJoinRows(
-      Connection conn, List<TrackerEventNoteToInsert> newNotes) throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<TrackerEventNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKER_EVENT_NOTES_INSERT_PREFIX, TRACKER_EVENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackerEventNoteToInsert item : chunk) {
-          ps.setLong(p++, item.eventId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertSingleEvents(Connection conn) throws SQLException {
-    if (singleEventInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < singleEventInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, singleEventInserts.size());
-      List<SingleEvent> chunk = singleEventInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(SINGLE_EVENT_INSERT_PREFIX, SINGLE_EVENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (SingleEvent e : chunk) {
-          p = bindSingleEventRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindSingleEventRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "SingleEvent "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateSingleEvents(Connection conn) throws SQLException {
-    if (singleEventUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < singleEventUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, singleEventUpdates.size());
-      List<SingleEvent> chunk = singleEventUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] programStageIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] status = new String[n];
-      String[] occurredDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      Long[] assignedUserIds = new Long[n];
-      String[] eventDataValues = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        SingleEvent e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        programStageIds[i] = e.getProgramStage().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
-        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(SINGLE_EVENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
-        ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(9, conn.createArrayOf("text", status));
-        ps.setArray(10, conn.createArrayOf("text", occurredDate));
-        ps.setArray(11, conn.createArrayOf("text", completedDate));
-        ps.setArray(12, conn.createArrayOf("text", completedBy));
-        ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
-        ps.setArray(14, conn.createArrayOf("text", eventDataValues));
-        ps.setArray(15, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code singleevent_notes} join table. */
-  private record SingleEventNoteToInsert(long eventId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertSingleEventNotes(Connection conn) throws SQLException {
-    List<SingleEventNoteToInsert> newNotes = collectNewSingleEventNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertSingleEventNotesJoinRows(conn, newNotes);
-  }
-
-  private List<SingleEventNoteToInsert> collectNewSingleEventNotes() {
-    List<SingleEventNoteToInsert> newNotes = new ArrayList<>();
-    collectNewSingleEventNotesFrom(singleEventInserts, newNotes);
-    collectNewSingleEventNotesFrom(singleEventUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewSingleEventNotesFrom(
-      List<SingleEvent> events, List<SingleEventNoteToInsert> out) {
-    for (SingleEvent e : events) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new SingleEventNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertSingleEventNotesJoinRows(
-      Connection conn, List<SingleEventNoteToInsert> newNotes) throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<SingleEventNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              SINGLE_EVENT_NOTES_INSERT_PREFIX, SINGLE_EVENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (SingleEventNoteToInsert item : chunk) {
-          ps.setLong(p++, item.eventId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /**
-   * Inserts the parent {@code relationship} rows. {@code from_relationshipitemid} and {@code
-   * to_relationshipitemid} are written as NULL here -- they're filled in by {@link
-   * #updateRelationshipFromTo} after the item rows have been inserted, since neither the parent nor
-   * the child FK constraints are deferrable. Relationship is INSERT-only in tracker imports, so no
-   * L1 detach/refresh is needed.
-   */
-  private void insertRelationships(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
-      List<Relationship> chunk = relationshipInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(RELATIONSHIP_INSERT_PREFIX, RELATIONSHIP_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (Relationship r : chunk) {
-          p = bindRelationshipRow(ps, p, r);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindRelationshipRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
-    if (r.getId() == 0) {
-      throw new SQLException(
-          "Relationship "
-              + r.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, r.getId());
-    ps.setString(p++, r.getUid());
-    if (r.getCode() != null) {
-      ps.setString(p++, r.getCode());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
-    if (r.getLastUpdatedBy() != null) {
-      ps.setLong(p++, r.getLastUpdatedBy().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toObjectStyleJson(r.getStyle()));
-    ps.setLong(p++, r.getRelationshipType().getId());
-    ps.setString(p++, r.getKey());
-    ps.setString(p++, r.getInvertedKey());
-    ps.setBoolean(p++, r.isDeleted());
-    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
-    return p;
-  }
-
-  /**
-   * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
-   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
-   * round-trip, assign them to the in-memory items (so the subsequent unnest UPDATE can read them
-   * back), then flatten the from/to items into a single multi-row INSERT.
-   */
-  private void insertRelationshipItems(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * relationshipInserts.size());
-    int cursor = 0;
-    for (Relationship r : relationshipInserts) {
-      r.getFrom().setId((int) itemIds[cursor++]);
-      r.getTo().setId((int) itemIds[cursor++]);
-    }
-
-    // Flatten (from + to) per relationship into a single list to drive one multi-row INSERT.
-    record ItemRow(long itemId, long relationshipId, RelationshipItem item) {}
-    List<ItemRow> rows = new ArrayList<>(2 * relationshipInserts.size());
-    for (Relationship r : relationshipInserts) {
-      rows.add(new ItemRow(r.getFrom().getId(), r.getId(), r.getFrom()));
-      rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
-    }
-
-    for (int from = 0; from < rows.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, rows.size());
-      List<ItemRow> chunk = rows.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              RELATIONSHIP_ITEM_INSERT_PREFIX, RELATIONSHIP_ITEM_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (ItemRow row : chunk) {
-          p = bindRelationshipItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindRelationshipItemRow(
-      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
-      throws SQLException {
-    ps.setLong(p++, itemId);
-    ps.setLong(p++, relationshipId);
-    if (item.getTrackedEntity() != null) {
-      ps.setLong(p++, item.getTrackedEntity().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getEnrollment() != null) {
-      ps.setLong(p++, item.getEnrollment().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
-    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
-    // non-null because a given UID exists in exactly one of the two event tables.
-    if (item.getTrackerEvent() != null) {
-      ps.setLong(p++, item.getTrackerEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getSingleEvent() != null) {
-      ps.setLong(p++, item.getSingleEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    return p;
-  }
-
-  /**
-   * Sets {@code relationship.from_relationshipitemid} and {@code to_relationshipitemid} once the
-   * item rows have been inserted by {@link #insertRelationshipItems}. Required because the circular
-   * FK between {@code relationship} and {@code relationshipitem} is not deferrable, so we had to
-   * leave the parent's from/to columns NULL on the initial INSERT.
-   */
-  private void updateRelationshipFromTo(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
-      List<Relationship> chunk = relationshipInserts.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      Long[] fromIds = new Long[n];
-      Long[] toIds = new Long[n];
-
-      for (int i = 0; i < n; i++) {
-        Relationship r = chunk.get(i);
-        ids[i] = r.getId();
-        fromIds[i] = (long) r.getFrom().getId();
-        toIds[i] = (long) r.getTo().getId();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(RELATIONSHIP_UPDATE_FROM_TO_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("bigint", fromIds));
-        ps.setArray(3, conn.createArrayOf("bigint", toIds));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTeavs(Connection conn) throws SQLException {
-    if (teavInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavInserts.size());
-      List<TrackedEntityAttributeValue> chunk = teavInserts.subList(from, to);
-      String sql = buildMultiRowInsertSql(TEAV_INSERT_PREFIX, TEAV_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackedEntityAttributeValue v : chunk) {
-          ps.setLong(p++, v.getTrackedEntity().getId());
-          ps.setLong(p++, v.getAttribute().getId());
-          ps.setTimestamp(p++, toTimestamp(v.getCreated()));
-          ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
-          setNullableString(ps, p++, v.getValue());
-          setNullableString(ps, p++, v.getUpdatedBy());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void updateTeavs(Connection conn) throws SQLException {
-    if (teavUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavUpdates.size());
-      List<TrackedEntityAttributeValue> chunk = teavUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] trackedEntityIds = new Long[n];
-      Long[] attributeIds = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] value = new String[n];
-      String[] updatedBy = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackedEntityAttributeValue v = chunk.get(i);
-        trackedEntityIds[i] = v.getTrackedEntity().getId();
-        attributeIds[i] = v.getAttribute().getId();
-        lastUpdated[i] = toTimestamptz(v.getLastUpdated());
-        value[i] = v.getValue();
-        updatedBy[i] = v.getUpdatedBy();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TEAV_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
-        ps.setArray(3, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(4, conn.createArrayOf("text", value));
-        ps.setArray(5, conn.createArrayOf("text", updatedBy));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void deleteTeavs(Connection conn) throws SQLException {
-    if (teavDeletes.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavDeletes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavDeletes.size());
-      List<TrackedEntityAttributeValue> chunk = teavDeletes.subList(from, to);
-      int n = chunk.size();
-
-      Long[] trackedEntityIds = new Long[n];
-      Long[] attributeIds = new Long[n];
-      for (int i = 0; i < n; i++) {
-        TrackedEntityAttributeValue v = chunk.get(i);
-        trackedEntityIds[i] = v.getTrackedEntity().getId();
-        attributeIds[i] = v.getAttribute().getId();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TEAV_DELETE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /**
-   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
-   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
-   * a {@code regclass}; the value is always a static literal controlled by us. Mirrors the helper
-   * in {@code AbstractTrackerPersister}.
-   */
-  private static long[] allocateIds(Connection conn, String sequenceName, int count)
-      throws SQLException {
-    long[] ids = new long[count];
-    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
-    try (PreparedStatement ps = conn.prepareStatement(sql)) {
-      ps.setInt(1, count);
-      try (ResultSet rs = ps.executeQuery()) {
-        int i = 0;
-        while (rs.next()) {
-          ids[i++] = rs.getLong(1);
-        }
-        if (i != count) {
-          throw new SQLException(
-              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
-        }
-      }
-    }
-    return ids;
-  }
-
-  private static String buildMultiRowInsertSql(
-      String prefix, String rowPlaceholders, int rowCount) {
-    StringBuilder sb =
-        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
-    sb.append(prefix);
-    for (int i = 0; i < rowCount; i++) {
-      if (i > 0) {
-        sb.append(", ");
-      }
-      sb.append(rowPlaceholders);
-    }
-    return sb.toString();
-  }
-
-  private static Timestamp toTimestamp(Date date) {
-    return date != null ? new Timestamp(date.getTime()) : null;
-  }
-
-  /**
-   * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
-   * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
-   * Timestamp[])} is not safe: pgjdbc stringifies each element via {@code Timestamp.toString()},
-   * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
-   * under the session {@code TimeZone} -- skewing every value when the session zone differs from
-   * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
-   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
-   * (pgjdbc appends the JVM zone offset there).
-   */
-  private static String toTimestamptz(Date date) {
-    return date != null
-        ? OffsetDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).toString()
-        : null;
-  }
-
-  private static void setNullableTimestamp(PreparedStatement ps, int index, Date date)
-      throws SQLException {
-    if (date != null) {
-      ps.setTimestamp(index, new Timestamp(date.getTime()));
-    } else {
-      ps.setNull(index, Types.TIMESTAMP);
-    }
-  }
-
-  private static void setNullableString(PreparedStatement ps, int index, String value)
-      throws SQLException {
-    if (value != null) {
-      ps.setString(index, value);
-    } else {
-      ps.setNull(index, Types.VARCHAR);
-    }
-  }
-
-  private String toJson(UserInfoSnapshot info) throws SQLException {
-    if (info == null) {
-      return null;
-    }
-    try {
-      return objectMapper.writeValueAsString(info);
-    } catch (JsonProcessingException e) {
-      throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
-    }
-  }
-
-  // Must mirror JsonEventDataValueSetBinaryType exactly: same MAPPER (configured with
-  // IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector, NON_NULL inclusion, etc.) and
-  // same per-value writer. Using a different ObjectMapper (e.g. the Spring-injected default) drops
-  // fields like UserInfoSnapshot.id that the JDBC reader requires.
-  private static final ObjectWriter EVENT_DATA_VALUE_WRITER =
-      JsonBinaryType.MAPPER.writerFor(EventDataValue.class);
-
-  /**
-   * Serializes the EventDataValues set as a JSON object keyed by {@code dataElement} uid, matching
-   * the on-disk shape produced by {@code JsonEventDataValueSetBinaryType}. An empty or null set is
-   * serialized as {@code "{}"} to match the column's NOT NULL default.
-   */
-  private String toEventDataValuesJson(Set<EventDataValue> values) throws SQLException {
-    try {
-      StringWriter sw = new StringWriter();
-      try (JsonGenerator gen = JsonBinaryType.MAPPER.getFactory().createGenerator(sw)) {
-        gen.writeStartObject();
-        if (values != null) {
-          for (EventDataValue edv : values) {
-            gen.writeFieldName(edv.getDataElement());
-            EVENT_DATA_VALUE_WRITER.writeValue(gen, edv);
-          }
-        }
-        gen.writeEndObject();
-      }
-      return sw.toString();
-    } catch (IOException e) {
-      throw new SQLException("Failed to serialize EventDataValues to JSON", e);
-    }
-  }
-
-  /**
-   * Serializes the relationship's {@link ObjectStyle} via {@link JsonBinaryType#MAPPER} to match
-   * the Hibernate {@code jbObjectStyle} UserType. Returns {@code null} for a null style so the
-   * caller can pass it straight to a {@code ?::jsonb} parameter as SQL NULL.
-   */
-  private String toObjectStyleJson(ObjectStyle style) throws SQLException {
-    if (style == null) {
-      return null;
-    }
-    try {
-      return JsonBinaryType.MAPPER.writeValueAsString(style);
-    } catch (JsonProcessingException e) {
-      throw new SQLException("Failed to serialize ObjectStyle to JSON", e);
-    }
+    trackedEntityWriter.flush(conn);
+    enrollmentWriter.flush(conn);
+    trackerEventWriter.flush(conn);
+    singleEventWriter.flush(conn);
+    relationshipWriter.flush(conn);
+    teavWriter.flush(conn);
+
+    trackedEntityWriter.clear();
+    enrollmentWriter.clear();
+    trackerEventWriter.clear();
+    singleEventWriter.clear();
+    relationshipWriter.clear();
+    teavWriter.clear();
   }
 
   private boolean isEmpty() {
-    return teInserts.isEmpty()
-        && teUpdates.isEmpty()
-        && enrollmentInserts.isEmpty()
-        && enrollmentUpdates.isEmpty()
-        && trackerEventInserts.isEmpty()
-        && trackerEventUpdates.isEmpty()
-        && singleEventInserts.isEmpty()
-        && singleEventUpdates.isEmpty()
-        && relationshipInserts.isEmpty()
-        && teavInserts.isEmpty()
-        && teavUpdates.isEmpty()
-        && teavDeletes.isEmpty();
-  }
-
-  private static <T> void truncate(List<T> list, int size) {
-    if (list.size() > size) {
-      list.subList(size, list.size()).clear();
-    }
+    return trackedEntityWriter.isEmpty()
+        && enrollmentWriter.isEmpty()
+        && trackerEventWriter.isEmpty()
+        && singleEventWriter.isEmpty()
+        && relationshipWriter.isEmpty()
+        && teavWriter.isEmpty();
   }
 
   record Mark(
-      EntityCounts te,
-      EntityCounts enrollment,
-      EntityCounts trackerEvent,
-      EntityCounts singleEvent,
+      UpsertTableWriter.Mark te,
+      UpsertTableWriter.Mark enrollment,
+      UpsertTableWriter.Mark trackerEvent,
+      UpsertTableWriter.Mark singleEvent,
       int relationshipInserts,
-      TeavCounts teav) {
-
-    record EntityCounts(int inserts, int updates) {}
-
-    record TeavCounts(int inserts, int updates, int deletes) {}
-  }
+      TeavWriter.Mark teav) {}
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.ObjectStyle;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
+import org.hisp.dhis.program.UserInfoSnapshot;
+
+/**
+ * Shared JDBC mechanics for the per-entity {@code *Writer} classes that make up {@link
+ * EntityWriteBatch}: id pre-allocation, multi-row INSERT SQL assembly, chunking, nullable binds,
+ * date/timestamp formatting, list truncation and the JSON serializers. Centralising the serializers
+ * here also centralises the invariant that {@code eventdatavalues} / {@code ObjectStyle} must be
+ * written with {@link JsonBinaryType#MAPPER} (a different {@code ObjectMapper} drops fields like
+ * {@code UserInfoSnapshot.id} that the JDBC reader requires).
+ */
+final class JdbcBatchSupport {
+
+  private JdbcBatchSupport() {}
+
+  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
+  static final int BATCH_SIZE = 128;
+
+  static final int SRID = 4326;
+
+  /** Body invoked once per {@code BATCH_SIZE}-sized chunk of a list. */
+  @FunctionalInterface
+  interface ChunkConsumer<T> {
+    void accept(List<T> chunk) throws SQLException;
+  }
+
+  /** Invokes {@code consumer} on successive {@link #BATCH_SIZE}-sized sublists of {@code list}. */
+  static <T> void forEachChunk(List<T> list, ChunkConsumer<T> consumer) throws SQLException {
+    for (int from = 0; from < list.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, list.size());
+      consumer.accept(list.subList(from, to));
+    }
+  }
+
+  /**
+   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
+   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
+   * a {@code regclass}; the value is always a static literal controlled by us.
+   */
+  static long[] allocateIds(Connection conn, String sequenceName, int count) throws SQLException {
+    long[] ids = new long[count];
+    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setInt(1, count);
+      try (ResultSet rs = ps.executeQuery()) {
+        int i = 0;
+        while (rs.next()) {
+          ids[i++] = rs.getLong(1);
+        }
+        if (i != count) {
+          throw new SQLException(
+              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
+        }
+      }
+    }
+    return ids;
+  }
+
+  static String buildMultiRowInsertSql(String prefix, String rowPlaceholders, int rowCount) {
+    StringBuilder sb =
+        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
+    sb.append(prefix);
+    for (int i = 0; i < rowCount; i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(rowPlaceholders);
+    }
+    return sb.toString();
+  }
+
+  static Timestamp toTimestamp(Date date) {
+    return date != null ? new Timestamp(date.getTime()) : null;
+  }
+
+  /**
+   * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
+   * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
+   * Timestamp[])} is not safe: pgjdbc stringifies each element via {@code Timestamp.toString()},
+   * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
+   * under the session {@code TimeZone} -- skewing every value when the session zone differs from
+   * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
+   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
+   * (pgjdbc appends the JVM zone offset there).
+   */
+  static String toTimestamptz(Date date) {
+    return date != null
+        ? OffsetDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).toString()
+        : null;
+  }
+
+  static void setNullableTimestamp(PreparedStatement ps, int index, Date date) throws SQLException {
+    if (date != null) {
+      ps.setTimestamp(index, new Timestamp(date.getTime()));
+    } else {
+      ps.setNull(index, Types.TIMESTAMP);
+    }
+  }
+
+  static void setNullableString(PreparedStatement ps, int index, String value) throws SQLException {
+    if (value != null) {
+      ps.setString(index, value);
+    } else {
+      ps.setNull(index, Types.VARCHAR);
+    }
+  }
+
+  static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  static String toJson(ObjectMapper objectMapper, UserInfoSnapshot info) throws SQLException {
+    if (info == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(info);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
+    }
+  }
+
+  // Must mirror JsonEventDataValueSetBinaryType exactly: same MAPPER (configured with
+  // IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector, NON_NULL inclusion, etc.) and
+  // same per-value writer. Using a different ObjectMapper (e.g. the Spring-injected default) drops
+  // fields like UserInfoSnapshot.id that the JDBC reader requires.
+  private static final ObjectWriter EVENT_DATA_VALUE_WRITER =
+      JsonBinaryType.MAPPER.writerFor(EventDataValue.class);
+
+  /**
+   * Serializes the EventDataValues set as a JSON object keyed by {@code dataElement} uid, matching
+   * the on-disk shape produced by {@code JsonEventDataValueSetBinaryType}. An empty or null set is
+   * serialized as {@code "{}"} to match the column's NOT NULL default.
+   */
+  static String toEventDataValuesJson(Set<EventDataValue> values) throws SQLException {
+    try {
+      StringWriter sw = new StringWriter();
+      try (JsonGenerator gen = JsonBinaryType.MAPPER.getFactory().createGenerator(sw)) {
+        gen.writeStartObject();
+        if (values != null) {
+          for (EventDataValue edv : values) {
+            gen.writeFieldName(edv.getDataElement());
+            EVENT_DATA_VALUE_WRITER.writeValue(gen, edv);
+          }
+        }
+        gen.writeEndObject();
+      }
+      return sw.toString();
+    } catch (IOException e) {
+      throw new SQLException("Failed to serialize EventDataValues to JSON", e);
+    }
+  }
+
+  /**
+   * Serializes the relationship's {@link ObjectStyle} via {@link JsonBinaryType#MAPPER} to match
+   * the Hibernate {@code jbObjectStyle} UserType. Returns {@code null} for a null style so the
+   * caller can pass it straight to a {@code ?::jsonb} parameter as SQL NULL.
+   */
+  static String toObjectStyleJson(ObjectStyle style) throws SQLException {
+    if (style == null) {
+      return null;
+    }
+    try {
+      return JsonBinaryType.MAPPER.writeValueAsString(style);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize ObjectStyle to JSON", e);
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import org.hisp.dhis.note.Note;
+
+/**
+ * Cascade-inserts new {@link Note}s for an entity type that carries notes (Enrollment,
+ * TrackerEvent, SingleEvent), replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour.
+ * Mirrors what Hibernate did on the owning collection: allocate ids for the new {@code note} rows
+ * from {@code note_sequence}, insert the {@code note} rows, then insert the join rows in the
+ * owner's notes join table ({@code enrollment_notes} / {@code trackerevent_notes} / {@code
+ * singleevent_notes}) with {@code sort_order} taken from the 1-based list position (per
+ * {@code @ListIndexBase(1)}).
+ *
+ * <p>On INSERT every Note is new; on UPDATE only Notes with {@code id == 0} are new (existing ones
+ * were loaded by the preheat). Notes are append-only on UPDATE.
+ *
+ * <p>One instance is configured per join table; the three entity writers each compose one.
+ */
+final class NoteCascadeWriter {
+
+  private static final String NOTE_INSERT_PREFIX =
+      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
+  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
+
+  private static final String JOIN_INSERT_ROW = "(?, ?, ?)";
+
+  /** A new {@link Note} to insert for a given owner row, with its 1-based sort order. */
+  record NoteRow(long ownerId, Note note, int sortOrder) {}
+
+  private final String joinInsertPrefix;
+
+  NoteCascadeWriter(String joinTable, String ownerIdColumn) {
+    this.joinInsertPrefix =
+        "insert into " + joinTable + " (" + ownerIdColumn + ", noteid, sort_order) values ";
+  }
+
+  /**
+   * Collects the new notes (no DB id) from the given inserted and updated owners and
+   * cascade-inserts them. {@code ownerId} extracts the owner's pre-allocated/persisted id; {@code
+   * notesGetter} returns the owner's notes list (may be {@code null}).
+   */
+  <E> void cascade(
+      Connection conn,
+      List<E> inserts,
+      List<E> updates,
+      ToLongFunction<E> ownerId,
+      Function<E, List<Note>> notesGetter)
+      throws SQLException {
+    List<NoteRow> newNotes = new ArrayList<>();
+    collectNewNotes(inserts, ownerId, notesGetter, newNotes);
+    collectNewNotes(updates, ownerId, notesGetter, newNotes);
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertJoinRows(conn, newNotes);
+  }
+
+  private static <E> void collectNewNotes(
+      List<E> owners,
+      ToLongFunction<E> ownerId,
+      Function<E, List<Note>> notesGetter,
+      List<NoteRow> out) {
+    for (E owner : owners) {
+      List<Note> notes = notesGetter.apply(owner);
+      if (notes == null) {
+        continue;
+      }
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new NoteRow(ownerId.applyAsLong(owner), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertNoteRows(Connection conn, List<NoteRow> newNotes) throws SQLException {
+    forEachChunk(
+        newNotes,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (NoteRow item : chunk) {
+              Note n = item.note();
+              ps.setLong(p++, n.getId());
+              ps.setString(p++, n.getUid());
+              ps.setTimestamp(p++, toTimestamp(n.getCreated()));
+              if (n.getLastUpdatedBy() != null) {
+                ps.setLong(p++, n.getLastUpdatedBy().getId());
+              } else {
+                ps.setNull(p++, Types.BIGINT);
+              }
+              if (n.getNoteText() != null) {
+                ps.setString(p++, n.getNoteText());
+              } else {
+                ps.setNull(p++, Types.VARCHAR);
+              }
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void insertJoinRows(Connection conn, List<NoteRow> newNotes) throws SQLException {
+    forEachChunk(
+        newNotes,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(joinInsertPrefix, JOIN_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (NoteRow item : chunk) {
+              ps.setLong(p++, item.ownerId());
+              ps.setLong(p++, item.note().getId());
+              ps.setInt(p++, item.sortOrder());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -69,6 +69,23 @@ public class RelationshipPersister
   }
 
   @Override
+  protected void assignId(org.hisp.dhis.tracker.model.Relationship entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(
+      org.hisp.dhis.tracker.model.Relationship entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(
+      org.hisp.dhis.tracker.model.Relationship entity, EntityWriteBatch batch) {
+    throw new UnsupportedOperationException("Relationships are not updated");
+  }
+
+  @Override
   protected org.hisp.dhis.tracker.model.Relationship convert(
       TrackerBundle bundle, Relationship trackerDto) {
     if (bundle.getStrategy(trackerDto) == TrackerImportStrategy.UPDATE) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -127,7 +127,8 @@ public class RelationshipPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       Relationship trackerDto,
-      org.hisp.dhis.tracker.model.Relationship entity) {
+      org.hisp.dhis.tracker.model.Relationship entity,
+      EntityWriteBatch batch) {
     // NOTHING TO DO
 
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toObjectStyleJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import org.hisp.dhis.tracker.model.Relationship;
+import org.hisp.dhis.tracker.model.RelationshipItem;
+
+/**
+ * Flushes staged {@link Relationship} inserts via three JDBC statements -- a multi-row INSERT into
+ * {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT into
+ * {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code relationship}
+ * to set the from/to FKs. The three-step shape breaks the circular, non-deferrable FK between the
+ * two tables. Ids come from {@code relationship_sequence} and {@code relationshipitem_sequence}.
+ *
+ * <p>Relationship is INSERT-only in tracker imports ({@code RelationshipPersister.convert} returns
+ * null on UPDATE strategy), so there is no update list and no L1 detach/refresh.
+ */
+final class RelationshipWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into relationship ("
+          + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
+          + " style, relationshiptypeid,"
+          + " from_relationshipitemid, to_relationshipitemid,"
+          + " key, inverted_key, deleted, createdatclient) values ";
+
+  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
+  // updateFromTo after the items are inserted.
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
+
+  private static final String ITEM_INSERT_PREFIX =
+      "insert into relationshipitem ("
+          + "relationshipitemid, relationshipid,"
+          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
+  private static final String ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  private static final String UPDATE_FROM_TO_SQL =
+      "update relationship r set"
+          + " from_relationshipitemid = v.from_id,"
+          + " to_relationshipitemid = v.to_id"
+          + " from ( select"
+          + " unnest(?::bigint[]) as relationshipid,"
+          + " unnest(?::bigint[]) as from_id,"
+          + " unnest(?::bigint[]) as to_id"
+          + " ) v where r.relationshipid = v.relationshipid";
+
+  private final List<Relationship> inserts = new ArrayList<>();
+
+  /**
+   * Relationships are never updated -- {@link AbstractTrackerPersister} ignores update payloads.
+   */
+  void stageInsert(Relationship relationship) {
+    inserts.add(relationship);
+  }
+
+  int mark() {
+    return inserts.size();
+  }
+
+  void rollbackTo(int mark) {
+    truncate(inserts, mark);
+  }
+
+  void clear() {
+    inserts.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    insertRelationships(conn);
+    insertRelationshipItems(conn);
+    updateFromTo(conn);
+  }
+
+  /**
+   * Inserts the parent {@code relationship} rows with from/to FKs left NULL (filled in by {@link
+   * #updateFromTo} once the item rows exist, since neither FK constraint is deferrable).
+   */
+  private void insertRelationships(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (Relationship r : chunk) {
+              p = bindRow(ps, p, r);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
+    if (r.getId() == 0) {
+      throw new SQLException(
+          "Relationship "
+              + r.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, r.getId());
+    ps.setString(p++, r.getUid());
+    if (r.getCode() != null) {
+      ps.setString(p++, r.getCode());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
+    if (r.getLastUpdatedBy() != null) {
+      ps.setLong(p++, r.getLastUpdatedBy().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toObjectStyleJson(r.getStyle()));
+    ps.setLong(p++, r.getRelationshipType().getId());
+    ps.setString(p++, r.getKey());
+    ps.setString(p++, r.getInvertedKey());
+    ps.setBoolean(p++, r.isDeleted());
+    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
+    return p;
+  }
+
+  /** Flattened from/to item with its pre-allocated id and parent relationship id. */
+  private record ItemRow(long itemId, long relationshipId, RelationshipItem item) {}
+
+  /**
+   * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
+   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
+   * round-trip, assign them to the in-memory items (so {@link #updateFromTo} can read them back),
+   * then flatten the from/to items into a single multi-row INSERT.
+   */
+  private void insertRelationshipItems(Connection conn) throws SQLException {
+    if (inserts.isEmpty()) {
+      return;
+    }
+    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * inserts.size());
+    int cursor = 0;
+    for (Relationship r : inserts) {
+      r.getFrom().setId((int) itemIds[cursor++]);
+      r.getTo().setId((int) itemIds[cursor++]);
+    }
+
+    List<ItemRow> rows = new ArrayList<>(2 * inserts.size());
+    for (Relationship r : inserts) {
+      rows.add(new ItemRow(r.getFrom().getId(), r.getId(), r.getFrom()));
+      rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
+    }
+
+    forEachChunk(
+        rows,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(ITEM_INSERT_PREFIX, ITEM_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (ItemRow row : chunk) {
+              p = bindItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindItemRow(
+      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
+      throws SQLException {
+    ps.setLong(p++, itemId);
+    ps.setLong(p++, relationshipId);
+    if (item.getTrackedEntity() != null) {
+      ps.setLong(p++, item.getTrackedEntity().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getEnrollment() != null) {
+      ps.setLong(p++, item.getEnrollment().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
+    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
+    // non-null because a given UID exists in exactly one of the two event tables.
+    if (item.getTrackerEvent() != null) {
+      ps.setLong(p++, item.getTrackerEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getSingleEvent() != null) {
+      ps.setLong(p++, item.getSingleEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    return p;
+  }
+
+  /**
+   * Sets {@code relationship.from_relationshipitemid} and {@code to_relationshipitemid} once the
+   * item rows have been inserted by {@link #insertRelationshipItems}.
+   */
+  private void updateFromTo(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          Long[] fromIds = new Long[n];
+          Long[] toIds = new Long[n];
+
+          for (int i = 0; i < n; i++) {
+            Relationship r = chunk.get(i);
+            ids[i] = r.getId();
+            fromIds[i] = (long) r.getFrom().getId();
+            toIds[i] = (long) r.getTo().getId();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_FROM_TO_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("bigint", fromIds));
+            ps.setArray(3, conn.createArrayOf("bigint", toIds));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -91,6 +91,21 @@ public class SingleEventPersister
   }
 
   @Override
+  protected void assignId(SingleEvent entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(SingleEvent entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(SingleEvent entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updatePreheat(TrackerPreheat preheat, SingleEvent event) {
     preheat.putSingleEvents(Collections.singletonList(event));
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -295,7 +295,8 @@ public class SingleEventPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.SingleEvent trackerDto,
-      SingleEvent entity) {
+      SingleEvent entity,
+      EntityWriteBatch batch) {
     // DO NOTHING. Event creation does not create ownership records.
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.SingleEvent;
+
+/**
+ * Flushes staged {@link SingleEvent} writes. Mirrors {@link TrackerEventWriter} but writes to
+ * {@code singleevent} (no {@code enrollmentid}, no {@code scheduleddate}); ids are pre-allocated
+ * from {@code singleevent_sequence}. New notes cascade into {@code note} + {@code
+ * singleevent_notes}.
+ */
+final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
+
+  private static final String INSERT_PREFIX =
+      "insert into singleevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch. Insert-
+  // only columns (uid, created, createdbyuserinfo, deleted) and columns owned by other code paths
+  // (lastsynchronized) are excluded.
+  private static final String UPDATE_SQL =
+      "update singleevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("singleevent_notes", "eventid");
+
+  SingleEventWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, SingleEvent::getId, SingleEvent::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (SingleEvent e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "SingleEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] programStageIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] status = new String[n];
+          String[] occurredDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          Long[] assignedUserIds = new Long[n];
+          String[] eventDataValues = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            SingleEvent e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            programStageIds[i] = e.getProgramStage().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            status[i] = e.getStatus().name();
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+            eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
+            ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(9, conn.createArrayOf("text", status));
+            ps.setArray(10, conn.createArrayOf("text", occurredDate));
+            ps.setArray(11, conn.createArrayOf("text", completedDate));
+            ps.setArray(12, conn.createArrayOf("text", completedBy));
+            ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
+            ps.setArray(14, conn.createArrayOf("text", eventDataValues));
+            ps.setArray(15, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableString;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+
+/**
+ * Flushes staged {@link TrackedEntityAttributeValue} writes via JDBC against {@code
+ * trackedentityattributevalue}: a multi-row INSERT, a single unnest UPDATE keyed on the composite
+ * ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single unnest DELETE on the
+ * same key. TEAV has a composite PK and no sequence, so no id pre-allocation is needed.
+ * Confidential attributes (and the {@code encryptedvalue} column) were removed in DHIS2-21518, so
+ * the value is stored as plain text in {@code value}.
+ */
+final class TeavWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentityattributevalue ("
+          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
+          + " value, updatedby) values ";
+  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  // `created` is insert-only and deliberately excluded from the UPDATE column set.
+  private static final String UPDATE_SQL =
+      "update trackedentityattributevalue teav set"
+          + " lastupdated = v.lastupdated,"
+          + " value = v.value,"
+          + " updatedby = v.updatedby"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::text[]) as value,"
+          + " unnest(?::text[]) as updatedby"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
+  // Unnest DELETE on the composite key, mirroring the unnest UPDATE shape rather than an
+  // IN (VALUES ...) form, to stay consistent with the other batch statements and avoid dynamic SQL.
+  private static final String DELETE_SQL =
+      "delete from trackedentityattributevalue teav"
+          + " using ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
+  private final List<TrackedEntityAttributeValue> inserts = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> updates = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> deletes = new ArrayList<>();
+
+  void stageInsert(TrackedEntityAttributeValue value) {
+    inserts.add(value);
+  }
+
+  void stageUpdate(TrackedEntityAttributeValue value) {
+    updates.add(value);
+  }
+
+  void stageDelete(TrackedEntityAttributeValue value) {
+    deletes.add(value);
+  }
+
+  /**
+   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
+   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
+   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
+   * each carrying the same attribute value -- so it can fold the second occurrence into the first
+   * staged instance instead of staging a second INSERT for the same composite key, which would
+   * violate the primary key at flush.
+   */
+  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
+    return Stream.concat(inserts.stream(), updates.stream())
+        .filter(v -> v.getTrackedEntity() == trackedEntity);
+  }
+
+  Mark mark() {
+    return new Mark(inserts.size(), updates.size(), deletes.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(inserts, mark.inserts());
+    truncate(updates, mark.updates());
+    truncate(deletes, mark.deletes());
+  }
+
+  void clear() {
+    inserts.clear();
+    updates.clear();
+    deletes.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty() && updates.isEmpty() && deletes.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    delete(conn);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntityAttributeValue v : chunk) {
+              ps.setLong(p++, v.getTrackedEntity().getId());
+              ps.setLong(p++, v.getAttribute().getId());
+              ps.setTimestamp(p++, toTimestamp(v.getCreated()));
+              ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
+              setNullableString(ps, p++, v.getValue());
+              setNullableString(ps, p++, v.getUpdatedBy());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] trackedEntityIds = new Long[n];
+          Long[] attributeIds = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] value = new String[n];
+          String[] updatedBy = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackedEntityAttributeValue v = chunk.get(i);
+            trackedEntityIds[i] = v.getTrackedEntity().getId();
+            attributeIds[i] = v.getAttribute().getId();
+            lastUpdated[i] = toTimestamptz(v.getLastUpdated());
+            value[i] = v.getValue();
+            updatedBy[i] = v.getUpdatedBy();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+            ps.setArray(3, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(4, conn.createArrayOf("text", value));
+            ps.setArray(5, conn.createArrayOf("text", updatedBy));
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void delete(Connection conn) throws SQLException {
+    forEachChunk(
+        deletes,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] trackedEntityIds = new Long[n];
+          Long[] attributeIds = new Long[n];
+          for (int i = 0; i < n; i++) {
+            TrackedEntityAttributeValue v = chunk.get(i);
+            trackedEntityIds[i] = v.getTrackedEntity().getId();
+            attributeIds[i] = v.getAttribute().getId();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(DELETE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  record Mark(int inserts, int updates, int deletes) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -121,7 +121,8 @@ public class TrackedEntityPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity entity) {
+      TrackedEntity entity,
+      EntityWriteBatch batch) {
     // DO NOTHING, TE alone does not have ownership records
 
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -68,6 +68,21 @@ public class TrackedEntityPersister
   }
 
   @Override
+  protected void assignId(TrackedEntity entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(TrackedEntity entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(TrackedEntity entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updateAttributes(
       Connection connection,
       TrackerPreheat preheat,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
+
+/**
+ * Flushes staged {@link TrackedEntityProgramOwner} rows via a single batched, multi-row JDBC INSERT
+ * into {@code trackedentityprogramowner}, replacing the per-new-enrollment Hibernate {@code save()}
+ * in {@code EnrollmentPersister.persistOwnership} (one {@code nextval} round-trip + one single-row
+ * INSERT each).
+ *
+ * <p>Ids are pre-allocated from {@code trackedentityprogramowner_sequence} (added in {@code
+ * V2_44_14}), the dedicated sequence the entity's {@code <generator class="sequence"/>} mapping now
+ * draws from. Both this JDBC import path and the remaining Hibernate insert paths for this table
+ * (ownership create-or-update and transfer) share that one sequence, so they cannot collide.
+ *
+ * <p>Ownership is INSERT-only here; the persister guards against duplicates against the preheat
+ * before staging, and the {@code (trackedentityid, programid)} unique key backstops it.
+ */
+final class TrackedEntityProgramOwnerWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentityprogramowner ("
+          + "trackedentityprogramownerid, trackedentityid, programid,"
+          + " created, lastupdated, organisationunitid, createdby) values ";
+  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?, ?)";
+
+  private final List<TrackedEntityProgramOwner> inserts = new ArrayList<>();
+
+  void stageInsert(TrackedEntityProgramOwner owner) {
+    inserts.add(owner);
+  }
+
+  int mark() {
+    return inserts.size();
+  }
+
+  void rollbackTo(int mark) {
+    truncate(inserts, mark);
+  }
+
+  void clear() {
+    inserts.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    if (inserts.isEmpty()) {
+      return;
+    }
+    long[] ids = allocateIds(conn, "trackedentityprogramowner_sequence", inserts.size());
+    int cursor = 0;
+    for (TrackedEntityProgramOwner owner : inserts) {
+      owner.setId((int) ids[cursor++]);
+    }
+
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntityProgramOwner owner : chunk) {
+              ps.setLong(p++, owner.getId());
+              ps.setLong(p++, owner.getTrackedEntity().getId());
+              ps.setLong(p++, owner.getProgram().getId());
+              ps.setTimestamp(p++, toTimestamp(owner.getCreated()));
+              ps.setTimestamp(p++, toTimestamp(owner.getLastUpdated()));
+              ps.setLong(p++, owner.getOrganisationUnit().getId());
+              ps.setString(p++, owner.getCreatedBy());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+
+/**
+ * Flushes staged {@link TrackedEntity} writes: a multi-row JDBC INSERT against {@code
+ * trackedentity} (ids pre-allocated from {@code trackedentity_sequence}) and a single unnest UPDATE
+ * writing only the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
+ */
+final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentity ("
+          + "trackedentityid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " inactive, deleted, lastsynchronized, potentialduplicate,"
+          + " organisationunitid, trackedentitytypeid,"
+          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, " + SRID + "), ?::jsonb, ?::jsonb)";
+
+  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch. Insert-only columns (uid,
+  // created, createdbyuserinfo) and columns owned by other code paths (deleted, lastsynchronized --
+  // the latter is bulk-updated by DefaultTrackerBundleService.postCommit) are deliberately
+  // excluded.
+  private static final String UPDATE_SQL =
+      "update trackedentity te set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " organisationunitid = v.organisationunitid,"
+          + " trackedentitytypeid = v.trackedentitytypeid,"
+          + " potentialduplicate = v.potentialduplicate,"
+          + " inactive = v.inactive,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as trackedentitytypeid,"
+          + " unnest(?::boolean[]) as potentialduplicate,"
+          + " unnest(?::boolean[]) as inactive,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where te.trackedentityid = v.trackedentityid";
+
+  private final ObjectMapper objectMapper;
+
+  TrackedEntityWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntity te : chunk) {
+              p = bindRow(ps, p, te);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, TrackedEntity te) throws SQLException {
+    if (te.getId() == 0) {
+      throw new SQLException(
+          "TrackedEntity "
+              + te.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, te.getId());
+    ps.setString(p++, te.getUid());
+    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
+    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getCreatedAtClient());
+    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
+    ps.setBoolean(p++, te.isInactive());
+    ps.setBoolean(p++, te.isDeleted());
+    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
+    ps.setBoolean(p++, te.isPotentialDuplicate());
+    ps.setLong(p++, te.getOrganisationUnit().getId());
+    ps.setLong(p++, te.getTrackedEntityType().getId());
+    if (te.getGeometry() != null) {
+      ps.setString(p++, te.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, toJson(objectMapper, te.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, te.getLastUpdatedByUserInfo()));
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] trackedEntityTypeIds = new Long[n];
+          Boolean[] potentialDuplicate = new Boolean[n];
+          Boolean[] inactive = new Boolean[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackedEntity te = chunk.get(i);
+            ids[i] = te.getId();
+            lastUpdated[i] = toTimestamptz(te.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(te.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(te.getLastUpdatedAtClient());
+            organisationUnitIds[i] = te.getOrganisationUnit().getId();
+            trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
+            potentialDuplicate[i] = te.isPotentialDuplicate();
+            inactive[i] = te.isInactive();
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, te.getLastUpdatedByUserInfo());
+            geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
+            ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
+            ps.setArray(8, conn.createArrayOf("boolean", inactive));
+            ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(10, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -353,7 +353,8 @@ public class TrackerEventPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent trackerDto,
-      TrackerEvent entity) {
+      TrackerEvent entity,
+      EntityWriteBatch batch) {
     // DO NOTHING. Event creation does not create ownership records.
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -92,6 +92,21 @@ public class TrackerEventPersister
   }
 
   @Override
+  protected void assignId(TrackerEvent entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(TrackerEvent entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(TrackerEvent entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updatePreheat(TrackerPreheat preheat, TrackerEvent event) {
     preheat.putTrackerEvents(Collections.singletonList(event));
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.TrackerEvent;
+
+/**
+ * Flushes staged {@link TrackerEvent} writes: a multi-row JDBC INSERT against {@code trackerevent}
+ * (ids pre-allocated from {@code trackerevent_sequence}; {@code eventdatavalues} jsonb serialized
+ * as a JSON object keyed by dataElement uid), a single unnest UPDATE, and a cascade insert of any
+ * new notes into {@code note} + {@code trackerevent_notes}.
+ */
+final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackerevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, scheduleddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch.
+  // Insert-
+  // only columns (uid, created, createdbyuserinfo, deleted) and columns owned by other code paths
+  // (lastsynchronized) are excluded.
+  private static final String UPDATE_SQL =
+      "update trackerevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " enrollmentid = v.enrollmentid,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " scheduleddate = v.scheduleddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as scheduleddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("trackerevent_notes", "eventid");
+
+  TrackerEventWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, TrackerEvent::getId, TrackerEvent::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackerEvent e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "TrackerEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getScheduledDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getEnrollment().getId());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] enrollmentIds = new Long[n];
+          Long[] programStageIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] status = new String[n];
+          String[] occurredDate = new String[n];
+          String[] scheduledDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          Long[] assignedUserIds = new Long[n];
+          String[] eventDataValues = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackerEvent e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            enrollmentIds[i] = e.getEnrollment().getId();
+            programStageIds[i] = e.getProgramStage().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            status[i] = e.getStatus().name();
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            scheduledDate[i] = toTimestamptz(e.getScheduledDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+            eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
+            ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
+            ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(10, conn.createArrayOf("text", status));
+            ps.setArray(11, conn.createArrayOf("text", occurredDate));
+            ps.setArray(12, conn.createArrayOf("text", scheduledDate));
+            ps.setArray(13, conn.createArrayOf("text", completedDate));
+            ps.setArray(14, conn.createArrayOf("text", completedBy));
+            ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
+            ps.setArray(16, conn.createArrayOf("text", eventDataValues));
+            ps.setArray(17, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base for the per-entity writers that stage inserts and updates of a single top-level entity type
+ * (TrackedEntity, Enrollment, TrackerEvent, SingleEvent). Owns the two staging lists and the
+ * mark/rollback/clear lifecycle shared with {@link ChangeLogAccumulator}; subclasses supply the
+ * type-specific {@link #flush(Connection)} (multi-row INSERT, unnest UPDATE and any notes cascade).
+ */
+abstract class UpsertTableWriter<E> {
+
+  protected final List<E> inserts = new ArrayList<>();
+  protected final List<E> updates = new ArrayList<>();
+
+  void stageInsert(E entity) {
+    inserts.add(entity);
+  }
+
+  void stageUpdate(E entity) {
+    updates.add(entity);
+  }
+
+  /** Whether the given entity is staged for insert (no DB row yet) in this batch. */
+  boolean isStagedAsInsert(E entity) {
+    return inserts.contains(entity);
+  }
+
+  Mark mark() {
+    return new Mark(inserts.size(), updates.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(inserts, mark.inserts());
+    truncate(updates, mark.updates());
+  }
+
+  void clear() {
+    inserts.clear();
+    updates.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty() && updates.isEmpty();
+  }
+
+  /** Applies the staged inserts and updates via JDBC on {@code conn}. */
+  abstract void flush(Connection conn) throws SQLException;
+
+  record Mark(int inserts, int updates) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
@@ -34,7 +34,10 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.tr
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Base for the per-entity writers that stage inserts and updates of a single top-level entity type
@@ -47,8 +50,14 @@ abstract class UpsertTableWriter<E> {
   protected final List<E> inserts = new ArrayList<>();
   protected final List<E> updates = new ArrayList<>();
 
+  // Membership index over `inserts` for O(1) isStagedAsInsert, which is called once per tracked
+  // entity during attribute handling -- a List.contains scan there is O(n) and turns a large
+  // insert batch quadratic. Identity-based: the instance staged is the same instance queried.
+  private final Set<E> insertSet = Collections.newSetFromMap(new IdentityHashMap<>());
+
   void stageInsert(E entity) {
     inserts.add(entity);
+    insertSet.add(entity);
   }
 
   void stageUpdate(E entity) {
@@ -57,7 +66,7 @@ abstract class UpsertTableWriter<E> {
 
   /** Whether the given entity is staged for insert (no DB row yet) in this batch. */
   boolean isStagedAsInsert(E entity) {
-    return inserts.contains(entity);
+    return insertSet.contains(entity);
   }
 
   Mark mark() {
@@ -65,12 +74,16 @@ abstract class UpsertTableWriter<E> {
   }
 
   void rollbackTo(Mark mark) {
+    for (int i = mark.inserts(); i < inserts.size(); i++) {
+      insertSet.remove(inserts.get(i));
+    }
     truncate(inserts, mark.inserts());
     truncate(updates, mark.updates());
   }
 
   void clear() {
     inserts.clear();
+    insertSet.clear();
     updates.clear();
   }
 


### PR DESCRIPTION
## Summary

Refactors the tracker import write path so the monolithic `EntityWriteBatch` (1767
lines) becomes a thin composite over focused, per-table writer classes, and removes the
runtime `instanceof` dispatch in `AbstractTrackerPersister`. This is a behavior-preserving
structural cleanup of the now-complete Hibernate→JDBC migration [DHIS2-21378]: no SQL,
column ordering, flush ordering, or transaction semantics change. It pays down the
duplication that the incremental migration accumulated and sets up the upcoming
persistence performance work (program-owner staging, batched TEAV lookup) so new batched
writers slot in without re-stamping the ~120-line per-entity boilerplate.

## Changes

**Split `EntityWriteBatch` into per-entity writers** (`bundle/persister/`)
- `EntityWriteBatch` shrinks from 1767 → 244 lines: it now owns only staging delegation,
  composite `mark`/`rollbackTo`, and the FK-safe flush order (TrackedEntity → Enrollment →
  TrackerEvent → SingleEvent → Relationship → TEAV). Its external API
  (`stageInsert`/`stageUpdate`/`stageTeav*`/`stagedFor`/`isStagedAsInsert`/`mark`/
  `rollbackTo`/`flush` + nested `Mark`) is unchanged.
- Adds `TrackedEntityWriter`, `EnrollmentWriter`, `TrackerEventWriter`,
  `SingleEventWriter`, `RelationshipWriter`, `TeavWriter` — each owns its SQL constants,
  bind logic, flush, staging list(s) and `mark`/`rollback` lifecycle. `RelationshipWriter`
  encapsulates the three-step circular-FK insert; `TeavWriter` the composite-PK
  insert/update/delete.
- Adds `UpsertTableWriter<E>` base for the four insert/update writers (shared list +
  mark/rollback/clear lifecycle).
- Adds `JdbcBatchSupport`: shared mechanics (`allocateIds`, `buildMultiRowInsertSql`,
  `forEachChunk`, timestamp/nullable binds, `truncate`) and the JSON serializers,
  centralising the `JsonBinaryType.MAPPER` invariant for `eventdatavalues` / `ObjectStyle`.
- Adds `NoteCascadeWriter`: collapses the three near-identical notes-cascade copies
  (enrollment / tracker-event / single-event) into one, parameterised by join table +
  owner-id column.

**Remove `instanceof` dispatch in `AbstractTrackerPersister.java`**
- Replaces the three private `instanceof` ladders (`assignId`, `stageInsert`,
  `stageUpdate`, including both "Unsupported entity type" fallthroughs) with abstract
  template methods, implemented by each concrete persister against its statically-known
  entity type. Overload selection now happens at compile time.
- `RelationshipPersister.stageUpdate` throws `UnsupportedOperationException` — "relationships
  are insert-only" becomes a property of the class instead of a comment repeated three times.
- A new entity type is now forced to wire itself up (compile-time exhaustiveness) instead
  of silently throwing at runtime. Drops four now-unused model imports.

## Next Steps

This is the structural groundwork (Step 1 + the dispatch cleanup) of the tracker
persistence follow-up plan.

**Done**
- ✅ Hibernate→JDBC migration complete on master (all entity types incl. TEAV; `EntityManager` removed)
- ✅ Split `EntityWriteBatch` into per-entity writers + shared support + notes cascade collapse (this PR)
- ✅ Remove `instanceof` ladders via typed template methods (this PR)

**To do**
- ⬜ Stage program-ownership inserts (new `trackedentityprogramowner_sequence` migration + `TrackedEntityProgramOwnerWriter`)
- ⬜ Batch the per-TE existing-TEAV lookup (`= ANY(?)` / preheat)
- ⬜ Constant-text `unnest` INSERTs so pgjdbc's prepared-statement cache engages
- ⬜ Cache serialized `UserInfoSnapshot` JSON
- ⬜ Remaining refactor: typed `EntityTableWriter<V>`/`StagingBuffer` unification, optional column-spec builder


[DHIS2-21378]: https://dhis2.atlassian.net/browse/DHIS2-21378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ