### PR TITLE
chore: Remove unused format methods [DHIS2-21627][2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -504,19 +504,4 @@ public abstract class AbstractTrackerPersister<
 
     return trackedEntityAttribute;
   }
-
-  protected static String formatDate(Date date) {
-    java.text.SimpleDateFormat formatter =
-        new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    return date != null ? formatter.format(date) : null;
-  }
-
-  protected static String formatGeometry(org.locationtech.jts.geom.Geometry geometry) {
-    if (geometry == null) {
-      return null;
-    }
-    return java.util.stream.Stream.of(geometry.getCoordinates())
-        .map(c -> String.format("(%f, %f)", c.x, c.y))
-        .collect(java.util.stream.Collectors.joining(", "));
-  }
 }


### PR DESCRIPTION
I'm removing two helper methods added when back porting that are not used in this version.