### PR TITLE
perf: avoid loading org unit group members for OUG{} indicator counts

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.organisationunit;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
@@ -43,4 +44,14 @@ public interface OrganisationUnitGroupStore
 
   OrganisationUnitGroup getOrgUnitGroupInGroupSet(
       Set<OrganisationUnitGroup> groups, OrganisationUnitGroupSet groupSet);
+
+  /**
+   * Returns the number of members (organisation units) for each of the given organisation unit
+   * groups, keyed by group UID. The count is computed with a {@code size}/{@code count} query and
+   * does not initialise the (potentially very large) members collection.
+   *
+   * @param uids the UIDs of the organisation unit groups to count members for.
+   * @return a map of organisation unit group UID to member count. Non-existent groups are omitted.
+   */
+  Map<String, Integer> getOrganisationUnitGroupMemberCounts(Set<String> uids);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -419,10 +419,9 @@ public class DefaultExpressionService implements ExpressionService {
         new CachingMap<String, Constant>()
             .load(idObjectManager.getAllNoAcl(Constant.class), IdentifiableObject::getUid);
 
-    // Resolve org unit group member counts with a single count query rather than loading the
-    // (potentially very large) members collections via getMembers().size(). A single OUG{}
-    // reference
-    // to a group with tens of thousands of members would otherwise hydrate all of them.
+    // Resolve org unit group member counts with a single count query. Reading the size of the lazy
+    // members collection directly would initialise it, hydrating every member of a group that may
+    // contain tens of thousands of org units into the session.
     Set<String> orgUnitGroupUids =
         indicators.stream()
             .flatMap(indicator -> Stream.of(indicator.getNumerator(), indicator.getDenominator()))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -419,15 +419,15 @@ public class DefaultExpressionService implements ExpressionService {
         new CachingMap<String, Constant>()
             .load(idObjectManager.getAllNoAcl(Constant.class), IdentifiableObject::getUid);
 
-    // Resolve org unit group member counts with a count query rather than loading the (potentially
-    // very large) members collections via getMembers().size(). A single OUG{} reference to a group
-    // with tens of thousands of members would otherwise hydrate all of them into the session.
-    Set<String> orgUnitGroupUids = new HashSet<>();
-
-    for (Indicator indicator : indicators) {
-      orgUnitGroupUids.addAll(getReferencedOrgUnitGroupUids(indicator.getNumerator()));
-      orgUnitGroupUids.addAll(getReferencedOrgUnitGroupUids(indicator.getDenominator()));
-    }
+    // Resolve org unit group member counts with a single count query rather than loading the
+    // (potentially very large) members collections via getMembers().size(). A single OUG{}
+    // reference
+    // to a group with tens of thousands of members would otherwise hydrate all of them.
+    Set<String> orgUnitGroupUids =
+        indicators.stream()
+            .flatMap(indicator -> Stream.of(indicator.getNumerator(), indicator.getDenominator()))
+            .flatMap(expression -> getReferencedOrgUnitGroupUids(expression).stream())
+            .collect(Collectors.toSet());
 
     Map<String, Integer> orgUnitGroupCounts =
         organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(orgUnitGroupUids);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -103,6 +103,7 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupStore;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
@@ -152,6 +153,8 @@ public class DefaultExpressionService implements ExpressionService {
   private final I18nManager i18nManager;
 
   private final SqlBuilder sqlBuilder;
+
+  private final OrganisationUnitGroupStore organisationUnitGroupStore;
 
   // -------------------------------------------------------------------------
   // Static data
@@ -254,7 +257,9 @@ public class DefaultExpressionService implements ExpressionService {
       IdentifiableObjectManager idObjectManager,
       I18nManager i18nManager,
       CacheProvider cacheProvider,
-      SqlBuilder sqlBuilder) {
+      SqlBuilder sqlBuilder,
+      @Qualifier("org.hisp.dhis.organisationunit.OrganisationUnitGroupStore")
+          OrganisationUnitGroupStore organisationUnitGroupStore) {
     checkNotNull(expressionStore);
     checkNotNull(constantService);
     checkNotNull(dimensionService);
@@ -262,6 +267,7 @@ public class DefaultExpressionService implements ExpressionService {
     checkNotNull(i18nManager);
     checkNotNull(cacheProvider);
     checkNotNull(sqlBuilder);
+    checkNotNull(organisationUnitGroupStore);
 
     this.expressionStore = expressionStore;
     this.constantService = constantService;
@@ -270,6 +276,7 @@ public class DefaultExpressionService implements ExpressionService {
     this.i18nManager = i18nManager;
     this.constantMapCache = cacheProvider.createAllConstantsCache();
     this.sqlBuilder = sqlBuilder;
+    this.organisationUnitGroupStore = organisationUnitGroupStore;
   }
 
   // -------------------------------------------------------------------------
@@ -402,7 +409,7 @@ public class DefaultExpressionService implements ExpressionService {
   }
 
   @Override
-  @Transactional
+  @Transactional(readOnly = true)
   public void substituteIndicatorExpressions(Collection<Indicator> indicators) {
     if (indicators == null || indicators.isEmpty()) {
       return;
@@ -412,18 +419,45 @@ public class DefaultExpressionService implements ExpressionService {
         new CachingMap<String, Constant>()
             .load(idObjectManager.getAllNoAcl(Constant.class), IdentifiableObject::getUid);
 
-    Map<String, OrganisationUnitGroup> orgUnitGroups =
-        new CachingMap<String, OrganisationUnitGroup>()
-            .load(
-                idObjectManager.getAllNoAcl(OrganisationUnitGroup.class),
-                IdentifiableObject::getUid);
+    // Resolve org unit group member counts with a count query rather than loading the (potentially
+    // very large) members collections via getMembers().size(). A single OUG{} reference to a group
+    // with tens of thousands of members would otherwise hydrate all of them into the session.
+    Set<String> orgUnitGroupUids = new HashSet<>();
+
+    for (Indicator indicator : indicators) {
+      orgUnitGroupUids.addAll(getReferencedOrgUnitGroupUids(indicator.getNumerator()));
+      orgUnitGroupUids.addAll(getReferencedOrgUnitGroupUids(indicator.getDenominator()));
+    }
+
+    Map<String, Integer> orgUnitGroupCounts =
+        organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(orgUnitGroupUids);
 
     for (Indicator indicator : indicators) {
       indicator.setExplodedNumerator(
-          regenerateIndicatorExpression(indicator.getNumerator(), constants, orgUnitGroups));
+          regenerateIndicatorExpression(indicator.getNumerator(), constants, orgUnitGroupCounts));
       indicator.setExplodedDenominator(
-          regenerateIndicatorExpression(indicator.getDenominator(), constants, orgUnitGroups));
+          regenerateIndicatorExpression(indicator.getDenominator(), constants, orgUnitGroupCounts));
     }
+  }
+
+  /**
+   * Returns the UIDs of the organisation unit groups referenced by {@code OUG{...}} in the given
+   * expression.
+   */
+  private Set<String> getReferencedOrgUnitGroupUids(String expression) {
+    Set<String> uids = new HashSet<>();
+
+    if (expression == null || expression.isEmpty()) {
+      return uids;
+    }
+
+    Matcher matcher = OU_GROUP_PATTERN.matcher(expression);
+
+    while (matcher.find()) {
+      uids.add(matcher.group(GROUP_ID));
+    }
+
+    return uids;
   }
 
   // -------------------------------------------------------------------------
@@ -741,9 +775,7 @@ public class DefaultExpressionService implements ExpressionService {
    * orgUnitCounts.
    */
   private String regenerateIndicatorExpression(
-      String expression,
-      Map<String, Constant> constants,
-      Map<String, OrganisationUnitGroup> orgUnitGroups) {
+      String expression, Map<String, Constant> constants, Map<String, Integer> orgUnitGroupCounts) {
     if (expression == null || expression.isEmpty()) {
       return null;
     }
@@ -778,10 +810,9 @@ public class DefaultExpressionService implements ExpressionService {
     while (matcher.find()) {
       String oug = matcher.group(GROUP_ID);
 
-      OrganisationUnitGroup group = orgUnitGroups.get(oug);
+      Integer memberCount = orgUnitGroupCounts.get(oug);
 
-      String replacement =
-          group != null ? String.valueOf(group.getMembers().size()) : NULL_REPLACEMENT;
+      String replacement = memberCount != null ? String.valueOf(memberCount) : NULL_REPLACEMENT;
 
       matcher.appendReplacement(sb, replacement);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
@@ -30,7 +30,9 @@
 package org.hisp.dhis.organisationunit.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -78,5 +80,29 @@ public class HibernateOrganisationUnitGroupStore
         .setParameter("groups", groups)
         .setMaxResults(1)
         .uniqueResult();
+  }
+
+  @Override
+  public Map<String, Integer> getOrganisationUnitGroupMemberCounts(Set<String> uids) {
+    Map<String, Integer> counts = new HashMap<>();
+
+    if (uids == null || uids.isEmpty()) {
+      return counts;
+    }
+
+    // size(g.members) translates to a count subquery; the members collection is never initialised.
+    List<Object[]> rows =
+        getSession()
+            .createQuery(
+                "select g.uid, size(g.members) from OrganisationUnitGroup g where g.uid in :uids",
+                Object[].class)
+            .setParameter("uids", uids)
+            .list();
+
+    for (Object[] row : rows) {
+      counts.put((String) row[0], ((Number) row[1]).intValue());
+    }
+
+    return counts;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -102,6 +103,7 @@ import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupStore;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
@@ -140,6 +142,8 @@ class ExpressionServiceTest extends TestBase {
   @Mock private SystemSettingsService settingsService;
 
   @Mock private SystemSettings settings;
+
+  @Mock private OrganisationUnitGroupStore organisationUnitGroupStore;
 
   private DefaultExpressionService target;
 
@@ -262,7 +266,8 @@ class ExpressionServiceTest extends TestBase {
             idObjectManager,
             i18nManager,
             cacheProvider,
-            sqlBuilder);
+            sqlBuilder,
+            organisationUnitGroupStore);
 
     categoryOptionA = new CategoryOption("Under 5");
     categoryOptionB = new CategoryOption("Over 5");
@@ -1054,11 +1059,10 @@ class ExpressionServiceTest extends TestBase {
     List<Constant> constants =
         ImmutableList.<Constant>builder().add(constantA).add(constantB).build();
 
-    List<OrganisationUnitGroup> orgUnitGroups =
-        ImmutableList.<OrganisationUnitGroup>builder().add(groupA).build();
-
     when(idObjectManager.getAllNoAcl(Constant.class)).thenReturn(constants);
-    when(idObjectManager.getAllNoAcl(OrganisationUnitGroup.class)).thenReturn(orgUnitGroups);
+    when(organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(
+            eq(Set.of(groupA.getUid()))))
+        .thenReturn(Map.of(groupA.getUid(), groupA.getMembers().size()));
 
     target.substituteIndicatorExpressions(indicators);
 
@@ -1066,6 +1070,9 @@ class ExpressionServiceTest extends TestBase {
     assertEquals("#{deabcdefghA." + coc.getUid() + "}*2.0", indicatorA.getExplodedDenominator());
     assertEquals("#{deabcdefghA." + coc.getUid() + "}*3", indicatorB.getExplodedNumerator());
     assertEquals(expressionZ, indicatorB.getExplodedDenominator());
+
+    // The members collection must never be loaded; counts come from the store count query.
+    verify(idObjectManager, never()).getAllNoAcl(OrganisationUnitGroup.class);
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1060,8 +1060,7 @@ class ExpressionServiceTest extends TestBase {
         ImmutableList.<Constant>builder().add(constantA).add(constantB).build();
 
     when(idObjectManager.getAllNoAcl(Constant.class)).thenReturn(constants);
-    when(organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(
-            eq(Set.of(groupA.getUid()))))
+    when(organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(Set.of(groupA.getUid())))
         .thenReturn(Map.of(groupA.getUid(), groupA.getMembers().size()));
 
     target.substituteIndicatorExpressions(indicators);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1649,4 +1649,25 @@ class ExpressionServiceTest extends PostgresIntegrationTestBase {
         validity("greatest(#{dataElemenA.catOptCombB},C{xxxxxxxxx05})", PREDICTOR_EXPRESSION));
     assertEquals(EXPRESSION_IS_NOT_WELL_FORMED, validity("1*", PREDICTOR_EXPRESSION));
   }
+
+  @Test
+  void testSubstituteIndicatorExpressionsResolvesOrgUnitGroupCounts() {
+    // Equivalence guard for the OUG{} count fix: substituteIndicatorExpressions must produce the
+    // same exploded expression as the previous group.getMembers().size() implementation, while
+    // resolving the count with a count query instead of initialising the members collection.
+    Indicator indicator = createIndicator('Z', indicatorTypeB);
+    indicator.setNumerator("OUG{" + orgUnitGroupA.getUid() + "}");
+    indicator.setDenominator("OUG{" + orgUnitGroupB.getUid() + "}");
+
+    expressionService.substituteIndicatorExpressions(List.of(indicator));
+
+    // The substituted count must equal what group.getMembers().size() returned before the change.
+    assertEquals(
+        String.valueOf(orgUnitGroupA.getMembers().size()), indicator.getExplodedNumerator());
+    assertEquals(
+        String.valueOf(orgUnitGroupB.getMembers().size()), indicator.getExplodedDenominator());
+    // orgUnitGroupA has 5 members, orgUnitGroupB has 3 (see setUp).
+    assertEquals("5", indicator.getExplodedNumerator());
+    assertEquals("3", indicator.getExplodedDenominator());
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
@@ -31,9 +31,11 @@ package org.hisp.dhis.organisationunit;
 
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,5 +75,34 @@ class OrganisationUnitGroupStoreTest extends OrganisationUnitBaseSpringTest {
     Set<OrganisationUnitGroup> groups = Sets.newHashSet(groupA, groupB);
     OrganisationUnitGroupSet groupSet = addOrganisationUnitGroupSet('A', groupA, groupC);
     assertEquals(groupA, groupStore.getOrgUnitGroupInGroupSet(groups, groupSet));
+  }
+
+  @Test
+  void testGetOrganisationUnitGroupMemberCounts() {
+    OrganisationUnit unitA = addOrganisationUnit('A');
+    OrganisationUnit unitB = addOrganisationUnit('B');
+    OrganisationUnit unitC = addOrganisationUnit('C');
+    OrganisationUnitGroup groupA = addOrganisationUnitGroup('A', unitA, unitB, unitC);
+    OrganisationUnitGroup groupB = addOrganisationUnitGroup('B', unitB);
+    OrganisationUnitGroup groupEmpty = addOrganisationUnitGroup('E');
+
+    Map<String, Integer> counts =
+        groupStore.getOrganisationUnitGroupMemberCounts(
+            Set.of(groupA.getUid(), groupB.getUid(), groupEmpty.getUid()));
+
+    assertEquals(3, counts.get(groupA.getUid()));
+    assertEquals(1, counts.get(groupB.getUid()));
+    assertEquals(0, counts.get(groupEmpty.getUid()));
+  }
+
+  @Test
+  void testGetOrganisationUnitGroupMemberCountsEmptyAndUnknown() {
+    OrganisationUnit unitA = addOrganisationUnit('A');
+    addOrganisationUnitGroup('A', unitA);
+
+    assertTrue(groupStore.getOrganisationUnitGroupMemberCounts(Set.of()).isEmpty());
+    assertTrue(
+        groupStore.getOrganisationUnitGroupMemberCounts(Set.of("nonExistnt0")).isEmpty(),
+        "unknown group UIDs must be omitted, not present with a zero count");
   }
 }


### PR DESCRIPTION
## Problem

`DefaultExpressionService.substituteIndicatorExpressions` resolves each `OUG{uid}` org unit group count in an indicator numerator/denominator expression via `group.getMembers().size()`. `members` is a lazy many-to-many `<set>`, so `.size()` forces full initialisation of the collection — hydrating **every member as a managed `OrganisationUnit` entity**. 

Example indicator expression
```
"numerator": "OUG{QdjMpXKVYEs}",
```

On master this method is reached on every (non-304) request to **`GET /api/dataEntry/metadata`** (`DataSetMetadataController` → `DataSetMetadataExportService`, the dataset metadata that backs the Aggregate Data Entry app). On a large instance — an org unit group with ~71,700 members — a single `OUG{}` reference makes the endpoint:

- hydrate the whole 71k-member collection per request
- incur a **single-OU rehydration N+1** (thousands of `select … where organisationunitid=?`) when the collection cache is warm but the entity cache is cold
- pay **commit-time dirty-checking** of the tens of thousands of hydrated entities (~2GB allocated per request)

(The same code path existed in 2.40 behind the now-removed `dhis-web-dataentry` `getMetaData.action`. Production profiling there — same `substituteIndicatorExpressions` call — showed a ~5s floor with spikes to 14–22s, which is the evidence motivating this fix; see Impact.)

## Fix

Resolve the count with a `count` subquery instead of initialising the collection:

- New `OrganisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(Set<String> uids)` — HQL `select g.uid, size(g.members) … where g.uid in :uids`. `size()` compiles to a count subquery; the members collection is **never** initialised.
- `substituteIndicatorExpressions` now collects only the referenced `OUG{}` UIDs, runs one count query, and substitutes the counts directly.
- `substituteIndicatorExpressions` marked `@Transactional(readOnly = true)`. It only mutates `Indicator.explodedNumerator`/`explodedDenominator`, which are **transient** computed display fields (no DB columns), so it never writes; `readOnly` sets the Hibernate flush mode to `MANUAL` as a guard against commit-time dirty-checking.

Glowroot on a patched system. All percentiles are under 100ms after the change. 

<img width="798" height="689" alt="image" src="https://github.com/user-attachments/assets/f2c9f065-f41e-475b-9bc9-f988bc9ffad0" />


## Behaviour

Preserved exactly. The substituted count is the **global** group membership total, as before — this path produces the displayed exploded formula. The runtime, org-unit-scoped `OUG{}` count used in analytics is a separate path (`orgUnitCountMap` in `getIndicatorValueObject`) and is untouched. An integration test asserts the new exploded output equals `String.valueOf(group.getMembers().size())` (the previous implementation) end-to-end.

## Impact

Measured on the affected 2.x production instance (same service method, via the legacy endpoint): floor **~5.2s → ~0.2s**, allocation **~2GB → ~40MB** per request, and the long tail removed structurally — there is no longer a large collection to load/thrash on. A trace before/after confirmed the `members` (71,708-row) query and the rehydration N+1 are gone, replaced by a single ~14ms count subquery. On master the same reduction applies to `GET /api/dataEntry/metadata`.

## Testing

- Unit: `ExpressionServiceTest#testSubstituteIndicatorExpressions` updated to drive the count via the store and assert the members collection is never loaded (`getAllNoAcl(OrganisationUnitGroup.class)` is never called).
- Integration (`dhis-test-integration`):
  - `OrganisationUnitGroupStoreTest` — member counts for populated/single/empty groups, plus empty/unknown-UID inputs.
  - `ExpressionServiceTest#testSubstituteIndicatorExpressionsResolvesOrgUnitGroupCounts` — end-to-end equivalence: exploded numerator/denominator equal `group.getMembers().size()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
