### PR TITLE
fix: resolve OUG{} indicator count to zero when org unit has no group members

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.expression.dataitem;
 import static java.lang.String.format;
 import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
 
+import java.util.Map;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
@@ -68,14 +69,13 @@ public class ItemOrgUnitGroupCount implements ExpressionItem {
 
   @Override
   public Object evaluate(ExprContext ctx, CommonExpressionVisitor visitor) {
-    Integer count = visitor.getParams().getOrgUnitCountMap().get(ctx.uid0.getText());
+    Map<String, Integer> orgUnitCountMap = visitor.getParams().getOrgUnitCountMap();
 
-    if (count == null) // Shouldn't happen for a valid expression.
-    {
-      throw new ParserExceptionWithoutContext(
-          format("Cannot find count for organisation unit: %s", ctx.uid0.getText()));
-    }
+    // The count map is absent for an organisation unit whose subtree contains no members of the
+    // group (the analytics org unit target aggregation returns no row for it), so a missing entry
+    // means a count of zero rather than an error.
+    Integer count = orgUnitCountMap != null ? orgUnitCountMap.get(ctx.uid0.getText()) : null;
 
-    return count.doubleValue();
+    return count != null ? count.doubleValue() : 0d;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -952,6 +952,31 @@ class ExpressionServiceTest extends TestBase {
   }
 
   @Test
+  void testGetExpressionValueOrgUnitGroupCountMissingMemberCountIsZero() {
+    // An OUG{} indicator queried for an org unit whose subtree has no members of the group: the
+    // analytics target map then has no entry for that org unit, so DataHandler passes a null (or
+    // entry-less) orgUnitCountMap down to expression evaluation. The org unit group count must
+    // resolve to 0 rather than throwing (previously a NullPointerException / "Cannot find count").
+    mockConstantService();
+
+    Map<DimensionalItemId, DimensionalItemObject> itemMap =
+        ImmutableMap.<DimensionalItemId, DimensionalItemObject>builder()
+            .put(getId(opA), opA)
+            .build();
+
+    Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
+    valueMap.put(opA, 12d);
+
+    // expressionH = #{deA.coc} * OUG{groupA}; with the group count resolving to 0 -> 12 * 0 = 0.
+
+    // Null map (no target entry for this org unit at all).
+    assertEquals(0d, exprValue(expressionH, itemMap, valueMap, null, null), DELTA);
+
+    // Non-null map missing this group's uid.
+    assertEquals(0d, exprValue(expressionH, itemMap, valueMap, new HashMap<>(), null), DELTA);
+  }
+
+  @Test
   void testGetIndicatorDimensionalItemMap2() {
     Set<DimensionalItemId> itemIds = Sets.newHashSet(getId(opA));
 


### PR DESCRIPTION
## Summary

Fixes https://dhis2.atlassian.net/browse/DHIS2-21677

Fixes a `NullPointerException` (HTTP 500) on analytics requests for any indicator that uses an
`OUG{<group>}` org unit group count, when queried over an org unit whose subtree contains **no
members** of that group.

```
GET /api/analytics?dimension=dx:<oug-indicator>,pe:LAST_12_MONTHS,ou:LEVEL-3
→ 500  NullPointerException at ItemOrgUnitGroupCount.evaluate
```

## Reproduction (stock 2.43 demo)

Confirmed on the public demo — not data/instance specific. With a test indicator whose numerator is `OUG{tDZVQ1WtwpA}` (UID `kaazKDSdTIr`):

- ✅ **LEVEL-1** works: `…/api/43/analytics?dimension=dx:kaazKDSdTIr,pe:LAST_12_MONTHS,ou:LEVEL-1`
  — the single root (Sierra Leone) has members of the group in its subtree, so the target
  aggregation returns a row.
- ❌ **LEVEL-3** throws the NPE: `…/api/43/analytics?dimension=dx:kaazKDSdTIr,pe:LAST_12_MONTHS,ou:LEVEL-3`
  — at least one org unit at level 3 has a subtree with zero members of the group, so the
  aggregation returns no row for it.

## Root cause

`ItemOrgUnitGroupCount.evaluate` read the count map unguarded:

```java
Integer count = visitor.getParams().getOrgUnitCountMap().get(ctx.uid0.getText());
```

In the analytics indicator path, `DataHandler.getIndicatorValue` builds the per-org-unit count map from an `ORG_UNIT_TARGET` aggregation and passes `permutationOrgUnitTargetMap.get(ou)` down — which
is **null** when that aggregation returns no row for the org unit, i.e. when the org unit's subtree
has zero members of the referenced group. `getOrgUnitCountMap()` is then null and `.get(...)` NPEs. `getIndicatorValueObject` does not catch it, so it surfaces as a 500.

The pre-existing `count == null` branch ("Cannot find count…", commented *"Shouldn't happen for a valid expression"*) only guarded a missing *entry* in a non-null map, and threw — which would also bubble up as a 500.

## Fix

A missing count means **zero members**, not an error. Treat both a null map and a missing group entry as `0`, consistent with how analytics handles absent counts elsewhere. If `OUG{}` sits in a denominator and resolves to 0, the existing divide-by-zero guard already yields a null indicator value.

```java
Map<String, Integer> orgUnitCountMap = visitor.getParams().getOrgUnitCountMap();
Integer count = orgUnitCountMap != null ? orgUnitCountMap.get(ctx.uid0.getText()) : null;
return count != null ? count.doubleValue() : 0d;
```

## Tests

New unit test `ExpressionServiceTest.testGetExpressionValueOrgUnitGroupCountMissingMemberCountIsZero` reproduces the NPE (null map) and the missing-entry case, asserting both resolve to 0. Verified failing (NPE) before the fix, passing after. Full `ExpressionServiceTest` (29 tests) green.

## Notes

- Pre-existing latent bug — the unguarded line dates to 2023. Rare because it needs both an `OUG{}` indicator and an org unit whose subtree has zero matching members. Reproduces on stock 2.43.
- JIRA ticket to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
