### PR TITLE
perf: Update user perf test response thresholds

### DIFF
--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -188,25 +188,25 @@ public class UsersPerformanceTest extends Simulation {
   // Recalibrate with: scripts/download-user-perf-results.sh --test-name users-smoke
   //                   scripts/analyze-user-perf-results.py --profile smoke
   private static final Map<Profile, Thresholds> POST_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1150, 1200), Profile.LOAD, new Thresholds(1250, 1500));
+      Map.of(Profile.SMOKE, new Thresholds(200, 200), Profile.LOAD, new Thresholds(200, 250));
 
   private static final Map<Profile, Thresholds> GET_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1050, 1400), Profile.LOAD, new Thresholds(700, 1050));
+      Map.of(Profile.SMOKE, new Thresholds(50, 60), Profile.LOAD, new Thresholds(50, 150));
 
   private static final Map<Profile, Thresholds> PUT_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1600, 1700), Profile.LOAD, new Thresholds(1500, 2100));
+      Map.of(Profile.SMOKE, new Thresholds(300, 300), Profile.LOAD, new Thresholds(300, 350));
 
   private static final Map<Profile, Thresholds> PATCH_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1350, 1750), Profile.LOAD, new Thresholds(850, 950));
+      Map.of(Profile.SMOKE, new Thresholds(50, 60), Profile.LOAD, new Thresholds(50, 100));
 
   private static final Map<Profile, Thresholds> PATCH_GROUPS_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1350, 1700), Profile.LOAD, new Thresholds(850, 950));
+      Map.of(Profile.SMOKE, new Thresholds(100, 110), Profile.LOAD, new Thresholds(100, 110));
 
   private static final Map<Profile, Thresholds> REPLICA_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1250, 1800), Profile.LOAD, new Thresholds(1050, 1200));
+      Map.of(Profile.SMOKE, new Thresholds(150, 160), Profile.LOAD, new Thresholds(150, 300));
 
   private static final Map<Profile, Thresholds> DELETE_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(1400, 1650), Profile.LOAD, new Thresholds(1450, 1950));
+      Map.of(Profile.SMOKE, new Thresholds(250, 260), Profile.LOAD, new Thresholds(250, 280));
 
   // Timestamp-based offset so each run generates unique usernames
   private static final int RUN_OFFSET = (int) (System.currentTimeMillis() % 10_000_000);

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -174,17 +174,14 @@ public class UsersPerformanceTest extends Simulation {
   private static final String DELETE_REQUEST = "DELETE User - delete";
   private static final int PATCH_GROUP_COUNT = Integer.parseInt(prop("patchGroupCount", "7"));
 
-  // Thresholds per profile, slack 1.5× observed p95/max, rounded to nearest 50ms.
+  // Thresholds per profile, (p95, max) in ms. Recalibrated 2026-06-22 from fresh sequential
+  // baselines analysed over 2026-06-16–06-22 (LOAD nightly × 10 iter, SMOKE nightly × 3 iter).
   //
-  // STALE — PENDING RECALIBRATION. The values below were calibrated under the OLD regime: all
-  // scenarios run in parallel, which on the shared CI runner caused CPU contention that inflated
-  // the
-  // tail (GET p95 reached 783ms on CI vs ~81ms in isolation). As of 2026-06-03 the test runs
-  // scenarios sequentially (in isolation) and authenticates once per virtual user, moving the
-  // one-time session-establishing bcrypt out of the measured requests, so measured times dropped
-  // sharply. These thresholds are now far too loose and provide little regression protection until
-  // recalibrated from fresh nightly baselines (~1 week of runs).
-  // Old baselines: LOAD 10 nightly × 10 iter (2026-04-02–04-11); SMOKE 14 nightly × 3 iter.
+  // The test runs scenarios sequentially (single-endpoint latency in isolation) and authenticates
+  // once per virtual user, keeping the one-time session-establishing bcrypt out of the measured
+  // requests. This is far cheaper than the old parallel regime, where CPU contention on the shared
+  // CI runner inflated the tail (GET p95 reached 783ms vs ~81ms in isolation) — hence the much
+  // tighter values below (e.g. GET LOAD dropped from 700/1050 to 50/150).
   // Recalibrate with: scripts/download-user-perf-results.sh --test-name users-smoke
   //                   scripts/analyze-user-perf-results.py --profile smoke
   private static final Map<Profile, Thresholds> POST_THRESH =


### PR DESCRIPTION
## Change

Update User performance test response thresholds after running against the larger `platform-perf-db`

Recalibrated from fresh sequential baselines analysed over 2026-06-16 – 2026-06-22 (7 days inclusive)

| Request                      | SMOKE From (p95 / max) | SMOKE To (p95 / max) | LOAD From  (p95 / max) | LOAD To  (p95 / max) |
|------------------------------|------------|----------|------------|----------|
| POST User - create           | 1150 / 1200 | 200 / 200 | 1250 / 1500 | 200 / 250 |
| GET User - by uid            | 1050 / 1400 | 50 / 60   | 700 / 1050  | 50 / 150  |
| PUT User - full update       | 1600 / 1700 | 300 / 300 | 1500 / 2100 | 300 / 350 |
| PATCH User - partial update  | 1350 / 1750 | 50 / 60   | 850 / 950   | 50 / 100  |
| PATCH User - replace userGroups | 1350 / 1700 | 100 / 110 | 850 / 950 | 100 / 110 |
| POST User - replicate        | 1250 / 1800 | 150 / 160 | 1050 / 1200 | 150 / 300 |
| DELETE User - delete         | 1400 / 1650 | 250 / 260 | 1450 / 1950 | 250 / 280 |


The new thresholds are much tighter and provide confidence for single invocations of APIs.

## Results from 7 days analysis
New thresholds based on the following averages for each profile

### Load

------------------------------------------------ 
AGGREGATE STATISTICS (all runs combined)
------------------------------------------------ 
| Scenario |                                   n |  min  | p50 |  p75 |  p95 |  p99 |  max |
| -- | -- | -- | -- | -- | -- | -- | -- |
| POST User - create |                       210 |   86 |  100 |  101 |  105 |  116 |  161 |
| GET User - by uid                       | 600    | 9    | 11  |  12   | 15   | 16   | 78 |
| PUT User - full update                |   210   | 146 |  162 |  163 |  171  | 191  | 229 |
| PATCH User - partial update       |       420 |   24 |   26  |  27   | 31   | 33   | 36 |
| PATCH User - replace userGroups  |        210 |   26 |   44  |  45  |  48 |   54  |  58 |
| POST User - replicate                   | 210   | 69  |  84  |  85  |  88  |  94  | 168 |
| DELETE User - delete                    | 210  | 129  | 134  | 136 |  141  | 144 |  147 |


### Smoke

------------------------------------------------ 
AGGREGATE STATISTICS (all runs combined)
------------------------------------------------
| Scenario   |                                n |  min |  p50 |  p75 |  p95 |  p99 |  max |
| -- | -- | -- | -- | -- | -- | -- | -- |
| POST User - create                  |      70  |  85  | 101  | 102 |  104  | 105   | 105 |
| GET User - by uid                      |  400   |  8  |  11  |  11  |  14  |  15  |  30 |
| PUT User - full update               |     70   | 146  | 163 |  164  | 168  | 176  | 176 |
| PATCH User - partial update      |        210 |   24 |   26  |  27  |  29  |  32  |  33 |
| PATCH User - replace userGroups  |        140 |   27  |  45  |  47  |  50  |  56  |  60 |
| POST User - replicate                  |  140   | 68   | 86   | 87   | 89   | 91   | 92 |
| DELETE User - delete                   |   70  | 130  | 137  | 139  | 144  | 148  | 148 |

## Next

- Monitor test runs over the next few weeks and adjust if necessary
- Modify the test so that it provides confidence in more realistic scenarios:
  - smoke
    - existing test shape
    - 1 user
    - 1 req/s
    - short duration (30s)
    - confidence with performant isolated API calls
  - load
    - new load shape
    - starting with 1 user
    - ramping up to 10 users over 30 seconds
    - 10 req/s
    - longer duration of 120s
    - confidence with performant, sustained API calls under load