### PR TITLE
backport: fix: resolve OUG{} indicator count to zero when org unit has no group members

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.expression.dataitem;
 import static java.lang.String.format;
 import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
 
+import java.util.Map;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
@@ -68,14 +69,13 @@ public class ItemOrgUnitGroupCount implements ExpressionItem {
 
   @Override
   public Object evaluate(ExprContext ctx, CommonExpressionVisitor visitor) {
-    Integer count = visitor.getParams().getOrgUnitCountMap().get(ctx.uid0.getText());
+    Map<String, Integer> orgUnitCountMap = visitor.getParams().getOrgUnitCountMap();
 
-    if (count == null) // Shouldn't happen for a valid expression.
-    {
-      throw new ParserExceptionWithoutContext(
-          format("Cannot find count for organisation unit: %s", ctx.uid0.getText()));
-    }
+    // The count map is absent for an organisation unit whose subtree contains no members of the
+    // group (the analytics org unit target aggregation returns no row for it), so a missing entry
+    // means a count of zero rather than an error.
+    Integer count = orgUnitCountMap != null ? orgUnitCountMap.get(ctx.uid0.getText()) : null;
 
-    return count.doubleValue();
+    return count != null ? count.doubleValue() : 0d;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -953,6 +953,31 @@ class ExpressionServiceTest extends TestBase {
   }
 
   @Test
+  void testGetExpressionValueOrgUnitGroupCountMissingMemberCountIsZero() {
+    // An OUG{} indicator queried for an org unit whose subtree has no members of the group: the
+    // analytics target map then has no entry for that org unit, so DataHandler passes a null (or
+    // entry-less) orgUnitCountMap down to expression evaluation. The org unit group count must
+    // resolve to 0 rather than throwing (previously a NullPointerException / "Cannot find count").
+    mockConstantService();
+
+    Map<DimensionalItemId, DimensionalItemObject> itemMap =
+        ImmutableMap.<DimensionalItemId, DimensionalItemObject>builder()
+            .put(getId(opA), opA)
+            .build();
+
+    Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
+    valueMap.put(opA, 12d);
+
+    // expressionH = #{deA.coc} * OUG{groupA}; with the group count resolving to 0 -> 12 * 0 = 0.
+
+    // Null map (no target entry for this org unit at all).
+    assertEquals(0d, exprValue(expressionH, itemMap, valueMap, null, null), DELTA);
+
+    // Non-null map missing this group's uid.
+    assertEquals(0d, exprValue(expressionH, itemMap, valueMap, new HashMap<>(), null), DELTA);
+  }
+
+  @Test
   void testGetIndicatorDimensionalItemMap2() {
     Set<DimensionalItemId> itemIds = Sets.newHashSet(getId(opA));
 


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/24266