### PR TITLE
fix: Sort and limit ev/enrol aggr. [DHIS2-21673]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -125,6 +125,9 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
 
   private SortOrder sortOrder;
 
+  /** The max limit of records to return. */
+  private Integer limit;
+
   private boolean totalPages;
 
   /** flag to enable enhanced OR conditions on queryItem dimensions/filters */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -373,6 +373,7 @@ public class EventDataQueryRequest {
               .userOrgUnit(criteria.getUserOrgUnit())
               .coordinateField(criteria.getCoordinateField())
               .sortOrder(criteria.getSortOrder())
+              .limit(criteria.getLimit())
               .totalPages(criteria.isTotalPages())
               .endpointItem(criteria.getEndpointItem())
               .endpointAction(criteria.getEndpointAction())

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentAggregateService.java
@@ -159,10 +159,8 @@ public class EnrollmentAggregateService {
     }
 
     // Sort grid, done again due to potential multiple partitions.
-    if (params.hasSortOrder() && grid.getHeight() > 0) {
-      if (grid.getIndexOfHeader("value") != -1) {
-        grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
-      }
+    if (params.hasSortOrder() && grid.getHeight() > 0 && grid.getIndexOfHeader("value") != -1) {
+      grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
     }
 
     // Limit grid.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentAggregateService.java
@@ -157,6 +157,18 @@ public class EnrollmentAggregateService {
 
       timer.getTime("Got enrollments " + grid.getHeight());
     }
+
+    // Sort grid, done again due to potential multiple partitions.
+    if (params.hasSortOrder() && grid.getHeight() > 0) {
+      if (grid.getIndexOfHeader("value") != -1) {
+        grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
+      }
+    }
+
+    // Limit grid.
+    if (params.hasLimit() && grid.getHeight() > params.getLimit()) {
+      grid.limitGrid(params.getLimit());
+    }
   }
 
   private List<DimensionalObject> getPeriods(EventQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
@@ -249,16 +249,6 @@ public class EventAggregateService {
     if (!params.isSkipData() || params.analyzeOnly()) {
       addHeaders(params, grid);
       addData(grid, params, maxLimit);
-
-      // Sort grid, done again due to potential multiple partitions
-      if (params.hasSortOrder() && grid.getHeight() > 0) {
-        grid.sortGrid(1, params.getSortOrderAsInt());
-      }
-
-      // Limit grid
-      if (params.hasLimit() && grid.getHeight() > params.getLimit()) {
-        grid.limitGrid(params.getLimit());
-      }
     }
 
     addPaging(params, UNLIMITED_PAGING, grid);
@@ -292,6 +282,18 @@ public class EventAggregateService {
     }
 
     timer.getTime("Got aggregated events");
+
+    // Sort grid, done again due to potential multiple partitions.
+    if (params.hasSortOrder() && grid.getHeight() > 0) {
+      if (grid.getIndexOfHeader("value") != -1) {
+        grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
+      }
+    }
+
+    // Limit grid.
+    if (params.hasLimit() && grid.getHeight() > params.getLimit()) {
+      grid.limitGrid(params.getLimit());
+    }
 
     if (maxLimit > 0 && grid.getHeight() > maxLimit) {
       throwIllegalQueryEx(E7128, maxLimit);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
@@ -284,10 +284,8 @@ public class EventAggregateService {
     timer.getTime("Got aggregated events");
 
     // Sort grid, done again due to potential multiple partitions.
-    if (params.hasSortOrder() && grid.getHeight() > 0) {
-      if (grid.getIndexOfHeader("value") != -1) {
-        grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
-      }
+    if (params.hasSortOrder() && grid.getHeight() > 0 && grid.getIndexOfHeader("value") != -1) {
+      grid.sortGrid(grid.getIndexOfHeader("value") + 1, params.getSortOrderAsInt());
     }
 
     // Limit grid.

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Iterables;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -1238,7 +1239,17 @@ public class ListGrid implements Grid, Serializable {
       Comparable<Object> value1 = (Comparable<Object>) list1.get(columnIndex);
       Comparable<Object> value2 = (Comparable<Object>) list2.get(columnIndex);
 
-      return order > 0 ? value2.compareTo(value1) : value1.compareTo(value2);
+      try {
+        // If it's a number we have to sort it as number, otherwise we have issues with values
+        // starting with "1".
+        BigDecimal v1 = new BigDecimal(String.valueOf(value1));
+        BigDecimal v2 = new BigDecimal(String.valueOf(value2));
+
+        return order > 0 ? v2.compareTo(v1) : v1.compareTo(v2);
+      } catch (NumberFormatException e) {
+        // Otherwise we sort it as simple text.
+        return order > 0 ? value2.compareTo(value1) : value1.compareTo(value2);
+      }
     }
   }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridTest.java
@@ -652,6 +652,38 @@ class GridTest {
   }
 
   @Test
+  void testGridRowComparatorWithNumberValuesAsStringsDesc() {
+    List<List<Object>> lists = new ArrayList<>();
+    List<Object> l1 = List.of("b", "b", "50");
+    List<Object> l2 = List.of("c", "c", "400");
+    List<Object> l3 = List.of("a", "a", "100");
+    lists.add(l1);
+    lists.add(l2);
+    lists.add(l3);
+    Comparator<List<Object>> comparator = new ListGrid.GridRowComparator(2, -1);
+    Collections.sort(lists, comparator);
+    assertEquals(l1, lists.get(0));
+    assertEquals(l3, lists.get(1));
+    assertEquals(l2, lists.get(2));
+  }
+
+  @Test
+  void testGridRowComparatorWithNumberValuesAsStringsAsc() {
+    List<List<Object>> lists = new ArrayList<>();
+    List<Object> l1 = List.of("b", "b", "50");
+    List<Object> l2 = List.of("c", "c", "400");
+    List<Object> l3 = List.of("a", "a", "100");
+    lists.add(l1);
+    lists.add(l2);
+    lists.add(l3);
+    Comparator<List<Object>> comparator = new ListGrid.GridRowComparator(2, 1);
+    Collections.sort(lists, comparator);
+    assertEquals(l2, lists.get(0));
+    assertEquals(l3, lists.get(1));
+    assertEquals(l1, lists.get(2));
+  }
+
+  @Test
   void testAddRegressionColumn() {
     gridA = new ListGrid();
     gridA.addRow();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
@@ -1492,4 +1492,63 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
             "PUZaKR0Jh2k.eventdate",
             "2022-05-30 12:05:00.0"));
   }
+
+  @Test
+  public void withSortOrderAndLimit() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("stage=A03MvHHogjR")
+            .add("displayProperty=NAME")
+            .add("sortOrder=desc")
+            .add("totalPages=false")
+            .add("limit=1")
+            .add("outputType=EVENT")
+            .add("dimension=ou:ImspTQPwCqd,pe:LAST_5_YEARS")
+            .add("relativePeriodDate=2026-06-23");
+
+    // When
+    ApiResponse response = actions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response, false, 1, 3, 3); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":50,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"pe\":{},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"ou\":{\"name\":\"Organisation unit\"},\"2025\":{\"name\":\"2025\"},\"2024\":{\"name\":\"2024\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"2023\":{\"name\":\"2023\"},\"2022\":{\"name\":\"2022\"},\"2021\":{\"name\":\"2021\"}},\"dimensions\":{\"pe\":[\"2021\",\"2022\",\"2023\",\"2024\",\"2025\"],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "pe", "Period", "TEXT", "java.lang.String", false, true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(
+        response, actualHeaders, Map.of("value", "11025", "ou", "ImspTQPwCqd", "pe", "2022"));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate11AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate11AutoTest.java
@@ -1420,11 +1420,7 @@ public class EventsAggregate11AutoTest extends AnalyticsApiTest {
     //    This helper checks basic counts and dimensions, adapting based on the runtime
     // 'expectPostgis' flag.
     validateResponseStructure(
-        response,
-        false,
-        2,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
+        response, false, 2, 3, 3); // Pass runtime flag, row count, and expected header counts
 
     // 2. Extract Headers into a List of Maps for easy access by name
     List<Map<String, Object>> actualHeaders =

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate11AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate11AutoTest.java
@@ -1397,4 +1397,71 @@ public class EventsAggregate11AutoTest extends AnalyticsApiTest {
         actualHeaders,
         Map.of("ZkbAXlQUYJG.ou", "O6uvpzGd5pu", "pe", "2022", "value", "6"));
   }
+
+  @Test
+  public void withSortOrderAndLimit() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("stage=A03MvHHogjR")
+            .add("displayProperty=NAME")
+            .add("sortOrder=asc")
+            .add("totalPages=false")
+            .add("limit=2")
+            .add("outputType=EVENT")
+            .add("dimension=ou:ImspTQPwCqd,pe:LAST_5_YEARS")
+            .add("relativePeriodDate=2026-06-23");
+
+    // When
+    ApiResponse response = actions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        false,
+        2,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ImspTQPwCqd\":{\"name\":\"Sierra Leone\"},\"pe\":{\"name\":\"Period\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"2025\":{\"name\":\"2025\"},\"ou\":{\"name\":\"Organisation unit\"},\"2024\":{\"name\":\"2024\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"2023\":{\"name\":\"2023\"},\"2022\":{\"name\":\"2022\"},\"2021\":{\"name\":\"2021\"},\"LAST_5_YEARS\":{\"name\":\"Last 5 years\"}},\"dimensions\":{\"pe\":[\"2021\",\"2022\",\"2023\",\"2024\",\"2025\"],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(
+        response, actualHeaders, Map.of("pe", "2022", "ou", "ImspTQPwCqd", "value", "8005"));
+
+    // Validate row exists with values from original row index 1
+    validateRowExists(
+        response, actualHeaders, Map.of("pe", "2021", "ou", "ImspTQPwCqd", "value", "11017"));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-aggregated.json
@@ -167,6 +167,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "withSortOrderAndLimit",
+      "query": "/api/analytics/enrollments/aggregate/IpHINAT79UW.json?dimension=ou:ImspTQPwCqd&dimension=pe:LAST_5_YEARS&stage=A03MvHHogjR&displayProperty=NAME&totalPages=false&outputType=EVENT&sortOrder=desc&limit=1&relativePeriodDate=2026-06-23",
+      "version": {
+        "min": 41
+      }
     }
   ]
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-aggregated.json
@@ -237,6 +237,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "withSortOrderAndLimit",
+      "query": "/api/analytics/events/aggregate/IpHINAT79UW.json?dimension=ou:ImspTQPwCqd&dimension=pe:LAST_5_YEARS&stage=A03MvHHogjR&displayProperty=NAME&totalPages=false&outputType=EVENT&sortOrder=asc&limit=2&relativePeriodDate=2026-06-23",
+      "version": {
+        "min": 41
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds support for `sortOrder` and `limit` for enrollments aggregate.

Also, fixes the sorting to consider the values as numeric when applicable, so the sort works properly. Currently, values are also treated as text, so the order does not work well when we have values starting with "1".