### PR TITLE
perf: Calibrate tracker import perf test thresholds [DHIS2-21378]

### DIFF
--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/tracker/TrackerTest.java
@@ -1042,11 +1042,11 @@ public class TrackerTest extends Simulation {
   }
 
   private static final EnumMap<Profile, Integer> MNCH_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 303, Profile.LOAD, 3526));
+      new EnumMap<>(Map.of(Profile.SMOKE, 140, Profile.LOAD, 982));
   private static final EnumMap<Profile, Integer> CHILD_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 168, Profile.LOAD, 1769));
+      new EnumMap<>(Map.of(Profile.SMOKE, 115, Profile.LOAD, 318));
   private static final EnumMap<Profile, Integer> ANC_IMPORT_P95 =
-      new EnumMap<>(Map.of(Profile.SMOKE, 119, Profile.LOAD, 2652));
+      new EnumMap<>(Map.of(Profile.SMOKE, 71, Profile.LOAD, 1124));
 
   private Stream<Assertion> getImportAssertions(Profile profile) {
     return Stream.of(


### PR DESCRIPTION
Recalibrate tracker import performance test thresholds after the work done on improving tracker import performance.

# Recalculated performance-test thresholds

- Workflow: `performance-tests-scheduled.yml` (dhis2/dhis2-core)
- Runs analysed: 8 (2026-06-18 → 2026-06-25)
- Formula: `max(ceil(max_p95 * 1.1) + 15, 25)` (ms)
- `max p95` = worst p95 observed across the analysed runs.
- Old threshold = current p95 assertion in perf-test source @ `a03204cbccd2`. `Δ%` = (new − old) / old.

## tracker-load

| Request | runs | 2026-06-18 | 2026-06-19 | 2026-06-20 | 2026-06-21 | 2026-06-22 | 2026-06-23 | 2026-06-24 | 2026-06-25 | min p95 | avg p95 | max p95 | min→max Δ% | New threshold | Old threshold | Δ% |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| ANC import | 8 | 685 | 194 | 649 | 537 | 184 | 1008 | 899 | 385 | 184 | 568 | 1008 | +448% | **1124** | 2652 | -58% |
| Child Programme import | 8 | 275 | 231 | 240 | 248 | 273 | 259 | 225 | 237 | 225 | 248 | 275 | +22% | **318** | 1769 | -82% |
| MNCH import | 8 | 743 | 720 | 649 | 705 | 534 | 804 | 879 | 687 | 534 | 715 | 879 | +65% | **982** | 3526 | -72% |

## tracker-smoke

| Request | runs | 2026-06-18 | 2026-06-19 | 2026-06-20 | 2026-06-21 | 2026-06-22 | 2026-06-23 | 2026-06-24 | 2026-06-25 | min p95 | avg p95 | max p95 | min→max Δ% | New threshold | Old threshold | Δ% |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| ANC import | 8 | 49 | 43 | 50 | 44 | 43 | 44 | 37 | 40 | 37 | 44 | 50 | +35% | **71** | 119 | -40% |
| Child Programme import | 8 | 90 | 75 | 89 | 89 | 85 | 76 | 62 | 66 | 62 | 79 | 90 | +45% | **115** | 168 | -32% |
| MNCH import | 8 | 104 | 108 | 112 | 108 | 108 | 113 | 91 | 82 | 82 | 103 | 113 | +38% | **140** | 303 | -54% |