### PR TITLE
feat: Tracker importer migration from Hibernate to JDBC [DHIS2-21378] (2.43)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStore.java
@@ -120,4 +120,10 @@ public interface FileResourceStore extends IdentifiableObjectStore<FileResource>
 
   List<FileResource> getUnassignedPassedGracePeriod(
       Set<FileResourceDomain> domainsToDeleteWhenUnassigned, DateTime minus);
+
+  /**
+   * Updates the assignment state and owner of the file resource with the given uid via a single
+   * JDBC UPDATE. No-op if no file resource with that uid exists.
+   */
+  void updateAssignment(@Nonnull String uid, boolean assigned, @Nonnull String fileResourceOwner);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
@@ -213,6 +213,16 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
   }
 
   @Override
+  public void updateAssignment(
+      @Nonnull String uid, boolean assigned, @Nonnull String fileResourceOwner) {
+    jdbcTemplate.update(
+        "update fileresource set isassigned = ?, fileresourceowner = ?, lastupdated = now() where uid = ?",
+        assigned,
+        fileResourceOwner,
+        uid);
+  }
+
+  @Override
   public List<FileResource> getUnassignedPassedGracePeriod(
       Set<FileResourceDomain> domainsToDeleteWhenUnassigned, DateTime gracePeriod) {
     @Language("SQL")

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/note/hibernate/Note.hbm.xml
@@ -9,7 +9,9 @@
   <class name="org.hisp.dhis.note.Note" table="note">
 
     <id name="id" column="noteid">
-      <generator class="native" />
+      <generator class="sequence">
+        <param name="sequence_name">note_sequence</param>
+      </generator>
     </id>
 
     <property name="uid" column="uid" unique="true" not-null="true" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/SingleEvent.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/SingleEvent.hbm.xml
@@ -8,7 +8,7 @@
 
     <id name="id" column="eventid">
       <generator class="sequence">
-        <param name="sequence_name">programstageinstance_sequence</param>
+        <param name="sequence_name">singleevent_sequence</param>
       </generator>
     </id>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
@@ -7,7 +7,10 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.tracker.model.Relationship" table="relationship">
 
-        <cache usage="read-write"/>
+        <!-- L2 cache disabled while the tracker importer is being migrated to JDBC. The JDBC INSERT
+             path bypasses Hibernate's cache invalidation hooks, so leaving the cache enabled risks
+             stale-cache reads of relationships written via JDBC. Re-enable once the importer no
+             longer touches relationships via Hibernate. -->
 
         <id name="id" column="relationshipid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
@@ -13,7 +13,9 @@
              longer touches relationships via Hibernate. -->
 
         <id name="id" column="relationshipid">
-            <generator class="native"/>
+            <generator class="sequence">
+                <param name="sequence_name">relationship_sequence</param>
+            </generator>
         </id>
 
         &identifiableProperties;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
@@ -12,7 +12,9 @@
              items via Hibernate. -->
 
         <id name="id" column="relationshipitemid">
-            <generator class="native" />
+            <generator class="sequence">
+                <param name="sequence_name">relationshipitem_sequence</param>
+            </generator>
         </id>
 
         <many-to-one name="relationship" class="org.hisp.dhis.tracker.model.Relationship"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipItem.hbm.xml
@@ -6,7 +6,10 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.tracker.model.RelationshipItem" table="relationshipitem">
 
-        <cache usage="read-write" />
+        <!-- L2 cache disabled while the tracker importer is being migrated to JDBC; relationship
+             items are eager-fetched from Relationship, so stale entries here would surface as
+             stale relationship reads. Re-enable once the importer no longer touches relationship
+             items via Hibernate. -->
 
         <id name="id" column="relationshipitemid">
             <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityProgramOwner.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityProgramOwner.hbm.xml
@@ -8,7 +8,9 @@
     table="trackedentityprogramowner">
 
     <id name="id" column="trackedentityprogramownerid">
-      <generator class="native" />
+      <generator class="sequence">
+        <param name="sequence_name">trackedentityprogramowner_sequence</param>
+      </generator>
     </id>
 
     <many-to-one name="trackedEntity" class="org.hisp.dhis.tracker.model.TrackedEntity"

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_63__rename_tracker_sequences_to_match_table_names.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_63__rename_tracker_sequences_to_match_table_names.sql
@@ -1,0 +1,22 @@
+-- DHIS2-21378: align tracker sequence names with the current table names and give
+-- relationship/relationshipitem their own sequences instead of the shared hibernate_sequence.
+
+-- Tables were renamed long ago (trackedentityinstance -> trackedentity,
+-- programinstance -> enrollment) but the sequences kept the legacy names.
+alter sequence if exists trackedentityinstance_sequence rename to trackedentity_sequence;
+alter sequence if exists programinstance_sequence rename to enrollment_sequence;
+
+-- After the event table split (V2_43_21) the SingleEvent Hibernate mapping kept drawing ids
+-- from the legacy programstageinstance_sequence while the JDBC import path used the canonical
+-- singleevent_sequence, so the two counters diverged. Resync the canonical sequence to the
+-- table's max id and drop the legacy sequence.
+select setval('singleevent_sequence', coalesce(max(eventid), 1)) from singleevent;
+drop sequence if exists programstageinstance_sequence;
+
+-- relationship and relationshipitem drew ids from the shared, global hibernate_sequence
+-- (<generator class="native"/>). Give them dedicated sequences, seeded from the current max ids.
+create sequence if not exists relationship_sequence;
+select setval('relationship_sequence', coalesce(max(relationshipid), 1)) from relationship;
+
+create sequence if not exists relationshipitem_sequence;
+select setval('relationshipitem_sequence', coalesce(max(relationshipitemid), 1)) from relationshipitem;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_64__add_trackedentityprogramowner_sequence.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_64__add_trackedentityprogramowner_sequence.sql
@@ -1,0 +1,7 @@
+-- DHIS2-21378: give trackedentityprogramowner its own sequence instead of the shared global
+-- hibernate_sequence. The table drew ids from hibernate_sequence (<generator class="native"/>);
+-- both the JDBC tracker-import write path (TrackedEntityProgramOwnerWriter) and the remaining
+-- Hibernate paths (ownership create-or-update and transfer) now use this dedicated sequence.
+-- Seed it from the current max id so the first nextval is above all existing rows.
+create sequence if not exists trackedentityprogramowner_sequence;
+select setval('trackedentityprogramowner_sequence', coalesce(max(trackedentityprogramownerid), 1)) from trackedentityprogramowner;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/PostgresIntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/PostgresIntegrationTestBase.java
@@ -29,9 +29,11 @@
  */
 package org.hisp.dhis.test.integration;
 
+import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.test.IntegrationTest;
 import org.hisp.dhis.test.IntegrationTestBase;
 import org.hisp.dhis.test.config.PostgresTestConfig;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -42,4 +44,20 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @IntegrationTest
 @ContextConfiguration(classes = {PostgresTestConfig.class})
-public abstract class PostgresIntegrationTestBase extends IntegrationTestBase {}
+public abstract class PostgresIntegrationTestBase extends IntegrationTestBase {
+
+  @Autowired private DbmsManager dbmsManager;
+
+  /**
+   * Flushes then detaches all Hibernate-managed entities. The tracker importer writes via JDBC,
+   * bypassing Hibernate, so entities loaded into the test's thread-bound session before an import
+   * linger there with stale pre-import state. Call this after importing tracker data whenever the
+   * test reads the import's outcome back through Hibernate. Only call it inside the test
+   * transaction (test methods of {@code @Transactional} tests) -- in {@code @BeforeAll} there is no
+   * transaction (the flush throws {@code TransactionRequiredException}) and no thread-bound session
+   * to clear in the first place.
+   */
+  protected final void clearSession() {
+    dbmsManager.clearSession();
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
@@ -124,8 +124,7 @@ class SingleEventChangeLogServiceTest extends PostgresIntegrationTestBase {
   void shouldFailWhenEventIsSoftDeleted() throws NotFoundException {
     trackerObjectDeletionService.deleteSingleEvents(List.of(UID.of("OTmjvJDn0Fu")));
 
-    manager.flush();
-    manager.clear();
+    clearSession();
 
     assertThrows(
         NotFoundException.class,
@@ -438,7 +437,7 @@ class SingleEventChangeLogServiceTest extends PostgresIntegrationTestBase {
                       TrackerImportParams.builder().build(),
                       TrackerObjects.builder().events(List.of(e)).build()));
             });
-    manager.clear();
+    clearSession();
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
@@ -438,6 +438,7 @@ class SingleEventChangeLogServiceTest extends PostgresIntegrationTestBase {
                       TrackerImportParams.builder().build(),
                       TrackerObjects.builder().events(List.of(e)).build()));
             });
+    manager.clear();
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityCacheTest.java
@@ -206,6 +206,8 @@ class TrackedEntityCacheTest extends PostgresIntegrationTestBase {
             TrackerImportParams.builder().importStrategy(TrackerImportStrategy.CREATE).build(),
             TrackerObjects.builder().enrollments(List.of(enrollment)).build()));
 
+    clearSession();
+
     // The cache is empty again, but this time, the owner should be found in the DB, so the user has
     // access to the te-program combination
     assertTrue(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
@@ -470,7 +470,7 @@ class TrackerEventChangeLogServiceTest extends PostgresIntegrationTestBase {
                       TrackerImportParams.builder().build(),
                       TrackerObjects.builder().events(List.of(e)).build()));
             });
-    manager.clear();
+    clearSession();
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
@@ -470,6 +470,7 @@ class TrackerEventChangeLogServiceTest extends PostgresIntegrationTestBase {
                       TrackerImportParams.builder().build(),
                       TrackerObjects.builder().events(List.of(e)).build()));
             });
+    manager.clear();
   }
 
   private void updateEventDates(UID event, Instant newDate) throws IOException {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -79,6 +80,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   private User importUser;
+  @Autowired private DbmsManager dbmsManager;
 
   @BeforeAll
   void setUp() throws IOException {
@@ -91,12 +93,14 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   @ParameterizedTest
   @MethodSource("statuses")
   void shouldCorrectlyPopulateCompletedDataWhenCreatingAnEnrollment(EnrollmentStatus status)
-      throws IOException, ForbiddenException, NotFoundException {
+      throws IOException, NotFoundException {
     TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects = testSetup.fromJson("tracker/te_enrollment_event.json");
     trackerObjects.getEnrollments().get(0).setStatus(status);
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    dbmsManager.clearSession();
 
     assertNoErrors(importReport);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -61,6 +63,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -72,6 +76,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private IdentifiableObjectManager manager;
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   private User importUser;
 
@@ -156,6 +161,73 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
         Arguments.of(COMPLETED, COMPLETED),
         Arguments.of(COMPLETED, CANCELLED),
         Arguments.of(COMPLETED, COMPLETED));
+  }
+
+  @Test
+  void shouldInsertNoteRowsAndJoinTableEntriesWhenEnrollmentIsCreatedWithNotes()
+      throws IOException {
+    testSetup.importTrackerData("tracker/one_te.json");
+    ImportReport report =
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_notes.json"));
+    assertNoErrors(report);
+
+    List<Map<String, Object>> joinRows =
+        jdbcTemplate.queryForList(
+            "select n.uid as noteuid, n.notetext, en.sort_order"
+                + " from enrollment_notes en"
+                + " join enrollment e on e.enrollmentid = en.enrollmentid"
+                + " join note n on n.noteid = en.noteid"
+                + " where e.uid = :uid"
+                + " order by en.sort_order",
+            new MapSqlParameterSource("uid", "TvctPPhpD8u"));
+
+    assertEquals(2, joinRows.size(), "expected two notes linked to the enrollment");
+    assertAll(
+        () -> assertEquals("NoteAlpha01", joinRows.get(0).get("noteuid")),
+        () -> assertEquals("First enrollment note", joinRows.get(0).get("notetext")),
+        () -> assertEquals(1, ((Number) joinRows.get(0).get("sort_order")).intValue()),
+        () -> assertEquals("NoteBeta002", joinRows.get(1).get("noteuid")),
+        () -> assertEquals("Second enrollment note", joinRows.get(1).get("notetext")),
+        () -> assertEquals(2, ((Number) joinRows.get(1).get("sort_order")).intValue()));
+  }
+
+  @Test
+  void shouldAppendNewNoteAndKeepExistingOnesWhenEnrollmentIsUpdatedWithExtraNote()
+      throws IOException {
+    testSetup.importTrackerData("tracker/one_te.json");
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_notes.json")));
+
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/one_enrollment_with_extra_note.json")));
+
+    List<Map<String, Object>> joinRows =
+        jdbcTemplate.queryForList(
+            "select n.uid as noteuid, n.notetext, en.sort_order"
+                + " from enrollment_notes en"
+                + " join enrollment e on e.enrollmentid = en.enrollmentid"
+                + " join note n on n.noteid = en.noteid"
+                + " where e.uid = :uid"
+                + " order by en.sort_order",
+            new MapSqlParameterSource("uid", "TvctPPhpD8u"));
+
+    assertEquals(3, joinRows.size(), "expected three notes (two from create, one appended)");
+    assertAll(
+        () -> assertEquals("NoteAlpha01", joinRows.get(0).get("noteuid")),
+        () -> assertEquals(1, ((Number) joinRows.get(0).get("sort_order")).intValue()),
+        () -> assertEquals("NoteBeta002", joinRows.get(1).get("noteuid")),
+        () -> assertEquals(2, ((Number) joinRows.get(1).get("sort_order")).intValue()),
+        () -> assertEquals("NoteGamma01", joinRows.get(2).get("noteuid")),
+        () ->
+            assertEquals(
+                "Third enrollment note appended on update", joinRows.get(2).get("notetext")),
+        () -> assertEquals(3, ((Number) joinRows.get(2).get("sort_order")).intValue()));
   }
 
   private void assertEnrollmentCompletedData(Enrollment enrollment) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EnrollmentImportTest.java
@@ -100,7 +100,7 @@ class EnrollmentImportTest extends PostgresIntegrationTestBase {
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
-    dbmsManager.clearSession();
+    clearSession();
 
     assertNoErrors(importReport);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -111,7 +111,7 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     testSetup.importTrackerData("tracker/event_with_updated_data_values.json", params);
 
-    manager.clear();
+    clearSession();
 
     List<TrackerEvent> updatedEvents = manager.getAll(TrackerEvent.class);
     assertEquals(1, updatedEvents.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -111,6 +111,8 @@ class EventDataValueTest extends PostgresIntegrationTestBase {
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     testSetup.importTrackerData("tracker/event_with_updated_data_values.json", params);
 
+    manager.clear();
+
     List<TrackerEvent> updatedEvents = manager.getAll(TrackerEvent.class);
     assertEquals(1, updatedEvents.size());
     TrackerEvent updatedEvent = manager.get(TrackerEvent.class, updatedEvents.get(0).getUid());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/GeometryImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/GeometryImportTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle;
+
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.SoftDeletableEntity;
+import org.hisp.dhis.organisationunit.FeatureType;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.tracker.TestSetup;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackerEvent;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies that the {@code geometry} column is correctly persisted on both insert and update by the
+ * JDBC writers (DHIS2-21378). The writers build the geometry with {@code ST_GeomFromText(...,
+ * 4326)} so we assert both the coordinates and that the SRID round-trips.
+ */
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GeometryImportTest extends PostgresIntegrationTestBase {
+
+  private static final int SRID = 4326;
+
+  /** Standalone tracked entity (no dependents) so its geometry import exercises the insert path. */
+  private static final String STANDALONE_TE_FILE = "tracker/another_single_te.json";
+
+  private static final String STANDALONE_TE_UID = "Fr9h5ps74jF";
+  private static final String ENROLLMENT_UID = "TvctPPhpD8u";
+  private static final String EVENT_UID = "D9PbzJY8bJO";
+
+  @Autowired private TestSetup testSetup;
+  @Autowired private TrackerImportService trackerImportService;
+  @Autowired private IdentifiableObjectManager manager;
+
+  private User importUser;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    testSetup.importMetadata();
+
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
+
+    // Enrollment geometry is validated against the program feature type, which is NONE in the base
+    // metadata. Allow points so the enrollment geometry can be imported.
+    Program program = manager.get(Program.class, "BFcipDERJnf");
+    program.setFeatureType(FeatureType.POINT);
+    manager.update(program);
+
+    // Tracked entity parent required by the enrollment and event imports below.
+    testSetup.importTrackerData("tracker/one_te.json");
+  }
+
+  @BeforeEach
+  void setUpUser() {
+    injectSecurityContextUser(importUser);
+  }
+
+  @Test
+  void shouldPersistGeometryWhenTrackedEntityIsCreatedAndUpdated() throws IOException {
+    Point created = point(11.1, 22.2);
+    importTrackedEntity(created, TrackerImportStrategy.CREATE);
+    assertGeometry(
+        created, getEntity(TrackedEntity.class, STANDALONE_TE_UID).getGeometry(), "tracked entity");
+
+    Point updated = point(33.3, 44.4);
+    importTrackedEntity(updated, TrackerImportStrategy.UPDATE);
+    assertGeometry(
+        updated, getEntity(TrackedEntity.class, STANDALONE_TE_UID).getGeometry(), "tracked entity");
+  }
+
+  @Test
+  void shouldPersistGeometryWhenEnrollmentIsCreatedAndUpdated() throws IOException {
+    Point created = point(11.1, 22.2);
+    importEnrollment(created, TrackerImportStrategy.CREATE);
+    assertGeometry(
+        created, getEntity(Enrollment.class, ENROLLMENT_UID).getGeometry(), "enrollment");
+
+    Point updated = point(33.3, 44.4);
+    importEnrollment(updated, TrackerImportStrategy.UPDATE);
+    assertGeometry(
+        updated, getEntity(Enrollment.class, ENROLLMENT_UID).getGeometry(), "enrollment");
+  }
+
+  @Test
+  void shouldPersistGeometryWhenEventIsCreatedAndUpdated() throws IOException {
+    // The event references the enrollment, which is not part of the shared setup.
+    testSetup.importTrackerData("tracker/one_enrollment.json");
+    clearSession();
+
+    Point created = point(11.1, 22.2);
+    importEvent(created, TrackerImportStrategy.CREATE);
+    assertGeometry(created, getEntity(TrackerEvent.class, EVENT_UID).getGeometry(), "event");
+
+    Point updated = point(33.3, 44.4);
+    importEvent(updated, TrackerImportStrategy.UPDATE);
+    assertGeometry(updated, getEntity(TrackerEvent.class, EVENT_UID).getGeometry(), "event");
+  }
+
+  private void importTrackedEntity(Geometry geometry, TrackerImportStrategy strategy)
+      throws IOException {
+    TrackerObjects objects = testSetup.fromJson(STANDALONE_TE_FILE);
+    objects.getTrackedEntities().get(0).setGeometry(geometry);
+    importAndClear(objects, strategy);
+  }
+
+  private void importEnrollment(Geometry geometry, TrackerImportStrategy strategy)
+      throws IOException {
+    TrackerObjects objects = testSetup.fromJson("tracker/one_enrollment.json");
+    objects.getEnrollments().get(0).setGeometry(geometry);
+    importAndClear(objects, strategy);
+  }
+
+  private void importEvent(Geometry geometry, TrackerImportStrategy strategy) throws IOException {
+    TrackerObjects objects = testSetup.fromJson("tracker/one_tracker_event.json");
+    objects.getEvents().get(0).setGeometry(geometry);
+    importAndClear(objects, strategy);
+  }
+
+  private void importAndClear(TrackerObjects objects, TrackerImportStrategy strategy) {
+    TrackerImportParams params = TrackerImportParams.builder().importStrategy(strategy).build();
+    assertNoErrors(trackerImportService.importTracker(params, objects));
+    clearSession();
+  }
+
+  private void assertGeometry(Point expected, Geometry actual, String entity) {
+    assertAll(
+        "geometry not persisted correctly for " + entity,
+        () -> assertNotNull(actual, "geometry was not persisted"),
+        () -> assertEquals("Point", actual.getGeometryType()),
+        () -> assertEquals(expected.getX(), actual.getCoordinate().x, 0.0001),
+        () -> assertEquals(expected.getY(), actual.getCoordinate().y, 0.0001),
+        () -> assertEquals(SRID, actual.getSRID(), "geometry SRID was not preserved"));
+  }
+
+  private Point point(double x, double y) {
+    Point point = new GeometryFactory().createPoint(new Coordinate(x, y));
+    point.setSRID(SRID);
+    return point;
+  }
+
+  /**
+   * Read with the entity manager so deleted entities and store-level filtering do not interfere; we
+   * only want to assert what the JDBC writer persisted.
+   */
+  @SuppressWarnings("unchecked")
+  private <T extends SoftDeletableEntity> T getEntity(Class<T> type, String uid) {
+    return (T)
+        entityManager
+            .createQuery("SELECT e FROM " + type.getSimpleName() + " e WHERE e.uid = :uid")
+            .setParameter("uid", uid)
+            .getSingleResult();
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertHasSize;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -624,6 +625,62 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
                     "Data integrity error for event %s. The lastUpdatedByUserinfo has not been"
                         + " saved during the import",
                     event.getUID())));
+  }
+
+  @Test
+  void shouldSetCreatedByUserInfoToImportUserWhenTrackedEntityIsCreated() {
+    assertCreatedByUserInfo(getTrackedEntity().getCreatedByUserInfo(), "tracked entity");
+  }
+
+  @Test
+  void shouldSetCreatedByUserInfoToImportUserWhenEnrollmentIsCreated() {
+    assertCreatedByUserInfo(getEnrollment().getCreatedByUserInfo(), "enrollment");
+  }
+
+  @Test
+  void shouldSetCreatedByUserInfoToImportUserWhenEventIsCreated() {
+    assertCreatedByUserInfo(getEvent().getCreatedByUserInfo(), "event");
+  }
+
+  @Test
+  void shouldNotChangeCreatedByUserInfoWhenTrackedEntityIsUpdatedByAnotherUser()
+      throws IOException {
+    String createdByBefore = getTrackedEntity().getCreatedByUserInfo().getUid();
+
+    User otherUser = user();
+    clearSession();
+
+    TrackerImportParams params =
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
+    testSetup.importTrackerData("tracker/one_te.json", params);
+    clearSession();
+
+    TrackedEntity afterUpdate = getTrackedEntity();
+    assertAll(
+        () ->
+            assertEquals(
+                importUser.getUid(),
+                createdByBefore,
+                "the tracked entity should have been created by the import user"),
+        () ->
+            assertEquals(
+                createdByBefore,
+                afterUpdate.getCreatedByUserInfo().getUid(),
+                "createdByUserInfo must not change when the tracked entity is updated"),
+        () ->
+            assertEquals(
+                otherUser.getUid(),
+                afterUpdate.getLastUpdatedByUserInfo().getUid(),
+                "lastUpdatedByUserInfo must reflect the updating user"));
+  }
+
+  private void assertCreatedByUserInfo(
+      org.hisp.dhis.program.UserInfoSnapshot createdByUserInfo, String entity) {
+    assertAll(
+        "createdByUserInfo not saved for " + entity,
+        () -> assertNotNull(createdByUserInfo, "createdByUserInfo was not saved"),
+        () -> assertEquals(importUser.getUid(), createdByUserInfo.getUid()),
+        () -> assertEquals(importUser.getUsername(), createdByUserInfo.getUsername()));
   }
 
   private void assertTrackedEntityUpdated(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.SoftDeletableEntity;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -77,8 +76,6 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
   @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private IdentifiableObjectManager manager;
-
-  @Autowired private DbmsManager dbmsManager;
 
   private org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity;
   private org.hisp.dhis.tracker.imports.domain.TrackedEntity anotherTrackedEntity;
@@ -146,7 +143,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
-    manager.clear();
+    clearSession();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();
@@ -172,7 +169,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
-    manager.clear();
+    clearSession();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();
@@ -695,14 +692,6 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
                 .build()));
   }
 
-  /**
-   * Flush the session to synchronize the hibernate objects with the database and clear the
-   * references used during the import, so we can compare an object before and after
-   */
-  void clearSession() {
-    dbmsManager.clearSession();
-  }
-
   Enrollment getEnrollment() {
     return getEntityJpql(Enrollment.class.getSimpleName(), enrollment.getUID().getValue());
   }
@@ -753,6 +742,6 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     ImportReport report = trackerImportService.importTracker(params, trackerObjects);
 
     assertNoErrors(report);
-    dbmsManager.clearSession();
+    clearSession();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -146,6 +146,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
+    manager.clear();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();
@@ -171,6 +172,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te_with_one_attribute.json", params);
+    manager.clear();
     Set<TrackedEntityAttributeValue> values = getTrackedEntity().getTrackedEntityAttributeValues();
     assertHasSize(1, values);
     TrackedEntityAttributeValue attributeValue = values.iterator().next();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/LastUpdateImportTest.java
@@ -130,7 +130,7 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     TrackerImportParams params =
         TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
     testSetup.importTrackerData("tracker/one_te.json", params);
-
+    clearSession();
     Date lastUpdateAfter = getTrackedEntity().getLastUpdated();
 
     assertTrue(
@@ -753,5 +753,6 @@ class LastUpdateImportTest extends PostgresIntegrationTestBase {
     ImportReport report = trackerImportService.importTracker(params, trackerObjects);
 
     assertNoErrors(report);
+    dbmsManager.clearSession();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -190,6 +190,7 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     ImportReport updatedReport = trackerImportService.importTracker(params, trackerObjects);
     manager.flush();
+    manager.clear();
     assertNoErrors(updatedReport);
     assertEquals(1, updatedReport.getStats().getUpdated());
     enrollments = manager.getAll(Enrollment.class);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -97,8 +97,6 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     testSetup.importTrackerData("tracker/ownership_enrollment.json");
 
     nonSuperUser = userService.getUser("Tu9fv8ezgHl");
-    manager.clear();
-    manager.flush();
   }
 
   @Test
@@ -128,8 +126,7 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     User nonSuperUser = userService.getUser(this.nonSuperUser.getUid());
     injectSecurityContextUser(nonSuperUser);
     TrackerObjects trackerObjects = testSetup.importTrackerData("tracker/ownership_event.json");
-    manager.flush();
-    manager.clear();
+    clearSession();
     TrackerObjects teTrackerObjects = testSetup.fromJson("tracker/ownership_te.json");
     TrackerObjects enTrackerObjects = testSetup.fromJson("tracker/ownership_enrollment.json");
 
@@ -189,8 +186,7 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     updatedEnrollment.setOccurredAt(Instant.now());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     ImportReport updatedReport = trackerImportService.importTracker(params, trackerObjects);
-    manager.flush();
-    manager.clear();
+    clearSession();
     assertNoErrors(updatedReport);
     assertEquals(1, updatedReport.getStats().getUpdated());
     enrollments = manager.getAll(Enrollment.class);
@@ -224,8 +220,7 @@ class OwnershipTest extends PostgresIntegrationTestBase {
     List<Enrollment> enrollments = manager.getAll(Enrollment.class);
     assertEquals(1, enrollments.stream().filter(en -> !en.isDeleted()).count());
     params.setImportStrategy(TrackerImportStrategy.DELETE);
-    manager.clear();
-    manager.flush();
+    clearSession();
     ImportReport updatedReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(updatedReport);
     assertEquals(1, updatedReport.getStats().getDeleted());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -32,6 +32,11 @@ package org.hisp.dhis.tracker.imports.bundle;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.tracker.Assertions.assertHasError;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -96,6 +101,58 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
 
     assertThat(importReport.getStatus(), is(Status.OK));
     assertThat(importReport.getStats().getCreated(), is(2));
+  }
+
+  @Test
+  void shouldPersistRelationshipFieldsAndItemWiringWhenRelationshipsAreCreated()
+      throws IOException {
+    injectSecurityContextUser(userService.getUser("M5zQapPyTZI"));
+
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            testSetup.fromJson("tracker/relationships.json")));
+    manager.flush();
+    manager.clear();
+
+    // Tracked entity -> enrollment relationship
+    Relationship teToEnrollment = manager.get(Relationship.class, "Nva3Xj2j75W");
+    assertAll(
+        "tracked entity to enrollment relationship not persisted correctly",
+        () -> assertNotNull(teToEnrollment, "relationship was not persisted"),
+        () -> assertFalse(teToEnrollment.isDeleted()),
+        () -> assertNotNull(teToEnrollment.getKey(), "relationship key was not persisted"),
+        () -> assertEquals("xLmPUYJX8Ks", teToEnrollment.getRelationshipType().getUid()),
+        () -> assertNotNull(teToEnrollment.getFrom(), "from relationship item was not wired"),
+        () ->
+            assertEquals(
+                "IOR1AXXl24H",
+                teToEnrollment.getFrom().getTrackedEntity().getUid(),
+                "from item should point to the tracked entity"),
+        () -> assertNotNull(teToEnrollment.getTo(), "to relationship item was not wired"),
+        () ->
+            assertEquals(
+                "TvctPPhpD8u",
+                teToEnrollment.getTo().getEnrollment().getUid(),
+                "to item should point to the enrollment"));
+
+    // Tracked entity -> event relationship
+    Relationship teToEvent = manager.get(Relationship.class, "HiXiipNGsxT");
+    assertAll(
+        "tracked entity to event relationship not persisted correctly",
+        () -> assertNotNull(teToEvent, "relationship was not persisted"),
+        () -> assertFalse(teToEvent.isDeleted()),
+        () -> assertEquals("TV9oB9LT3sh", teToEvent.getRelationshipType().getUid()),
+        () ->
+            assertEquals(
+                "IOR1AXXl24H",
+                teToEvent.getFrom().getTrackedEntity().getUid(),
+                "from item should point to the tracked entity"),
+        () ->
+            assertEquals(
+                "D9PbzJY8bJO",
+                teToEvent.getTo().getTrackerEvent().getUid(),
+                "to item should point to the tracker event"));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -144,4 +144,24 @@ class RelationshipImportTest extends PostgresIntegrationTestBase {
     assertHasError(importReport, ValidationCode.E4017);
     assertThat(importReport.getStats().getIgnored(), is(2));
   }
+
+  @Test
+  void shouldRejectDuplicateRelationships() throws IOException {
+    injectSecurityContextUser(userService.getUser("M5zQapPyTZI"));
+    TrackerImportParams params = TrackerImportParams.builder().build();
+
+    ImportReport first =
+        trackerImportService.importTracker(
+            params, testSetup.fromJson("tracker/relationships.json"));
+    assertThat(first.getStatus(), is(Status.OK));
+    assertThat(first.getStats().getCreated(), is(2));
+
+    ImportReport second =
+        trackerImportService.importTracker(
+            params, testSetup.fromJson("tracker/relationships_duplicate.json"));
+
+    assertHasError(second, ValidationCode.E4018);
+    assertThat(second.getStats().getIgnored(), is(2));
+    assertThat(second.getStats().getCreated(), is(0));
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -48,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
 import org.hisp.dhis.dxf2.metadata.MetadataObjects;
@@ -60,7 +62,13 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TestSetup;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheatService;
@@ -83,6 +91,8 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
   @Autowired private TestSetup testSetup;
 
   @Autowired private TrackerPreheatService trackerPreheatService;
+
+  @Autowired private TrackerImportService trackerImportService;
 
   @Autowired private TrackedEntityAttributeService trackedEntityAttributeService;
 
@@ -136,6 +146,51 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
     List<TrackedEntityAttributeValue> attributeValues =
         trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
     attributeValues.forEach(av -> assertEquals(importUser.getUsername(), av.getStoredBy()));
+  }
+
+  @Test
+  void shouldUpdateExistingAttributeValueWhenImportingWithNonUidIdScheme() throws IOException {
+    testSetup.importTrackerData("tracker/te_with_tea_data.json");
+    clearSession();
+
+    // The persister must recognize the attribute value as existing (and route it to an UPDATE
+    // instead of a duplicate INSERT, which would violate the composite PK) regardless of the
+    // idScheme the import resolves attributes with.
+    TrackerObjects update =
+        TrackerObjects.builder()
+            .trackedEntities(
+                List.of(
+                    org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
+                        .trackedEntity(UID.of("CLR1fvPj4ic"))
+                        .trackedEntityType(MetadataIdentifier.ofName("Person"))
+                        .orgUnit(MetadataIdentifier.ofName("Country"))
+                        .attributes(
+                            List.of(
+                                Attribute.builder()
+                                    .attribute(MetadataIdentifier.ofName("Attribute_Text"))
+                                    .value("updated value")
+                                    .build()))
+                        .build()))
+            .build();
+    TrackerImportParams params =
+        TrackerImportParams.builder()
+            .importStrategy(TrackerImportStrategy.UPDATE)
+            .idSchemes(TrackerIdSchemeParams.builder().idScheme(TrackerIdSchemeParam.NAME).build())
+            .build();
+
+    assertNoErrors(trackerImportService.importTracker(params, update));
+    clearSession();
+
+    TrackedEntity trackedEntity = manager.getAll(TrackedEntity.class).get(0);
+    List<TrackedEntityAttributeValue> attributeValues =
+        trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
+    assertEquals(3, attributeValues.size());
+    TrackedEntityAttributeValue updatedValue =
+        attributeValues.stream()
+            .filter(av -> "TsfP85GKsU5".equals(av.getAttribute().getUid()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("updated value", updatedValue.getValue());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -97,6 +97,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends PostgresIntegrationT
     List<TrackedEntityAttributeValue> attributeValues =
         trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
     assertEquals(5, attributeValues.size());
+    manager.clear();
     fileResource = fileResourceService.getFileResource(fileResource.getUid());
     assertTrue(fileResource.isAssigned());
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -235,6 +235,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
+    manager.clear();
+
     List<String> firstEventDataValues = getValueForAssignedDataElement(firstEventUid);
     List<String> secondEventDataValues = getValueForAssignedDataElement(secondEventUid);
     List<String> thirdEventDataValues = getValueForAssignedDataElement(thirdEventUid);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -235,7 +235,7 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
 
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
-    manager.clear();
+    clearSession();
 
     List<String> firstEventDataValues = getValueForAssignedDataElement(firstEventUid);
     List<String> secondEventDataValues = getValueForAssignedDataElement(secondEventUid);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -367,6 +367,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
     // When -> Update the event and adds 3 more notes
     ImportReport importReport =
         createEvent("tracker/validations/events-with-notes-update-data.json");
+    manager.clear();
     // Then
     final TrackerEvent event = getEventFromReport(importReport);
     assertThat(event.getNotes(), hasSize(6));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -367,7 +367,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
     // When -> Update the event and adds 3 more notes
     ImportReport importReport =
         createEvent("tracker/validations/events-with-notes-update-data.json");
-    manager.clear();
+    clearSession();
     // Then
     final TrackerEvent event = getEventFromReport(importReport);
     assertThat(event.getNotes(), hasSize(6));
@@ -421,8 +421,7 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
 
     assertNoErrors(importReport);
 
-    manager.flush();
-    manager.clear();
+    clearSession();
 
     TrackerObjects deleteTrackerObjects =
         testSetup.fromJson("tracker/validations/event-data-delete.json");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
@@ -108,6 +108,7 @@ class TeTaValidationTest extends PostgresIntegrationTestBase {
     List<TrackedEntityAttributeValue> attributeValues =
         trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
     assertEquals(1, attributeValues.size());
+    manager.clear();
     fileResource = fileResourceService.getFileResource(fileResource.getUid());
     assertTrue(fileResource.isAssigned());
   }
@@ -137,6 +138,7 @@ class TeTaValidationTest extends PostgresIntegrationTestBase {
     List<TrackedEntityAttributeValue> attributeValues =
         trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
     assertEquals(1, attributeValues.size());
+    manager.clear();
     fileResource = fileResourceService.getFileResource(fileResource.getUid());
     assertTrue(fileResource.isAssigned());
     trackerObjects =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_extra_note.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_extra_note.json
@@ -1,0 +1,46 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": { "idScheme": "UID" },
+    "orgUnitIdScheme": { "idScheme": "UID" },
+    "programIdScheme": { "idScheme": "UID" },
+    "programStageIdScheme": { "idScheme": "UID" },
+    "idScheme": { "idScheme": "UID" },
+    "categoryOptionComboIdScheme": { "idScheme": "UID" },
+    "categoryOptionIdScheme": { "idScheme": "UID" }
+  },
+  "importStrategy": "UPDATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": { "idScheme": "UID", "identifier": "BFcipDERJnf" },
+      "status": "ACTIVE",
+      "orgUnit": { "idScheme": "UID", "identifier": "h4w96yEMlzO" },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": [
+        { "note": "NoteGamma01", "value": "Third enrollment note appended on update" }
+      ],
+      "attributeOptionCombo": { "idScheme": "UID", "identifier": "HllvX50cXC0" }
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_notes.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/one_enrollment_with_notes.json
@@ -1,0 +1,47 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": { "idScheme": "UID" },
+    "orgUnitIdScheme": { "idScheme": "UID" },
+    "programIdScheme": { "idScheme": "UID" },
+    "programStageIdScheme": { "idScheme": "UID" },
+    "idScheme": { "idScheme": "UID" },
+    "categoryOptionComboIdScheme": { "idScheme": "UID" },
+    "categoryOptionIdScheme": { "idScheme": "UID" }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": { "idScheme": "UID", "identifier": "BFcipDERJnf" },
+      "status": "ACTIVE",
+      "orgUnit": { "idScheme": "UID", "identifier": "h4w96yEMlzO" },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": [
+        { "note": "NoteAlpha01", "value": "First enrollment note" },
+        { "note": "NoteBeta002", "value": "Second enrollment note" }
+      ],
+      "attributeOptionCombo": { "idScheme": "UID", "identifier": "HllvX50cXC0" }
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/relationships_duplicate.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/relationships_duplicate.json
@@ -4,7 +4,7 @@
   "events": [],
   "relationships": [
     {
-      "relationship": "Nva3Xj2j75W",
+      "relationship": "Dupe111Rel1",
       "relationshipType": {
         "idScheme": "UID",
         "identifier": "xLmPUYJX8Ks"
@@ -19,7 +19,7 @@
       }
     },
     {
-      "relationship": "HiXiipNGsxT",
+      "relationship": "Dupe222Rel2",
       "relationshipType": {
         "idScheme": "UID",
         "identifier": "TV9oB9LT3sh"

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/ControllerIntegrationTestBase.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/ControllerIntegrationTestBase.java
@@ -140,6 +140,22 @@ public abstract class ControllerIntegrationTestBase extends IntegrationTestBase
     currentUser = getAdminUser();
   }
 
+  /**
+   * Simulates a fresh per-request {@code EntityManager}. {@code /api/tracker/**} is excluded from
+   * the {@code ConditionalOpenEntityManagerInViewFilter} (OSIV is deliberately off for tracker), so
+   * its Hibernate session is transaction-scoped: it is opened for the request's
+   * {@code @Transactional} boundary and closed when that transaction completes, so each {@code
+   * /tracker} request starts with a fresh persistence context. These MockMvc tests otherwise share
+   * one thread-bound session across requests; since the tracker importer writes via JDBC (bypassing
+   * Hibernate), a previous request's now-stale managed entity would linger in the L1 cache and be
+   * returned to a later read or import preheat. Flushing then clearing the session between requests
+   * reproduces the production per-request isolation ({@code clearSession()} flushes before
+   * clearing).
+   */
+  protected final void startNewRequestSession() {
+    dbmsManager.clearSession();
+  }
+
   protected final void doInTransaction(Runnable operation) {
     final int defaultPropagationBehaviour = txTemplate.getPropagationBehavior();
     txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -403,22 +403,6 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
-  /**
-   * Simulates a fresh per-request {@code EntityManager}. {@code /api/tracker/**} is excluded from
-   * the {@code ConditionalOpenEntityManagerInViewFilter} (OSIV is deliberately off for tracker), so
-   * its Hibernate session is transaction-scoped: it is opened for the import's
-   * {@code @Transactional} boundary and closed when that transaction completes, so each {@code
-   * /tracker} request starts with a fresh persistence context. These MockMvc tests otherwise share
-   * one thread-bound session across imports; since the tracker importer writes via JDBC (bypassing
-   * Hibernate), a previous import's now-stale managed entity would linger in the L1 cache and be
-   * returned to the next import's preheat. Flushing then clearing the session between imports
-   * reproduces the production per-request isolation.
-   */
-  private void startNewRequestSession() {
-    dbmsManager.flushSession();
-    dbmsManager.clearSession();
-  }
-
   private TrackedEntity trackedEntity() {
     TrackedEntity te = trackedEntity(orgUnit);
     manager.save(te, false);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportChangeLogsControllerTest.java
@@ -384,21 +384,39 @@ class EventsExportChangeLogsControllerTest extends PostgresControllerIntegration
   }
 
   private void updateDataValue(String value) {
+    String body = createDataValueJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST("/tracker?async=false&importStrategy=UPDATE", createDataValueJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
   private void updateScheduledAtEventField(String value) {
+    String body = createScheduledAtEventFieldJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST(
-                "/tracker?async=false&importStrategy=UPDATE",
-                createScheduledAtEventFieldJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
+  }
+
+  /**
+   * Simulates a fresh per-request {@code EntityManager}. {@code /api/tracker/**} is excluded from
+   * the {@code ConditionalOpenEntityManagerInViewFilter} (OSIV is deliberately off for tracker), so
+   * its Hibernate session is transaction-scoped: it is opened for the import's
+   * {@code @Transactional} boundary and closed when that transaction completes, so each {@code
+   * /tracker} request starts with a fresh persistence context. These MockMvc tests otherwise share
+   * one thread-bound session across imports; since the tracker importer writes via JDBC (bypassing
+   * Hibernate), a previous import's now-stale managed entity would linger in the L1 cache and be
+   * returned to the next import's preheat. Flushing then clearing the session between imports
+   * reproduces the production per-request isolation.
+   */
+  private void startNewRequestSession() {
+    dbmsManager.flushSession();
+    dbmsManager.clearSession();
   }
 
   private TrackedEntity trackedEntity() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportChangeLogsControllerTest.java
@@ -365,21 +365,36 @@ class SingleEventsExportChangeLogsControllerTest extends PostgresControllerInteg
   }
 
   private void updateDataValue(String value) {
+    String body = createDataValueJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST("/tracker?async=false&importStrategy=UPDATE", createDataValueJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
   private void updateScheduledAtEventField(String value) {
+    String body = createScheduledAtEventFieldJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST(
-                "/tracker?async=false&importStrategy=UPDATE",
-                createScheduledAtEventFieldJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
+  }
+
+  /**
+   * Simulates a fresh per-request {@code EntityManager}. Production registers an {@code
+   * OpenEntityManagerInViewFilter}, so every {@code /tracker} request gets its own Hibernate
+   * session. These MockMvc tests otherwise share one thread-bound session across imports; since the
+   * tracker importer writes via JDBC (bypassing Hibernate), a previous import's now-stale managed
+   * entity would linger in the L1 cache and be returned to the next import's preheat. Flushing then
+   * clearing the session between imports reproduces the production per-request isolation.
+   */
+  private void startNewRequestSession() {
+    dbmsManager.flushSession();
+    dbmsManager.clearSession();
   }
 
   private SingleEvent event() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/singleevent/SingleEventsExportChangeLogsControllerTest.java
@@ -384,19 +384,6 @@ class SingleEventsExportChangeLogsControllerTest extends PostgresControllerInteg
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
-  /**
-   * Simulates a fresh per-request {@code EntityManager}. Production registers an {@code
-   * OpenEntityManagerInViewFilter}, so every {@code /tracker} request gets its own Hibernate
-   * session. These MockMvc tests otherwise share one thread-bound session across imports; since the
-   * tracker importer writes via JDBC (bypassing Hibernate), a previous import's now-stale managed
-   * entity would linger in the L1 cache and be returned to the next import's preheat. Flushing then
-   * clearing the session between imports reproduces the production per-request isolation.
-   */
-  private void startNewRequestSession() {
-    dbmsManager.flushSession();
-    dbmsManager.clearSession();
-  }
-
   private SingleEvent event() {
     SingleEvent eventA = new SingleEvent();
     eventA.setProgramStage(programStage);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackerevent/TrackerEventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackerevent/TrackerEventsExportChangeLogsControllerTest.java
@@ -390,21 +390,39 @@ class TrackerEventsExportChangeLogsControllerTest extends PostgresControllerInte
   }
 
   private void updateDataValue(String value) {
+    String body = createDataValueJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST("/tracker?async=false&importStrategy=UPDATE", createDataValueJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
   private void updateScheduledAtEventField(String value) {
+    String body = createScheduledAtEventFieldJson(event, value);
+    startNewRequestSession();
     JsonWebMessage importResponse =
-        POST(
-                "/tracker?async=false&importStrategy=UPDATE",
-                createScheduledAtEventFieldJson(event, value))
+        POST("/tracker?async=false&importStrategy=UPDATE", body)
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
+  }
+
+  /**
+   * Simulates a fresh per-request {@code EntityManager}. {@code /api/tracker/**} is excluded from
+   * the {@code ConditionalOpenEntityManagerInViewFilter} (OSIV is deliberately off for tracker), so
+   * its Hibernate session is transaction-scoped: it is opened for the import's
+   * {@code @Transactional} boundary and closed when that transaction completes, so each {@code
+   * /tracker} request starts with a fresh persistence context. These MockMvc tests otherwise share
+   * one thread-bound session across imports; since the tracker importer writes via JDBC (bypassing
+   * Hibernate), a previous import's now-stale managed entity would linger in the L1 cache and be
+   * returned to the next import's preheat. Flushing then clearing the session between imports
+   * reproduces the production per-request isolation.
+   */
+  private void startNewRequestSession() {
+    dbmsManager.flushSession();
+    dbmsManager.clearSession();
   }
 
   private TrackerEvent event() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackerevent/TrackerEventsExportChangeLogsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackerevent/TrackerEventsExportChangeLogsControllerTest.java
@@ -409,22 +409,6 @@ class TrackerEventsExportChangeLogsControllerTest extends PostgresControllerInte
     assertEquals(HttpStatus.OK.toString(), importResponse.getStatus());
   }
 
-  /**
-   * Simulates a fresh per-request {@code EntityManager}. {@code /api/tracker/**} is excluded from
-   * the {@code ConditionalOpenEntityManagerInViewFilter} (OSIV is deliberately off for tracker), so
-   * its Hibernate session is transaction-scoped: it is opened for the import's
-   * {@code @Transactional} boundary and closed when that transaction completes, so each {@code
-   * /tracker} request starts with a fresh persistence context. These MockMvc tests otherwise share
-   * one thread-bound session across imports; since the tracker importer writes via JDBC (bypassing
-   * Hibernate), a previous import's now-stale managed entity would linger in the L1 cache and be
-   * returned to the next import's preheat. Flushing then clearing the session between imports
-   * reproduces the production per-request isolation.
-   */
-  private void startNewRequestSession() {
-    dbmsManager.flushSession();
-    dbmsManager.clearSession();
-  }
-
   private TrackerEvent event() {
     TrackerEvent eventA = new TrackerEvent();
     eventA.setProgramStage(programStage);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerEventSMSTest.java
@@ -882,7 +882,9 @@ class TrackerEventSMSTest extends PostgresControllerIntegrationTestBase {
     event.setProgramStage(trackerProgramStage);
     event.setOrganisationUnit(enrollment.getOrganisationUnit());
     event.setAttributeOptionCombo(coc);
-    event.setOccurredDate(new Date());
+    // SMS submissions encode dates with second precision, so the occurred date must not carry
+    // milliseconds or it won't survive the SMS encode/decode round-trip in shouldUpdateEvent().
+    event.setOccurredDate(DateUtils.getDate(2024, 9, 2, 10, 15));
     event.setAutoFields();
     manager.save(event);
     return event;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.webapi.controller.tracker.JsonImportReport;
@@ -57,7 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
  * requests
  */
 @Transactional
-class TrackerImportReportTest extends H2ControllerIntegrationTestBase {
+class TrackerImportReportTest extends PostgresControllerIntegrationTestBase {
 
   private static final String ORG_UNIT_UID = "PSeMWi7rBgb";
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/DefaultTrackedEntityProgramOwnerService.java
@@ -62,6 +62,11 @@ public class DefaultTrackedEntityProgramOwnerService implements TrackedEntityPro
         buildTrackedEntityProgramOwner(trackedEntity, program, orgUnit));
   }
 
+  @Override
+  public void invalidateOwnershipCache(TrackedEntity trackedEntity, Program program) {
+    trackedEntityProgramOwnerStore.invalidateOwnershipCache(trackedEntity, program);
+  }
+
   private TrackedEntityProgramOwner buildTrackedEntityProgramOwner(
       TrackedEntity trackedEntity, Program program, OrganisationUnit ou) {
     TrackedEntityProgramOwner teProgramOwner =

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/HibernateTrackedEntityProgramOwnerStore.java
@@ -111,16 +111,19 @@ public class HibernateTrackedEntityProgramOwnerStore
   @Override
   public void save(@Nonnull TrackedEntityProgramOwner trackedEntityProgramOwner) {
     super.save(trackedEntityProgramOwner);
-    ownerCache.invalidate(
-        getOwnershipCacheKey(
-            trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram()));
+    invalidateOwnershipCache(
+        trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram());
   }
 
   @Override
   public void update(@Nonnull TrackedEntityProgramOwner trackedEntityProgramOwner) {
     super.update(trackedEntityProgramOwner);
-    ownerCache.invalidate(
-        getOwnershipCacheKey(
-            trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram()));
+    invalidateOwnershipCache(
+        trackedEntityProgramOwner.getTrackedEntity(), trackedEntityProgramOwner.getProgram());
+  }
+
+  @Override
+  public void invalidateOwnershipCache(TrackedEntity te, Program program) {
+    ownerCache.invalidate(getOwnershipCacheKey(te, program));
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerService.java
@@ -72,4 +72,11 @@ public interface TrackedEntityProgramOwnerService {
    */
   void createTrackedEntityProgramOwner(
       TrackedEntity trackedEntity, Program program, OrganisationUnit orgUnit);
+
+  /**
+   * Invalidates the cached ownership org unit for the te-program combination. Used by write paths
+   * that persist ownership without going through this service's {@code create*} methods (e.g. the
+   * JDBC tracker-import write batch in {@code EntityWriteBatch}).
+   */
+  void invalidateOwnershipCache(TrackedEntity trackedEntity, Program program);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/acl/TrackedEntityProgramOwnerStore.java
@@ -47,4 +47,11 @@ public interface TrackedEntityProgramOwnerStore extends GenericStore<TrackedEnti
   TrackedEntityProgramOwner getTrackedEntityProgramOwner(TrackedEntity te, Program program);
 
   List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits(Set<Long> teIds);
+
+  /**
+   * Invalidates the cached ownership org unit for the te-program combination. Used by write paths
+   * that persist ownership outside this store (e.g. the JDBC tracker-import write batch) and so do
+   * not go through {@link #save} / {@link #update}, which invalidate the cache themselves.
+   */
+  void invalidateOwnershipCache(TrackedEntity te, Program program);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
+import org.hibernate.annotations.QueryHints;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.SoftDeletableEntity;
 import org.hisp.dhis.common.SortDirection;
@@ -175,7 +176,14 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
         or (r.invertedKey in (:keys) and r.relationshipType.bidirectional = true))""";
     List<String> relationshipKeysAsString =
         relationshipKeys.stream().map(RelationshipKey::asString).toList();
-    return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString).list();
+    // Query cache must be off here: the tracker importer writes relationships through JDBC, which
+    // bypasses Hibernate's query-cache invalidation. Leaving the cache on would let an earlier
+    // empty result for a key linger across imports and silently disable duplicate detection.
+    return getQuery(hql, Relationship.class)
+        .setParameter("keys", relationshipKeysAsString)
+        .setCacheable(false)
+        .setHint(QueryHints.CACHEABLE, false)
+        .list();
   }
 
   public List<RelationshipItem> getRelationshipItemsByTrackedEntity(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.annotations.QueryHints;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.SoftDeletableEntity;
 import org.hisp.dhis.common.SortDirection;
@@ -85,7 +84,12 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher,
       AclService aclService) {
-    super(entityManager, jdbcTemplate, publisher, Relationship.class, aclService, true);
+    // cacheable=false: every query space this store reads (relationship, relationshipitem,
+    // trackedentity, enrollment, trackerevent, singleevent) is written via raw JDBC in the
+    // importer, which bypasses Hibernate's query-cache invalidation -- cached results would go
+    // stale across imports (e.g. an empty duplicate-check result would silently disable
+    // duplicate detection).
+    super(entityManager, jdbcTemplate, publisher, Relationship.class, aclService, false);
   }
 
   public Optional<TrackedEntity> findTrackedEntity(UID trackedEntity, boolean includeDeleted) {
@@ -176,14 +180,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
         or (r.invertedKey in (:keys) and r.relationshipType.bidirectional = true))""";
     List<String> relationshipKeysAsString =
         relationshipKeys.stream().map(RelationshipKey::asString).toList();
-    // Query cache must be off here: the tracker importer writes relationships through JDBC, which
-    // bypasses Hibernate's query-cache invalidation. Leaving the cache on would let an earlier
-    // empty result for a key linger across imports and silently disable duplicate detection.
-    return getQuery(hql, Relationship.class)
-        .setParameter("keys", relationshipKeysAsString)
-        .setCacheable(false)
-        .setHint(QueryHints.CACHEABLE, false)
-        .list();
+    return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString).list();
   }
 
   public List<RelationshipItem> getRelationshipItemsByTrackedEntity(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -108,16 +108,11 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
       return new CommitResult(PersistenceReport.emptyReport(), List.of());
     }
 
-    PersistResult trackedEntities =
-        commitService.getTrackerPersister().persist(entityManager, bundle);
-    PersistResult enrollments =
-        commitService.getEnrollmentPersister().persist(entityManager, bundle);
-    PersistResult trackerEvents =
-        commitService.getTrackerEventPersister().persist(entityManager, bundle);
-    PersistResult singleEvents =
-        commitService.getSingleEventPersister().persist(entityManager, bundle);
-    PersistResult relationships =
-        commitService.getRelationshipPersister().persist(entityManager, bundle);
+    PersistResult trackedEntities = commitService.getTrackerPersister().persist(bundle);
+    PersistResult enrollments = commitService.getEnrollmentPersister().persist(bundle);
+    PersistResult trackerEvents = commitService.getTrackerEventPersister().persist(bundle);
+    PersistResult singleEvents = commitService.getSingleEventPersister().persist(bundle);
+    PersistResult relationships = commitService.getRelationshipPersister().persist(bundle);
 
     PersistenceReport report =
         new PersistenceReport(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -32,13 +32,11 @@ package org.hisp.dhis.tracker.imports.bundle;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import jakarta.persistence.EntityManager;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.Session;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -58,6 +56,8 @@ import org.hisp.dhis.tracker.imports.programrule.ProgramRuleService;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,7 +69,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DefaultTrackerBundleService implements TrackerBundleService {
   private final TrackerPreheatService trackerPreheatService;
 
-  private final EntityManager entityManager;
+  private final NamedParameterJdbcTemplate jdbcTemplate;
 
   private final CommitService commitService;
 
@@ -141,31 +141,30 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
       return;
     }
 
-    List<List<UID>> uidsPartitions =
-        Lists.partition(Lists.newArrayList(bundle.getUpdatedTrackedEntities()), 20000);
-
-    try (Session session = entityManager.unwrap(Session.class)) {
-      for (List<UID> trackedEntities : uidsPartitions) {
-        if (trackedEntities.isEmpty()) {
-          continue;
-        }
-        executeLastUpdatedQuery(session, UID.toValueList(trackedEntities), bundle.getUser());
-      }
-    }
-  }
-
-  private void executeLastUpdatedQuery(
-      Session session, List<String> trackedEntities, UserDetails user) {
+    String userInfoJson;
     try {
-      UserInfoSnapshot userInfo = UserInfoSnapshot.from(user);
-      session
-          .getNamedQuery("updateTrackedEntitiesLastUpdated")
-          .setParameter("trackedEntities", trackedEntities)
-          .setParameter("lastUpdated", new Date())
-          .setParameter("lastupdatedbyuserinfo", mapper.writeValueAsString(userInfo))
-          .executeUpdate();
+      userInfoJson = mapper.writeValueAsString(UserInfoSnapshot.from(bundle.getUser()));
     } catch (JsonProcessingException e) {
       throw new PersistenceException(e);
+    }
+
+    Date lastUpdated = new Date();
+    String sql =
+        "update trackedentity set lastUpdated = :lastUpdated,"
+            + " lastupdatedbyuserinfo = CAST(:lastupdatedbyuserinfo as jsonb)"
+            + " where uid in (:trackedEntities)";
+
+    for (List<UID> partition :
+        Lists.partition(Lists.newArrayList(bundle.getUpdatedTrackedEntities()), 20000)) {
+      if (partition.isEmpty()) {
+        continue;
+      }
+      MapSqlParameterSource params =
+          new MapSqlParameterSource()
+              .addValue("trackedEntities", UID.toValueList(partition))
+              .addValue("lastUpdated", lastUpdated)
+              .addValue("lastupdatedbyuserinfo", userInfoJson);
+      jdbcTemplate.update(sql, params);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -95,6 +96,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   @PersistenceContext private EntityManager entityManager;
 
   protected final DataSource dataSource;
+
+  protected final FileResourceStore fileResourceStore;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
@@ -362,9 +365,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       return;
     }
 
-    fileResource.setAssigned(isAssign);
-    fileResource.setFileResourceOwner(fileResourceOwner);
-    entityManager.merge(fileResource);
+    fileResourceStore.updateAssignment(fileResource.getUid(), isAssign, fileResourceOwner);
   }
 
   protected void handleTrackedEntityAttributeValues(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -35,6 +35,9 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
@@ -82,17 +85,20 @@ import org.hisp.dhis.user.UserDetails;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends IdentifiableObject>
     implements TrackerPersister<T, V> {
+  private static final DateTimeFormatter DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+
+  @PersistenceContext private EntityManager entityManager;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
    * flow of Tracker entities
    *
-   * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
    * @return a {@link TrackerTypeReport}
    */
   @Override
-  public PersistResult persist(EntityManager entityManager, TrackerBundle bundle) {
+  public PersistResult persist(TrackerBundle bundle) {
     //
     // Init the report that will hold the results of the persist operation
     //
@@ -134,7 +140,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
         if (isNew(bundle, trackerDto)) {
           entityManager.persist(convertedDto);
           updateDataValues(
-              entityManager,
               bundle.getPreheat(),
               trackerDto,
               convertedDto,
@@ -144,12 +149,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           typeReport.getStats().incCreated();
           typeReport.addEntity(objectReport);
           updateAttributes(
-              entityManager,
-              bundle.getPreheat(),
-              trackerDto,
-              convertedDto,
-              bundle.getUser(),
-              changeLogs);
+              bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
           bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
         } else {
           if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -157,7 +157,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             // Relationships are not updated. A warning was already added to the report
           } else {
             updateDataValues(
-                entityManager,
                 bundle.getPreheat(),
                 trackerDto,
                 convertedDto,
@@ -165,12 +164,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 bundle.getUser(),
                 changeLogs);
             updateAttributes(
-                entityManager,
-                bundle.getPreheat(),
-                trackerDto,
-                convertedDto,
-                bundle.getUser(),
-                changeLogs);
+                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
             entityManager.merge(convertedDto);
             typeReport.getStats().incUpdated();
             typeReport.addEntity(objectReport);
@@ -254,7 +248,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       T trackerDto,
       V payloadEntity,
@@ -264,7 +257,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /** Execute the persistence of Attribute values linked to the entity being processed */
   protected abstract void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       T trackerDto,
       V hibernateEntity,
@@ -334,22 +326,16 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   // // // // // // // //
   // // // // // // // //
 
-  protected void assignFileResource(
-      EntityManager entityManager, TrackerPreheat preheat, String fileResourceOwner, String fr) {
-    assignFileResource(entityManager, preheat, fileResourceOwner, fr, true);
+  protected void assignFileResource(TrackerPreheat preheat, String fileResourceOwner, String fr) {
+    assignFileResource(preheat, fileResourceOwner, fr, true);
   }
 
-  protected void unassignFileResource(
-      EntityManager entityManager, TrackerPreheat preheat, String fileResourceOwner, String fr) {
-    assignFileResource(entityManager, preheat, fileResourceOwner, fr, false);
+  protected void unassignFileResource(TrackerPreheat preheat, String fileResourceOwner, String fr) {
+    assignFileResource(preheat, fileResourceOwner, fr, false);
   }
 
   private void assignFileResource(
-      EntityManager entityManager,
-      TrackerPreheat preheat,
-      String fileResourceOwner,
-      String fr,
-      boolean isAssign) {
+      TrackerPreheat preheat, String fileResourceOwner, String fr, boolean isAssign) {
     FileResource fileResource = preheat.get(FileResource.class, fr);
 
     if (fileResource == null) {
@@ -362,7 +348,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected void handleTrackedEntityAttributeValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
@@ -394,10 +379,9 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
           if (isDelete && !isNew) {
-            delete(entityManager, preheat, currentValue, trackedEntity, user, changeLogs);
+            delete(preheat, currentValue, trackedEntity, user, changeLogs);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
-                entityManager,
                 preheat,
                 trackedEntity,
                 attribute,
@@ -411,7 +395,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   private void saveOrUpdateAttributeValue(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntity trackedEntity,
       Attribute attribute,
@@ -433,26 +416,17 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             .setLastUpdated(new Date());
 
     saveOrUpdate(
-        entityManager,
-        preheat,
-        isNew,
-        trackedEntity,
-        attributeToPersist,
-        previousValue,
-        user,
-        changeLogs);
+        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs);
   }
 
   private void delete(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       TrackedEntity trackedEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
-      unassignFileResource(
-          entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
+      unassignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     entityManager.remove(
@@ -470,7 +444,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   private void saveOrUpdate(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       boolean isNew,
       TrackedEntity trackedEntity,
@@ -479,8 +452,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     if (isFileResource(trackedEntityAttributeValue)) {
-      assignFileResource(
-          entityManager, preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
+      assignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     ChangeLogType changeLogType;
@@ -522,9 +494,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected static String formatDate(Date date) {
-    java.text.SimpleDateFormat formatter =
-        new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    return date != null ? formatter.format(date) : null;
+    return date != null ? DATE_FORMATTER.format(date.toInstant()) : null;
   }
 
   protected static String formatGeometry(org.locationtech.jts.geom.Geometry geometry) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -43,6 +43,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -78,8 +79,12 @@ import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
+import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.Relationship;
+import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.model.TrackerEvent;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
@@ -151,7 +156,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           // Save or update the entity
           //
           if (isNew(bundle, trackerDto)) {
-            entityManager.persist(convertedDto);
+            stageInsert(convertedDto, batch);
             updateDataValues(
                 bundle.getPreheat(),
                 trackerDto,
@@ -183,7 +188,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                   bundle.getUser(),
                   changeLogs,
                   batch);
-              entityManager.merge(convertedDto);
+              stageUpdate(convertedDto, batch);
               typeReport.getStats().incUpdated();
               typeReport.addEntity(objectReport);
               bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
@@ -254,6 +259,40 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       DataSourceUtils.releaseConnection(conn, dataSource);
     }
     return new PersistResult(typeReport, notifications);
+  }
+
+  private void stageInsert(V convertedDto, EntityWriteBatch batch) {
+    if (convertedDto instanceof TrackedEntity te) {
+      batch.stageInsert(te);
+    } else if (convertedDto instanceof Enrollment e) {
+      batch.stageInsert(e);
+    } else if (convertedDto instanceof TrackerEvent e) {
+      batch.stageInsert(e);
+    } else if (convertedDto instanceof SingleEvent e) {
+      batch.stageInsert(e);
+    } else if (convertedDto instanceof Relationship r) {
+      batch.stageInsert(r);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported entity type: " + convertedDto.getClass().getName());
+    }
+  }
+
+  // Relationships are not updated -- the persister branch above ignores update payloads before
+  // this is called -- so no Relationship case is needed here.
+  private void stageUpdate(V convertedDto, EntityWriteBatch batch) {
+    if (convertedDto instanceof TrackedEntity te) {
+      batch.stageUpdate(te);
+    } else if (convertedDto instanceof Enrollment e) {
+      batch.stageUpdate(e);
+    } else if (convertedDto instanceof TrackerEvent e) {
+      batch.stageUpdate(e);
+    } else if (convertedDto instanceof SingleEvent e) {
+      batch.stageUpdate(e);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported entity type for update: " + convertedDto.getClass().getName());
+    }
   }
 
   // // // // // // // //
@@ -404,19 +443,24 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     // already attached to the session, preventing a duplicate em.persist that would throw
     // EntityExistsException. The batch overlay catches the within-persister case (e.g. two
     // enrollments under the same TE both carrying the same attribute) where the second occurrence
-    // would otherwise produce a fresh instance with the same composite key.
+    // would otherwise produce a fresh instance with the same composite key. A transient TE
+    // (id == 0) has no DB rows yet -- the insert is still staged in the batch -- so binding it as
+    // a query parameter would throw TransientObjectException; skip the JPQL in that case and rely
+    // on the batch overlay alone.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
-        entityManager
-            .createQuery(
-                "select v from TrackedEntityAttributeValue v where v.trackedEntity = :te",
-                TrackedEntityAttributeValue.class)
-            .setParameter("te", trackedEntity)
-            .getResultList()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    teav -> idSchemes.toMetadataIdentifier(teav.getAttribute()),
-                    Function.identity()));
+        trackedEntity.getId() == 0
+            ? new HashMap<>()
+            : entityManager
+                .createQuery(
+                    "select v from TrackedEntityAttributeValue v where v.trackedEntity = :te",
+                    TrackedEntityAttributeValue.class)
+                .setParameter("te", trackedEntity)
+                .getResultList()
+                .stream()
+                .collect(
+                    Collectors.toMap(
+                        teav -> idSchemes.toMetadataIdentifier(teav.getAttribute()),
+                        Function.identity()));
     batch
         .stagedFor(trackedEntity)
         .forEach(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -35,8 +35,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -53,7 +51,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import lombok.AccessLevel;
@@ -101,7 +98,10 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   private static final DateTimeFormatter DATE_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
-  @PersistenceContext private EntityManager entityManager;
+  private static final String EXISTING_ATTRIBUTE_VALUES_SQL =
+      "select trackedentityattributeid, value"
+          + " from trackedentityattributevalue"
+          + " where trackedentityid = ?";
 
   protected final DataSource dataSource;
 
@@ -176,7 +176,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             typeReport.getStats().incCreated();
             typeReport.addEntity(objectReport);
             updateAttributes(
-                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs, batch);
+                conn,
+                bundle.getPreheat(),
+                trackerDto,
+                convertedDto,
+                bundle.getUser(),
+                changeLogs,
+                batch);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
           } else {
             if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -191,6 +197,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                   bundle.getUser(),
                   changeLogs);
               updateAttributes(
+                  conn,
                   bundle.getPreheat(),
                   trackerDto,
                   convertedDto,
@@ -220,8 +227,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           if (FlushMode.OBJECT == bundle.getFlushMode()) {
             // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
             // (trackedentityid, eventid) exist before changelog rows reference them.
-            batch.flush(entityManager, conn);
-            entityManager.flush();
+            batch.flush(conn);
             changeLogs.flushAll(conn);
           }
         } catch (Exception e) {
@@ -258,8 +264,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       if (FlushMode.AUTO == bundle.getFlushMode()) {
         // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
         // (trackedentityid, eventid) exist before changelog rows reference them.
-        batch.flush(entityManager, conn);
-        entityManager.flush();
+        batch.flush(conn);
         changeLogs.flushAll(conn);
       }
     } catch (SQLException e) {
@@ -361,7 +366,17 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
    */
   protected abstract V convert(TrackerBundle bundle, T trackerDto);
 
-  /** Persists ownership records for the given entity */
+  /**
+   * Persists ownership records for the given entity. The only non-trivial implementation
+   * (enrollments creating a {@link org.hisp.dhis.tracker.model.TrackedEntityProgramOwner}) still
+   * goes through a Hibernate {@code save()} that is never flushed per entity -- a per-entity
+   * session flush would dirty-check the whole preheat-populated persistence context, which is the
+   * overhead the JDBC write path removed. Consequence: a constraint violation on the owner row
+   * (only reachable via a concurrent import racing on the {@code trackedentityid + programid}
+   * unique key) surfaces at transaction commit, outside the per-entity try/catch in {@link
+   * #persist}, so in non-atomic mode stats can report the enrollment as created while the commit
+   * then fails.
+   */
   protected abstract void persistOwnership(TrackerBundle bundle, T trackerDto, V entity);
 
   /** Execute the persistence of Data values linked to the entity being processed */
@@ -373,8 +388,14 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       UserDetails user,
       ChangeLogAccumulator changeLogs);
 
-  /** Execute the persistence of Attribute values linked to the entity being processed */
+  /**
+   * Execute the persistence of Attribute values linked to the entity being processed. {@code
+   * connection} is the transaction-bound JDBC connection held by {@link #persist} -- attribute
+   * handling reads existing values through it so the reads see rows staged by earlier persisters in
+   * the same (uncommitted) transaction.
+   */
   protected abstract void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       T trackerDto,
       V hibernateEntity,
@@ -499,6 +520,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected void handleTrackedEntityAttributeValues(
+      Connection connection,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
@@ -510,37 +532,27 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     }
 
     TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
-    // TODO [Phase 6 / DHIS2-21378]: drop this JPQL query and the batch overlay below once
-    // EntityWriteBatch is shared across persisters and writes go through JDBC instead of the
-    // EntityManager. At that point the batch itself is the source of truth for "what has already
-    // been staged for this TE", and DB rows can be loaded eagerly by the preheat -- no per-call
-    // round-trip needed here. Until then: build the lookup from the EntityManager rather than
-    // the lazy TE collection. The collection is a Hibernate PersistentSet whose in-memory state
-    // diverges from the persistence context once a write to a TE attribute has been deferred
-    // (staged in EntityWriteBatch) and flushed by a prior persister -- the same logical TEAV
-    // (composite key trackedentityid + trackedentityattributeid) can appear on a TrackedEntity
-    // payload and on an Enrollment payload, and querying the EM here sees both DB rows and TEAVs
-    // already attached to the session, preventing a duplicate em.persist that would throw
-    // EntityExistsException. The batch overlay catches the within-persister case (e.g. two
-    // enrollments under the same TE both carrying the same attribute) where the second occurrence
-    // would otherwise produce a fresh instance with the same composite key. A TE staged for
-    // insert in this batch has no DB row yet -- whether or not its id is set (Phase 4a pre-
-    // allocates the id from the sequence) -- so the JPQL would always return empty and the lookup
-    // can be skipped.
+    // TODO [Phase 6 / DHIS2-21378]: drop this lookup and the batch overlay below once
+    // EntityWriteBatch is shared across persisters (it is currently created per persist() call).
+    // At that point the batch itself is the source of truth for "what has already been staged for
+    // this TE", and DB rows can be loaded eagerly by the preheat -- no per-call round-trip needed
+    // here. Until then: read the existing values straight from the DB via JDBC on the
+    // transaction-bound connection. TEAV writes also go through JDBC on that same connection (see
+    // EntityWriteBatch), so a TEAV inserted/updated by a prior persister in this same import is an
+    // uncommitted row that is nonetheless visible to this read because both run in the same
+    // transaction -- the same logical TEAV (composite key
+    // trackedentityid + trackedentityattributeid) can appear on a TrackedEntity payload and on an
+    // Enrollment payload, and finding the existing row here routes the second occurrence to an
+    // UPDATE instead of a duplicate INSERT (which would violate the composite PK). The batch
+    // overlay catches the within-persister case (e.g. two enrollments under the same TE both
+    // carrying the same attribute) where the second occurrence would otherwise produce a fresh
+    // instance with the same composite key. A TE staged for insert in this batch has no DB row yet
+    // -- whether or not its id is set (Phase 4a pre-allocates the id from the sequence) -- so the
+    // read would always return empty and can be skipped.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
         batch.isStagedAsInsert(trackedEntity)
             ? new HashMap<>()
-            : entityManager
-                .createQuery(
-                    "select v from TrackedEntityAttributeValue v where v.trackedEntity = :te",
-                    TrackedEntityAttributeValue.class)
-                .setParameter("te", trackedEntity)
-                .getResultList()
-                .stream()
-                .collect(
-                    Collectors.toMap(
-                        teav -> idSchemes.toMetadataIdentifier(teav.getAttribute()),
-                        Function.identity()));
+            : loadExistingAttributeValues(connection, preheat, idSchemes, trackedEntity);
     batch
         .stagedFor(trackedEntity)
         .forEach(
@@ -575,6 +587,53 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 batch);
           }
         });
+  }
+
+  /**
+   * Reads the tracked entity's existing attribute values straight from the DB via JDBC on the
+   * transaction-bound connection held by {@link #persist}, keyed by the attribute's {@link
+   * MetadataIdentifier}. Replaces the former JPQL lookup so the persister no longer needs an {@code
+   * EntityManager}; the values are plain {@link TrackedEntityAttributeValue} instances (not
+   * Hibernate-managed), matching what the {@code value} property mapping ({@code
+   * access="property"}) produces on load. Attributes are resolved from the preheat by primary key,
+   * which is independent of the import's configured idScheme -- the preheat lookup maps are keyed
+   * by the idScheme identifier, so resolving by the UID read from the DB would silently miss every
+   * existing value under idScheme CODE/NAME/ATTRIBUTE, turning updates into duplicate INSERTs.
+   * Existing values for attributes not in the preheat are skipped -- the caller only probes
+   * attributes that appear in the payload, and those are always preheated.
+   */
+  private Map<MetadataIdentifier, TrackedEntityAttributeValue> loadExistingAttributeValues(
+      Connection connection,
+      TrackerPreheat preheat,
+      TrackerIdSchemeParams idSchemes,
+      TrackedEntity trackedEntity) {
+    Map<Long, TrackedEntityAttribute> attributesById =
+        preheat.getAll(TrackedEntityAttribute.class).stream()
+            .collect(Collectors.toMap(TrackedEntityAttribute::getId, a -> a, (a, b) -> a));
+    Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById = new HashMap<>();
+    try (PreparedStatement ps = connection.prepareStatement(EXISTING_ATTRIBUTE_VALUES_SQL)) {
+      ps.setLong(1, trackedEntity.getId());
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          TrackedEntityAttribute attribute =
+              attributesById.get(rs.getLong("trackedentityattributeid"));
+          if (attribute == null) {
+            continue;
+          }
+          TrackedEntityAttributeValue value =
+              new TrackedEntityAttributeValue()
+                  .setAttribute(attribute)
+                  .setTrackedEntity(trackedEntity)
+                  .setValue(rs.getString("value"));
+          attributeValueById.put(idSchemes.toMetadataIdentifier(attribute), value);
+        }
+      }
+    } catch (SQLException e) {
+      throw new PersistenceException(
+          "Failed to load existing attribute values for tracked entity " + trackedEntity.getUid(),
+          e);
+    }
+    return attributeValueById;
   }
 
   private void saveOrUpdateAttributeValue(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -295,6 +295,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       e.setId(id);
     } else if (convertedDto instanceof TrackerEvent ev) {
       ev.setId(id);
+    } else if (convertedDto instanceof SingleEvent sev) {
+      sev.setId(id);
     } else {
       throw new IllegalStateException(
           "Pre-allocated id assignment not implemented for "

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -79,12 +79,10 @@ import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
-import org.hisp.dhis.tracker.model.Enrollment;
-import org.hisp.dhis.tracker.model.Relationship;
-import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.model.TrackerEvent;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
@@ -164,7 +162,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             if (preAllocatedIds != null) {
               assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
             }
-            persistOwnership(bundle, trackerDto, convertedDto);
+            persistOwnership(bundle, trackerDto, convertedDto, batch);
             stageInsert(convertedDto, batch);
             updateDataValues(
                 bundle.getPreheat(),
@@ -293,58 +291,25 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     return allocateIds(conn, sequenceName, createCount);
   }
 
-  private void assignId(V convertedDto, long id) {
-    if (convertedDto instanceof TrackedEntity te) {
-      te.setId(id);
-    } else if (convertedDto instanceof Enrollment e) {
-      e.setId(id);
-    } else if (convertedDto instanceof TrackerEvent ev) {
-      ev.setId(id);
-    } else if (convertedDto instanceof SingleEvent sev) {
-      sev.setId(id);
-    } else if (convertedDto instanceof Relationship r) {
-      r.setId(id);
-    } else {
-      throw new IllegalStateException(
-          "Pre-allocated id assignment not implemented for "
-              + convertedDto.getClass().getName()
-              + " -- sequenceName() returned non-null but assignId does not handle this type.");
-    }
-  }
+  /**
+   * Assigns a pre-allocated id to a new entity. Implemented by each concrete persister against its
+   * statically-known entity type {@code V}; only invoked when {@link #sequenceName()} is non-null.
+   */
+  protected abstract void assignId(V convertedDto, long id);
 
-  private void stageInsert(V convertedDto, EntityWriteBatch batch) {
-    if (convertedDto instanceof TrackedEntity te) {
-      batch.stageInsert(te);
-    } else if (convertedDto instanceof Enrollment e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof TrackerEvent e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof SingleEvent e) {
-      batch.stageInsert(e);
-    } else if (convertedDto instanceof Relationship r) {
-      batch.stageInsert(r);
-    } else {
-      throw new IllegalArgumentException(
-          "Unsupported entity type: " + convertedDto.getClass().getName());
-    }
-  }
+  /**
+   * Stages a new entity for insertion in the batch. Implemented by each concrete persister against
+   * its statically-known entity type {@code V}, so the correct {@link EntityWriteBatch} overload is
+   * selected at compile time rather than by runtime type dispatch.
+   */
+  protected abstract void stageInsert(V convertedDto, EntityWriteBatch batch);
 
-  // Relationships are not updated -- the persister branch above ignores update payloads before
-  // this is called -- so no Relationship case is needed here.
-  private void stageUpdate(V convertedDto, EntityWriteBatch batch) {
-    if (convertedDto instanceof TrackedEntity te) {
-      batch.stageUpdate(te);
-    } else if (convertedDto instanceof Enrollment e) {
-      batch.stageUpdate(e);
-    } else if (convertedDto instanceof TrackerEvent e) {
-      batch.stageUpdate(e);
-    } else if (convertedDto instanceof SingleEvent e) {
-      batch.stageUpdate(e);
-    } else {
-      throw new IllegalArgumentException(
-          "Unsupported entity type for update: " + convertedDto.getClass().getName());
-    }
-  }
+  /**
+   * Stages an existing entity for update in the batch. {@link RelationshipPersister} throws, as
+   * relationships are never updated -- the persister branch in {@link #persist} ignores update
+   * payloads before this is called.
+   */
+  protected abstract void stageUpdate(V convertedDto, EntityWriteBatch batch);
 
   // // // // // // // //
   // // // // // // // //
@@ -368,16 +333,15 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /**
    * Persists ownership records for the given entity. The only non-trivial implementation
-   * (enrollments creating a {@link org.hisp.dhis.tracker.model.TrackedEntityProgramOwner}) still
-   * goes through a Hibernate {@code save()} that is never flushed per entity -- a per-entity
-   * session flush would dirty-check the whole preheat-populated persistence context, which is the
-   * overhead the JDBC write path removed. Consequence: a constraint violation on the owner row
-   * (only reachable via a concurrent import racing on the {@code trackedentityid + programid}
-   * unique key) surfaces at transaction commit, outside the per-entity try/catch in {@link
-   * #persist}, so in non-atomic mode stats can report the enrollment as created while the commit
-   * then fails.
+   * (enrollments creating a {@link org.hisp.dhis.tracker.model.TrackedEntityProgramOwner}) stages
+   * the owner row into {@code batch} for a single batched multi-row INSERT at flush, alongside the
+   * other entity writes. Staging within the per-entity try/catch means a rollback also drops the
+   * staged owner, and the {@code trackedentityid + programid} unique-key violation (only reachable
+   * via a concurrent import racing on the same key) now surfaces at the batch flush rather than at
+   * transaction commit.
    */
-  protected abstract void persistOwnership(TrackerBundle bundle, T trackerDto, V entity);
+  protected abstract void persistOwnership(
+      TrackerBundle bundle, T trackerDto, V entity, EntityWriteBatch batch);
 
   /** Execute the persistence of Data values linked to the entity being processed */
   protected abstract void updateDataValues(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -34,9 +34,12 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -104,6 +107,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   protected final FileResourceStore fileResourceStore;
 
+  protected final ObjectMapper objectMapper;
+
   /**
    * Template method that can be used by classes extending this class to execute the persistence
    * flow of Tracker entities
@@ -120,7 +125,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
     List<EntityNotifications> notifications = new ArrayList<>();
     ChangeLogAccumulator changeLogs = new ChangeLogAccumulator();
-    EntityWriteBatch batch = new EntityWriteBatch();
+    EntityWriteBatch batch = new EntityWriteBatch(objectMapper);
 
     //
     // Extract the entities to persist from the Bundle
@@ -129,6 +134,11 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
     Connection conn = DataSourceUtils.getConnection(dataSource);
     try {
+      // Pre-allocate primary keys in a single round-trip for entity types that opt in.
+      // The cursor advances only on isNew branches inside the loop below.
+      long[] preAllocatedIds = preAllocateIds(conn, bundle, dtos);
+      int preAllocatedIdsCursor = 0;
+
       for (T trackerDto : dtos) {
 
         Entity objectReport = new Entity(getType(), trackerDto.getUID());
@@ -146,6 +156,15 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           // Convert the TrackerDto into an Hibernate-managed entity
           //
           V convertedDto = convert(bundle, trackerDto);
+
+          //
+          // Assign the pre-allocated id (if any) before staging so the flush path can emit it
+          // unchanged, and so any TEAV/changelog code that reads convertedDto.getId() sees the
+          // final value.
+          //
+          if (preAllocatedIds != null && isNew(bundle, trackerDto)) {
+            assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
+          }
 
           //
           // Handle ownership records, if required
@@ -211,7 +230,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           if (FlushMode.OBJECT == bundle.getFlushMode()) {
             // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
             // (trackedentityid, eventid) exist before changelog rows reference them.
-            batch.flush(entityManager);
+            batch.flush(entityManager, conn);
             entityManager.flush();
             changeLogs.flushAll(conn);
           }
@@ -249,7 +268,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       if (FlushMode.AUTO == bundle.getFlushMode()) {
         // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
         // (trackedentityid, eventid) exist before changelog rows reference them.
-        batch.flush(entityManager);
+        batch.flush(entityManager, conn);
         entityManager.flush();
         changeLogs.flushAll(conn);
       }
@@ -259,6 +278,35 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       DataSourceUtils.releaseConnection(conn, dataSource);
     }
     return new PersistResult(typeReport, notifications);
+  }
+
+  private long[] preAllocateIds(Connection conn, TrackerBundle bundle, List<T> dtos)
+      throws SQLException {
+    String sequenceName = sequenceName();
+    if (sequenceName == null) {
+      return null;
+    }
+    int createCount = 0;
+    for (T dto : dtos) {
+      if (isNew(bundle, dto)) {
+        createCount++;
+      }
+    }
+    if (createCount == 0) {
+      return null;
+    }
+    return allocateIds(conn, sequenceName, createCount);
+  }
+
+  private void assignId(V convertedDto, long id) {
+    if (convertedDto instanceof TrackedEntity te) {
+      te.setId(id);
+    } else {
+      throw new IllegalStateException(
+          "Pre-allocated id assignment not implemented for "
+              + convertedDto.getClass().getName()
+              + " -- sequenceName() returned non-null but assignId does not handle this type.");
+    }
   }
 
   private void stageInsert(V convertedDto, EntityWriteBatch batch) {
@@ -393,6 +441,40 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   @SuppressWarnings("unchecked")
   protected abstract List<T> getByType(TrackerBundle bundle);
 
+  /**
+   * Returns the PostgreSQL sequence used to allocate primary keys for this entity type, or {@code
+   * null} if id allocation should be left to Hibernate. When non-null, {@link #persist} pre-fetches
+   * one id per CREATE entity in a single round-trip and assigns the id before staging so the flush
+   * path can emit a multi-row INSERT.
+   */
+  protected abstract String sequenceName();
+
+  /**
+   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
+   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
+   * a {@code regclass}, and the value comes from {@link #sequenceName()} — controlled by us, not
+   * user input.
+   */
+  private static long[] allocateIds(Connection conn, String sequenceName, int count)
+      throws SQLException {
+    long[] ids = new long[count];
+    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setInt(1, count);
+      try (ResultSet rs = ps.executeQuery()) {
+        int i = 0;
+        while (rs.next()) {
+          ids[i++] = rs.getLong(1);
+        }
+        if (i != count) {
+          throw new SQLException(
+              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
+        }
+      }
+    }
+    return ids;
+  }
+
   // // // // // // // //
   // // // // // // // //
   // SHARED METHODS //
@@ -443,12 +525,12 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     // already attached to the session, preventing a duplicate em.persist that would throw
     // EntityExistsException. The batch overlay catches the within-persister case (e.g. two
     // enrollments under the same TE both carrying the same attribute) where the second occurrence
-    // would otherwise produce a fresh instance with the same composite key. A transient TE
-    // (id == 0) has no DB rows yet -- the insert is still staged in the batch -- so binding it as
-    // a query parameter would throw TransientObjectException; skip the JPQL in that case and rely
-    // on the batch overlay alone.
+    // would otherwise produce a fresh instance with the same composite key. A TE staged for
+    // insert in this batch has no DB row yet -- whether or not its id is set (Phase 4a pre-
+    // allocates the id from the sequence) -- so the JPQL would always return empty and the lookup
+    // can be skipped.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
-        trackedEntity.getId() == 0
+        batch.isStagedAsInsert(trackedEntity)
             ? new HashMap<>()
             : entityManager
                 .createQuery(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -81,8 +81,6 @@ import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.model.TrackerEvent;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -115,6 +115,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
     List<EntityNotifications> notifications = new ArrayList<>();
     ChangeLogAccumulator changeLogs = new ChangeLogAccumulator();
+    EntityWriteBatch batch = new EntityWriteBatch();
 
     //
     // Extract the entities to persist from the Bundle
@@ -131,7 +132,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
         boolean completedInThisImport =
             !bundle.isSkipSideEffects()
                 && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
-        ChangeLogAccumulator.Mark mark = changeLogs.mark();
+        ChangeLogAccumulator.Mark changeLogMark = changeLogs.mark();
+        EntityWriteBatch.Mark batchMark = batch.mark();
         try {
           V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
 
@@ -160,7 +162,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             typeReport.getStats().incCreated();
             typeReport.addEntity(objectReport);
             updateAttributes(
-                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+                bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs, batch);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
           } else {
             if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -175,7 +177,12 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                   bundle.getUser(),
                   changeLogs);
               updateAttributes(
-                  bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+                  bundle.getPreheat(),
+                  trackerDto,
+                  convertedDto,
+                  bundle.getUser(),
+                  changeLogs,
+                  batch);
               entityManager.merge(convertedDto);
               typeReport.getStats().incUpdated();
               typeReport.addEntity(objectReport);
@@ -199,11 +206,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           if (FlushMode.OBJECT == bundle.getFlushMode()) {
             // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
             // (trackedentityid, eventid) exist before changelog rows reference them.
+            batch.flush(entityManager);
             entityManager.flush();
             changeLogs.flushAll(conn);
           }
         } catch (Exception e) {
-          changeLogs.rollbackTo(mark);
+          batch.rollbackTo(batchMark);
+          changeLogs.rollbackTo(changeLogMark);
 
           final String msg =
               "A Tracker Entity of type '"
@@ -235,6 +244,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       if (FlushMode.AUTO == bundle.getFlushMode()) {
         // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
         // (trackedentityid, eventid) exist before changelog rows reference them.
+        batch.flush(entityManager);
         entityManager.flush();
         changeLogs.flushAll(conn);
       }
@@ -284,7 +294,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       T trackerDto,
       V hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs);
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch);
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -373,18 +384,44 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
 
     TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
+    // TODO [Phase 6 / DHIS2-21378]: drop this JPQL query and the batch overlay below once
+    // EntityWriteBatch is shared across persisters and writes go through JDBC instead of the
+    // EntityManager. At that point the batch itself is the source of truth for "what has already
+    // been staged for this TE", and DB rows can be loaded eagerly by the preheat -- no per-call
+    // round-trip needed here. Until then: build the lookup from the EntityManager rather than
+    // the lazy TE collection. The collection is a Hibernate PersistentSet whose in-memory state
+    // diverges from the persistence context once a write to a TE attribute has been deferred
+    // (staged in EntityWriteBatch) and flushed by a prior persister -- the same logical TEAV
+    // (composite key trackedentityid + trackedentityattributeid) can appear on a TrackedEntity
+    // payload and on an Enrollment payload, and querying the EM here sees both DB rows and TEAVs
+    // already attached to the session, preventing a duplicate em.persist that would throw
+    // EntityExistsException. The batch overlay catches the within-persister case (e.g. two
+    // enrollments under the same TE both carrying the same attribute) where the second occurrence
+    // would otherwise produce a fresh instance with the same composite key.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
-        trackedEntity.getTrackedEntityAttributeValues().stream()
+        entityManager
+            .createQuery(
+                "select v from TrackedEntityAttributeValue v where v.trackedEntity = :te",
+                TrackedEntityAttributeValue.class)
+            .setParameter("te", trackedEntity)
+            .getResultList()
+            .stream()
             .collect(
                 Collectors.toMap(
                     teav -> idSchemes.toMetadataIdentifier(teav.getAttribute()),
                     Function.identity()));
+    batch
+        .stagedFor(trackedEntity)
+        .forEach(
+            teav ->
+                attributeValueById.put(idSchemes.toMetadataIdentifier(teav.getAttribute()), teav));
 
     payloadAttributes.forEach(
         attribute -> {
@@ -400,7 +437,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
           if (isDelete && !isNew) {
-            delete(preheat, currentValue, trackedEntity, user, changeLogs);
+            delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
           } else if (valueChanged) {
             saveOrUpdateAttributeValue(
                 preheat,
@@ -410,7 +447,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 isNew,
                 previousValue,
                 user,
-                changeLogs);
+                changeLogs,
+                batch);
           }
         });
   }
@@ -423,7 +461,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       boolean isNew,
       String previousValue,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     TrackedEntityAttributeValue attributeToPersist =
         Optional.ofNullable(currentValue)
             .orElseGet(
@@ -437,7 +476,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             .setLastUpdated(new Date());
 
     saveOrUpdate(
-        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs);
+        preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs, batch);
   }
 
   private void delete(
@@ -445,15 +484,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       TrackedEntity trackedEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (isFileResource(trackedEntityAttributeValue)) {
       unassignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
-    entityManager.remove(
-        entityManager.contains(trackedEntityAttributeValue)
-            ? trackedEntityAttributeValue
-            : entityManager.merge(trackedEntityAttributeValue));
+    batch.stageTeavDelete(trackedEntityAttributeValue);
 
     changeLogs.addTrackedEntityChangeLog(
         trackedEntity,
@@ -471,20 +508,18 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       TrackedEntityAttributeValue trackedEntityAttributeValue,
       String previousValue,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     if (isFileResource(trackedEntityAttributeValue)) {
       assignFileResource(preheat, trackedEntity.getUid(), trackedEntityAttributeValue.getValue());
     }
 
     ChangeLogType changeLogType;
     if (isNew) {
-      entityManager.persist(trackedEntityAttributeValue);
-      // In case it's a newly created attribute we'll add it back to TE,
-      // so it can end up in preheat
-      trackedEntity.getTrackedEntityAttributeValues().add(trackedEntityAttributeValue);
+      batch.stageTeavInsert(trackedEntityAttributeValue);
       changeLogType = CREATE;
     } else {
-      entityManager.merge(trackedEntityAttributeValue);
+      batch.stageTeavUpdate(trackedEntityAttributeValue);
       changeLogType = UPDATE;
     }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -297,6 +297,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       ev.setId(id);
     } else if (convertedDto instanceof SingleEvent sev) {
       sev.setId(id);
+    } else if (convertedDto instanceof Relationship r) {
+      r.setId(id);
     } else {
       throw new IllegalStateException(
           "Pre-allocated id assignment not implemented for "

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -36,6 +36,8 @@ import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,6 +80,7 @@ import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 /**
  * @author Luciano Fiandesio
@@ -89,6 +93,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
   @PersistenceContext private EntityManager entityManager;
+
+  protected final DataSource dataSource;
 
   /**
    * Template method that can be used by classes extending this class to execute the persistence
@@ -112,50 +118,35 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
     //
     List<T> dtos = getByType(bundle);
 
-    for (T trackerDto : dtos) {
+    Connection conn = DataSourceUtils.getConnection(dataSource);
+    try {
+      for (T trackerDto : dtos) {
 
-      Entity objectReport = new Entity(getType(), trackerDto.getUID());
-      boolean isNewEntity = isNew(bundle, trackerDto);
-      // Capture before convert() which mutates the preheat entity's status
-      boolean completedInThisImport =
-          !bundle.isSkipSideEffects()
-              && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
-      ChangeLogAccumulator.Mark mark = changeLogs.mark();
-      try {
-        V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
+        Entity objectReport = new Entity(getType(), trackerDto.getUID());
+        boolean isNewEntity = isNew(bundle, trackerDto);
+        // Capture before convert() which mutates the preheat entity's status
+        boolean completedInThisImport =
+            !bundle.isSkipSideEffects()
+                && isBeingCompleted(bundle.getPreheat(), trackerDto, isNewEntity);
+        ChangeLogAccumulator.Mark mark = changeLogs.mark();
+        try {
+          V originalEntity = cloneEntityProperties(bundle.getPreheat(), trackerDto);
 
-        //
-        // Convert the TrackerDto into an Hibernate-managed entity
-        //
-        V convertedDto = convert(bundle, trackerDto);
+          //
+          // Convert the TrackerDto into an Hibernate-managed entity
+          //
+          V convertedDto = convert(bundle, trackerDto);
 
-        //
-        // Handle ownership records, if required
-        //
-        persistOwnership(bundle, trackerDto, convertedDto);
+          //
+          // Handle ownership records, if required
+          //
+          persistOwnership(bundle, trackerDto, convertedDto);
 
-        //
-        // Save or update the entity
-        //
-        if (isNew(bundle, trackerDto)) {
-          entityManager.persist(convertedDto);
-          updateDataValues(
-              bundle.getPreheat(),
-              trackerDto,
-              convertedDto,
-              originalEntity,
-              bundle.getUser(),
-              changeLogs);
-          typeReport.getStats().incCreated();
-          typeReport.addEntity(objectReport);
-          updateAttributes(
-              bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
-          bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
-        } else {
-          if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
-            typeReport.getStats().incIgnored();
-            // Relationships are not updated. A warning was already added to the report
-          } else {
+          //
+          // Save or update the entity
+          //
+          if (isNew(bundle, trackerDto)) {
+            entityManager.persist(convertedDto);
             updateDataValues(
                 bundle.getPreheat(),
                 trackerDto,
@@ -163,62 +154,91 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                 originalEntity,
                 bundle.getUser(),
                 changeLogs);
+            typeReport.getStats().incCreated();
+            typeReport.addEntity(objectReport);
             updateAttributes(
                 bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
-            entityManager.merge(convertedDto);
-            typeReport.getStats().incUpdated();
-            typeReport.addEntity(objectReport);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
+          } else {
+            if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
+              typeReport.getStats().incIgnored();
+              // Relationships are not updated. A warning was already added to the report
+            } else {
+              updateDataValues(
+                  bundle.getPreheat(),
+                  trackerDto,
+                  convertedDto,
+                  originalEntity,
+                  bundle.getUser(),
+                  changeLogs);
+              updateAttributes(
+                  bundle.getPreheat(), trackerDto, convertedDto, bundle.getUser(), changeLogs);
+              entityManager.merge(convertedDto);
+              typeReport.getStats().incUpdated();
+              typeReport.addEntity(objectReport);
+              bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
+            }
           }
-        }
 
-        if (!bundle.isSkipSideEffects()) {
-          EntityNotifications entityNotifications =
-              collectNotifications(bundle, convertedDto, isNewEntity, completedInThisImport);
-          if (entityNotifications != null) {
-            notifications.add(entityNotifications);
+          if (!bundle.isSkipSideEffects()) {
+            EntityNotifications entityNotifications =
+                collectNotifications(bundle, convertedDto, isNewEntity, completedInThisImport);
+            if (entityNotifications != null) {
+              notifications.add(entityNotifications);
+            }
           }
-        }
 
-        //
-        // Add the entity to the Preheat
-        //
-        updatePreheat(bundle.getPreheat(), convertedDto);
+          //
+          // Add the entity to the Preheat
+          //
+          updatePreheat(bundle.getPreheat(), convertedDto);
 
-        if (FlushMode.OBJECT == bundle.getFlushMode()) {
-          // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
-          // (trackedentityid, eventid) exist before changelog rows reference them.
-          entityManager.flush();
-          changeLogs.flushAll(entityManager);
-        }
-      } catch (Exception e) {
-        changeLogs.rollbackTo(mark);
+          if (FlushMode.OBJECT == bundle.getFlushMode()) {
+            // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+            // (trackedentityid, eventid) exist before changelog rows reference them.
+            entityManager.flush();
+            changeLogs.flushAll(conn);
+          }
+        } catch (Exception e) {
+          changeLogs.rollbackTo(mark);
 
-        final String msg =
-            "A Tracker Entity of type '"
-                + getType().getName()
-                + "' ("
-                + trackerDto.getUID()
-                + ") failed to persist.";
+          final String msg =
+              "A Tracker Entity of type '"
+                  + getType().getName()
+                  + "' ("
+                  + trackerDto.getUID()
+                  + ") failed to persist.";
 
-        if (AtomicMode.ALL.equals(bundle.getAtomicMode())) {
-          throw new PersistenceException(msg, e);
-        } else {
-          // TODO currently we do not keep track of the failed entity
-          // in the TrackerObjectReport
+          if (AtomicMode.ALL.equals(bundle.getAtomicMode())) {
+            throw new PersistenceException(msg, e);
+          } else {
+            // TODO currently we do not keep track of the failed entity
+            // in the TrackerObjectReport
 
-          log.warn(msg + "\nThe Import process will process remaining entities.", e);
+            // TODO: if the failure originated from a JDBC flush (changeLogs.flushAll or, from
+            // Phase 3 onward, EntityWriteBatch.flush), the underlying PostgreSQL connection is
+            // now in an aborted-transaction state. Any subsequent SQL on the same connection
+            // will fail with "current transaction is aborted". This means a single JDBC flush
+            // failure in non-atomic mode silently cascades and causes all remaining entities to
+            // be ignored as well. Consider wrapping each entity's JDBC flush in a savepoint so
+            // that a failure can be rolled back to the savepoint and the connection stays usable.
+            log.warn(msg + "\nThe Import process will process remaining entities.", e);
 
-          typeReport.getStats().incIgnored();
+            typeReport.getStats().incIgnored();
+          }
         }
       }
-    }
 
-    if (FlushMode.AUTO == bundle.getFlushMode()) {
-      // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
-      // (trackedentityid, eventid) exist before changelog rows reference them.
-      entityManager.flush();
-      changeLogs.flushAll(entityManager);
+      if (FlushMode.AUTO == bundle.getFlushMode()) {
+        // Flush entity INSERTs/UPDATEs before changelog INSERTs so FK references
+        // (trackedentityid, eventid) exist before changelog rows reference them.
+        entityManager.flush();
+        changeLogs.flushAll(conn);
+      }
+    } catch (SQLException e) {
+      throw new PersistenceException(e);
+    } finally {
+      DataSourceUtils.releaseConnection(conn, dataSource);
     }
     return new PersistResult(typeReport, notifications);
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -158,23 +158,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           V convertedDto = convert(bundle, trackerDto);
 
           //
-          // Assign the pre-allocated id (if any) before staging so the flush path can emit it
-          // unchanged, and so any TEAV/changelog code that reads convertedDto.getId() sees the
-          // final value.
-          //
-          if (preAllocatedIds != null && isNew(bundle, trackerDto)) {
-            assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
-          }
-
-          //
-          // Handle ownership records, if required
-          //
-          persistOwnership(bundle, trackerDto, convertedDto);
-
-          //
           // Save or update the entity
           //
           if (isNew(bundle, trackerDto)) {
+            if (preAllocatedIds != null) {
+              assignId(convertedDto, preAllocatedIds[preAllocatedIdsCursor++]);
+            }
+            persistOwnership(bundle, trackerDto, convertedDto);
             stageInsert(convertedDto, batch);
             updateDataValues(
                 bundle.getPreheat(),
@@ -301,6 +291,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   private void assignId(V convertedDto, long id) {
     if (convertedDto instanceof TrackedEntity te) {
       te.setId(id);
+    } else if (convertedDto instanceof Enrollment e) {
+      e.setId(id);
     } else {
       throw new IllegalStateException(
           "Pre-allocated id assignment not implemented for "

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -293,6 +293,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       te.setId(id);
     } else if (convertedDto instanceof Enrollment e) {
       e.setId(id);
+    } else if (convertedDto instanceof TrackerEvent ev) {
+      ev.setId(id);
     } else {
       throw new IllegalStateException(
           "Pre-allocated id assignment not implemented for "

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -96,10 +96,15 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   private static final DateTimeFormatter DATE_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
+  // One batched read of existing attribute values for every tracked entity touched by this
+  // persister run, keyed by tracked-entity uid (resolved by the join so callers need only the
+  // payload uids, not pre-resolved DB ids). New tracked entities have no row yet at read time, so
+  // the join simply returns nothing for them. Replaces the former per-tracked-entity SELECT.
   private static final String EXISTING_ATTRIBUTE_VALUES_SQL =
-      "select trackedentityattributeid, value"
-          + " from trackedentityattributevalue"
-          + " where trackedentityid = ?";
+      "select teav.trackedentityid, teav.trackedentityattributeid, teav.value"
+          + " from trackedentityattributevalue teav"
+          + " join trackedentity te on te.trackedentityid = teav.trackedentityid"
+          + " where te.uid = any(?)";
 
   protected final DataSource dataSource;
 
@@ -136,6 +141,15 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
       // The cursor advances only on isNew branches inside the loop below.
       long[] preAllocatedIds = preAllocateIds(conn, bundle, dtos);
       int preAllocatedIdsCursor = 0;
+
+      // One batched read of existing attribute values for all tracked entities this run touches,
+      // keyed by tracked-entity id. Threaded into attribute handling as a mutable per-run map: it
+      // is seeded from the DB (so it sees rows an earlier persister flushed on this connection) and
+      // updated as TEAVs are staged, so a second occurrence of the same logical TEAV within this
+      // run is routed to an UPDATE instead of a duplicate INSERT.
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues =
+          loadExistingAttributeValues(
+              conn, bundle.getPreheat(), trackedEntityUidsForAttributeLoad(dtos));
 
       for (T trackerDto : dtos) {
 
@@ -174,13 +188,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             typeReport.getStats().incCreated();
             typeReport.addEntity(objectReport);
             updateAttributes(
-                conn,
                 bundle.getPreheat(),
                 trackerDto,
                 convertedDto,
                 bundle.getUser(),
                 changeLogs,
-                batch);
+                batch,
+                existingAttributeValues);
             bundle.addUpdatedTrackedEntities(getUpdatedTrackedEntities(convertedDto));
           } else {
             if (trackerDto.getTrackerType() == TrackerType.RELATIONSHIP) {
@@ -195,13 +209,13 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
                   bundle.getUser(),
                   changeLogs);
               updateAttributes(
-                  conn,
                   bundle.getPreheat(),
                   trackerDto,
                   convertedDto,
                   bundle.getUser(),
                   changeLogs,
-                  batch);
+                  batch,
+                  existingAttributeValues);
               stageUpdate(convertedDto, batch);
               typeReport.getStats().incUpdated();
               typeReport.addEntity(objectReport);
@@ -354,18 +368,27 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
   /**
    * Execute the persistence of Attribute values linked to the entity being processed. {@code
-   * connection} is the transaction-bound JDBC connection held by {@link #persist} -- attribute
-   * handling reads existing values through it so the reads see rows staged by earlier persisters in
-   * the same (uncommitted) transaction.
+   * existingAttributeValues} is the per-run map of already-known attribute values keyed by tracked
+   * entity id (see {@link #persist}); attribute handling reads and mutates it instead of querying
+   * the DB per tracked entity.
    */
   protected abstract void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       T trackerDto,
       V hibernateEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch);
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues);
+
+  /**
+   * The uids of the tracked entities whose existing attribute values must be bulk-loaded before the
+   * persist loop. Empty by default (persisters that do not write tracked-entity attribute values);
+   * overridden by the TrackedEntity and Enrollment persisters.
+   */
+  protected Set<String> trackedEntityUidsForAttributeLoad(List<T> dtos) {
+    return Set.of();
+  }
 
   /** Updates the {@link TrackerPreheat} object with the entity that has been persisted */
   protected abstract void updatePreheat(TrackerPreheat preheat, V convertedDto);
@@ -421,7 +444,6 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   /** Get the Tracker Type for which the current Persister is responsible for. */
   protected abstract TrackerType getType();
 
-  @SuppressWarnings("unchecked")
   protected abstract List<T> getByType(TrackerBundle bundle);
 
   /**
@@ -440,22 +462,7 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
    */
   private static long[] allocateIds(Connection conn, String sequenceName, int count)
       throws SQLException {
-    long[] ids = new long[count];
-    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
-    try (PreparedStatement ps = conn.prepareStatement(sql)) {
-      ps.setInt(1, count);
-      try (ResultSet rs = ps.executeQuery()) {
-        int i = 0;
-        while (rs.next()) {
-          ids[i++] = rs.getLong(1);
-        }
-        if (i != count) {
-          throw new SQLException(
-              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
-        }
-      }
-    }
-    return ids;
+    return JdbcBatchSupport.allocateIds(conn, sequenceName, count);
   }
 
   // // // // // // // //
@@ -484,44 +491,29 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
   }
 
   protected void handleTrackedEntityAttributeValues(
-      Connection connection,
       TrackerPreheat preheat,
       List<Attribute> payloadAttributes,
       TrackedEntity trackedEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     if (payloadAttributes.isEmpty()) {
       return;
     }
 
-    TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
-    // TODO [Phase 6 / DHIS2-21378]: drop this lookup and the batch overlay below once
-    // EntityWriteBatch is shared across persisters (it is currently created per persist() call).
-    // At that point the batch itself is the source of truth for "what has already been staged for
-    // this TE", and DB rows can be loaded eagerly by the preheat -- no per-call round-trip needed
-    // here. Until then: read the existing values straight from the DB via JDBC on the
-    // transaction-bound connection. TEAV writes also go through JDBC on that same connection (see
-    // EntityWriteBatch), so a TEAV inserted/updated by a prior persister in this same import is an
-    // uncommitted row that is nonetheless visible to this read because both run in the same
-    // transaction -- the same logical TEAV (composite key
-    // trackedentityid + trackedentityattributeid) can appear on a TrackedEntity payload and on an
-    // Enrollment payload, and finding the existing row here routes the second occurrence to an
-    // UPDATE instead of a duplicate INSERT (which would violate the composite PK). The batch
-    // overlay catches the within-persister case (e.g. two enrollments under the same TE both
-    // carrying the same attribute) where the second occurrence would otherwise produce a fresh
-    // instance with the same composite key. A TE staged for insert in this batch has no DB row yet
-    // -- whether or not its id is set (Phase 4a pre-allocates the id from the sequence) -- so the
-    // read would always return empty and can be skipped.
+    // The per-tracked-entity slice of the run's existing-values map. Seeded by the bulk read in
+    // persist() and kept current here: each staged save/update is reflected back so a later
+    // occurrence of the same logical TEAV (composite key trackedentityid +
+    // trackedentityattributeid)
+    // within this run -- e.g. two enrollments under the same TE both carrying the same attribute --
+    // is routed to an UPDATE instead of a duplicate INSERT. A brand-new tracked entity simply has
+    // no
+    // row in the read, so its slice starts empty. The bulk read leaves trackedEntity unset (it has
+    // only the id), so bind it to this entity for the writers and change logs.
     Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById =
-        batch.isStagedAsInsert(trackedEntity)
-            ? new HashMap<>()
-            : loadExistingAttributeValues(connection, preheat, idSchemes, trackedEntity);
-    batch
-        .stagedFor(trackedEntity)
-        .forEach(
-            teav ->
-                attributeValueById.put(idSchemes.toMetadataIdentifier(teav.getAttribute()), teav));
+        existingAttributeValues.computeIfAbsent(trackedEntity.getId(), k -> new HashMap<>());
+    attributeValueById.values().forEach(v -> v.setTrackedEntity(trackedEntity));
 
     payloadAttributes.forEach(
         attribute -> {
@@ -538,45 +530,53 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
           if (isDelete && !isNew) {
             delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
+            // Leave the entry in the map: the DELETE is not flushed until the end of the run, so a
+            // later occurrence of the same TE+attribute in this run must still see it as existing
+            // (matching the pre-batch DB-read behaviour).
           } else if (valueChanged) {
-            saveOrUpdateAttributeValue(
-                preheat,
-                trackedEntity,
-                attribute,
-                currentValue,
-                isNew,
-                previousValue,
-                user,
-                changeLogs,
-                batch);
+            TrackedEntityAttributeValue persisted =
+                saveOrUpdateAttributeValue(
+                    preheat,
+                    trackedEntity,
+                    attribute,
+                    currentValue,
+                    isNew,
+                    previousValue,
+                    user,
+                    changeLogs,
+                    batch);
+            attributeValueById.put(attribute.getAttribute(), persisted);
           }
         });
   }
 
   /**
-   * Reads the tracked entity's existing attribute values straight from the DB via JDBC on the
-   * transaction-bound connection held by {@link #persist}, keyed by the attribute's {@link
-   * MetadataIdentifier}. Replaces the former JPQL lookup so the persister no longer needs an {@code
-   * EntityManager}; the values are plain {@link TrackedEntityAttributeValue} instances (not
-   * Hibernate-managed), matching what the {@code value} property mapping ({@code
-   * access="property"}) produces on load. Attributes are resolved from the preheat by primary key,
-   * which is independent of the import's configured idScheme -- the preheat lookup maps are keyed
-   * by the idScheme identifier, so resolving by the UID read from the DB would silently miss every
-   * existing value under idScheme CODE/NAME/ATTRIBUTE, turning updates into duplicate INSERTs.
-   * Existing values for attributes not in the preheat are skipped -- the caller only probes
-   * attributes that appear in the payload, and those are always preheated.
+   * Reads, in a single round-trip, the existing attribute values of every tracked entity in {@code
+   * trackedEntityUids}, grouped by tracked-entity id and keyed within each group by the attribute's
+   * {@link MetadataIdentifier}. Runs on the transaction-bound connection held by {@link #persist},
+   * so it sees rows an earlier persister flushed on the same (uncommitted) transaction. The values
+   * are plain {@link TrackedEntityAttributeValue} instances (not Hibernate-managed), matching what
+   * the {@code value} property mapping ({@code access="property"}) produces on load, with {@code
+   * trackedEntity} left unset (the caller binds it). Attributes are resolved from the preheat by
+   * primary key, which is independent of the import's configured idScheme -- the preheat lookup
+   * maps are keyed by the idScheme identifier, so resolving by the UID read from the DB would
+   * silently miss every existing value under idScheme CODE/NAME/ATTRIBUTE, turning updates into
+   * duplicate INSERTs. Existing values for attributes not in the preheat are skipped -- the caller
+   * only probes attributes that appear in the payload, and those are always preheated.
    */
-  private Map<MetadataIdentifier, TrackedEntityAttributeValue> loadExistingAttributeValues(
-      Connection connection,
-      TrackerPreheat preheat,
-      TrackerIdSchemeParams idSchemes,
-      TrackedEntity trackedEntity) {
+  private Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>>
+      loadExistingAttributeValues(
+          Connection connection, TrackerPreheat preheat, Set<String> trackedEntityUids) {
+    Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingByTe = new HashMap<>();
+    if (trackedEntityUids.isEmpty()) {
+      return existingByTe;
+    }
+    TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
     Map<Long, TrackedEntityAttribute> attributesById =
         preheat.getAll(TrackedEntityAttribute.class).stream()
             .collect(Collectors.toMap(TrackedEntityAttribute::getId, a -> a, (a, b) -> a));
-    Map<MetadataIdentifier, TrackedEntityAttributeValue> attributeValueById = new HashMap<>();
     try (PreparedStatement ps = connection.prepareStatement(EXISTING_ATTRIBUTE_VALUES_SQL)) {
-      ps.setLong(1, trackedEntity.getId());
+      ps.setArray(1, connection.createArrayOf("text", trackedEntityUids.toArray(new String[0])));
       try (ResultSet rs = ps.executeQuery()) {
         while (rs.next()) {
           TrackedEntityAttribute attribute =
@@ -587,20 +587,19 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           TrackedEntityAttributeValue value =
               new TrackedEntityAttributeValue()
                   .setAttribute(attribute)
-                  .setTrackedEntity(trackedEntity)
                   .setValue(rs.getString("value"));
-          attributeValueById.put(idSchemes.toMetadataIdentifier(attribute), value);
+          existingByTe
+              .computeIfAbsent(rs.getLong("trackedentityid"), k -> new HashMap<>())
+              .put(idSchemes.toMetadataIdentifier(attribute), value);
         }
       }
     } catch (SQLException e) {
-      throw new PersistenceException(
-          "Failed to load existing attribute values for tracked entity " + trackedEntity.getUid(),
-          e);
+      throw new PersistenceException("Failed to load existing attribute values", e);
     }
-    return attributeValueById;
+    return existingByTe;
   }
 
-  private void saveOrUpdateAttributeValue(
+  private TrackedEntityAttributeValue saveOrUpdateAttributeValue(
       TrackerPreheat preheat,
       TrackedEntity trackedEntity,
       Attribute attribute,
@@ -624,6 +623,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
 
     saveOrUpdate(
         preheat, isNew, trackedEntity, attributeToPersist, previousValue, user, changeLogs, batch);
+
+    return attributeToPersist;
   }
 
   private void delete(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/ChangeLogAccumulator.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -40,7 +39,6 @@ import java.util.Date;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import org.hibernate.Session;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
@@ -185,15 +183,15 @@ class ChangeLogAccumulator {
     truncate(singleEventChangeLogs, mark.singleEventSize);
   }
 
-  void flushAll(EntityManager entityManager) {
+  void flushAll(Connection connection) throws SQLException {
     if (teChangeLogs.isEmpty()
         && trackerEventChangeLogs.isEmpty()
         && singleEventChangeLogs.isEmpty()) {
       return;
     }
 
-    Session session = entityManager.unwrap(Session.class);
-    session.doWork(this::insertAll);
+    insertAll(connection);
+
     teChangeLogs.clear();
     trackerEventChangeLogs.clear();
     singleEventChangeLogs.clear();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -71,13 +71,15 @@ public class EnrollmentPersister
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     handleTrackedEntityAttributeValues(
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
         user,
-        changeLogs);
+        changeLogs,
+        batch);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -70,7 +70,7 @@ public class EnrollmentPersister
 
   @Override
   protected String sequenceName() {
-    return "programinstance_sequence";
+    return "enrollment_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -60,9 +61,15 @@ public class EnrollmentPersister
   public EnrollmentPersister(
       DataSource dataSource,
       FileResourceStore fileResourceStore,
+      ObjectMapper objectMapper,
       TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
-    super(dataSource, fileResourceStore);
+    super(dataSource, fileResourceStore, objectMapper);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
+  }
+
+  @Override
+  protected String sequenceName() {
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -74,6 +75,7 @@ public class EnrollmentPersister
 
   @Override
   protected void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
@@ -81,6 +83,7 @@ public class EnrollmentPersister
       ChangeLogAccumulator changeLogs,
       EntityWriteBatch batch) {
     handleTrackedEntityAttributeValues(
+        connection,
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -48,6 +48,8 @@ import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -71,6 +73,21 @@ public class EnrollmentPersister
   @Override
   protected String sequenceName() {
     return "enrollment_sequence";
+  }
+
+  @Override
+  protected void assignId(Enrollment entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(Enrollment entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(Enrollment entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
   }
 
   @Override
@@ -155,7 +172,8 @@ public class EnrollmentPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
-      Enrollment entity) {
+      Enrollment entity,
+      EntityWriteBatch batch) {
     if ((bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
         || bundle
                 .getPreheat()
@@ -163,8 +181,20 @@ public class EnrollmentPersister
                 .get(entity.getTrackedEntity().getUID())
                 .get(entity.getProgram().getUid())
             == null)) {
-      trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
-          entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
+      // Mirrors DefaultTrackedEntityProgramOwnerService.createTrackedEntityProgramOwner, but stages
+      // the row into the write batch instead of a per-enrollment Hibernate save (see
+      // AbstractTrackerPersister#persistOwnership and TrackedEntityProgramOwnerWriter).
+      TrackedEntityProgramOwner owner =
+          new TrackedEntityProgramOwner(
+              entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
+      owner.updateDates();
+      owner.setCreatedBy(CurrentUserUtil.getCurrentUsername());
+      batch.stageOwnershipInsert(owner);
+      // The store's save()/update() invalidate the program-owner cache; since we bypass the store,
+      // invalidate it here so a stale "no owner / registering org unit" entry cached before this
+      // import does not survive the newly created ownership.
+      trackedEntityProgramOwnerService.invalidateOwnershipCache(
+          entity.getTrackedEntity(), entity.getProgram());
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -62,14 +61,12 @@ public class EnrollmentPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
     handleTrackedEntityAttributeValues(
-        entityManager,
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
@@ -156,7 +153,6 @@ public class EnrollmentPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
       Enrollment payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.notification.NotificationTrigger;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
@@ -58,8 +59,9 @@ public class EnrollmentPersister
 
   public EnrollmentPersister(
       DataSource dataSource,
+      FileResourceStore fileResourceStore,
       TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
-    super(dataSource);
+    super(dataSource, fileResourceStore);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.notification.NotificationTrigger;
@@ -55,7 +56,10 @@ public class EnrollmentPersister
     extends AbstractTrackerPersister<org.hisp.dhis.tracker.imports.domain.Enrollment, Enrollment> {
   private final TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
-  public EnrollmentPersister(TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
+  public EnrollmentPersister(
+      DataSource dataSource,
+      TrackedEntityProgramOwnerService trackedEntityProgramOwnerService) {
+    super(dataSource);
     this.trackedEntityProgramOwnerService = trackedEntityProgramOwnerService;
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -69,7 +69,7 @@ public class EnrollmentPersister
 
   @Override
   protected String sequenceName() {
-    return null;
+    return "programinstance_sequence";
   }
 
   @Override
@@ -153,14 +153,13 @@ public class EnrollmentPersister
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.Enrollment trackerDto,
       Enrollment entity) {
-    if (isNew(bundle, trackerDto)
-        && (bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
-            || bundle
-                    .getPreheat()
-                    .getProgramOwner()
-                    .get(entity.getTrackedEntity().getUID())
-                    .get(entity.getProgram().getUid())
-                == null)) {
+    if ((bundle.getPreheat().getProgramOwner().get(entity.getTrackedEntity().getUID()) == null
+        || bundle
+                .getPreheat()
+                .getProgramOwner()
+                .get(entity.getTrackedEntity().getUID())
+                .get(entity.getProgram().getUid())
+            == null)) {
       trackedEntityProgramOwnerService.createTrackedEntityProgramOwner(
           entity.getTrackedEntity(), entity.getProgram(), entity.getOrganisationUnit());
     }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -30,10 +30,11 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.fileresource.FileResourceStore;
@@ -44,10 +45,12 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.acl.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
@@ -92,21 +95,31 @@ public class EnrollmentPersister
 
   @Override
   protected void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
       Enrollment enrollmentToPersist,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     handleTrackedEntityAttributeValues(
-        connection,
         preheat,
         enrollment.getAttributes(),
         enrollmentToPersist.getTrackedEntity(),
         user,
         changeLogs,
-        batch);
+        batch,
+        existingAttributeValues);
+  }
+
+  @Override
+  protected Set<String> trackedEntityUidsForAttributeLoad(
+      List<org.hisp.dhis.tracker.imports.domain.Enrollment> dtos) {
+    return dtos.stream()
+        .map(org.hisp.dhis.tracker.imports.domain.Enrollment::getTrackedEntity)
+        .filter(java.util.Objects::nonNull)
+        .map(UID::getValue)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.Enrollment;
+
+/**
+ * Flushes staged {@link Enrollment} writes: a multi-row JDBC INSERT against {@code enrollment} (ids
+ * pre-allocated from {@code enrollment_sequence}), a single unnest UPDATE, and a cascade insert of
+ * any new notes into {@code note} + {@code enrollment_notes}.
+ */
+final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
+
+  private static final String INSERT_PREFIX =
+      "insert into enrollment ("
+          + "enrollmentid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " enrollmentdate, occurreddate, completeddate, completedby,"
+          + " status, followup, deleted,"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
+          + " geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch. Insert-
+  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths (deleted)
+  // are deliberately excluded. status, completeddate, completedby are included even though the
+  // mapper only touches them on a status change -- writing the unchanged values back is a no-op
+  // against the existing row.
+  private static final String UPDATE_SQL =
+      "update enrollment e set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " trackedentityid = v.trackedentityid,"
+          + " programid = v.programid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " enrollmentdate = v.enrollmentdate,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " status = v.status,"
+          + " followup = v.followup,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::timestamptz[]) as enrollmentdate,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::boolean[]) as followup,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where e.enrollmentid = v.enrollmentid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("enrollment_notes", "enrollmentid");
+
+  EnrollmentWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, Enrollment::getId, Enrollment::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (Enrollment e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "Enrollment "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, e.getStatus().name());
+    if (e.getFollowup() != null) {
+      ps.setBoolean(p++, e.getFollowup());
+    } else {
+      ps.setNull(p++, Types.BOOLEAN);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    ps.setLong(p++, e.getTrackedEntity().getId());
+    ps.setLong(p++, e.getProgram().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] trackedEntityIds = new Long[n];
+          Long[] programIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] enrollmentDate = new String[n];
+          String[] occurredDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          String[] status = new String[n];
+          Boolean[] followup = new Boolean[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            Enrollment e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            trackedEntityIds[i] = e.getTrackedEntity().getId();
+            programIds[i] = e.getProgram().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            enrollmentDate[i] = toTimestamptz(e.getEnrollmentDate());
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            status[i] = e.getStatus().name();
+            followup[i] = e.getFollowup();
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(7, conn.createArrayOf("bigint", programIds));
+            ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(10, conn.createArrayOf("text", enrollmentDate));
+            ps.setArray(11, conn.createArrayOf("text", occurredDate));
+            ps.setArray(12, conn.createArrayOf("text", completedDate));
+            ps.setArray(13, conn.createArrayOf("text", completedBy));
+            ps.setArray(14, conn.createArrayOf("text", status));
+            ps.setArray(15, conn.createArrayOf("boolean", followup));
+            ps.setArray(16, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
@@ -57,14 +57,16 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
           + "enrollmentid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " createdbyuserinfo, lastupdatedbyuserinfo, enrollmentdate, occurreddate, completeddate,"
           + " completedby, status, followup, deleted,"
-          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid, geometry)"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid, geometry,"
+          + " storedby)"
           + " select enrollmentid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, enrollmentdate, occurreddate,"
           + " completeddate, completedby, status, followup, deleted,"
           + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
           + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + ") end"
+          + ") end,"
+          + " storedby"
           + " from ( select"
           + " unnest(?::bigint[]) as enrollmentid,"
           + " unnest(?::text[]) as uid,"
@@ -85,7 +87,8 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
           + " unnest(?::bigint[]) as programid,"
           + " unnest(?::bigint[]) as organisationunitid,"
           + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::text[]) as geometry"
+          + " unnest(?::text[]) as geometry,"
+          + " unnest(?::text[]) as storedby"
           + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch. Insert-
@@ -178,6 +181,7 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
             ps.setArray(p++, bigintArray(conn, chunk, e -> e.getOrganisationUnit().getId()));
             ps.setArray(p++, bigintArray(conn, chunk, e -> e.getAttributeOptionCombo().getId()));
             ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
+            ps.setArray(p++, textArray(conn, chunk, Enrollment::getStoredBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
@@ -30,18 +30,18 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.booleanArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import org.hisp.dhis.tracker.model.Enrollment;
 
 /**
@@ -51,21 +51,44 @@ import org.hisp.dhis.tracker.model.Enrollment;
  */
 final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count. INSERT column order, the SELECT projection and the unnest aliases are
+  // kept in lockstep.
+  private static final String INSERT_SQL =
       "insert into enrollment ("
-          + "enrollmentid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " enrollmentdate, occurreddate, completeddate, completedby,"
-          + " status, followup, deleted,"
+          + "enrollmentid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo, enrollmentdate, occurreddate, completeddate,"
+          + " completedby, status, followup, deleted,"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid, geometry)"
+          + " select enrollmentid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, enrollmentdate, occurreddate,"
+          + " completeddate, completedby, status, followup, deleted,"
           + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
-          + " geometry) values ";
-
-  private static final String INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-          + "ST_GeomFromText(?, "
+          + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + "))";
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as createdbyuserinfo,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::timestamptz[]) as enrollmentdate,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::boolean[]) as followup,"
+          + " unnest(?::boolean[]) as deleted,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch. Insert-
   // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths (deleted)
@@ -129,18 +152,41 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          for (Enrollment e : chunk) {
+            requirePreallocatedId(e);
+          }
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (Enrollment e : chunk) {
-              p = bindRow(ps, p, e);
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, Enrollment::getId));
+            ps.setArray(p++, textArray(conn, chunk, Enrollment::getUid));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+            ps.setArray(
+                p++,
+                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getEnrollmentDate())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCompletedDate())));
+            ps.setArray(p++, textArray(conn, chunk, Enrollment::getCompletedBy));
+            ps.setArray(p++, textArray(conn, chunk, e -> e.getStatus().name()));
+            ps.setArray(p++, booleanArray(conn, chunk, Enrollment::getFollowup));
+            ps.setArray(p++, booleanArray(conn, chunk, Enrollment::isDeleted));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getTrackedEntity().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getProgram().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getOrganisationUnit().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getAttributeOptionCombo().getId()));
+            ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
+  private static void requirePreallocatedId(Enrollment e) throws SQLException {
     if (e.getId() == 0) {
       throw new SQLException(
           "Enrollment "
@@ -148,39 +194,6 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
               + " has no pre-allocated id; AbstractTrackerPersister"
               + " must pre-allocate ids when sequenceName() is non-null.");
     }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
-    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, e.getStatus().name());
-    if (e.getFollowup() != null) {
-      ps.setBoolean(p++, e.getFollowup());
-    } else {
-      ps.setNull(p++, Types.BOOLEAN);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    ps.setLong(p++, e.getTrackedEntity().getId());
-    ps.setLong(p++, e.getProgram().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
   }
 
   private void update(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentWriter.java
@@ -35,10 +35,8 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bo
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -134,11 +132,11 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
           + " unnest(?::text[]) as geometry"
           + " ) v where e.enrollmentid = v.enrollmentid";
 
-  private final ObjectMapper objectMapper;
+  private final UserInfoJsonCache userInfo;
   private final NoteCascadeWriter notes = new NoteCascadeWriter("enrollment_notes", "enrollmentid");
 
-  EnrollmentWriter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  EnrollmentWriter(UserInfoJsonCache userInfo) {
+    this.userInfo = userInfo;
   }
 
   @Override
@@ -165,10 +163,9 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
             ps.setArray(
                 p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
             ps.setArray(
-                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getCreatedByUserInfo())));
             ps.setArray(
-                p++,
-                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getLastUpdatedByUserInfo())));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getEnrollmentDate())));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCompletedDate())));
@@ -225,7 +222,7 @@ final class EnrollmentWriter extends UpsertTableWriter<Enrollment> {
             lastUpdated[i] = toTimestamptz(e.getLastUpdated());
             createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
             lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            lastUpdatedByUserInfo[i] = userInfo.toJson(e.getLastUpdatedByUserInfo());
             trackedEntityIds[i] = e.getTrackedEntity().getId();
             programIds[i] = e.getProgram().getId();
             organisationUnitIds[i] = e.getOrganisationUnit().getId();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -82,12 +82,16 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       jsonb column is serialized as a JSON object keyed by dataElement uid, matching {@code
  *       JsonEventDataValueSetBinaryType}.
  *   <li>TrackerEvent updates are flushed via a JDBC unnest UPDATE against {@code trackerevent}.
- *   <li>Any new {@code note}s on inserted or updated enrollments / tracker events are
- *       cascade-inserted in further multi-row INSERTs (into {@code note} plus the matching {@code
- *       enrollment_notes} / {@code trackerevent_notes} join), replacing Hibernate's
- *       {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on UPDATE.
- *   <li>All remaining entity types (SingleEvent, Relationship) still delegate to {@link
- *       EntityManager}; their Phase 6 JDBC replacements follow.
+ *   <li>SingleEvent inserts / updates use the same shape as TrackerEvent but write to {@code
+ *       singleevent} (no {@code enrollmentid}, no {@code scheduleddate}); ids are pre-allocated
+ *       from {@code singleevent_sequence}.
+ *   <li>Any new {@code note}s on inserted or updated enrollments / tracker events / single events
+ *       are cascade-inserted in further multi-row INSERTs (into {@code note} plus the matching
+ *       {@code enrollment_notes} / {@code trackerevent_notes} / {@code singleevent_notes} join),
+ *       replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on
+ *       UPDATE.
+ *   <li>Relationship is the only remaining top-level entity type still delegating to {@link
+ *       EntityManager}; its Phase 6 JDBC replacement follows.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -287,6 +291,69 @@ class EntityWriteBatch {
       "insert into trackerevent_notes (eventid, noteid, sort_order) values ";
   private static final String TRACKER_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
+  // SingleEvent mirrors TrackerEvent without enrollmentid (single events aren't tied to an
+  // enrollment) and without scheduleddate. Sequence is singleevent_sequence per
+  // V2_43_21__split_event_table.sql.
+  private static final String SINGLE_EVENT_INSERT_PREFIX =
+      "insert into singleevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String SINGLE_EVENT_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + TRACKED_ENTITY_SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch (see
+  // TrackerObjectsMapper.java:270-322). Insert-only columns (uid, created, createdbyuserinfo,
+  // deleted) and columns owned by other code paths (lastsynchronized) are excluded.
+  private static final String SINGLE_EVENT_UPDATE_SQL =
+      "update singleevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  private static final String SINGLE_EVENT_NOTES_INSERT_PREFIX =
+      "insert into singleevent_notes (eventid, noteid, sort_order) values ";
+  private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
+
   private final ObjectMapper objectMapper;
 
   private final List<TrackedEntity> teInserts = new ArrayList<>();
@@ -430,8 +497,10 @@ class EntityWriteBatch {
     updateTrackerEvents(conn);
     insertTrackerEventNotes(conn);
     refreshUpdatedTrackerEvents(entityManager);
-    persistAll(entityManager, singleEventInserts);
-    mergeAll(entityManager, singleEventUpdates);
+    insertSingleEvents(conn);
+    updateSingleEvents(conn);
+    insertSingleEventNotes(conn);
+    refreshUpdatedSingleEvents(entityManager);
     persistAll(entityManager, relationshipInserts);
 
     for (TrackedEntityAttributeValue v : teavInserts) {
@@ -851,11 +920,8 @@ class EntityWriteBatch {
   /**
    * Reload the L1-cached TrackerEvent entities affected by {@link #updateTrackerEvents} from DB.
    * Must run AFTER {@link #insertTrackerEventNotes} so the refreshed entity's eager-fetched notes
-   * collection picks up the newly-appended notes. Using {@code em.refresh} (instead of {@code
-   * em.detach}) mirrors the side effect of the pre-migration {@code em.merge(detachedDto)} path
-   * that updated the L1-managed instance in place -- callers (and tests like {@code
-   * TrackerEventSMSTest.shouldUpdateEvent}) that hold a reference to the entity and compare it to a
-   * freshly-read row rely on the local reference seeing the new state.
+   * collection picks up the newly-appended notes. Mirrors the side effect of the pre-migration
+   * {@code em.merge(detachedDto)} path that updated the L1-managed instance in place.
    */
   private void refreshUpdatedTrackerEvents(EntityManager entityManager) {
     for (TrackerEvent e : trackerEventUpdates) {
@@ -1039,6 +1105,206 @@ class EntityWriteBatch {
     }
   }
 
+  private void insertSingleEvents(Connection conn) throws SQLException {
+    if (singleEventInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < singleEventInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, singleEventInserts.size());
+      List<SingleEvent> chunk = singleEventInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(SINGLE_EVENT_INSERT_PREFIX, SINGLE_EVENT_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (SingleEvent e : chunk) {
+          p = bindSingleEventRow(ps, p, e);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindSingleEventRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "SingleEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void updateSingleEvents(Connection conn) throws SQLException {
+    if (singleEventUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < singleEventUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, singleEventUpdates.size());
+      List<SingleEvent> chunk = singleEventUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      Long[] programStageIds = new Long[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] attributeOptionComboIds = new Long[n];
+      String[] status = new String[n];
+      Timestamp[] occurredDate = new Timestamp[n];
+      Timestamp[] completedDate = new Timestamp[n];
+      String[] completedBy = new String[n];
+      Long[] assignedUserIds = new Long[n];
+      String[] eventDataValues = new String[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        SingleEvent e = chunk.get(i);
+        ids[i] = e.getId();
+        lastUpdated[i] = toTimestamp(e.getLastUpdated());
+        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
+        programStageIds[i] = e.getProgramStage().getId();
+        organisationUnitIds[i] = e.getOrganisationUnit().getId();
+        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+        status[i] = e.getStatus().name();
+        occurredDate[i] = toTimestamp(e.getOccurredDate());
+        completedDate[i] = toTimestamp(e.getCompletedDate());
+        completedBy[i] = e.getCompletedBy();
+        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(SINGLE_EVENT_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
+        ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
+        ps.setArray(9, conn.createArrayOf("text", status));
+        ps.setArray(10, conn.createArrayOf("timestamptz", occurredDate));
+        ps.setArray(11, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(12, conn.createArrayOf("text", completedBy));
+        ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
+        ps.setArray(14, conn.createArrayOf("text", eventDataValues));
+        ps.setArray(15, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // L1 staleness is fixed by refreshUpdatedSingleEvents() called from flush() AFTER
+    // insertSingleEventNotes -- same reasoning as refreshUpdatedTrackerEvents.
+  }
+
+  private void refreshUpdatedSingleEvents(EntityManager entityManager) {
+    for (SingleEvent e : singleEventUpdates) {
+      SingleEvent managed = entityManager.find(SingleEvent.class, e.getId());
+      if (managed != null) {
+        entityManager.refresh(managed);
+      }
+    }
+  }
+
+  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code singleevent_notes} join table. */
+  private record SingleEventNoteToInsert(long eventId, Note note, int sortOrder)
+      implements NoteToInsert {}
+
+  private void insertSingleEventNotes(Connection conn) throws SQLException {
+    List<SingleEventNoteToInsert> newNotes = collectNewSingleEventNotes();
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertSingleEventNotesJoinRows(conn, newNotes);
+  }
+
+  private List<SingleEventNoteToInsert> collectNewSingleEventNotes() {
+    List<SingleEventNoteToInsert> newNotes = new ArrayList<>();
+    collectNewSingleEventNotesFrom(singleEventInserts, newNotes);
+    collectNewSingleEventNotesFrom(singleEventUpdates, newNotes);
+    return newNotes;
+  }
+
+  private static void collectNewSingleEventNotesFrom(
+      List<SingleEvent> events, List<SingleEventNoteToInsert> out) {
+    for (SingleEvent e : events) {
+      if (e.getNotes() == null) {
+        continue;
+      }
+      List<Note> notes = e.getNotes();
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new SingleEventNoteToInsert(e.getId(), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertSingleEventNotesJoinRows(
+      Connection conn, List<SingleEventNoteToInsert> newNotes) throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
+      List<SingleEventNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              SINGLE_EVENT_NOTES_INSERT_PREFIX, SINGLE_EVENT_NOTES_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (SingleEventNoteToInsert item : chunk) {
+          ps.setLong(p++, item.eventId());
+          ps.setLong(p++, item.note().getId());
+          ps.setInt(p++, item.sortOrder());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
   /**
    * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
    * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
@@ -1152,12 +1418,6 @@ class EntityWriteBatch {
   private static <T> void persistAll(EntityManager entityManager, List<T> entities) {
     for (T entity : entities) {
       entityManager.persist(entity);
-    }
-  }
-
-  private static <T> void mergeAll(EntityManager entityManager, List<T> entities) {
-    for (T entity : entities) {
-      entityManager.merge(entity);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -41,6 +41,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -105,8 +107,23 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       column were removed in DHIS2-21518, so the value is written as plain text in {@code value}.
  * </ul>
  *
- * <p>All reads and writes in the import path are JDBC, so no Hibernate-managed entities of these
- * types are loaded during commit and there is no L1 cache to reconcile after the writes.
+ * <p>All reads and writes in the import path go through JDBC, bypassing the Hibernate persistence
+ * context. Two consequences:
+ *
+ * <ul>
+ *   <li>L1 cache: the import itself never reads these entities back through Hibernate after the
+ *       writes, so nothing reconciles the persistence context at flush time. This is safe for
+ *       transaction-scoped sessions, but it is NOT a guarantee that the session is empty: preheat
+ *       strategies leave managed originals in the persistence context (DetachUtils maps detached
+ *       copies, it does not evict), so code holding a session open across the import transaction
+ *       (e.g. an SMS listener whose class-level {@code @Transactional} spans preheat, commit and
+ *       post-import reads) would observe stale pre-import state through that session.
+ *   <li>Auditing: the entity types written here are {@code @Auditable} (TEAV at scope TRACKER), and
+ *       JDBC writes skip Hibernate's Post{Insert,Update,Delete}AuditListener, so no audit events
+ *       are emitted for them. Deliberate trade-off: TRACKER-scope auditing is off by default, and
+ *       attribute-value history -- the sensitive payload -- is covered by the {@code
+ *       trackedentitychangelog} rows written by {@link ChangeLogAccumulator}.
+ * </ul>
  *
  * <p>Top-level entities are flushed before TEAVs so that ids are set and rows are present in the DB
  * before any TEAV that references them. Within top-level entities the order (TE inserts, TE
@@ -517,8 +534,8 @@ class EntityWriteBatch {
    * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
    * is being processed twice within one persister run -- e.g. two enrollments under the same TE
    * each carrying the same attribute value -- so it can fold the second occurrence into the first
-   * staged instance instead of producing a duplicate {@code em.persist} that would throw {@code
-   * EntityExistsException}.
+   * staged instance instead of staging a second INSERT for the same composite key, which would
+   * violate the primary key at flush.
    */
   Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
     return Stream.concat(teavInserts.stream(), teavUpdates.stream())
@@ -527,7 +544,7 @@ class EntityWriteBatch {
 
   /**
    * Whether the given TrackedEntity is being inserted in this batch (no DB row yet). Used by the
-   * attribute-handling code to skip the "load existing TEAVs" JPQL query, which would always return
+   * attribute-handling code to skip the JDBC read of existing TEAVs, which would always return
    * empty for a fresh insert.
    */
   boolean isStagedAsInsert(TrackedEntity trackedEntity) {
@@ -562,9 +579,9 @@ class EntityWriteBatch {
   /**
    * Applies all staged writes via JDBC on {@code conn} (including cascade INSERTs into {@code note}
    * and the per-entity notes join tables). The connection must be the one bound to the current
-   * Spring-managed transaction so the JDBC statements execute under the same commit. All reads and
-   * writes in the import path are JDBC, so no Hibernate-managed entities of these types are loaded
-   * during commit and there is no L1 cache to reconcile.
+   * Spring-managed transaction so the JDBC statements execute under the same commit. The writes
+   * bypass the Hibernate persistence context and audit listeners -- see the class javadoc for the
+   * scope of that trade-off.
    */
   void flush(Connection conn) throws SQLException {
     if (isEmpty()) {
@@ -614,9 +631,9 @@ class EntityWriteBatch {
       int n = chunk.size();
 
       Long[] ids = new Long[n];
-      Timestamp[] lastUpdated = new Timestamp[n];
-      Timestamp[] createdAtClient = new Timestamp[n];
-      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdated = new String[n];
+      String[] createdAtClient = new String[n];
+      String[] lastUpdatedAtClient = new String[n];
       Long[] organisationUnitIds = new Long[n];
       Long[] trackedEntityTypeIds = new Long[n];
       Boolean[] potentialDuplicate = new Boolean[n];
@@ -627,9 +644,9 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         TrackedEntity te = chunk.get(i);
         ids[i] = te.getId();
-        lastUpdated[i] = toTimestamp(te.getLastUpdated());
-        createdAtClient[i] = toTimestamp(te.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamp(te.getLastUpdatedAtClient());
+        lastUpdated[i] = toTimestamptz(te.getLastUpdated());
+        createdAtClient[i] = toTimestamptz(te.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamptz(te.getLastUpdatedAtClient());
         organisationUnitIds[i] = te.getOrganisationUnit().getId();
         trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
         potentialDuplicate[i] = te.isPotentialDuplicate();
@@ -640,9 +657,9 @@ class EntityWriteBatch {
 
       try (PreparedStatement ps = conn.prepareStatement(TRACKED_ENTITY_UPDATE_SQL)) {
         ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
         ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
         ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
         ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
@@ -777,17 +794,17 @@ class EntityWriteBatch {
       int n = chunk.size();
 
       Long[] ids = new Long[n];
-      Timestamp[] lastUpdated = new Timestamp[n];
-      Timestamp[] createdAtClient = new Timestamp[n];
-      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdated = new String[n];
+      String[] createdAtClient = new String[n];
+      String[] lastUpdatedAtClient = new String[n];
       String[] lastUpdatedByUserInfo = new String[n];
       Long[] trackedEntityIds = new Long[n];
       Long[] programIds = new Long[n];
       Long[] organisationUnitIds = new Long[n];
       Long[] attributeOptionComboIds = new Long[n];
-      Timestamp[] enrollmentDate = new Timestamp[n];
-      Timestamp[] occurredDate = new Timestamp[n];
-      Timestamp[] completedDate = new Timestamp[n];
+      String[] enrollmentDate = new String[n];
+      String[] occurredDate = new String[n];
+      String[] completedDate = new String[n];
       String[] completedBy = new String[n];
       String[] status = new String[n];
       Boolean[] followup = new Boolean[n];
@@ -796,17 +813,17 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         Enrollment e = chunk.get(i);
         ids[i] = e.getId();
-        lastUpdated[i] = toTimestamp(e.getLastUpdated());
-        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
         lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
         trackedEntityIds[i] = e.getTrackedEntity().getId();
         programIds[i] = e.getProgram().getId();
         organisationUnitIds[i] = e.getOrganisationUnit().getId();
         attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        enrollmentDate[i] = toTimestamp(e.getEnrollmentDate());
-        occurredDate[i] = toTimestamp(e.getOccurredDate());
-        completedDate[i] = toTimestamp(e.getCompletedDate());
+        enrollmentDate[i] = toTimestamptz(e.getEnrollmentDate());
+        occurredDate[i] = toTimestamptz(e.getOccurredDate());
+        completedDate[i] = toTimestamptz(e.getCompletedDate());
         completedBy[i] = e.getCompletedBy();
         status[i] = e.getStatus().name();
         followup[i] = e.getFollowup();
@@ -815,17 +832,17 @@ class EntityWriteBatch {
 
       try (PreparedStatement ps = conn.prepareStatement(ENROLLMENT_UPDATE_SQL)) {
         ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
         ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
         ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
         ps.setArray(7, conn.createArrayOf("bigint", programIds));
         ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
         ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(10, conn.createArrayOf("timestamptz", enrollmentDate));
-        ps.setArray(11, conn.createArrayOf("timestamptz", occurredDate));
-        ps.setArray(12, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(10, conn.createArrayOf("text", enrollmentDate));
+        ps.setArray(11, conn.createArrayOf("text", occurredDate));
+        ps.setArray(12, conn.createArrayOf("text", completedDate));
         ps.setArray(13, conn.createArrayOf("text", completedBy));
         ps.setArray(14, conn.createArrayOf("text", status));
         ps.setArray(15, conn.createArrayOf("boolean", followup));
@@ -910,18 +927,18 @@ class EntityWriteBatch {
       int n = chunk.size();
 
       Long[] ids = new Long[n];
-      Timestamp[] lastUpdated = new Timestamp[n];
-      Timestamp[] createdAtClient = new Timestamp[n];
-      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdated = new String[n];
+      String[] createdAtClient = new String[n];
+      String[] lastUpdatedAtClient = new String[n];
       String[] lastUpdatedByUserInfo = new String[n];
       Long[] enrollmentIds = new Long[n];
       Long[] programStageIds = new Long[n];
       Long[] organisationUnitIds = new Long[n];
       Long[] attributeOptionComboIds = new Long[n];
       String[] status = new String[n];
-      Timestamp[] occurredDate = new Timestamp[n];
-      Timestamp[] scheduledDate = new Timestamp[n];
-      Timestamp[] completedDate = new Timestamp[n];
+      String[] occurredDate = new String[n];
+      String[] scheduledDate = new String[n];
+      String[] completedDate = new String[n];
       String[] completedBy = new String[n];
       Long[] assignedUserIds = new Long[n];
       String[] eventDataValues = new String[n];
@@ -930,18 +947,18 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         TrackerEvent e = chunk.get(i);
         ids[i] = e.getId();
-        lastUpdated[i] = toTimestamp(e.getLastUpdated());
-        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
         lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
         enrollmentIds[i] = e.getEnrollment().getId();
         programStageIds[i] = e.getProgramStage().getId();
         organisationUnitIds[i] = e.getOrganisationUnit().getId();
         attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
         status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamp(e.getOccurredDate());
-        scheduledDate[i] = toTimestamp(e.getScheduledDate());
-        completedDate[i] = toTimestamp(e.getCompletedDate());
+        occurredDate[i] = toTimestamptz(e.getOccurredDate());
+        scheduledDate[i] = toTimestamptz(e.getScheduledDate());
+        completedDate[i] = toTimestamptz(e.getCompletedDate());
         completedBy[i] = e.getCompletedBy();
         assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
         eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
@@ -950,18 +967,18 @@ class EntityWriteBatch {
 
       try (PreparedStatement ps = conn.prepareStatement(TRACKER_EVENT_UPDATE_SQL)) {
         ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
         ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
         ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
         ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
         ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
         ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
         ps.setArray(10, conn.createArrayOf("text", status));
-        ps.setArray(11, conn.createArrayOf("timestamptz", occurredDate));
-        ps.setArray(12, conn.createArrayOf("timestamptz", scheduledDate));
-        ps.setArray(13, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(11, conn.createArrayOf("text", occurredDate));
+        ps.setArray(12, conn.createArrayOf("text", scheduledDate));
+        ps.setArray(13, conn.createArrayOf("text", completedDate));
         ps.setArray(14, conn.createArrayOf("text", completedBy));
         ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
         ps.setArray(16, conn.createArrayOf("text", eventDataValues));
@@ -1216,16 +1233,16 @@ class EntityWriteBatch {
       int n = chunk.size();
 
       Long[] ids = new Long[n];
-      Timestamp[] lastUpdated = new Timestamp[n];
-      Timestamp[] createdAtClient = new Timestamp[n];
-      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdated = new String[n];
+      String[] createdAtClient = new String[n];
+      String[] lastUpdatedAtClient = new String[n];
       String[] lastUpdatedByUserInfo = new String[n];
       Long[] programStageIds = new Long[n];
       Long[] organisationUnitIds = new Long[n];
       Long[] attributeOptionComboIds = new Long[n];
       String[] status = new String[n];
-      Timestamp[] occurredDate = new Timestamp[n];
-      Timestamp[] completedDate = new Timestamp[n];
+      String[] occurredDate = new String[n];
+      String[] completedDate = new String[n];
       String[] completedBy = new String[n];
       Long[] assignedUserIds = new Long[n];
       String[] eventDataValues = new String[n];
@@ -1234,16 +1251,16 @@ class EntityWriteBatch {
       for (int i = 0; i < n; i++) {
         SingleEvent e = chunk.get(i);
         ids[i] = e.getId();
-        lastUpdated[i] = toTimestamp(e.getLastUpdated());
-        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
         lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
         programStageIds[i] = e.getProgramStage().getId();
         organisationUnitIds[i] = e.getOrganisationUnit().getId();
         attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
         status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamp(e.getOccurredDate());
-        completedDate[i] = toTimestamp(e.getCompletedDate());
+        occurredDate[i] = toTimestamptz(e.getOccurredDate());
+        completedDate[i] = toTimestamptz(e.getCompletedDate());
         completedBy[i] = e.getCompletedBy();
         assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
         eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
@@ -1252,16 +1269,16 @@ class EntityWriteBatch {
 
       try (PreparedStatement ps = conn.prepareStatement(SINGLE_EVENT_UPDATE_SQL)) {
         ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
         ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
         ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
         ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
         ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
         ps.setArray(9, conn.createArrayOf("text", status));
-        ps.setArray(10, conn.createArrayOf("timestamptz", occurredDate));
-        ps.setArray(11, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(10, conn.createArrayOf("text", occurredDate));
+        ps.setArray(11, conn.createArrayOf("text", completedDate));
         ps.setArray(12, conn.createArrayOf("text", completedBy));
         ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
         ps.setArray(14, conn.createArrayOf("text", eventDataValues));
@@ -1531,7 +1548,7 @@ class EntityWriteBatch {
 
       Long[] trackedEntityIds = new Long[n];
       Long[] attributeIds = new Long[n];
-      Timestamp[] lastUpdated = new Timestamp[n];
+      String[] lastUpdated = new String[n];
       String[] value = new String[n];
       String[] storedBy = new String[n];
 
@@ -1539,7 +1556,7 @@ class EntityWriteBatch {
         TrackedEntityAttributeValue v = chunk.get(i);
         trackedEntityIds[i] = v.getTrackedEntity().getId();
         attributeIds[i] = v.getAttribute().getId();
-        lastUpdated[i] = toTimestamp(v.getLastUpdated());
+        lastUpdated[i] = toTimestamptz(v.getLastUpdated());
         value[i] = v.getValue();
         storedBy[i] = v.getStoredBy();
       }
@@ -1547,7 +1564,7 @@ class EntityWriteBatch {
       try (PreparedStatement ps = conn.prepareStatement(TEAV_UPDATE_SQL)) {
         ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
         ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
-        ps.setArray(3, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("text", lastUpdated));
         ps.setArray(4, conn.createArrayOf("text", value));
         ps.setArray(5, conn.createArrayOf("text", storedBy));
         ps.executeUpdate();
@@ -1622,6 +1639,22 @@ class EntityWriteBatch {
 
   private static Timestamp toTimestamp(Date date) {
     return date != null ? new Timestamp(date.getTime()) : null;
+  }
+
+  /**
+   * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
+   * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
+   * Timestamp[])} is not safe: pgjdbc stringifies each element via {@code Timestamp.toString()},
+   * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
+   * under the session {@code TimeZone} -- skewing every value when the session zone differs from
+   * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
+   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
+   * (pgjdbc appends the JVM zone offset there).
+   */
+  private static String toTimestamptz(Date date) {
+    return date != null
+        ? OffsetDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).toString()
+        : null;
   }
 
   private static void setNullableTimestamp(PreparedStatement ps, int index, Date date)

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -29,36 +29,16 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
-import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
-import org.hisp.dhis.note.Note;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
-import org.hisp.dhis.tracker.model.RelationshipItem;
 import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
 import org.hisp.dhis.tracker.model.TrackerEvent;
 
 /**
@@ -66,44 +46,24 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
  * per-entity error isolation in non-atomic mode.
  *
- * <p>Scope:
+ * <p>This class is a thin composite: the per-table SQL, binding and flush mechanics live in the
+ * dedicated {@code *Writer} classes ({@link TrackedEntityWriter}, {@link EnrollmentWriter}, {@link
+ * TrackerEventWriter}, {@link SingleEventWriter}, {@link RelationshipWriter}, {@link TeavWriter}),
+ * with shared helpers in {@link JdbcBatchSupport} and the notes cascade in {@link
+ * NoteCascadeWriter}. This class owns only the staging delegation, the composite mark/rollback and
+ * the FK-safe flush order. Scope of each writer:
  *
  * <ul>
- *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
- *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       trackedentity_sequence} in one round-trip.
- *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
- *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
- *       update branch.
- *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
- *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code enrollment_sequence}.
- *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
- *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
- *   <li>TrackerEvent inserts are flushed via a multi-row JDBC INSERT against {@code trackerevent}
- *       -- ids are pre-allocated from {@code trackerevent_sequence}. The {@code eventdatavalues}
- *       jsonb column is serialized as a JSON object keyed by dataElement uid, matching {@code
- *       JsonEventDataValueSetBinaryType}.
- *   <li>TrackerEvent updates are flushed via a JDBC unnest UPDATE against {@code trackerevent}.
- *   <li>SingleEvent inserts / updates use the same shape as TrackerEvent but write to {@code
- *       singleevent} (no {@code enrollmentid}, no {@code scheduleddate}); ids are pre-allocated
- *       from {@code singleevent_sequence}.
- *   <li>Any new {@code note}s on inserted or updated enrollments / tracker events / single events
- *       are cascade-inserted in further multi-row INSERTs (into {@code note} plus the matching
- *       {@code enrollment_notes} / {@code trackerevent_notes} / {@code singleevent_notes} join),
- *       replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on
- *       UPDATE.
- *   <li>Relationship inserts are flushed via three JDBC statements -- a multi-row INSERT into
- *       {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT
- *       into {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code
- *       relationship} to set the from/to FKs. The three-step shape breaks the circular FK between
- *       the two tables, which is not deferrable in the live schema. Ids come from {@code
- *       relationship_sequence} and {@code relationshipitem_sequence}. Relationship is INSERT-only
- *       -- the persister rejects UPDATE strategy upstream.
- *   <li>TrackedEntityAttributeValues are flushed via JDBC against {@code
- *       trackedentityattributevalue} -- a multi-row INSERT, a single unnest UPDATE keyed on the
- *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single
- *       unnest DELETE on the same key. Confidential attributes and the {@code encryptedvalue}
- *       column were removed in DHIS2-21518, so the value is written as plain text in {@code value}.
+ *   <li>TrackedEntity -- multi-row INSERT + unnest UPDATE on {@code trackedentity} ({@code
+ *       trackedentity_sequence}).
+ *   <li>Enrollment -- multi-row INSERT + unnest UPDATE on {@code enrollment} ({@code
+ *       enrollment_sequence}) plus the notes cascade.
+ *   <li>TrackerEvent / SingleEvent -- multi-row INSERT + unnest UPDATE on {@code trackerevent} /
+ *       {@code singleevent} ({@code eventdatavalues} jsonb keyed by dataElement uid) plus notes.
+ *   <li>Relationship -- INSERT-only three-step (parent INSERT with NULL from/to, item INSERT,
+ *       unnest UPDATE to set the from/to FKs) breaking the circular, non-deferrable FK.
+ *   <li>TrackedEntityAttributeValue -- multi-row INSERT, unnest UPDATE and unnest DELETE on the
+ *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK.
  * </ul>
  *
  * <p>All reads and writes in the import path go through JDBC, bypassing the Hibernate persistence
@@ -125,9 +85,9 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * </ul>
  *
  * <p>Top-level entities are flushed before TEAVs so that ids are set and rows are present in the DB
- * before any TEAV that references them. Within top-level entities the order (TE inserts, TE
- * updates, Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order
- * enforced by {@code DefaultTrackerBundleService.commit()} and is FK-safe.
+ * before any TEAV that references them. Within top-level entities the order (TrackedEntity,
+ * Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order enforced by
+ * {@code DefaultTrackerBundleService.commit()} and is FK-safe.
  *
  * <p>Each {@link AbstractTrackerPersister#persist} call creates its own batch, so in practice only
  * one top-level entity type list is populated per batch (the persister's own type) alongside any
@@ -135,409 +95,87 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  */
 class EntityWriteBatch {
 
-  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
-  private static final int BATCH_SIZE = 128;
-
-  private static final int TRACKED_ENTITY_SRID = 4326;
-
-  private static final String TRACKED_ENTITY_INSERT_PREFIX =
-      "insert into trackedentity ("
-          + "trackedentityid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " inactive, deleted, lastsynchronized, potentialduplicate,"
-          + " organisationunitid, trackedentitytypeid,"
-          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
-
-  private static final String TRACKED_ENTITY_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "), ?::jsonb, ?::jsonb)";
-
-  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch (see lines 90-104). Insert-
-  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths
-  // (deleted, lastsynchronized -- the latter is bulk-updated by
-  // DefaultTrackerBundleService.postCommit) are deliberately excluded.
-  private static final String TRACKED_ENTITY_UPDATE_SQL =
-      "update trackedentity te set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " organisationunitid = v.organisationunitid,"
-          + " trackedentitytypeid = v.trackedentitytypeid,"
-          + " potentialduplicate = v.potentialduplicate,"
-          + " inactive = v.inactive,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as trackedentitytypeid,"
-          + " unnest(?::boolean[]) as potentialduplicate,"
-          + " unnest(?::boolean[]) as inactive,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where te.trackedentityid = v.trackedentityid";
-
-  private static final String ENROLLMENT_INSERT_PREFIX =
-      "insert into enrollment ("
-          + "enrollmentid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " enrollmentdate, occurreddate, completeddate, completedby,"
-          + " status, followup, deleted,"
-          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
-          + " geometry) values ";
-
-  private static final String ENROLLMENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch (see
-  // lines 124-180). Insert-only columns (uid, created, createdbyuserinfo) and columns owned by
-  // other code paths (deleted) are deliberately excluded. status, completeddate, completedby are
-  // included even though the mapper only touches them on a status change -- writing the unchanged
-  // values back is a no-op against the existing row.
-  private static final String ENROLLMENT_UPDATE_SQL =
-      "update enrollment e set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " trackedentityid = v.trackedentityid,"
-          + " programid = v.programid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " enrollmentdate = v.enrollmentdate,"
-          + " occurreddate = v.occurreddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " status = v.status,"
-          + " followup = v.followup,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as enrollmentid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as programid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::timestamptz[]) as enrollmentdate,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::boolean[]) as followup,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where e.enrollmentid = v.enrollmentid";
-
-  private static final String TRACKER_EVENT_INSERT_PREFIX =
-      "insert into trackerevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, scheduleddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
-          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String TRACKER_EVENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch
-  // (see TrackerObjectsMapper.java:199-251). Insert-only columns (uid, created,
-  // createdbyuserinfo, deleted) and columns owned by other code paths (lastsynchronized) are
-  // excluded.
-  private static final String TRACKER_EVENT_UPDATE_SQL =
-      "update trackerevent ev set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " enrollmentid = v.enrollmentid,"
-          + " programstageid = v.programstageid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " status = v.status,"
-          + " occurreddate = v.occurreddate,"
-          + " scheduleddate = v.scheduleddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " assigneduserid = v.assigneduserid,"
-          + " eventdatavalues = v.eventdatavalues::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as eventid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as enrollmentid,"
-          + " unnest(?::bigint[]) as programstageid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as scheduleddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::bigint[]) as assigneduserid,"
-          + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where ev.eventid = v.eventid";
-
-  // Cascade-INSERT targets for entities that carry notes (Enrollment, TrackerEvent). See
-  // Enrollment.java:192-199 and TrackerEvent.hbm.xml:65-70.
-  private static final String NOTE_INSERT_PREFIX =
-      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
-  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
-
-  private static final String ENROLLMENT_NOTES_INSERT_PREFIX =
-      "insert into enrollment_notes (enrollmentid, noteid, sort_order) values ";
-  private static final String ENROLLMENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  private static final String TRACKER_EVENT_NOTES_INSERT_PREFIX =
-      "insert into trackerevent_notes (eventid, noteid, sort_order) values ";
-  private static final String TRACKER_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  // SingleEvent mirrors TrackerEvent without enrollmentid (single events aren't tied to an
-  // enrollment) and without scheduleddate. Sequence is singleevent_sequence per
-  // V2_43_21__split_event_table.sql.
-  private static final String SINGLE_EVENT_INSERT_PREFIX =
-      "insert into singleevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
-          + " programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String SINGLE_EVENT_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
-          + TRACKED_ENTITY_SRID
-          + "))";
-
-  // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch (see
-  // TrackerObjectsMapper.java:270-322). Insert-only columns (uid, created, createdbyuserinfo,
-  // deleted) and columns owned by other code paths (lastsynchronized) are excluded.
-  private static final String SINGLE_EVENT_UPDATE_SQL =
-      "update singleevent ev set"
-          + " lastupdated = v.lastupdated,"
-          + " createdatclient = v.createdatclient,"
-          + " lastupdatedatclient = v.lastupdatedatclient,"
-          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
-          + " programstageid = v.programstageid,"
-          + " organisationunitid = v.organisationunitid,"
-          + " attributeoptioncomboid = v.attributeoptioncomboid,"
-          + " status = v.status,"
-          + " occurreddate = v.occurreddate,"
-          + " completeddate = v.completeddate,"
-          + " completedby = v.completedby,"
-          + " assigneduserid = v.assigneduserid,"
-          + " eventdatavalues = v.eventdatavalues::jsonb,"
-          + " geometry = case when v.geometry is null then null"
-          + " else ST_GeomFromText(v.geometry, "
-          + TRACKED_ENTITY_SRID
-          + ") end"
-          + " from ( select"
-          + " unnest(?::bigint[]) as eventid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::timestamptz[]) as createdatclient,"
-          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
-          + " unnest(?::bigint[]) as programstageid,"
-          + " unnest(?::bigint[]) as organisationunitid,"
-          + " unnest(?::bigint[]) as attributeoptioncomboid,"
-          + " unnest(?::text[]) as status,"
-          + " unnest(?::timestamptz[]) as occurreddate,"
-          + " unnest(?::timestamptz[]) as completeddate,"
-          + " unnest(?::text[]) as completedby,"
-          + " unnest(?::bigint[]) as assigneduserid,"
-          + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
-          + " ) v where ev.eventid = v.eventid";
-
-  private static final String SINGLE_EVENT_NOTES_INSERT_PREFIX =
-      "insert into singleevent_notes (eventid, noteid, sort_order) values ";
-  private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
-
-  // Relationship is INSERT-only in tracker imports (RelationshipPersister.convert returns null on
-  // UPDATE strategy). Relationship ids come from `relationship_sequence`, item ids from
-  // `relationshipitem_sequence`.
-  //
-  // The two tables form a circular FK (relationship.from/to_relationshipitemid <->
-  // relationshipitem.relationshipid) with non-deferrable constraints. We break the cycle by
-  // inserting the relationship row first with from/to as NULL, then the items pointing at the
-  // pre-allocated relationshipid, then an unnest UPDATE to set the from/to FKs.
-  private static final String RELATIONSHIP_INSERT_PREFIX =
-      "insert into relationship ("
-          + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
-          + " style, relationshiptypeid,"
-          + " from_relationshipitemid, to_relationshipitemid,"
-          + " key, inverted_key, deleted, createdatclient) values ";
-
-  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
-  // updateRelationshipFromTo after the items are inserted.
-  private static final String RELATIONSHIP_INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
-
-  private static final String RELATIONSHIP_ITEM_INSERT_PREFIX =
-      "insert into relationshipitem ("
-          + "relationshipitemid, relationshipid,"
-          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
-  private static final String RELATIONSHIP_ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
-
-  private static final String RELATIONSHIP_UPDATE_FROM_TO_SQL =
-      "update relationship r set"
-          + " from_relationshipitemid = v.from_id,"
-          + " to_relationshipitemid = v.to_id"
-          + " from ( select"
-          + " unnest(?::bigint[]) as relationshipid,"
-          + " unnest(?::bigint[]) as from_id,"
-          + " unnest(?::bigint[]) as to_id"
-          + " ) v where r.relationshipid = v.relationshipid";
-
-  // TrackedEntityAttributeValue has a composite PK (trackedentityid, trackedentityattributeid) and
-  // no sequence, so no id pre-allocation is needed. Confidential attributes (and the encrypted
-  // value column) were removed in DHIS2-21518, so the value is stored as plain text in `value`.
-  private static final String TEAV_INSERT_PREFIX =
-      "insert into trackedentityattributevalue ("
-          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
-          + " value, storedby) values ";
-  private static final String TEAV_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
-
-  // `created` is insert-only and deliberately excluded from the UPDATE column set.
-  private static final String TEAV_UPDATE_SQL =
-      "update trackedentityattributevalue teav set"
-          + " lastupdated = v.lastupdated,"
-          + " value = v.value,"
-          + " storedby = v.storedby"
-          + " from ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as trackedentityattributeid,"
-          + " unnest(?::timestamptz[]) as lastupdated,"
-          + " unnest(?::text[]) as value,"
-          + " unnest(?::text[]) as storedby"
-          + " ) v where teav.trackedentityid = v.trackedentityid"
-          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
-
-  // Unnest DELETE on the composite key, mirroring the unnest UPDATE shape rather than the plan's
-  // IN (VALUES ...) form, to stay consistent with the other batch statements and avoid dynamic SQL.
-  private static final String TEAV_DELETE_SQL =
-      "delete from trackedentityattributevalue teav"
-          + " using ( select"
-          + " unnest(?::bigint[]) as trackedentityid,"
-          + " unnest(?::bigint[]) as trackedentityattributeid"
-          + " ) v where teav.trackedentityid = v.trackedentityid"
-          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
-
-  private final ObjectMapper objectMapper;
-
-  private final List<TrackedEntity> teInserts = new ArrayList<>();
-  private final List<TrackedEntity> teUpdates = new ArrayList<>();
-
-  private final List<Enrollment> enrollmentInserts = new ArrayList<>();
-  private final List<Enrollment> enrollmentUpdates = new ArrayList<>();
-
-  private final List<TrackerEvent> trackerEventInserts = new ArrayList<>();
-  private final List<TrackerEvent> trackerEventUpdates = new ArrayList<>();
-
-  private final List<SingleEvent> singleEventInserts = new ArrayList<>();
-  private final List<SingleEvent> singleEventUpdates = new ArrayList<>();
-
-  private final List<Relationship> relationshipInserts = new ArrayList<>();
-
-  private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
-  private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
-  private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+  private final TrackedEntityWriter trackedEntityWriter;
+  private final EnrollmentWriter enrollmentWriter;
+  private final TrackerEventWriter trackerEventWriter;
+  private final SingleEventWriter singleEventWriter;
+  private final RelationshipWriter relationshipWriter = new RelationshipWriter();
+  private final TrackedEntityProgramOwnerWriter ownershipWriter =
+      new TrackedEntityProgramOwnerWriter();
+  private final TeavWriter teavWriter = new TeavWriter();
 
   EntityWriteBatch(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+    this.trackedEntityWriter = new TrackedEntityWriter(objectMapper);
+    this.enrollmentWriter = new EnrollmentWriter(objectMapper);
+    this.trackerEventWriter = new TrackerEventWriter(objectMapper);
+    this.singleEventWriter = new SingleEventWriter(objectMapper);
   }
 
   void stageInsert(TrackedEntity trackedEntity) {
-    teInserts.add(trackedEntity);
+    trackedEntityWriter.stageInsert(trackedEntity);
   }
 
   void stageUpdate(TrackedEntity trackedEntity) {
-    teUpdates.add(trackedEntity);
+    trackedEntityWriter.stageUpdate(trackedEntity);
   }
 
   void stageInsert(Enrollment enrollment) {
-    enrollmentInserts.add(enrollment);
+    enrollmentWriter.stageInsert(enrollment);
   }
 
   void stageUpdate(Enrollment enrollment) {
-    enrollmentUpdates.add(enrollment);
+    enrollmentWriter.stageUpdate(enrollment);
   }
 
   void stageInsert(TrackerEvent event) {
-    trackerEventInserts.add(event);
+    trackerEventWriter.stageInsert(event);
   }
 
   void stageUpdate(TrackerEvent event) {
-    trackerEventUpdates.add(event);
+    trackerEventWriter.stageUpdate(event);
   }
 
   void stageInsert(SingleEvent event) {
-    singleEventInserts.add(event);
+    singleEventWriter.stageInsert(event);
   }
 
   void stageUpdate(SingleEvent event) {
-    singleEventUpdates.add(event);
+    singleEventWriter.stageUpdate(event);
   }
 
   /**
    * Relationships are never updated -- {@link AbstractTrackerPersister} ignores update payloads.
    */
   void stageInsert(Relationship relationship) {
-    relationshipInserts.add(relationship);
-  }
-
-  void stageTeavInsert(TrackedEntityAttributeValue value) {
-    teavInserts.add(value);
-  }
-
-  void stageTeavUpdate(TrackedEntityAttributeValue value) {
-    teavUpdates.add(value);
-  }
-
-  void stageTeavDelete(TrackedEntityAttributeValue value) {
-    teavDeletes.add(value);
+    relationshipWriter.stageInsert(relationship);
   }
 
   /**
-   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
-   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
-   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
-   * each carrying the same attribute value -- so it can fold the second occurrence into the first
-   * staged instance instead of staging a second INSERT for the same composite key, which would
-   * violate the primary key at flush.
+   * Stages a program-ownership row for a newly created enrollment. INSERT-only; {@link
+   * EnrollmentPersister} guards against duplicates before staging.
+   */
+  void stageOwnershipInsert(TrackedEntityProgramOwner owner) {
+    ownershipWriter.stageInsert(owner);
+  }
+
+  void stageTeavInsert(TrackedEntityAttributeValue value) {
+    teavWriter.stageInsert(value);
+  }
+
+  void stageTeavUpdate(TrackedEntityAttributeValue value) {
+    teavWriter.stageUpdate(value);
+  }
+
+  void stageTeavDelete(TrackedEntityAttributeValue value) {
+    teavWriter.stageDelete(value);
+  }
+
+  /**
+   * TEAVs already staged for insert or update against the given TrackedEntity. See {@link
+   * TeavWriter#stagedFor}.
    */
   Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
-    return Stream.concat(teavInserts.stream(), teavUpdates.stream())
-        .filter(v -> v.getTrackedEntity() == trackedEntity);
+    return teavWriter.stagedFor(trackedEntity);
   }
 
   /**
@@ -546,32 +184,28 @@ class EntityWriteBatch {
    * empty for a fresh insert.
    */
   boolean isStagedAsInsert(TrackedEntity trackedEntity) {
-    return teInserts.contains(trackedEntity);
+    return trackedEntityWriter.isStagedAsInsert(trackedEntity);
   }
 
   Mark mark() {
     return new Mark(
-        new Mark.EntityCounts(teInserts.size(), teUpdates.size()),
-        new Mark.EntityCounts(enrollmentInserts.size(), enrollmentUpdates.size()),
-        new Mark.EntityCounts(trackerEventInserts.size(), trackerEventUpdates.size()),
-        new Mark.EntityCounts(singleEventInserts.size(), singleEventUpdates.size()),
-        relationshipInserts.size(),
-        new Mark.TeavCounts(teavInserts.size(), teavUpdates.size(), teavDeletes.size()));
+        trackedEntityWriter.mark(),
+        enrollmentWriter.mark(),
+        trackerEventWriter.mark(),
+        singleEventWriter.mark(),
+        relationshipWriter.mark(),
+        ownershipWriter.mark(),
+        teavWriter.mark());
   }
 
   void rollbackTo(Mark mark) {
-    truncate(teInserts, mark.te().inserts());
-    truncate(teUpdates, mark.te().updates());
-    truncate(enrollmentInserts, mark.enrollment().inserts());
-    truncate(enrollmentUpdates, mark.enrollment().updates());
-    truncate(trackerEventInserts, mark.trackerEvent().inserts());
-    truncate(trackerEventUpdates, mark.trackerEvent().updates());
-    truncate(singleEventInserts, mark.singleEvent().inserts());
-    truncate(singleEventUpdates, mark.singleEvent().updates());
-    truncate(relationshipInserts, mark.relationshipInserts());
-    truncate(teavInserts, mark.teav().inserts());
-    truncate(teavUpdates, mark.teav().updates());
-    truncate(teavDeletes, mark.teav().deletes());
+    trackedEntityWriter.rollbackTo(mark.te());
+    enrollmentWriter.rollbackTo(mark.enrollment());
+    trackerEventWriter.rollbackTo(mark.trackerEvent());
+    singleEventWriter.rollbackTo(mark.singleEvent());
+    relationshipWriter.rollbackTo(mark.relationshipInserts());
+    ownershipWriter.rollbackTo(mark.ownershipInserts());
+    teavWriter.rollbackTo(mark.teav());
   }
 
   /**
@@ -580,1188 +214,50 @@ class EntityWriteBatch {
    * Spring-managed transaction so the JDBC statements execute under the same commit. The writes
    * bypass the Hibernate persistence context and audit listeners -- see the class javadoc for the
    * scope of that trade-off.
+   *
+   * <p>Writers run in FK-safe order: TrackedEntity -> Enrollment -> program ownership ->
+   * TrackerEvent -> SingleEvent -> Relationship -> TEAV. Each writer applies its own inserts before
+   * updates before notes. Program ownership is flushed after Enrollment (it references the tracked
+   * entity, program and org unit, all already present).
    */
   void flush(Connection conn) throws SQLException {
     if (isEmpty()) {
       return;
     }
 
-    insertTrackedEntities(conn);
-    updateTrackedEntities(conn);
-    insertEnrollments(conn);
-    updateEnrollments(conn);
-    insertEnrollmentNotes(conn);
-    insertTrackerEvents(conn);
-    updateTrackerEvents(conn);
-    insertTrackerEventNotes(conn);
-    insertSingleEvents(conn);
-    updateSingleEvents(conn);
-    insertSingleEventNotes(conn);
-    insertRelationships(conn);
-    insertRelationshipItems(conn);
-    updateRelationshipFromTo(conn);
-
-    insertTeavs(conn);
-    updateTeavs(conn);
-    deleteTeavs(conn);
-
-    teInserts.clear();
-    teUpdates.clear();
-    enrollmentInserts.clear();
-    enrollmentUpdates.clear();
-    trackerEventInserts.clear();
-    trackerEventUpdates.clear();
-    singleEventInserts.clear();
-    singleEventUpdates.clear();
-    relationshipInserts.clear();
-    teavInserts.clear();
-    teavUpdates.clear();
-    teavDeletes.clear();
-  }
-
-  private void updateTrackedEntities(Connection conn) throws SQLException {
-    if (teUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teUpdates.size());
-      List<TrackedEntity> chunk = teUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] trackedEntityTypeIds = new Long[n];
-      Boolean[] potentialDuplicate = new Boolean[n];
-      Boolean[] inactive = new Boolean[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackedEntity te = chunk.get(i);
-        ids[i] = te.getId();
-        lastUpdated[i] = toTimestamptz(te.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(te.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(te.getLastUpdatedAtClient());
-        organisationUnitIds[i] = te.getOrganisationUnit().getId();
-        trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
-        potentialDuplicate[i] = te.isPotentialDuplicate();
-        inactive[i] = te.isInactive();
-        lastUpdatedByUserInfo[i] = toJson(te.getLastUpdatedByUserInfo());
-        geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TRACKED_ENTITY_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
-        ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
-        ps.setArray(8, conn.createArrayOf("boolean", inactive));
-        ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(10, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTrackedEntities(Connection conn) throws SQLException {
-    if (teInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teInserts.size());
-      List<TrackedEntity> chunk = teInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKED_ENTITY_INSERT_PREFIX, TRACKED_ENTITY_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackedEntity te : chunk) {
-          p = bindTrackedEntityRow(ps, p, te);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindTrackedEntityRow(PreparedStatement ps, int p, TrackedEntity te)
-      throws SQLException {
-    if (te.getId() == 0) {
-      throw new SQLException(
-          "TrackedEntity "
-              + te.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, te.getId());
-    ps.setString(p++, te.getUid());
-    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
-    setNullableTimestamp(ps, p++, te.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
-    ps.setBoolean(p++, te.isInactive());
-    ps.setBoolean(p++, te.isDeleted());
-    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
-    ps.setBoolean(p++, te.isPotentialDuplicate());
-    ps.setLong(p++, te.getOrganisationUnit().getId());
-    ps.setLong(p++, te.getTrackedEntityType().getId());
-    if (te.getGeometry() != null) {
-      ps.setString(p++, te.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, toJson(te.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(te.getLastUpdatedByUserInfo()));
-    return p;
-  }
-
-  private void insertEnrollments(Connection conn) throws SQLException {
-    if (enrollmentInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < enrollmentInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, enrollmentInserts.size());
-      List<Enrollment> chunk = enrollmentInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(ENROLLMENT_INSERT_PREFIX, ENROLLMENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (Enrollment e : chunk) {
-          p = bindEnrollmentRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindEnrollmentRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "Enrollment "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, e.getStatus().name());
-    if (e.getFollowup() != null) {
-      ps.setBoolean(p++, e.getFollowup());
-    } else {
-      ps.setNull(p++, Types.BOOLEAN);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    ps.setLong(p++, e.getTrackedEntity().getId());
-    ps.setLong(p++, e.getProgram().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateEnrollments(Connection conn) throws SQLException {
-    if (enrollmentUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < enrollmentUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, enrollmentUpdates.size());
-      List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] trackedEntityIds = new Long[n];
-      Long[] programIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] enrollmentDate = new String[n];
-      String[] occurredDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      String[] status = new String[n];
-      Boolean[] followup = new Boolean[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        Enrollment e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        trackedEntityIds[i] = e.getTrackedEntity().getId();
-        programIds[i] = e.getProgram().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        enrollmentDate[i] = toTimestamptz(e.getEnrollmentDate());
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        status[i] = e.getStatus().name();
-        followup[i] = e.getFollowup();
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(ENROLLMENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(7, conn.createArrayOf("bigint", programIds));
-        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(10, conn.createArrayOf("text", enrollmentDate));
-        ps.setArray(11, conn.createArrayOf("text", occurredDate));
-        ps.setArray(12, conn.createArrayOf("text", completedDate));
-        ps.setArray(13, conn.createArrayOf("text", completedBy));
-        ps.setArray(14, conn.createArrayOf("text", status));
-        ps.setArray(15, conn.createArrayOf("boolean", followup));
-        ps.setArray(16, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTrackerEvents(Connection conn) throws SQLException {
-    if (trackerEventInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < trackerEventInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, trackerEventInserts.size());
-      List<TrackerEvent> chunk = trackerEventInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKER_EVENT_INSERT_PREFIX, TRACKER_EVENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackerEvent e : chunk) {
-          p = bindTrackerEventRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindTrackerEventRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "TrackerEvent "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getScheduledDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getEnrollment().getId());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateTrackerEvents(Connection conn) throws SQLException {
-    if (trackerEventUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < trackerEventUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, trackerEventUpdates.size());
-      List<TrackerEvent> chunk = trackerEventUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] enrollmentIds = new Long[n];
-      Long[] programStageIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] status = new String[n];
-      String[] occurredDate = new String[n];
-      String[] scheduledDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      Long[] assignedUserIds = new Long[n];
-      String[] eventDataValues = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackerEvent e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        enrollmentIds[i] = e.getEnrollment().getId();
-        programStageIds[i] = e.getProgramStage().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        scheduledDate[i] = toTimestamptz(e.getScheduledDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
-        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TRACKER_EVENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
-        ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
-        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(10, conn.createArrayOf("text", status));
-        ps.setArray(11, conn.createArrayOf("text", occurredDate));
-        ps.setArray(12, conn.createArrayOf("text", scheduledDate));
-        ps.setArray(13, conn.createArrayOf("text", completedDate));
-        ps.setArray(14, conn.createArrayOf("text", completedBy));
-        ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
-        ps.setArray(16, conn.createArrayOf("text", eventDataValues));
-        ps.setArray(17, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Shared shape between {@code enrollment_notes} and {@code trackerevent_notes} cascade rows. */
-  private interface NoteToInsert {
-    Note note();
-  }
-
-  /**
-   * Cascade-insert any notes attached to enrollments that were just inserted by {@link
-   * #insertEnrollments} or appended to existing enrollments by {@link #updateEnrollments}. Mirrors
-   * what Hibernate did via {@code @OneToMany(cascade=ALL)} on {@code Enrollment.notes} (see {@code
-   * Enrollment.java:192-199}): allocate ids for the new {@code note} rows from {@code
-   * note_sequence}, insert the {@code note} rows, then insert the join rows in {@code
-   * enrollment_notes} with {@code sort_order} taken from the list position (1-based, per
-   * {@code @ListIndexBase(1)}). On INSERT every Note is new; on UPDATE only Notes with {@code id ==
-   * 0} are new (existing ones were loaded by the preheat).
-   */
-  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertEnrollmentNotes(Connection conn) throws SQLException {
-    List<EnrollmentNoteToInsert> newNotes = collectNewEnrollmentNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertEnrollmentNotesJoinRows(conn, newNotes);
-  }
-
-  /**
-   * For each enrollment being inserted or updated, collect the {@link Note}s that are new (no DB
-   * id) along with their 1-based sort order, which is the position in the {@code getNotes()} list.
-   * For inserts every note is new; for updates the preheat-loaded list already contains existing
-   * notes with non-zero ids, so we skip those.
-   */
-  private List<EnrollmentNoteToInsert> collectNewEnrollmentNotes() {
-    List<EnrollmentNoteToInsert> newNotes = new ArrayList<>();
-    collectNewNotesFrom(enrollmentInserts, newNotes);
-    collectNewNotesFrom(enrollmentUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewNotesFrom(
-      List<Enrollment> enrollments, List<EnrollmentNoteToInsert> out) {
-    for (Enrollment e : enrollments) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new EnrollmentNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertNoteRows(Connection conn, List<? extends NoteToInsert> newNotes)
-      throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<? extends NoteToInsert> chunk = newNotes.subList(from, to);
-      String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (NoteToInsert item : chunk) {
-          Note n = item.note();
-          ps.setLong(p++, n.getId());
-          ps.setString(p++, n.getUid());
-          ps.setTimestamp(p++, toTimestamp(n.getCreated()));
-          if (n.getLastUpdatedBy() != null) {
-            ps.setLong(p++, n.getLastUpdatedBy().getId());
-          } else {
-            ps.setNull(p++, Types.BIGINT);
-          }
-          if (n.getNoteText() != null) {
-            ps.setString(p++, n.getNoteText());
-          } else {
-            ps.setNull(p++, Types.VARCHAR);
-          }
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertEnrollmentNotesJoinRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
-      throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              ENROLLMENT_NOTES_INSERT_PREFIX, ENROLLMENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (EnrollmentNoteToInsert item : chunk) {
-          ps.setLong(p++, item.enrollmentId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code trackerevent_notes} join table. */
-  private record TrackerEventNoteToInsert(long eventId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertTrackerEventNotes(Connection conn) throws SQLException {
-    List<TrackerEventNoteToInsert> newNotes = collectNewTrackerEventNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertTrackerEventNotesJoinRows(conn, newNotes);
-  }
-
-  private List<TrackerEventNoteToInsert> collectNewTrackerEventNotes() {
-    List<TrackerEventNoteToInsert> newNotes = new ArrayList<>();
-    collectNewTrackerEventNotesFrom(trackerEventInserts, newNotes);
-    collectNewTrackerEventNotesFrom(trackerEventUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewTrackerEventNotesFrom(
-      List<TrackerEvent> events, List<TrackerEventNoteToInsert> out) {
-    for (TrackerEvent e : events) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new TrackerEventNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertTrackerEventNotesJoinRows(
-      Connection conn, List<TrackerEventNoteToInsert> newNotes) throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<TrackerEventNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              TRACKER_EVENT_NOTES_INSERT_PREFIX, TRACKER_EVENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackerEventNoteToInsert item : chunk) {
-          ps.setLong(p++, item.eventId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertSingleEvents(Connection conn) throws SQLException {
-    if (singleEventInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < singleEventInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, singleEventInserts.size());
-      List<SingleEvent> chunk = singleEventInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(SINGLE_EVENT_INSERT_PREFIX, SINGLE_EVENT_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (SingleEvent e : chunk) {
-          p = bindSingleEventRow(ps, p, e);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindSingleEventRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
-    if (e.getId() == 0) {
-      throw new SQLException(
-          "SingleEvent "
-              + e.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
-  }
-
-  private void updateSingleEvents(Connection conn) throws SQLException {
-    if (singleEventUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < singleEventUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, singleEventUpdates.size());
-      List<SingleEvent> chunk = singleEventUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] createdAtClient = new String[n];
-      String[] lastUpdatedAtClient = new String[n];
-      String[] lastUpdatedByUserInfo = new String[n];
-      Long[] programStageIds = new Long[n];
-      Long[] organisationUnitIds = new Long[n];
-      Long[] attributeOptionComboIds = new Long[n];
-      String[] status = new String[n];
-      String[] occurredDate = new String[n];
-      String[] completedDate = new String[n];
-      String[] completedBy = new String[n];
-      Long[] assignedUserIds = new Long[n];
-      String[] eventDataValues = new String[n];
-      String[] geometry = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        SingleEvent e = chunk.get(i);
-        ids[i] = e.getId();
-        lastUpdated[i] = toTimestamptz(e.getLastUpdated());
-        createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
-        lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
-        programStageIds[i] = e.getProgramStage().getId();
-        organisationUnitIds[i] = e.getOrganisationUnit().getId();
-        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
-        status[i] = e.getStatus().name();
-        occurredDate[i] = toTimestamptz(e.getOccurredDate());
-        completedDate[i] = toTimestamptz(e.getCompletedDate());
-        completedBy[i] = e.getCompletedBy();
-        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
-        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
-        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(SINGLE_EVENT_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(3, conn.createArrayOf("text", createdAtClient));
-        ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
-        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
-        ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
-        ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
-        ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
-        ps.setArray(9, conn.createArrayOf("text", status));
-        ps.setArray(10, conn.createArrayOf("text", occurredDate));
-        ps.setArray(11, conn.createArrayOf("text", completedDate));
-        ps.setArray(12, conn.createArrayOf("text", completedBy));
-        ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
-        ps.setArray(14, conn.createArrayOf("text", eventDataValues));
-        ps.setArray(15, conn.createArrayOf("text", geometry));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code singleevent_notes} join table. */
-  private record SingleEventNoteToInsert(long eventId, Note note, int sortOrder)
-      implements NoteToInsert {}
-
-  private void insertSingleEventNotes(Connection conn) throws SQLException {
-    List<SingleEventNoteToInsert> newNotes = collectNewSingleEventNotes();
-    if (newNotes.isEmpty()) {
-      return;
-    }
-
-    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
-    for (int i = 0; i < newNotes.size(); i++) {
-      newNotes.get(i).note().setId(noteIds[i]);
-    }
-
-    insertNoteRows(conn, newNotes);
-    insertSingleEventNotesJoinRows(conn, newNotes);
-  }
-
-  private List<SingleEventNoteToInsert> collectNewSingleEventNotes() {
-    List<SingleEventNoteToInsert> newNotes = new ArrayList<>();
-    collectNewSingleEventNotesFrom(singleEventInserts, newNotes);
-    collectNewSingleEventNotesFrom(singleEventUpdates, newNotes);
-    return newNotes;
-  }
-
-  private static void collectNewSingleEventNotesFrom(
-      List<SingleEvent> events, List<SingleEventNoteToInsert> out) {
-    for (SingleEvent e : events) {
-      if (e.getNotes() == null) {
-        continue;
-      }
-      List<Note> notes = e.getNotes();
-      for (int i = 0; i < notes.size(); i++) {
-        Note n = notes.get(i);
-        if (n.getId() == 0) {
-          out.add(new SingleEventNoteToInsert(e.getId(), n, i + 1));
-        }
-      }
-    }
-  }
-
-  private void insertSingleEventNotesJoinRows(
-      Connection conn, List<SingleEventNoteToInsert> newNotes) throws SQLException {
-    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<SingleEventNoteToInsert> chunk = newNotes.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              SINGLE_EVENT_NOTES_INSERT_PREFIX, SINGLE_EVENT_NOTES_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (SingleEventNoteToInsert item : chunk) {
-          ps.setLong(p++, item.eventId());
-          ps.setLong(p++, item.note().getId());
-          ps.setInt(p++, item.sortOrder());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /**
-   * Inserts the parent {@code relationship} rows. {@code from_relationshipitemid} and {@code
-   * to_relationshipitemid} are written as NULL here -- they're filled in by {@link
-   * #updateRelationshipFromTo} after the item rows have been inserted, since neither the parent nor
-   * the child FK constraints are deferrable. Relationship is INSERT-only in tracker imports, so no
-   * L1 detach/refresh is needed.
-   */
-  private void insertRelationships(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
-      List<Relationship> chunk = relationshipInserts.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(RELATIONSHIP_INSERT_PREFIX, RELATIONSHIP_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (Relationship r : chunk) {
-          p = bindRelationshipRow(ps, p, r);
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindRelationshipRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
-    if (r.getId() == 0) {
-      throw new SQLException(
-          "Relationship "
-              + r.getUid()
-              + " has no pre-allocated id; AbstractTrackerPersister"
-              + " must pre-allocate ids when sequenceName() is non-null.");
-    }
-    ps.setLong(p++, r.getId());
-    ps.setString(p++, r.getUid());
-    if (r.getCode() != null) {
-      ps.setString(p++, r.getCode());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
-    if (r.getLastUpdatedBy() != null) {
-      ps.setLong(p++, r.getLastUpdatedBy().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toObjectStyleJson(r.getStyle()));
-    ps.setLong(p++, r.getRelationshipType().getId());
-    ps.setString(p++, r.getKey());
-    ps.setString(p++, r.getInvertedKey());
-    ps.setBoolean(p++, r.isDeleted());
-    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
-    return p;
-  }
-
-  /**
-   * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
-   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
-   * round-trip, assign them to the in-memory items (so the subsequent unnest UPDATE can read them
-   * back), then flatten the from/to items into a single multi-row INSERT.
-   */
-  private void insertRelationshipItems(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * relationshipInserts.size());
-    int cursor = 0;
-    for (Relationship r : relationshipInserts) {
-      r.getFrom().setId((int) itemIds[cursor++]);
-      r.getTo().setId((int) itemIds[cursor++]);
-    }
-
-    // Flatten (from + to) per relationship into a single list to drive one multi-row INSERT.
-    record ItemRow(long itemId, long relationshipId, RelationshipItem item) {}
-    List<ItemRow> rows = new ArrayList<>(2 * relationshipInserts.size());
-    for (Relationship r : relationshipInserts) {
-      rows.add(new ItemRow(r.getFrom().getId(), r.getId(), r.getFrom()));
-      rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
-    }
-
-    for (int from = 0; from < rows.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, rows.size());
-      List<ItemRow> chunk = rows.subList(from, to);
-      String sql =
-          buildMultiRowInsertSql(
-              RELATIONSHIP_ITEM_INSERT_PREFIX, RELATIONSHIP_ITEM_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (ItemRow row : chunk) {
-          p = bindRelationshipItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private int bindRelationshipItemRow(
-      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
-      throws SQLException {
-    ps.setLong(p++, itemId);
-    ps.setLong(p++, relationshipId);
-    if (item.getTrackedEntity() != null) {
-      ps.setLong(p++, item.getTrackedEntity().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getEnrollment() != null) {
-      ps.setLong(p++, item.getEnrollment().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
-    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
-    // non-null because a given UID exists in exactly one of the two event tables.
-    if (item.getTrackerEvent() != null) {
-      ps.setLong(p++, item.getTrackerEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getSingleEvent() != null) {
-      ps.setLong(p++, item.getSingleEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    return p;
-  }
-
-  /**
-   * Sets {@code relationship.from_relationshipitemid} and {@code to_relationshipitemid} once the
-   * item rows have been inserted by {@link #insertRelationshipItems}. Required because the circular
-   * FK between {@code relationship} and {@code relationshipitem} is not deferrable, so we had to
-   * leave the parent's from/to columns NULL on the initial INSERT.
-   */
-  private void updateRelationshipFromTo(Connection conn) throws SQLException {
-    if (relationshipInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
-      List<Relationship> chunk = relationshipInserts.subList(from, to);
-      int n = chunk.size();
-
-      Long[] ids = new Long[n];
-      Long[] fromIds = new Long[n];
-      Long[] toIds = new Long[n];
-
-      for (int i = 0; i < n; i++) {
-        Relationship r = chunk.get(i);
-        ids[i] = r.getId();
-        fromIds[i] = (long) r.getFrom().getId();
-        toIds[i] = (long) r.getTo().getId();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(RELATIONSHIP_UPDATE_FROM_TO_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", ids));
-        ps.setArray(2, conn.createArrayOf("bigint", fromIds));
-        ps.setArray(3, conn.createArrayOf("bigint", toIds));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void insertTeavs(Connection conn) throws SQLException {
-    if (teavInserts.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavInserts.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavInserts.size());
-      List<TrackedEntityAttributeValue> chunk = teavInserts.subList(from, to);
-      String sql = buildMultiRowInsertSql(TEAV_INSERT_PREFIX, TEAV_INSERT_ROW, chunk.size());
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        int p = 1;
-        for (TrackedEntityAttributeValue v : chunk) {
-          ps.setLong(p++, v.getTrackedEntity().getId());
-          ps.setLong(p++, v.getAttribute().getId());
-          ps.setTimestamp(p++, toTimestamp(v.getCreated()));
-          ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
-          setNullableString(ps, p++, v.getValue());
-          setNullableString(ps, p++, v.getStoredBy());
-        }
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void updateTeavs(Connection conn) throws SQLException {
-    if (teavUpdates.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavUpdates.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavUpdates.size());
-      List<TrackedEntityAttributeValue> chunk = teavUpdates.subList(from, to);
-      int n = chunk.size();
-
-      Long[] trackedEntityIds = new Long[n];
-      Long[] attributeIds = new Long[n];
-      String[] lastUpdated = new String[n];
-      String[] value = new String[n];
-      String[] storedBy = new String[n];
-
-      for (int i = 0; i < n; i++) {
-        TrackedEntityAttributeValue v = chunk.get(i);
-        trackedEntityIds[i] = v.getTrackedEntity().getId();
-        attributeIds[i] = v.getAttribute().getId();
-        lastUpdated[i] = toTimestamptz(v.getLastUpdated());
-        value[i] = v.getValue();
-        storedBy[i] = v.getStoredBy();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TEAV_UPDATE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
-        ps.setArray(3, conn.createArrayOf("text", lastUpdated));
-        ps.setArray(4, conn.createArrayOf("text", value));
-        ps.setArray(5, conn.createArrayOf("text", storedBy));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  private void deleteTeavs(Connection conn) throws SQLException {
-    if (teavDeletes.isEmpty()) {
-      return;
-    }
-    for (int from = 0; from < teavDeletes.size(); from += BATCH_SIZE) {
-      int to = Math.min(from + BATCH_SIZE, teavDeletes.size());
-      List<TrackedEntityAttributeValue> chunk = teavDeletes.subList(from, to);
-      int n = chunk.size();
-
-      Long[] trackedEntityIds = new Long[n];
-      Long[] attributeIds = new Long[n];
-      for (int i = 0; i < n; i++) {
-        TrackedEntityAttributeValue v = chunk.get(i);
-        trackedEntityIds[i] = v.getTrackedEntity().getId();
-        attributeIds[i] = v.getAttribute().getId();
-      }
-
-      try (PreparedStatement ps = conn.prepareStatement(TEAV_DELETE_SQL)) {
-        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
-        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
-        ps.executeUpdate();
-      }
-    }
-  }
-
-  /**
-   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
-   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
-   * a {@code regclass}; the value is always a static literal controlled by us. Mirrors the helper
-   * in {@code AbstractTrackerPersister}.
-   */
-  private static long[] allocateIds(Connection conn, String sequenceName, int count)
-      throws SQLException {
-    long[] ids = new long[count];
-    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
-    try (PreparedStatement ps = conn.prepareStatement(sql)) {
-      ps.setInt(1, count);
-      try (ResultSet rs = ps.executeQuery()) {
-        int i = 0;
-        while (rs.next()) {
-          ids[i++] = rs.getLong(1);
-        }
-        if (i != count) {
-          throw new SQLException(
-              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
-        }
-      }
-    }
-    return ids;
-  }
-
-  private static String buildMultiRowInsertSql(
-      String prefix, String rowPlaceholders, int rowCount) {
-    StringBuilder sb =
-        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
-    sb.append(prefix);
-    for (int i = 0; i < rowCount; i++) {
-      if (i > 0) {
-        sb.append(", ");
-      }
-      sb.append(rowPlaceholders);
-    }
-    return sb.toString();
-  }
-
-  private static Timestamp toTimestamp(Date date) {
-    return date != null ? new Timestamp(date.getTime()) : null;
-  }
-
-  /**
-   * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
-   * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
-   * Timestamp[])} is not safe: pgjdbc stringifies each element via {@code Timestamp.toString()},
-   * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
-   * under the session {@code TimeZone} -- skewing every value when the session zone differs from
-   * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
-   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
-   * (pgjdbc appends the JVM zone offset there).
-   */
-  private static String toTimestamptz(Date date) {
-    return date != null
-        ? OffsetDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).toString()
-        : null;
-  }
-
-  private static void setNullableTimestamp(PreparedStatement ps, int index, Date date)
-      throws SQLException {
-    if (date != null) {
-      ps.setTimestamp(index, new Timestamp(date.getTime()));
-    } else {
-      ps.setNull(index, Types.TIMESTAMP);
-    }
-  }
-
-  private static void setNullableString(PreparedStatement ps, int index, String value)
-      throws SQLException {
-    if (value != null) {
-      ps.setString(index, value);
-    } else {
-      ps.setNull(index, Types.VARCHAR);
-    }
-  }
-
-  private String toJson(UserInfoSnapshot info) throws SQLException {
-    if (info == null) {
-      return null;
-    }
-    try {
-      return objectMapper.writeValueAsString(info);
-    } catch (JsonProcessingException e) {
-      throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
-    }
-  }
-
-  // Must mirror JsonEventDataValueSetBinaryType exactly: same MAPPER (configured with
-  // IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector, NON_NULL inclusion, etc.) and
-  // same per-value writer. Using a different ObjectMapper (e.g. the Spring-injected default) drops
-  // fields like UserInfoSnapshot.id that the JDBC reader requires.
-  private static final ObjectWriter EVENT_DATA_VALUE_WRITER =
-      JsonBinaryType.MAPPER.writerFor(EventDataValue.class);
-
-  /**
-   * Serializes the EventDataValues set as a JSON object keyed by {@code dataElement} uid, matching
-   * the on-disk shape produced by {@code JsonEventDataValueSetBinaryType}. An empty or null set is
-   * serialized as {@code "{}"} to match the column's NOT NULL default.
-   */
-  private String toEventDataValuesJson(Set<EventDataValue> values) throws SQLException {
-    try {
-      StringWriter sw = new StringWriter();
-      try (JsonGenerator gen = JsonBinaryType.MAPPER.getFactory().createGenerator(sw)) {
-        gen.writeStartObject();
-        if (values != null) {
-          for (EventDataValue edv : values) {
-            gen.writeFieldName(edv.getDataElement());
-            EVENT_DATA_VALUE_WRITER.writeValue(gen, edv);
-          }
-        }
-        gen.writeEndObject();
-      }
-      return sw.toString();
-    } catch (IOException e) {
-      throw new SQLException("Failed to serialize EventDataValues to JSON", e);
-    }
-  }
-
-  /**
-   * Serializes the relationship's {@link ObjectStyle} via {@link JsonBinaryType#MAPPER} to match
-   * the Hibernate {@code jbObjectStyle} UserType. Returns {@code null} for a null style so the
-   * caller can pass it straight to a {@code ?::jsonb} parameter as SQL NULL.
-   */
-  private String toObjectStyleJson(ObjectStyle style) throws SQLException {
-    if (style == null) {
-      return null;
-    }
-    try {
-      return JsonBinaryType.MAPPER.writeValueAsString(style);
-    } catch (JsonProcessingException e) {
-      throw new SQLException("Failed to serialize ObjectStyle to JSON", e);
-    }
+    trackedEntityWriter.flush(conn);
+    enrollmentWriter.flush(conn);
+    ownershipWriter.flush(conn);
+    trackerEventWriter.flush(conn);
+    singleEventWriter.flush(conn);
+    relationshipWriter.flush(conn);
+    teavWriter.flush(conn);
+
+    trackedEntityWriter.clear();
+    enrollmentWriter.clear();
+    ownershipWriter.clear();
+    trackerEventWriter.clear();
+    singleEventWriter.clear();
+    relationshipWriter.clear();
+    teavWriter.clear();
   }
 
   private boolean isEmpty() {
-    return teInserts.isEmpty()
-        && teUpdates.isEmpty()
-        && enrollmentInserts.isEmpty()
-        && enrollmentUpdates.isEmpty()
-        && trackerEventInserts.isEmpty()
-        && trackerEventUpdates.isEmpty()
-        && singleEventInserts.isEmpty()
-        && singleEventUpdates.isEmpty()
-        && relationshipInserts.isEmpty()
-        && teavInserts.isEmpty()
-        && teavUpdates.isEmpty()
-        && teavDeletes.isEmpty();
-  }
-
-  private static <T> void truncate(List<T> list, int size) {
-    if (list.size() > size) {
-      list.subList(size, list.size()).clear();
-    }
+    return trackedEntityWriter.isEmpty()
+        && enrollmentWriter.isEmpty()
+        && ownershipWriter.isEmpty()
+        && trackerEventWriter.isEmpty()
+        && singleEventWriter.isEmpty()
+        && relationshipWriter.isEmpty()
+        && teavWriter.isEmpty();
   }
 
   record Mark(
-      EntityCounts te,
-      EntityCounts enrollment,
-      EntityCounts trackerEvent,
-      EntityCounts singleEvent,
+      UpsertTableWriter.Mark te,
+      UpsertTableWriter.Mark enrollment,
+      UpsertTableWriter.Mark trackerEvent,
+      UpsertTableWriter.Mark singleEvent,
       int relationshipInserts,
-      TeavCounts teav) {
-
-    record EntityCounts(int inserts, int updates) {}
-
-    record TeavCounts(int inserts, int updates, int deletes) {}
-  }
+      int ownershipInserts,
+      TeavWriter.Mark teav) {}
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -29,10 +29,19 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
 import org.hisp.dhis.tracker.model.SingleEvent;
@@ -45,19 +54,49 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
  * per-entity error isolation in non-atomic mode.
  *
- * <p>Current scope: inserts and updates for TrackedEntity, Enrollment, TrackerEvent, SingleEvent;
- * inserts only for Relationship (updates are rejected upstream by {@link
- * AbstractTrackerPersister}); inserts, updates, and deletes for TEAVs. The flush implementation
- * delegates back to {@link EntityManager} so that Hibernate continues to drive persistence while
- * the staging shape is in place. Phase 6 replaces {@link #flush(EntityManager)} with a
- * connection-based implementation that emits multi-row INSERT / unnest UPDATE / tuple DELETE
- * statements.
+ * <p>Scope:
+ *
+ * <ul>
+ *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
+ *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
+ *       trackedentityinstance_sequence} in one round-trip.
+ *   <li>TrackedEntity updates and all other entity types (Enrollment, TrackerEvent, SingleEvent,
+ *       Relationship) still delegate to {@link EntityManager}; their Phase 6 JDBC replacements
+ *       follow.
+ *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
+ * </ul>
+ *
+ * <p>Top-level entities are flushed before TEAVs so that ids are set (and rows present in the DB or
+ * in the Hibernate persistence context) before any TEAV that references them. Within top-level
+ * entities the order (TE inserts, TE updates, Enrollment, TrackerEvent, SingleEvent, Relationship)
+ * matches the persister call order enforced by {@code DefaultTrackerBundleService.commit()} and is
+ * FK-safe.
  *
  * <p>Each {@link AbstractTrackerPersister#persist} call creates its own batch, so in practice only
  * one top-level entity type list is populated per batch (the persister's own type) alongside any
  * TEAVs staged by its attribute-handling code.
  */
 class EntityWriteBatch {
+
+  /** Cap on rows per multi-row INSERT statement, to keep query text manageable. */
+  private static final int INSERT_BATCH_SIZE = 128;
+
+  private static final int TRACKED_ENTITY_SRID = 4326;
+
+  private static final String TRACKED_ENTITY_INSERT_PREFIX =
+      "insert into trackedentity ("
+          + "trackedentityid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " inactive, deleted, lastsynchronized, potentialduplicate,"
+          + " organisationunitid, trackedentitytypeid,"
+          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
+
+  private static final String TRACKED_ENTITY_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, "
+          + TRACKED_ENTITY_SRID
+          + "), ?::jsonb, ?::jsonb)";
+
+  private final ObjectMapper objectMapper;
 
   private final List<TrackedEntity> teInserts = new ArrayList<>();
   private final List<TrackedEntity> teUpdates = new ArrayList<>();
@@ -76,6 +115,10 @@ class EntityWriteBatch {
   private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
   private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
   private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+
+  EntityWriteBatch(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
   void stageInsert(TrackedEntity trackedEntity) {
     teInserts.add(trackedEntity);
@@ -141,6 +184,15 @@ class EntityWriteBatch {
         .filter(v -> v.getTrackedEntity() == trackedEntity);
   }
 
+  /**
+   * Whether the given TrackedEntity is being inserted in this batch (no DB row yet). Used by the
+   * attribute-handling code to skip the "load existing TEAVs" JPQL query, which would always return
+   * empty for a fresh insert.
+   */
+  boolean isStagedAsInsert(TrackedEntity trackedEntity) {
+    return teInserts.contains(trackedEntity);
+  }
+
   Mark mark() {
     return new Mark(
         new Mark.EntityCounts(teInserts.size(), teUpdates.size()),
@@ -167,21 +219,17 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes through the provided {@link EntityManager}. Temporary delegating
-   * implementation; Phase 6 swaps this for JDBC multi-row statements that take a {@link
-   * java.sql.Connection}.
-   *
-   * <p>Top-level entities are flushed before TEAVs so that Hibernate assigns ids (and inserts the
-   * rows, when {@code em.flush()} runs) before any TEAV that references them. The top-level order
-   * (TE, Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order
-   * enforced by {@code DefaultTrackerBundleService.commit()} and is FK-safe.
+   * Applies all staged writes. TrackedEntity inserts go through a JDBC multi-row INSERT on {@code
+   * conn}; everything else still delegates to {@code entityManager}. The connection must be the one
+   * bound to the current Spring-managed transaction so that the JDBC INSERT and any subsequent
+   * Hibernate flush execute under the same commit.
    */
-  void flush(EntityManager entityManager) {
+  void flush(EntityManager entityManager, Connection conn) throws SQLException {
     if (isEmpty()) {
       return;
     }
 
-    persistAll(entityManager, teInserts);
+    insertTrackedEntities(conn);
     mergeAll(entityManager, teUpdates);
     persistAll(entityManager, enrollmentInserts);
     mergeAll(entityManager, enrollmentUpdates);
@@ -213,6 +261,95 @@ class EntityWriteBatch {
     teavInserts.clear();
     teavUpdates.clear();
     teavDeletes.clear();
+  }
+
+  private void insertTrackedEntities(Connection conn) throws SQLException {
+    if (teInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teInserts.size(); from += INSERT_BATCH_SIZE) {
+      int to = Math.min(from + INSERT_BATCH_SIZE, teInserts.size());
+      List<TrackedEntity> chunk = teInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              TRACKED_ENTITY_INSERT_PREFIX, TRACKED_ENTITY_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (TrackedEntity te : chunk) {
+          p = bindTrackedEntityRow(ps, p, te);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindTrackedEntityRow(PreparedStatement ps, int p, TrackedEntity te)
+      throws SQLException {
+    if (te.getId() == 0) {
+      throw new SQLException(
+          "TrackedEntity "
+              + te.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, te.getId());
+    ps.setString(p++, te.getUid());
+    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
+    setNullableTimestamp(ps, p++, te.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
+    ps.setBoolean(p++, te.isInactive());
+    ps.setBoolean(p++, te.isDeleted());
+    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
+    ps.setBoolean(p++, te.isPotentialDuplicate());
+    ps.setLong(p++, te.getOrganisationUnit().getId());
+    ps.setLong(p++, te.getTrackedEntityType().getId());
+    if (te.getGeometry() != null) {
+      ps.setString(p++, te.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, toJson(te.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(te.getLastUpdatedByUserInfo()));
+    return p;
+  }
+
+  private static String buildMultiRowInsertSql(
+      String prefix, String rowPlaceholders, int rowCount) {
+    StringBuilder sb =
+        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
+    sb.append(prefix);
+    for (int i = 0; i < rowCount; i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(rowPlaceholders);
+    }
+    return sb.toString();
+  }
+
+  private static Timestamp toTimestamp(Date date) {
+    return date != null ? new Timestamp(date.getTime()) : null;
+  }
+
+  private static void setNullableTimestamp(PreparedStatement ps, int index, Date date)
+      throws SQLException {
+    if (date != null) {
+      ps.setTimestamp(index, new Timestamp(date.getTime()));
+    } else {
+      ps.setNull(index, Types.TIMESTAMP);
+    }
+  }
+
+  private String toJson(UserInfoSnapshot info) throws SQLException {
+    if (info == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(info);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
+    }
   }
 
   private boolean isEmpty() {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
@@ -63,8 +65,16 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
  *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
  *       update branch.
- *   <li>All other entity types (Enrollment, TrackerEvent, SingleEvent, Relationship) still delegate
- *       to {@link EntityManager}; their Phase 6 JDBC replacements follow.
+ *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
+ *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
+ *       programinstance_sequence}.
+ *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
+ *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
+ *   <li>Any new {@code note}s on either inserted or updated enrollments are cascade-inserted in two
+ *       further multi-row INSERTs (into {@code note} and {@code enrollment_notes}), replacing
+ *       Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on UPDATE.
+ *   <li>All remaining entity types (TrackerEvent, SingleEvent, Relationship) still delegate to
+ *       {@link EntityManager}; their Phase 6 JDBC replacements follow.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -80,11 +90,8 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  */
 class EntityWriteBatch {
 
-  /** Cap on rows per multi-row INSERT statement, to keep query text manageable. */
-  private static final int INSERT_BATCH_SIZE = 128;
-
-  /** Cap on rows per unnest UPDATE statement, to bound peak array memory per chunk. */
-  private static final int UPDATE_BATCH_SIZE = 128;
+  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
+  private static final int BATCH_SIZE = 128;
 
   private static final int TRACKED_ENTITY_SRID = 4326;
 
@@ -131,6 +138,75 @@ class EntityWriteBatch {
           + " unnest(?::text[]) as lastupdatedbyuserinfo,"
           + " unnest(?::text[]) as geometry"
           + " ) v where te.trackedentityid = v.trackedentityid";
+
+  private static final String ENROLLMENT_INSERT_PREFIX =
+      "insert into enrollment ("
+          + "enrollmentid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " enrollmentdate, occurreddate, completeddate, completedby,"
+          + " status, followup, deleted,"
+          + " trackedentityid, programid, organisationunitid, attributeoptioncomboid,"
+          + " geometry) values ";
+
+  private static final String ENROLLMENT_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+          + "ST_GeomFromText(?, "
+          + TRACKED_ENTITY_SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(Enrollment) outside the new-entity branch (see
+  // lines 124-180). Insert-only columns (uid, created, createdbyuserinfo) and columns owned by
+  // other code paths (deleted) are deliberately excluded. status, completeddate, completedby are
+  // included even though the mapper only touches them on a status change -- writing the unchanged
+  // values back is a no-op against the existing row.
+  private static final String ENROLLMENT_UPDATE_SQL =
+      "update enrollment e set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " trackedentityid = v.trackedentityid,"
+          + " programid = v.programid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " enrollmentdate = v.enrollmentdate,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " status = v.status,"
+          + " followup = v.followup,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::timestamptz[]) as enrollmentdate,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::boolean[]) as followup,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where e.enrollmentid = v.enrollmentid";
+
+  // Cascade-INSERT targets for new enrollments that carry notes. See Enrollment.java:192-199.
+  private static final String NOTE_INSERT_PREFIX =
+      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
+  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
+
+  private static final String ENROLLMENT_NOTES_INSERT_PREFIX =
+      "insert into enrollment_notes (enrollmentid, noteid, sort_order) values ";
+  private static final String ENROLLMENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
   private final ObjectMapper objectMapper;
 
@@ -255,10 +331,11 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes. TrackedEntity inserts and updates go through JDBC on {@code conn};
-   * everything else still delegates to {@code entityManager}. The connection must be the one bound
-   * to the current Spring-managed transaction so that the JDBC statements and any subsequent
-   * Hibernate flush execute under the same commit.
+   * Applies all staged writes. TrackedEntity and Enrollment writes go through JDBC on {@code conn}
+   * (including cascade INSERTs into {@code note} / {@code enrollment_notes}); TrackerEvent,
+   * SingleEvent, Relationship and TEAV writes still delegate to {@code entityManager}. The
+   * connection must be the one bound to the current Spring-managed transaction so that the JDBC
+   * statements and any subsequent Hibernate flush execute under the same commit.
    */
   void flush(EntityManager entityManager, Connection conn) throws SQLException {
     if (isEmpty()) {
@@ -267,8 +344,9 @@ class EntityWriteBatch {
 
     insertTrackedEntities(conn);
     updateTrackedEntities(entityManager, conn);
-    persistAll(entityManager, enrollmentInserts);
-    mergeAll(entityManager, enrollmentUpdates);
+    insertEnrollments(conn);
+    updateEnrollments(entityManager, conn);
+    insertEnrollmentNotes(conn);
     persistAll(entityManager, trackerEventInserts);
     mergeAll(entityManager, trackerEventUpdates);
     persistAll(entityManager, singleEventInserts);
@@ -304,8 +382,8 @@ class EntityWriteBatch {
     if (teUpdates.isEmpty()) {
       return;
     }
-    for (int from = 0; from < teUpdates.size(); from += UPDATE_BATCH_SIZE) {
-      int to = Math.min(from + UPDATE_BATCH_SIZE, teUpdates.size());
+    for (int from = 0; from < teUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teUpdates.size());
       List<TrackedEntity> chunk = teUpdates.subList(from, to);
       int n = chunk.size();
 
@@ -366,8 +444,8 @@ class EntityWriteBatch {
     if (teInserts.isEmpty()) {
       return;
     }
-    for (int from = 0; from < teInserts.size(); from += INSERT_BATCH_SIZE) {
-      int to = Math.min(from + INSERT_BATCH_SIZE, teInserts.size());
+    for (int from = 0; from < teInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teInserts.size());
       List<TrackedEntity> chunk = teInserts.subList(from, to);
       String sql =
           buildMultiRowInsertSql(
@@ -411,6 +489,276 @@ class EntityWriteBatch {
     ps.setString(p++, toJson(te.getCreatedByUserInfo()));
     ps.setString(p++, toJson(te.getLastUpdatedByUserInfo()));
     return p;
+  }
+
+  private void insertEnrollments(Connection conn) throws SQLException {
+    if (enrollmentInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < enrollmentInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, enrollmentInserts.size());
+      List<Enrollment> chunk = enrollmentInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(ENROLLMENT_INSERT_PREFIX, ENROLLMENT_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (Enrollment e : chunk) {
+          p = bindEnrollmentRow(ps, p, e);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindEnrollmentRow(PreparedStatement ps, int p, Enrollment e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "Enrollment "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
+    ps.setTimestamp(p++, toTimestamp(e.getEnrollmentDate()));
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, e.getStatus().name());
+    if (e.getFollowup() != null) {
+      ps.setBoolean(p++, e.getFollowup());
+    } else {
+      ps.setNull(p++, Types.BOOLEAN);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    ps.setLong(p++, e.getTrackedEntity().getId());
+    ps.setLong(p++, e.getProgram().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void updateEnrollments(EntityManager entityManager, Connection conn) throws SQLException {
+    if (enrollmentUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < enrollmentUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, enrollmentUpdates.size());
+      List<Enrollment> chunk = enrollmentUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      Long[] trackedEntityIds = new Long[n];
+      Long[] programIds = new Long[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] attributeOptionComboIds = new Long[n];
+      Timestamp[] enrollmentDate = new Timestamp[n];
+      Timestamp[] occurredDate = new Timestamp[n];
+      Timestamp[] completedDate = new Timestamp[n];
+      String[] completedBy = new String[n];
+      String[] status = new String[n];
+      Boolean[] followup = new Boolean[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        Enrollment e = chunk.get(i);
+        ids[i] = e.getId();
+        lastUpdated[i] = toTimestamp(e.getLastUpdated());
+        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
+        trackedEntityIds[i] = e.getTrackedEntity().getId();
+        programIds[i] = e.getProgram().getId();
+        organisationUnitIds[i] = e.getOrganisationUnit().getId();
+        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+        enrollmentDate[i] = toTimestamp(e.getEnrollmentDate());
+        occurredDate[i] = toTimestamp(e.getOccurredDate());
+        completedDate[i] = toTimestamp(e.getCompletedDate());
+        completedBy[i] = e.getCompletedBy();
+        status[i] = e.getStatus().name();
+        followup[i] = e.getFollowup();
+        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(ENROLLMENT_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityIds));
+        ps.setArray(7, conn.createArrayOf("bigint", programIds));
+        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+        ps.setArray(10, conn.createArrayOf("timestamptz", enrollmentDate));
+        ps.setArray(11, conn.createArrayOf("timestamptz", occurredDate));
+        ps.setArray(12, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(13, conn.createArrayOf("text", completedBy));
+        ps.setArray(14, conn.createArrayOf("text", status));
+        ps.setArray(15, conn.createArrayOf("boolean", followup));
+        ps.setArray(16, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // Same L1 staleness fix as updateTrackedEntities -- the JDBC UPDATE bypasses Hibernate, so the
+    // preheat-loaded managed Enrollment in the persistence context still carries the pre-update
+    // state. Detach it so any subsequent JPQL read reloads the fresh DB row.
+    for (Enrollment e : enrollmentUpdates) {
+      Enrollment managed = entityManager.find(Enrollment.class, e.getId());
+      if (managed != null) {
+        entityManager.detach(managed);
+      }
+    }
+  }
+
+  /**
+   * Cascade-insert any notes attached to enrollments that were just inserted by {@link
+   * #insertEnrollments} or appended to existing enrollments by {@link #updateEnrollments}. Mirrors
+   * what Hibernate did via {@code @OneToMany(cascade=ALL)} on {@code Enrollment.notes} (see {@code
+   * Enrollment.java:192-199}): allocate ids for the new {@code note} rows from {@code
+   * note_sequence}, insert the {@code note} rows, then insert the join rows in {@code
+   * enrollment_notes} with {@code sort_order} taken from the list position (1-based, per
+   * {@code @ListIndexBase(1)}). On INSERT every Note is new; on UPDATE only Notes with {@code id ==
+   * 0} are new (existing ones were loaded by the preheat).
+   */
+  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder) {}
+
+  private void insertEnrollmentNotes(Connection conn) throws SQLException {
+    List<EnrollmentNoteToInsert> newNotes = collectNewEnrollmentNotes();
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertEnrollmentNotesJoinRows(conn, newNotes);
+  }
+
+  /**
+   * For each enrollment being inserted or updated, collect the {@link Note}s that are new (no DB
+   * id) along with their 1-based sort order, which is the position in the {@code getNotes()} list.
+   * For inserts every note is new; for updates the preheat-loaded list already contains existing
+   * notes with non-zero ids, so we skip those.
+   */
+  private List<EnrollmentNoteToInsert> collectNewEnrollmentNotes() {
+    List<EnrollmentNoteToInsert> newNotes = new ArrayList<>();
+    collectNewNotesFrom(enrollmentInserts, newNotes);
+    collectNewNotesFrom(enrollmentUpdates, newNotes);
+    return newNotes;
+  }
+
+  private static void collectNewNotesFrom(
+      List<Enrollment> enrollments, List<EnrollmentNoteToInsert> out) {
+    for (Enrollment e : enrollments) {
+      if (e.getNotes() == null) {
+        continue;
+      }
+      List<Note> notes = e.getNotes();
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new EnrollmentNoteToInsert(e.getId(), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertNoteRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
+      throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
+      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (EnrollmentNoteToInsert item : chunk) {
+          Note n = item.note();
+          ps.setLong(p++, n.getId());
+          ps.setString(p++, n.getUid());
+          ps.setTimestamp(p++, toTimestamp(n.getCreated()));
+          if (n.getLastUpdatedBy() != null) {
+            ps.setLong(p++, n.getLastUpdatedBy().getId());
+          } else {
+            ps.setNull(p++, Types.BIGINT);
+          }
+          if (n.getNoteText() != null) {
+            ps.setString(p++, n.getNoteText());
+          } else {
+            ps.setNull(p++, Types.VARCHAR);
+          }
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void insertEnrollmentNotesJoinRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
+      throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
+      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              ENROLLMENT_NOTES_INSERT_PREFIX, ENROLLMENT_NOTES_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (EnrollmentNoteToInsert item : chunk) {
+          ps.setLong(p++, item.enrollmentId());
+          ps.setLong(p++, item.note().getId());
+          ps.setInt(p++, item.sortOrder());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  /**
+   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
+   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
+   * a {@code regclass}; the value is always a static literal controlled by us. Mirrors the helper
+   * in {@code AbstractTrackerPersister}.
+   */
+  private static long[] allocateIds(Connection conn, String sequenceName, int count)
+      throws SQLException {
+    long[] ids = new long[count];
+    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setInt(1, count);
+      try (ResultSet rs = ps.executeQuery()) {
+        int i = 0;
+        while (rs.next()) {
+          ids[i++] = rs.getLong(1);
+        }
+        if (i != count) {
+          throw new SQLException(
+              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
+        }
+      }
+    }
+    return ids;
   }
 
   private static String buildMultiRowInsertSql(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+
+/**
+ * Accumulates entity-level writes staged during the persist loop and applies them at a single flush
+ * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
+ * per-entity error isolation in non-atomic mode.
+ *
+ * <p>Phase 3 scope: TEAV inserts/updates/deletes only. The flush implementation currently delegates
+ * back to {@link EntityManager} so that Hibernate continues to drive persistence while the staging
+ * shape is in place. Phase 6 replaces {@link #flush(EntityManager)} with a connection-based
+ * implementation that emits multi-row INSERT / unnest UPDATE / tuple DELETE statements. Top-level
+ * entities (TrackedEntity, Enrollment, events, relationships) are added by Phase 4.
+ */
+class EntityWriteBatch {
+
+  private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+
+  void stageTeavInsert(TrackedEntityAttributeValue value) {
+    teavInserts.add(value);
+  }
+
+  void stageTeavUpdate(TrackedEntityAttributeValue value) {
+    teavUpdates.add(value);
+  }
+
+  void stageTeavDelete(TrackedEntityAttributeValue value) {
+    teavDeletes.add(value);
+  }
+
+  /**
+   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
+   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
+   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
+   * each carrying the same attribute value -- so it can fold the second occurrence into the first
+   * staged instance instead of producing a duplicate {@code em.persist} that would throw {@code
+   * EntityExistsException}.
+   */
+  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
+    return Stream.concat(teavInserts.stream(), teavUpdates.stream())
+        .filter(v -> v.getTrackedEntity() == trackedEntity);
+  }
+
+  Mark mark() {
+    return new Mark(teavInserts.size(), teavUpdates.size(), teavDeletes.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(teavInserts, mark.teavInsertSize);
+    truncate(teavUpdates, mark.teavUpdateSize);
+    truncate(teavDeletes, mark.teavDeleteSize);
+  }
+
+  /**
+   * Applies all staged writes through the provided {@link EntityManager}. Temporary delegating
+   * implementation; Phase 6 swaps this for JDBC multi-row statements that take a {@link
+   * java.sql.Connection}.
+   */
+  void flush(EntityManager entityManager) {
+    if (teavInserts.isEmpty() && teavUpdates.isEmpty() && teavDeletes.isEmpty()) {
+      return;
+    }
+
+    for (TrackedEntityAttributeValue v : teavInserts) {
+      entityManager.persist(v);
+    }
+    for (TrackedEntityAttributeValue v : teavUpdates) {
+      entityManager.merge(v);
+    }
+    for (TrackedEntityAttributeValue v : teavDeletes) {
+      entityManager.remove(entityManager.contains(v) ? v : entityManager.merge(v));
+    }
+
+    teavInserts.clear();
+    teavUpdates.clear();
+    teavDeletes.clear();
+  }
+
+  private static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  record Mark(int teavInsertSize, int teavUpdateSize, int teavDeleteSize) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.stream.Stream;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
 import org.hisp.dhis.tracker.model.SingleEvent;
@@ -168,23 +167,6 @@ class EntityWriteBatch {
 
   void stageTeavDelete(TrackedEntityAttributeValue value) {
     teavWriter.stageDelete(value);
-  }
-
-  /**
-   * TEAVs already staged for insert or update against the given TrackedEntity. See {@link
-   * TeavWriter#stagedFor}.
-   */
-  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
-    return teavWriter.stagedFor(trackedEntity);
-  }
-
-  /**
-   * Whether the given TrackedEntity is being inserted in this batch (no DB row yet). Used by the
-   * attribute-handling code to skip the JDBC read of existing TEAVs, which would always return
-   * empty for a fresh insert.
-   */
-  boolean isStagedAsInsert(TrackedEntity trackedEntity) {
-    return trackedEntityWriter.isStagedAsInsert(trackedEntity);
   }
 
   Mark mark() {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -47,12 +47,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.Relationship;
+import org.hisp.dhis.tracker.model.RelationshipItem;
 import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
@@ -90,8 +92,13 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       {@code enrollment_notes} / {@code trackerevent_notes} / {@code singleevent_notes} join),
  *       replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on
  *       UPDATE.
- *   <li>Relationship is the only remaining top-level entity type still delegating to {@link
- *       EntityManager}; its Phase 6 JDBC replacement follows.
+ *   <li>Relationship inserts are flushed via three JDBC statements -- a multi-row INSERT into
+ *       {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT
+ *       into {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code
+ *       relationship} to set the from/to FKs. The three-step shape breaks the circular FK between
+ *       the two tables, which is not deferrable in the live schema. Both tables use the shared
+ *       {@code hibernate_sequence}. Relationship is INSERT-only -- the persister rejects UPDATE
+ *       strategy upstream.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -354,6 +361,43 @@ class EntityWriteBatch {
       "insert into singleevent_notes (eventid, noteid, sort_order) values ";
   private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
+  // Relationship is INSERT-only in tracker imports (RelationshipPersister.convert returns null on
+  // UPDATE strategy). Both relationship and relationshipitem use `hibernate_sequence` (no
+  // dedicated sequence was provisioned in any Flyway migration -- the hbm.xml `<generator
+  // class="native"/>` resolves to the shared global counter).
+  //
+  // The two tables form a circular FK (relationship.from/to_relationshipitemid <->
+  // relationshipitem.relationshipid) with non-deferrable constraints. We break the cycle by
+  // inserting the relationship row first with from/to as NULL, then the items pointing at the
+  // pre-allocated relationshipid, then an unnest UPDATE to set the from/to FKs.
+  private static final String RELATIONSHIP_INSERT_PREFIX =
+      "insert into relationship ("
+          + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
+          + " style, relationshiptypeid,"
+          + " from_relationshipitemid, to_relationshipitemid,"
+          + " key, inverted_key, deleted, createdatclient) values ";
+
+  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
+  // updateRelationshipFromTo after the items are inserted.
+  private static final String RELATIONSHIP_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
+
+  private static final String RELATIONSHIP_ITEM_INSERT_PREFIX =
+      "insert into relationshipitem ("
+          + "relationshipitemid, relationshipid,"
+          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
+  private static final String RELATIONSHIP_ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  private static final String RELATIONSHIP_UPDATE_FROM_TO_SQL =
+      "update relationship r set"
+          + " from_relationshipitemid = v.from_id,"
+          + " to_relationshipitemid = v.to_id"
+          + " from ( select"
+          + " unnest(?::bigint[]) as relationshipid,"
+          + " unnest(?::bigint[]) as from_id,"
+          + " unnest(?::bigint[]) as to_id"
+          + " ) v where r.relationshipid = v.relationshipid";
+
   private final ObjectMapper objectMapper;
 
   private final List<TrackedEntity> teInserts = new ArrayList<>();
@@ -501,7 +545,9 @@ class EntityWriteBatch {
     updateSingleEvents(conn);
     insertSingleEventNotes(conn);
     refreshUpdatedSingleEvents(entityManager);
-    persistAll(entityManager, relationshipInserts);
+    insertRelationships(conn);
+    insertRelationshipItems(conn);
+    updateRelationshipFromTo(conn);
 
     for (TrackedEntityAttributeValue v : teavInserts) {
       entityManager.persist(v);
@@ -1306,6 +1352,170 @@ class EntityWriteBatch {
   }
 
   /**
+   * Inserts the parent {@code relationship} rows. {@code from_relationshipitemid} and {@code
+   * to_relationshipitemid} are written as NULL here -- they're filled in by {@link
+   * #updateRelationshipFromTo} after the item rows have been inserted, since neither the parent nor
+   * the child FK constraints are deferrable. Relationship is INSERT-only in tracker imports, so no
+   * L1 detach/refresh is needed.
+   */
+  private void insertRelationships(Connection conn) throws SQLException {
+    if (relationshipInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
+      List<Relationship> chunk = relationshipInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(RELATIONSHIP_INSERT_PREFIX, RELATIONSHIP_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (Relationship r : chunk) {
+          p = bindRelationshipRow(ps, p, r);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindRelationshipRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
+    if (r.getId() == 0) {
+      throw new SQLException(
+          "Relationship "
+              + r.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, r.getId());
+    ps.setString(p++, r.getUid());
+    if (r.getCode() != null) {
+      ps.setString(p++, r.getCode());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
+    if (r.getLastUpdatedBy() != null) {
+      ps.setLong(p++, r.getLastUpdatedBy().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toObjectStyleJson(r.getStyle()));
+    ps.setLong(p++, r.getRelationshipType().getId());
+    ps.setString(p++, r.getKey());
+    ps.setString(p++, r.getInvertedKey());
+    ps.setBoolean(p++, r.isDeleted());
+    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
+    return p;
+  }
+
+  /**
+   * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
+   * we allocate {@code 2 * relationships.size()} ids from {@code hibernate_sequence} in one
+   * round-trip, assign them to the in-memory items (so the subsequent unnest UPDATE can read them
+   * back), then flatten the from/to items into a single multi-row INSERT.
+   */
+  private void insertRelationshipItems(Connection conn) throws SQLException {
+    if (relationshipInserts.isEmpty()) {
+      return;
+    }
+    long[] itemIds = allocateIds(conn, "hibernate_sequence", 2 * relationshipInserts.size());
+    int cursor = 0;
+    for (Relationship r : relationshipInserts) {
+      r.getFrom().setId((int) itemIds[cursor++]);
+      r.getTo().setId((int) itemIds[cursor++]);
+    }
+
+    // Flatten (from + to) per relationship into a single list to drive one multi-row INSERT.
+    record ItemRow(long itemId, long relationshipId, RelationshipItem item) {}
+    List<ItemRow> rows = new ArrayList<>(2 * relationshipInserts.size());
+    for (Relationship r : relationshipInserts) {
+      rows.add(new ItemRow(r.getFrom().getId(), r.getId(), r.getFrom()));
+      rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
+    }
+
+    for (int from = 0; from < rows.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, rows.size());
+      List<ItemRow> chunk = rows.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              RELATIONSHIP_ITEM_INSERT_PREFIX, RELATIONSHIP_ITEM_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (ItemRow row : chunk) {
+          p = bindRelationshipItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindRelationshipItemRow(
+      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
+      throws SQLException {
+    ps.setLong(p++, itemId);
+    ps.setLong(p++, relationshipId);
+    if (item.getTrackedEntity() != null) {
+      ps.setLong(p++, item.getTrackedEntity().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getEnrollment() != null) {
+      ps.setLong(p++, item.getEnrollment().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
+    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
+    // non-null because a given UID exists in exactly one of the two event tables.
+    if (item.getTrackerEvent() != null) {
+      ps.setLong(p++, item.getTrackerEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getSingleEvent() != null) {
+      ps.setLong(p++, item.getSingleEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    return p;
+  }
+
+  /**
+   * Sets {@code relationship.from_relationshipitemid} and {@code to_relationshipitemid} once the
+   * item rows have been inserted by {@link #insertRelationshipItems}. Required because the circular
+   * FK between {@code relationship} and {@code relationshipitem} is not deferrable, so we had to
+   * leave the parent's from/to columns NULL on the initial INSERT.
+   */
+  private void updateRelationshipFromTo(Connection conn) throws SQLException {
+    if (relationshipInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < relationshipInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, relationshipInserts.size());
+      List<Relationship> chunk = relationshipInserts.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Long[] fromIds = new Long[n];
+      Long[] toIds = new Long[n];
+
+      for (int i = 0; i < n; i++) {
+        Relationship r = chunk.get(i);
+        ids[i] = r.getId();
+        fromIds[i] = (long) r.getFrom().getId();
+        toIds[i] = (long) r.getTo().getId();
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(RELATIONSHIP_UPDATE_FROM_TO_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("bigint", fromIds));
+        ps.setArray(3, conn.createArrayOf("bigint", toIds));
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  /**
    * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
    * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
    * a {@code regclass}; the value is always a static literal controlled by us. Mirrors the helper
@@ -1400,6 +1610,22 @@ class EntityWriteBatch {
     }
   }
 
+  /**
+   * Serializes the relationship's {@link ObjectStyle} via {@link JsonBinaryType#MAPPER} to match
+   * the Hibernate {@code jbObjectStyle} UserType. Returns {@code null} for a null style so the
+   * caller can pass it straight to a {@code ?::jsonb} parameter as SQL NULL.
+   */
+  private String toObjectStyleJson(ObjectStyle style) throws SQLException {
+    if (style == null) {
+      return null;
+    }
+    try {
+      return JsonBinaryType.MAPPER.writeValueAsString(style);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize ObjectStyle to JSON", e);
+    }
+  }
+
   private boolean isEmpty() {
     return teInserts.isEmpty()
         && teUpdates.isEmpty()
@@ -1413,12 +1639,6 @@ class EntityWriteBatch {
         && teavInserts.isEmpty()
         && teavUpdates.isEmpty()
         && teavDeletes.isEmpty();
-  }
-
-  private static <T> void persistAll(EntityManager entityManager, List<T> entities) {
-    for (T entity : entities) {
-      entityManager.persist(entity);
-    }
   }
 
   private static <T> void truncate(List<T> list, int size) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -60,9 +60,11 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
  *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
  *       trackedentityinstance_sequence} in one round-trip.
- *   <li>TrackedEntity updates and all other entity types (Enrollment, TrackerEvent, SingleEvent,
- *       Relationship) still delegate to {@link EntityManager}; their Phase 6 JDBC replacements
- *       follow.
+ *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
+ *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
+ *       update branch.
+ *   <li>All other entity types (Enrollment, TrackerEvent, SingleEvent, Relationship) still delegate
+ *       to {@link EntityManager}; their Phase 6 JDBC replacements follow.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -81,6 +83,9 @@ class EntityWriteBatch {
   /** Cap on rows per multi-row INSERT statement, to keep query text manageable. */
   private static final int INSERT_BATCH_SIZE = 128;
 
+  /** Cap on rows per unnest UPDATE statement, to bound peak array memory per chunk. */
+  private static final int UPDATE_BATCH_SIZE = 128;
+
   private static final int TRACKED_ENTITY_SRID = 4326;
 
   private static final String TRACKED_ENTITY_INSERT_PREFIX =
@@ -95,6 +100,37 @@ class EntityWriteBatch {
       "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, "
           + TRACKED_ENTITY_SRID
           + "), ?::jsonb, ?::jsonb)";
+
+  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch (see lines 90-104). Insert-
+  // only columns (uid, created, createdbyuserinfo) and columns owned by other code paths
+  // (deleted, lastsynchronized -- the latter is bulk-updated by
+  // DefaultTrackerBundleService.postCommit) are deliberately excluded.
+  private static final String TRACKED_ENTITY_UPDATE_SQL =
+      "update trackedentity te set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " organisationunitid = v.organisationunitid,"
+          + " trackedentitytypeid = v.trackedentitytypeid,"
+          + " potentialduplicate = v.potentialduplicate,"
+          + " inactive = v.inactive,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as trackedentitytypeid,"
+          + " unnest(?::boolean[]) as potentialduplicate,"
+          + " unnest(?::boolean[]) as inactive,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where te.trackedentityid = v.trackedentityid";
 
   private final ObjectMapper objectMapper;
 
@@ -219,9 +255,9 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes. TrackedEntity inserts go through a JDBC multi-row INSERT on {@code
-   * conn}; everything else still delegates to {@code entityManager}. The connection must be the one
-   * bound to the current Spring-managed transaction so that the JDBC INSERT and any subsequent
+   * Applies all staged writes. TrackedEntity inserts and updates go through JDBC on {@code conn};
+   * everything else still delegates to {@code entityManager}. The connection must be the one bound
+   * to the current Spring-managed transaction so that the JDBC statements and any subsequent
    * Hibernate flush execute under the same commit.
    */
   void flush(EntityManager entityManager, Connection conn) throws SQLException {
@@ -230,7 +266,7 @@ class EntityWriteBatch {
     }
 
     insertTrackedEntities(conn);
-    mergeAll(entityManager, teUpdates);
+    updateTrackedEntities(entityManager, conn);
     persistAll(entityManager, enrollmentInserts);
     mergeAll(entityManager, enrollmentUpdates);
     persistAll(entityManager, trackerEventInserts);
@@ -261,6 +297,69 @@ class EntityWriteBatch {
     teavInserts.clear();
     teavUpdates.clear();
     teavDeletes.clear();
+  }
+
+  private void updateTrackedEntities(EntityManager entityManager, Connection conn)
+      throws SQLException {
+    if (teUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teUpdates.size(); from += UPDATE_BATCH_SIZE) {
+      int to = Math.min(from + UPDATE_BATCH_SIZE, teUpdates.size());
+      List<TrackedEntity> chunk = teUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] trackedEntityTypeIds = new Long[n];
+      Boolean[] potentialDuplicate = new Boolean[n];
+      Boolean[] inactive = new Boolean[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        TrackedEntity te = chunk.get(i);
+        ids[i] = te.getId();
+        lastUpdated[i] = toTimestamp(te.getLastUpdated());
+        createdAtClient[i] = toTimestamp(te.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(te.getLastUpdatedAtClient());
+        organisationUnitIds[i] = te.getOrganisationUnit().getId();
+        trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
+        potentialDuplicate[i] = te.isPotentialDuplicate();
+        inactive[i] = te.isInactive();
+        lastUpdatedByUserInfo[i] = toJson(te.getLastUpdatedByUserInfo());
+        geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(TRACKED_ENTITY_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
+        ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
+        ps.setArray(8, conn.createArrayOf("boolean", inactive));
+        ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(10, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // The TrackedEntity entities passed in here are detached copies from the preheat. The
+    // Hibernate persistence context separately holds the entities loaded by the preheat's queries
+    // (M_managed), and they still carry their pre-update state. Detach them so any subsequent
+    // JPQL read in this session reloads the fresh DB row instead of returning the stale L1
+    // instance. This detaching will be removed once all entity types are migrated to JDBC and
+    // entityManager is no longer needed.
+    for (TrackedEntity te : teUpdates) {
+      TrackedEntity managed = entityManager.find(TrackedEntity.class, te.getId());
+      if (managed != null) {
+        entityManager.detach(managed);
+      }
+    }
   }
 
   private void insertTrackedEntities(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -104,10 +104,11 @@ class EntityWriteBatch {
   private final TeavWriter teavWriter = new TeavWriter();
 
   EntityWriteBatch(ObjectMapper objectMapper) {
-    this.trackedEntityWriter = new TrackedEntityWriter(objectMapper);
-    this.enrollmentWriter = new EnrollmentWriter(objectMapper);
-    this.trackerEventWriter = new TrackerEventWriter(objectMapper);
-    this.singleEventWriter = new SingleEventWriter(objectMapper);
+    UserInfoJsonCache userInfo = new UserInfoJsonCache(objectMapper);
+    this.trackedEntityWriter = new TrackedEntityWriter(userInfo);
+    this.enrollmentWriter = new EnrollmentWriter(userInfo);
+    this.trackerEventWriter = new TrackerEventWriter(userInfo);
+    this.singleEventWriter = new SingleEventWriter(userInfo);
   }
 
   void stageInsert(TrackedEntity trackedEntity) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -71,13 +71,12 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  * <ul>
  *   <li>TrackedEntity inserts are flushed via a multi-row JDBC INSERT against {@code trackedentity}
  *       -- ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       trackedentityinstance_sequence} in one round-trip.
+ *       trackedentity_sequence} in one round-trip.
  *   <li>TrackedEntity updates are flushed via a single JDBC unnest UPDATE against {@code
  *       trackedentity}, writing only the columns mutated by {@code TrackerObjectsMapper.map} on the
  *       update branch.
  *   <li>Enrollment inserts are flushed via a multi-row JDBC INSERT against {@code enrollment} --
- *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code
- *       programinstance_sequence}.
+ *       ids are pre-allocated by {@link AbstractTrackerPersister} from {@code enrollment_sequence}.
  *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
  *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
  *   <li>TrackerEvent inserts are flushed via a multi-row JDBC INSERT against {@code trackerevent}
@@ -97,9 +96,9 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT
  *       into {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code
  *       relationship} to set the from/to FKs. The three-step shape breaks the circular FK between
- *       the two tables, which is not deferrable in the live schema. Both tables use the shared
- *       {@code hibernate_sequence}. Relationship is INSERT-only -- the persister rejects UPDATE
- *       strategy upstream.
+ *       the two tables, which is not deferrable in the live schema. Ids come from {@code
+ *       relationship_sequence} and {@code relationshipitem_sequence}. Relationship is INSERT-only
+ *       -- the persister rejects UPDATE strategy upstream.
  *   <li>TrackedEntityAttributeValues are flushed via JDBC against {@code
  *       trackedentityattributevalue} -- a multi-row INSERT, a single unnest UPDATE keyed on the
  *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single
@@ -384,9 +383,8 @@ class EntityWriteBatch {
   private static final String SINGLE_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
   // Relationship is INSERT-only in tracker imports (RelationshipPersister.convert returns null on
-  // UPDATE strategy). Both relationship and relationshipitem use `hibernate_sequence` (no
-  // dedicated sequence was provisioned in any Flyway migration -- the hbm.xml `<generator
-  // class="native"/>` resolves to the shared global counter).
+  // UPDATE strategy). Relationship ids come from `relationship_sequence`, item ids from
+  // `relationshipitem_sequence`.
   //
   // The two tables form a circular FK (relationship.from/to_relationshipitemid <->
   // relationshipitem.relationshipid) with non-deferrable constraints. We break the cycle by
@@ -1409,7 +1407,7 @@ class EntityWriteBatch {
 
   /**
    * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
-   * we allocate {@code 2 * relationships.size()} ids from {@code hibernate_sequence} in one
+   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
    * round-trip, assign them to the in-memory items (so the subsequent unnest UPDATE can read them
    * back), then flatten the from/to items into a single multi-row INSERT.
    */
@@ -1417,7 +1415,7 @@ class EntityWriteBatch {
     if (relationshipInserts.isEmpty()) {
       return;
     }
-    long[] itemIds = allocateIds(conn, "hibernate_sequence", 2 * relationshipInserts.size());
+    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * relationshipInserts.size());
     int cursor = 0;
     for (Relationship r : relationshipInserts) {
       r.getFrom().setId((int) itemIds[cursor++]);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -33,25 +33,88 @@ import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hisp.dhis.tracker.model.Enrollment;
+import org.hisp.dhis.tracker.model.Relationship;
+import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.model.TrackerEvent;
 
 /**
  * Accumulates entity-level writes staged during the persist loop and applies them at a single flush
  * point. Mirrors {@link ChangeLogAccumulator} and shares the same mark/rollback contract for
  * per-entity error isolation in non-atomic mode.
  *
- * <p>Phase 3 scope: TEAV inserts/updates/deletes only. The flush implementation currently delegates
- * back to {@link EntityManager} so that Hibernate continues to drive persistence while the staging
- * shape is in place. Phase 6 replaces {@link #flush(EntityManager)} with a connection-based
- * implementation that emits multi-row INSERT / unnest UPDATE / tuple DELETE statements. Top-level
- * entities (TrackedEntity, Enrollment, events, relationships) are added by Phase 4.
+ * <p>Current scope: inserts and updates for TrackedEntity, Enrollment, TrackerEvent, SingleEvent;
+ * inserts only for Relationship (updates are rejected upstream by {@link
+ * AbstractTrackerPersister}); inserts, updates, and deletes for TEAVs. The flush implementation
+ * delegates back to {@link EntityManager} so that Hibernate continues to drive persistence while
+ * the staging shape is in place. Phase 6 replaces {@link #flush(EntityManager)} with a
+ * connection-based implementation that emits multi-row INSERT / unnest UPDATE / tuple DELETE
+ * statements.
+ *
+ * <p>Each {@link AbstractTrackerPersister#persist} call creates its own batch, so in practice only
+ * one top-level entity type list is populated per batch (the persister's own type) alongside any
+ * TEAVs staged by its attribute-handling code.
  */
 class EntityWriteBatch {
+
+  private final List<TrackedEntity> teInserts = new ArrayList<>();
+  private final List<TrackedEntity> teUpdates = new ArrayList<>();
+
+  private final List<Enrollment> enrollmentInserts = new ArrayList<>();
+  private final List<Enrollment> enrollmentUpdates = new ArrayList<>();
+
+  private final List<TrackerEvent> trackerEventInserts = new ArrayList<>();
+  private final List<TrackerEvent> trackerEventUpdates = new ArrayList<>();
+
+  private final List<SingleEvent> singleEventInserts = new ArrayList<>();
+  private final List<SingleEvent> singleEventUpdates = new ArrayList<>();
+
+  private final List<Relationship> relationshipInserts = new ArrayList<>();
 
   private final List<TrackedEntityAttributeValue> teavInserts = new ArrayList<>();
   private final List<TrackedEntityAttributeValue> teavUpdates = new ArrayList<>();
   private final List<TrackedEntityAttributeValue> teavDeletes = new ArrayList<>();
+
+  void stageInsert(TrackedEntity trackedEntity) {
+    teInserts.add(trackedEntity);
+  }
+
+  void stageUpdate(TrackedEntity trackedEntity) {
+    teUpdates.add(trackedEntity);
+  }
+
+  void stageInsert(Enrollment enrollment) {
+    enrollmentInserts.add(enrollment);
+  }
+
+  void stageUpdate(Enrollment enrollment) {
+    enrollmentUpdates.add(enrollment);
+  }
+
+  void stageInsert(TrackerEvent event) {
+    trackerEventInserts.add(event);
+  }
+
+  void stageUpdate(TrackerEvent event) {
+    trackerEventUpdates.add(event);
+  }
+
+  void stageInsert(SingleEvent event) {
+    singleEventInserts.add(event);
+  }
+
+  void stageUpdate(SingleEvent event) {
+    singleEventUpdates.add(event);
+  }
+
+  /**
+   * Relationships are never updated -- {@link AbstractTrackerPersister} ignores update payloads.
+   */
+  void stageInsert(Relationship relationship) {
+    relationshipInserts.add(relationship);
+  }
 
   void stageTeavInsert(TrackedEntityAttributeValue value) {
     teavInserts.add(value);
@@ -79,24 +142,54 @@ class EntityWriteBatch {
   }
 
   Mark mark() {
-    return new Mark(teavInserts.size(), teavUpdates.size(), teavDeletes.size());
+    return new Mark(
+        new Mark.EntityCounts(teInserts.size(), teUpdates.size()),
+        new Mark.EntityCounts(enrollmentInserts.size(), enrollmentUpdates.size()),
+        new Mark.EntityCounts(trackerEventInserts.size(), trackerEventUpdates.size()),
+        new Mark.EntityCounts(singleEventInserts.size(), singleEventUpdates.size()),
+        relationshipInserts.size(),
+        new Mark.TeavCounts(teavInserts.size(), teavUpdates.size(), teavDeletes.size()));
   }
 
   void rollbackTo(Mark mark) {
-    truncate(teavInserts, mark.teavInsertSize);
-    truncate(teavUpdates, mark.teavUpdateSize);
-    truncate(teavDeletes, mark.teavDeleteSize);
+    truncate(teInserts, mark.te().inserts());
+    truncate(teUpdates, mark.te().updates());
+    truncate(enrollmentInserts, mark.enrollment().inserts());
+    truncate(enrollmentUpdates, mark.enrollment().updates());
+    truncate(trackerEventInserts, mark.trackerEvent().inserts());
+    truncate(trackerEventUpdates, mark.trackerEvent().updates());
+    truncate(singleEventInserts, mark.singleEvent().inserts());
+    truncate(singleEventUpdates, mark.singleEvent().updates());
+    truncate(relationshipInserts, mark.relationshipInserts());
+    truncate(teavInserts, mark.teav().inserts());
+    truncate(teavUpdates, mark.teav().updates());
+    truncate(teavDeletes, mark.teav().deletes());
   }
 
   /**
    * Applies all staged writes through the provided {@link EntityManager}. Temporary delegating
    * implementation; Phase 6 swaps this for JDBC multi-row statements that take a {@link
    * java.sql.Connection}.
+   *
+   * <p>Top-level entities are flushed before TEAVs so that Hibernate assigns ids (and inserts the
+   * rows, when {@code em.flush()} runs) before any TEAV that references them. The top-level order
+   * (TE, Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order
+   * enforced by {@code DefaultTrackerBundleService.commit()} and is FK-safe.
    */
   void flush(EntityManager entityManager) {
-    if (teavInserts.isEmpty() && teavUpdates.isEmpty() && teavDeletes.isEmpty()) {
+    if (isEmpty()) {
       return;
     }
+
+    persistAll(entityManager, teInserts);
+    mergeAll(entityManager, teUpdates);
+    persistAll(entityManager, enrollmentInserts);
+    mergeAll(entityManager, enrollmentUpdates);
+    persistAll(entityManager, trackerEventInserts);
+    mergeAll(entityManager, trackerEventUpdates);
+    persistAll(entityManager, singleEventInserts);
+    mergeAll(entityManager, singleEventUpdates);
+    persistAll(entityManager, relationshipInserts);
 
     for (TrackedEntityAttributeValue v : teavInserts) {
       entityManager.persist(v);
@@ -108,9 +201,45 @@ class EntityWriteBatch {
       entityManager.remove(entityManager.contains(v) ? v : entityManager.merge(v));
     }
 
+    teInserts.clear();
+    teUpdates.clear();
+    enrollmentInserts.clear();
+    enrollmentUpdates.clear();
+    trackerEventInserts.clear();
+    trackerEventUpdates.clear();
+    singleEventInserts.clear();
+    singleEventUpdates.clear();
+    relationshipInserts.clear();
     teavInserts.clear();
     teavUpdates.clear();
     teavDeletes.clear();
+  }
+
+  private boolean isEmpty() {
+    return teInserts.isEmpty()
+        && teUpdates.isEmpty()
+        && enrollmentInserts.isEmpty()
+        && enrollmentUpdates.isEmpty()
+        && trackerEventInserts.isEmpty()
+        && trackerEventUpdates.isEmpty()
+        && singleEventInserts.isEmpty()
+        && singleEventUpdates.isEmpty()
+        && relationshipInserts.isEmpty()
+        && teavInserts.isEmpty()
+        && teavUpdates.isEmpty()
+        && teavDeletes.isEmpty();
+  }
+
+  private static <T> void persistAll(EntityManager entityManager, List<T> entities) {
+    for (T entity : entities) {
+      entityManager.persist(entity);
+    }
+  }
+
+  private static <T> void mergeAll(EntityManager entityManager, List<T> entities) {
+    for (T entity : entities) {
+      entityManager.merge(entity);
+    }
   }
 
   private static <T> void truncate(List<T> list, int size) {
@@ -119,5 +248,16 @@ class EntityWriteBatch {
     }
   }
 
-  record Mark(int teavInsertSize, int teavUpdateSize, int teavDeleteSize) {}
+  record Mark(
+      EntityCounts te,
+      EntityCounts enrollment,
+      EntityCounts trackerEvent,
+      EntityCounts singleEvent,
+      int relationshipInserts,
+      TeavCounts teav) {
+
+    record EntityCounts(int inserts, int updates) {}
+
+    record TeavCounts(int inserts, int updates, int deletes) {}
+  }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import jakarta.persistence.EntityManager;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.sql.Connection;
@@ -99,14 +98,20 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       the two tables, which is not deferrable in the live schema. Both tables use the shared
  *       {@code hibernate_sequence}. Relationship is INSERT-only -- the persister rejects UPDATE
  *       strategy upstream.
- *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
+ *   <li>TrackedEntityAttributeValues are flushed via JDBC against {@code
+ *       trackedentityattributevalue} -- a multi-row INSERT, a single unnest UPDATE keyed on the
+ *       composite ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single
+ *       unnest DELETE on the same key. Confidential attributes and the {@code encryptedvalue}
+ *       column were removed in DHIS2-21518, so the value is written as plain text in {@code value}.
  * </ul>
  *
- * <p>Top-level entities are flushed before TEAVs so that ids are set (and rows present in the DB or
- * in the Hibernate persistence context) before any TEAV that references them. Within top-level
- * entities the order (TE inserts, TE updates, Enrollment, TrackerEvent, SingleEvent, Relationship)
- * matches the persister call order enforced by {@code DefaultTrackerBundleService.commit()} and is
- * FK-safe.
+ * <p>All reads and writes in the import path are JDBC, so no Hibernate-managed entities of these
+ * types are loaded during commit and there is no L1 cache to reconcile after the writes.
+ *
+ * <p>Top-level entities are flushed before TEAVs so that ids are set and rows are present in the DB
+ * before any TEAV that references them. Within top-level entities the order (TE inserts, TE
+ * updates, Enrollment, TrackerEvent, SingleEvent, Relationship) matches the persister call order
+ * enforced by {@code DefaultTrackerBundleService.commit()} and is FK-safe.
  *
  * <p>Each {@link AbstractTrackerPersister#persist} call creates its own batch, so in practice only
  * one top-level entity type list is populated per batch (the persister's own type) alongside any
@@ -398,6 +403,40 @@ class EntityWriteBatch {
           + " unnest(?::bigint[]) as to_id"
           + " ) v where r.relationshipid = v.relationshipid";
 
+  // TrackedEntityAttributeValue has a composite PK (trackedentityid, trackedentityattributeid) and
+  // no sequence, so no id pre-allocation is needed. Confidential attributes (and the encrypted
+  // value column) were removed in DHIS2-21518, so the value is stored as plain text in `value`.
+  private static final String TEAV_INSERT_PREFIX =
+      "insert into trackedentityattributevalue ("
+          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
+          + " value, storedby) values ";
+  private static final String TEAV_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  // `created` is insert-only and deliberately excluded from the UPDATE column set.
+  private static final String TEAV_UPDATE_SQL =
+      "update trackedentityattributevalue teav set"
+          + " lastupdated = v.lastupdated,"
+          + " value = v.value,"
+          + " storedby = v.storedby"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::text[]) as value,"
+          + " unnest(?::text[]) as storedby"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
+  // Unnest DELETE on the composite key, mirroring the unnest UPDATE shape rather than the plan's
+  // IN (VALUES ...) form, to stay consistent with the other batch statements and avoid dynamic SQL.
+  private static final String TEAV_DELETE_SQL =
+      "delete from trackedentityattributevalue teav"
+          + " using ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
   private final ObjectMapper objectMapper;
 
   private final List<TrackedEntity> teInserts = new ArrayList<>();
@@ -521,43 +560,35 @@ class EntityWriteBatch {
   }
 
   /**
-   * Applies all staged writes. TrackedEntity and Enrollment writes go through JDBC on {@code conn}
-   * (including cascade INSERTs into {@code note} / {@code enrollment_notes}); TrackerEvent,
-   * SingleEvent, Relationship and TEAV writes still delegate to {@code entityManager}. The
-   * connection must be the one bound to the current Spring-managed transaction so that the JDBC
-   * statements and any subsequent Hibernate flush execute under the same commit.
+   * Applies all staged writes via JDBC on {@code conn} (including cascade INSERTs into {@code note}
+   * and the per-entity notes join tables). The connection must be the one bound to the current
+   * Spring-managed transaction so the JDBC statements execute under the same commit. All reads and
+   * writes in the import path are JDBC, so no Hibernate-managed entities of these types are loaded
+   * during commit and there is no L1 cache to reconcile.
    */
-  void flush(EntityManager entityManager, Connection conn) throws SQLException {
+  void flush(Connection conn) throws SQLException {
     if (isEmpty()) {
       return;
     }
 
     insertTrackedEntities(conn);
-    updateTrackedEntities(entityManager, conn);
+    updateTrackedEntities(conn);
     insertEnrollments(conn);
-    updateEnrollments(entityManager, conn);
+    updateEnrollments(conn);
     insertEnrollmentNotes(conn);
     insertTrackerEvents(conn);
     updateTrackerEvents(conn);
     insertTrackerEventNotes(conn);
-    refreshUpdatedTrackerEvents(entityManager);
     insertSingleEvents(conn);
     updateSingleEvents(conn);
     insertSingleEventNotes(conn);
-    refreshUpdatedSingleEvents(entityManager);
     insertRelationships(conn);
     insertRelationshipItems(conn);
     updateRelationshipFromTo(conn);
 
-    for (TrackedEntityAttributeValue v : teavInserts) {
-      entityManager.persist(v);
-    }
-    for (TrackedEntityAttributeValue v : teavUpdates) {
-      entityManager.merge(v);
-    }
-    for (TrackedEntityAttributeValue v : teavDeletes) {
-      entityManager.remove(entityManager.contains(v) ? v : entityManager.merge(v));
-    }
+    insertTeavs(conn);
+    updateTeavs(conn);
+    deleteTeavs(conn);
 
     teInserts.clear();
     teUpdates.clear();
@@ -573,8 +604,7 @@ class EntityWriteBatch {
     teavDeletes.clear();
   }
 
-  private void updateTrackedEntities(EntityManager entityManager, Connection conn)
-      throws SQLException {
+  private void updateTrackedEntities(Connection conn) throws SQLException {
     if (teUpdates.isEmpty()) {
       return;
     }
@@ -620,17 +650,6 @@ class EntityWriteBatch {
         ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
         ps.setArray(10, conn.createArrayOf("text", geometry));
         ps.executeUpdate();
-      }
-    }
-    // The TrackedEntity entities passed in here are detached copies from the preheat. The
-    // Hibernate persistence context separately holds the entities loaded by the preheat's queries
-    // (M_managed), and they still carry their pre-update state. Detach them so any subsequent
-    // JPQL read in this session reloads the fresh DB row instead of returning the stale L1
-    // instance.
-    for (TrackedEntity te : teUpdates) {
-      TrackedEntity managed = entityManager.find(TrackedEntity.class, te.getId());
-      if (managed != null) {
-        entityManager.detach(managed);
       }
     }
   }
@@ -748,7 +767,7 @@ class EntityWriteBatch {
     return p;
   }
 
-  private void updateEnrollments(EntityManager entityManager, Connection conn) throws SQLException {
+  private void updateEnrollments(Connection conn) throws SQLException {
     if (enrollmentUpdates.isEmpty()) {
       return;
     }
@@ -812,15 +831,6 @@ class EntityWriteBatch {
         ps.setArray(15, conn.createArrayOf("boolean", followup));
         ps.setArray(16, conn.createArrayOf("text", geometry));
         ps.executeUpdate();
-      }
-    }
-    // Same L1 staleness fix as updateTrackedEntities -- the JDBC UPDATE bypasses Hibernate, so the
-    // preheat-loaded managed Enrollment in the persistence context still carries the pre-update
-    // state. Detach it so any subsequent JPQL read reloads the fresh DB row.
-    for (Enrollment e : enrollmentUpdates) {
-      Enrollment managed = entityManager.find(Enrollment.class, e.getId());
-      if (managed != null) {
-        entityManager.detach(managed);
       }
     }
   }
@@ -957,23 +967,6 @@ class EntityWriteBatch {
         ps.setArray(16, conn.createArrayOf("text", eventDataValues));
         ps.setArray(17, conn.createArrayOf("text", geometry));
         ps.executeUpdate();
-      }
-    }
-    // L1 staleness is fixed by refreshUpdatedTrackerEvents() called from flush() AFTER
-    // insertTrackerEventNotes so the refreshed entity sees the just-written notes join rows.
-  }
-
-  /**
-   * Reload the L1-cached TrackerEvent entities affected by {@link #updateTrackerEvents} from DB.
-   * Must run AFTER {@link #insertTrackerEventNotes} so the refreshed entity's eager-fetched notes
-   * collection picks up the newly-appended notes. Mirrors the side effect of the pre-migration
-   * {@code em.merge(detachedDto)} path that updated the L1-managed instance in place.
-   */
-  private void refreshUpdatedTrackerEvents(EntityManager entityManager) {
-    for (TrackerEvent e : trackerEventUpdates) {
-      TrackerEvent managed = entityManager.find(TrackerEvent.class, e.getId());
-      if (managed != null) {
-        entityManager.refresh(managed);
       }
     }
   }
@@ -1276,17 +1269,6 @@ class EntityWriteBatch {
         ps.executeUpdate();
       }
     }
-    // L1 staleness is fixed by refreshUpdatedSingleEvents() called from flush() AFTER
-    // insertSingleEventNotes -- same reasoning as refreshUpdatedTrackerEvents.
-  }
-
-  private void refreshUpdatedSingleEvents(EntityManager entityManager) {
-    for (SingleEvent e : singleEventUpdates) {
-      SingleEvent managed = entityManager.find(SingleEvent.class, e.getId());
-      if (managed != null) {
-        entityManager.refresh(managed);
-      }
-    }
   }
 
   /** Parallel of {@link EnrollmentNoteToInsert} for the {@code singleevent_notes} join table. */
@@ -1515,6 +1497,89 @@ class EntityWriteBatch {
     }
   }
 
+  private void insertTeavs(Connection conn) throws SQLException {
+    if (teavInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teavInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teavInserts.size());
+      List<TrackedEntityAttributeValue> chunk = teavInserts.subList(from, to);
+      String sql = buildMultiRowInsertSql(TEAV_INSERT_PREFIX, TEAV_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (TrackedEntityAttributeValue v : chunk) {
+          ps.setLong(p++, v.getTrackedEntity().getId());
+          ps.setLong(p++, v.getAttribute().getId());
+          ps.setTimestamp(p++, toTimestamp(v.getCreated()));
+          ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
+          setNullableString(ps, p++, v.getValue());
+          setNullableString(ps, p++, v.getStoredBy());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void updateTeavs(Connection conn) throws SQLException {
+    if (teavUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teavUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teavUpdates.size());
+      List<TrackedEntityAttributeValue> chunk = teavUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] trackedEntityIds = new Long[n];
+      Long[] attributeIds = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      String[] value = new String[n];
+      String[] storedBy = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        TrackedEntityAttributeValue v = chunk.get(i);
+        trackedEntityIds[i] = v.getTrackedEntity().getId();
+        attributeIds[i] = v.getAttribute().getId();
+        lastUpdated[i] = toTimestamp(v.getLastUpdated());
+        value[i] = v.getValue();
+        storedBy[i] = v.getStoredBy();
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(TEAV_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+        ps.setArray(3, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(4, conn.createArrayOf("text", value));
+        ps.setArray(5, conn.createArrayOf("text", storedBy));
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private void deleteTeavs(Connection conn) throws SQLException {
+    if (teavDeletes.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < teavDeletes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, teavDeletes.size());
+      List<TrackedEntityAttributeValue> chunk = teavDeletes.subList(from, to);
+      int n = chunk.size();
+
+      Long[] trackedEntityIds = new Long[n];
+      Long[] attributeIds = new Long[n];
+      for (int i = 0; i < n; i++) {
+        TrackedEntityAttributeValue v = chunk.get(i);
+        trackedEntityIds[i] = v.getTrackedEntity().getId();
+        attributeIds[i] = v.getAttribute().getId();
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(TEAV_DELETE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+        ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+        ps.executeUpdate();
+      }
+    }
+  }
+
   /**
    * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
    * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
@@ -1565,6 +1630,15 @@ class EntityWriteBatch {
       ps.setTimestamp(index, new Timestamp(date.getTime()));
     } else {
       ps.setNull(index, Types.TIMESTAMP);
+    }
+  }
+
+  private static void setNullableString(PreparedStatement ps, int index, String value)
+      throws SQLException {
+    if (value != null) {
+      ps.setString(index, value);
+    } else {
+      ps.setNull(index, Types.VARCHAR);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EntityWriteBatch.java
@@ -29,9 +29,13 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import jakarta.persistence.EntityManager;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -41,7 +45,10 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.model.Enrollment;
@@ -70,11 +77,17 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  *       programinstance_sequence}.
  *   <li>Enrollment updates are flushed via a single JDBC unnest UPDATE against {@code enrollment},
  *       writing the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
- *   <li>Any new {@code note}s on either inserted or updated enrollments are cascade-inserted in two
- *       further multi-row INSERTs (into {@code note} and {@code enrollment_notes}), replacing
- *       Hibernate's {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on UPDATE.
- *   <li>All remaining entity types (TrackerEvent, SingleEvent, Relationship) still delegate to
- *       {@link EntityManager}; their Phase 6 JDBC replacements follow.
+ *   <li>TrackerEvent inserts are flushed via a multi-row JDBC INSERT against {@code trackerevent}
+ *       -- ids are pre-allocated from {@code trackerevent_sequence}. The {@code eventdatavalues}
+ *       jsonb column is serialized as a JSON object keyed by dataElement uid, matching {@code
+ *       JsonEventDataValueSetBinaryType}.
+ *   <li>TrackerEvent updates are flushed via a JDBC unnest UPDATE against {@code trackerevent}.
+ *   <li>Any new {@code note}s on inserted or updated enrollments / tracker events are
+ *       cascade-inserted in further multi-row INSERTs (into {@code note} plus the matching {@code
+ *       enrollment_notes} / {@code trackerevent_notes} join), replacing Hibernate's
+ *       {@code @OneToMany(cascade=ALL)} behaviour. Notes are append-only on UPDATE.
+ *   <li>All remaining entity types (SingleEvent, Relationship) still delegate to {@link
+ *       EntityManager}; their Phase 6 JDBC replacements follow.
  *   <li>TEAVs continue to delegate to {@link EntityManager} until their Phase 6 turn.
  * </ul>
  *
@@ -199,7 +212,69 @@ class EntityWriteBatch {
           + " unnest(?::text[]) as geometry"
           + " ) v where e.enrollmentid = v.enrollmentid";
 
-  // Cascade-INSERT targets for new enrollments that carry notes. See Enrollment.java:192-199.
+  private static final String TRACKER_EVENT_INSERT_PREFIX =
+      "insert into trackerevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, scheduleddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String TRACKER_EVENT_INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + TRACKED_ENTITY_SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch
+  // (see TrackerObjectsMapper.java:199-251). Insert-only columns (uid, created,
+  // createdbyuserinfo, deleted) and columns owned by other code paths (lastsynchronized) are
+  // excluded.
+  private static final String TRACKER_EVENT_UPDATE_SQL =
+      "update trackerevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " enrollmentid = v.enrollmentid,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " scheduleddate = v.scheduleddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + TRACKED_ENTITY_SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as scheduleddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  // Cascade-INSERT targets for entities that carry notes (Enrollment, TrackerEvent). See
+  // Enrollment.java:192-199 and TrackerEvent.hbm.xml:65-70.
   private static final String NOTE_INSERT_PREFIX =
       "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
   private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
@@ -207,6 +282,10 @@ class EntityWriteBatch {
   private static final String ENROLLMENT_NOTES_INSERT_PREFIX =
       "insert into enrollment_notes (enrollmentid, noteid, sort_order) values ";
   private static final String ENROLLMENT_NOTES_INSERT_ROW = "(?, ?, ?)";
+
+  private static final String TRACKER_EVENT_NOTES_INSERT_PREFIX =
+      "insert into trackerevent_notes (eventid, noteid, sort_order) values ";
+  private static final String TRACKER_EVENT_NOTES_INSERT_ROW = "(?, ?, ?)";
 
   private final ObjectMapper objectMapper;
 
@@ -347,8 +426,10 @@ class EntityWriteBatch {
     insertEnrollments(conn);
     updateEnrollments(entityManager, conn);
     insertEnrollmentNotes(conn);
-    persistAll(entityManager, trackerEventInserts);
-    mergeAll(entityManager, trackerEventUpdates);
+    insertTrackerEvents(conn);
+    updateTrackerEvents(conn);
+    insertTrackerEventNotes(conn);
+    refreshUpdatedTrackerEvents(entityManager);
     persistAll(entityManager, singleEventInserts);
     mergeAll(entityManager, singleEventUpdates);
     persistAll(entityManager, relationshipInserts);
@@ -430,8 +511,7 @@ class EntityWriteBatch {
     // Hibernate persistence context separately holds the entities loaded by the preheat's queries
     // (M_managed), and they still carry their pre-update state. Detach them so any subsequent
     // JPQL read in this session reloads the fresh DB row instead of returning the stale L1
-    // instance. This detaching will be removed once all entity types are migrated to JDBC and
-    // entityManager is no longer needed.
+    // instance.
     for (TrackedEntity te : teUpdates) {
       TrackedEntity managed = entityManager.find(TrackedEntity.class, te.getId());
       if (managed != null) {
@@ -630,6 +710,167 @@ class EntityWriteBatch {
     }
   }
 
+  private void insertTrackerEvents(Connection conn) throws SQLException {
+    if (trackerEventInserts.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < trackerEventInserts.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, trackerEventInserts.size());
+      List<TrackerEvent> chunk = trackerEventInserts.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              TRACKER_EVENT_INSERT_PREFIX, TRACKER_EVENT_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (TrackerEvent e : chunk) {
+          p = bindTrackerEventRow(ps, p, e);
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  private int bindTrackerEventRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "TrackerEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getScheduledDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getEnrollment().getId());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void updateTrackerEvents(Connection conn) throws SQLException {
+    if (trackerEventUpdates.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < trackerEventUpdates.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, trackerEventUpdates.size());
+      List<TrackerEvent> chunk = trackerEventUpdates.subList(from, to);
+      int n = chunk.size();
+
+      Long[] ids = new Long[n];
+      Timestamp[] lastUpdated = new Timestamp[n];
+      Timestamp[] createdAtClient = new Timestamp[n];
+      Timestamp[] lastUpdatedAtClient = new Timestamp[n];
+      String[] lastUpdatedByUserInfo = new String[n];
+      Long[] enrollmentIds = new Long[n];
+      Long[] programStageIds = new Long[n];
+      Long[] organisationUnitIds = new Long[n];
+      Long[] attributeOptionComboIds = new Long[n];
+      String[] status = new String[n];
+      Timestamp[] occurredDate = new Timestamp[n];
+      Timestamp[] scheduledDate = new Timestamp[n];
+      Timestamp[] completedDate = new Timestamp[n];
+      String[] completedBy = new String[n];
+      Long[] assignedUserIds = new Long[n];
+      String[] eventDataValues = new String[n];
+      String[] geometry = new String[n];
+
+      for (int i = 0; i < n; i++) {
+        TrackerEvent e = chunk.get(i);
+        ids[i] = e.getId();
+        lastUpdated[i] = toTimestamp(e.getLastUpdated());
+        createdAtClient[i] = toTimestamp(e.getCreatedAtClient());
+        lastUpdatedAtClient[i] = toTimestamp(e.getLastUpdatedAtClient());
+        lastUpdatedByUserInfo[i] = toJson(e.getLastUpdatedByUserInfo());
+        enrollmentIds[i] = e.getEnrollment().getId();
+        programStageIds[i] = e.getProgramStage().getId();
+        organisationUnitIds[i] = e.getOrganisationUnit().getId();
+        attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+        status[i] = e.getStatus().name();
+        occurredDate[i] = toTimestamp(e.getOccurredDate());
+        scheduledDate[i] = toTimestamp(e.getScheduledDate());
+        completedDate[i] = toTimestamp(e.getCompletedDate());
+        completedBy[i] = e.getCompletedBy();
+        assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+        eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+        geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+      }
+
+      try (PreparedStatement ps = conn.prepareStatement(TRACKER_EVENT_UPDATE_SQL)) {
+        ps.setArray(1, conn.createArrayOf("bigint", ids));
+        ps.setArray(2, conn.createArrayOf("timestamptz", lastUpdated));
+        ps.setArray(3, conn.createArrayOf("timestamptz", createdAtClient));
+        ps.setArray(4, conn.createArrayOf("timestamptz", lastUpdatedAtClient));
+        ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+        ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
+        ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
+        ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+        ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+        ps.setArray(10, conn.createArrayOf("text", status));
+        ps.setArray(11, conn.createArrayOf("timestamptz", occurredDate));
+        ps.setArray(12, conn.createArrayOf("timestamptz", scheduledDate));
+        ps.setArray(13, conn.createArrayOf("timestamptz", completedDate));
+        ps.setArray(14, conn.createArrayOf("text", completedBy));
+        ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
+        ps.setArray(16, conn.createArrayOf("text", eventDataValues));
+        ps.setArray(17, conn.createArrayOf("text", geometry));
+        ps.executeUpdate();
+      }
+    }
+    // L1 staleness is fixed by refreshUpdatedTrackerEvents() called from flush() AFTER
+    // insertTrackerEventNotes so the refreshed entity sees the just-written notes join rows.
+  }
+
+  /**
+   * Reload the L1-cached TrackerEvent entities affected by {@link #updateTrackerEvents} from DB.
+   * Must run AFTER {@link #insertTrackerEventNotes} so the refreshed entity's eager-fetched notes
+   * collection picks up the newly-appended notes. Using {@code em.refresh} (instead of {@code
+   * em.detach}) mirrors the side effect of the pre-migration {@code em.merge(detachedDto)} path
+   * that updated the L1-managed instance in place -- callers (and tests like {@code
+   * TrackerEventSMSTest.shouldUpdateEvent}) that hold a reference to the entity and compare it to a
+   * freshly-read row rely on the local reference seeing the new state.
+   */
+  private void refreshUpdatedTrackerEvents(EntityManager entityManager) {
+    for (TrackerEvent e : trackerEventUpdates) {
+      TrackerEvent managed = entityManager.find(TrackerEvent.class, e.getId());
+      if (managed != null) {
+        entityManager.refresh(managed);
+      }
+    }
+  }
+
+  /** Shared shape between {@code enrollment_notes} and {@code trackerevent_notes} cascade rows. */
+  private interface NoteToInsert {
+    Note note();
+  }
+
   /**
    * Cascade-insert any notes attached to enrollments that were just inserted by {@link
    * #insertEnrollments} or appended to existing enrollments by {@link #updateEnrollments}. Mirrors
@@ -640,7 +881,8 @@ class EntityWriteBatch {
    * {@code @ListIndexBase(1)}). On INSERT every Note is new; on UPDATE only Notes with {@code id ==
    * 0} are new (existing ones were loaded by the preheat).
    */
-  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder) {}
+  private record EnrollmentNoteToInsert(long enrollmentId, Note note, int sortOrder)
+      implements NoteToInsert {}
 
   private void insertEnrollmentNotes(Connection conn) throws SQLException {
     List<EnrollmentNoteToInsert> newNotes = collectNewEnrollmentNotes();
@@ -686,15 +928,15 @@ class EntityWriteBatch {
     }
   }
 
-  private void insertNoteRows(Connection conn, List<EnrollmentNoteToInsert> newNotes)
+  private void insertNoteRows(Connection conn, List<? extends NoteToInsert> newNotes)
       throws SQLException {
     for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
       int to = Math.min(from + BATCH_SIZE, newNotes.size());
-      List<EnrollmentNoteToInsert> chunk = newNotes.subList(from, to);
+      List<? extends NoteToInsert> chunk = newNotes.subList(from, to);
       String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
       try (PreparedStatement ps = conn.prepareStatement(sql)) {
         int p = 1;
-        for (EnrollmentNoteToInsert item : chunk) {
+        for (NoteToInsert item : chunk) {
           Note n = item.note();
           ps.setLong(p++, n.getId());
           ps.setString(p++, n.getUid());
@@ -727,6 +969,68 @@ class EntityWriteBatch {
         int p = 1;
         for (EnrollmentNoteToInsert item : chunk) {
           ps.setLong(p++, item.enrollmentId());
+          ps.setLong(p++, item.note().getId());
+          ps.setInt(p++, item.sortOrder());
+        }
+        ps.executeUpdate();
+      }
+    }
+  }
+
+  /** Parallel of {@link EnrollmentNoteToInsert} for the {@code trackerevent_notes} join table. */
+  private record TrackerEventNoteToInsert(long eventId, Note note, int sortOrder)
+      implements NoteToInsert {}
+
+  private void insertTrackerEventNotes(Connection conn) throws SQLException {
+    List<TrackerEventNoteToInsert> newNotes = collectNewTrackerEventNotes();
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertTrackerEventNotesJoinRows(conn, newNotes);
+  }
+
+  private List<TrackerEventNoteToInsert> collectNewTrackerEventNotes() {
+    List<TrackerEventNoteToInsert> newNotes = new ArrayList<>();
+    collectNewTrackerEventNotesFrom(trackerEventInserts, newNotes);
+    collectNewTrackerEventNotesFrom(trackerEventUpdates, newNotes);
+    return newNotes;
+  }
+
+  private static void collectNewTrackerEventNotesFrom(
+      List<TrackerEvent> events, List<TrackerEventNoteToInsert> out) {
+    for (TrackerEvent e : events) {
+      if (e.getNotes() == null) {
+        continue;
+      }
+      List<Note> notes = e.getNotes();
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new TrackerEventNoteToInsert(e.getId(), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertTrackerEventNotesJoinRows(
+      Connection conn, List<TrackerEventNoteToInsert> newNotes) throws SQLException {
+    for (int from = 0; from < newNotes.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, newNotes.size());
+      List<TrackerEventNoteToInsert> chunk = newNotes.subList(from, to);
+      String sql =
+          buildMultiRowInsertSql(
+              TRACKER_EVENT_NOTES_INSERT_PREFIX, TRACKER_EVENT_NOTES_INSERT_ROW, chunk.size());
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        int p = 1;
+        for (TrackerEventNoteToInsert item : chunk) {
+          ps.setLong(p++, item.eventId());
           ps.setLong(p++, item.note().getId());
           ps.setInt(p++, item.sortOrder());
         }
@@ -796,6 +1100,37 @@ class EntityWriteBatch {
       return objectMapper.writeValueAsString(info);
     } catch (JsonProcessingException e) {
       throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
+    }
+  }
+
+  // Must mirror JsonEventDataValueSetBinaryType exactly: same MAPPER (configured with
+  // IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector, NON_NULL inclusion, etc.) and
+  // same per-value writer. Using a different ObjectMapper (e.g. the Spring-injected default) drops
+  // fields like UserInfoSnapshot.id that the JDBC reader requires.
+  private static final ObjectWriter EVENT_DATA_VALUE_WRITER =
+      JsonBinaryType.MAPPER.writerFor(EventDataValue.class);
+
+  /**
+   * Serializes the EventDataValues set as a JSON object keyed by {@code dataElement} uid, matching
+   * the on-disk shape produced by {@code JsonEventDataValueSetBinaryType}. An empty or null set is
+   * serialized as {@code "{}"} to match the column's NOT NULL default.
+   */
+  private String toEventDataValuesJson(Set<EventDataValue> values) throws SQLException {
+    try {
+      StringWriter sw = new StringWriter();
+      try (JsonGenerator gen = JsonBinaryType.MAPPER.getFactory().createGenerator(sw)) {
+        gen.writeStartObject();
+        if (values != null) {
+          for (EventDataValue edv : values) {
+            gen.writeFieldName(edv.getDataElement());
+            EVENT_DATA_VALUE_WRITER.writeValue(gen, edv);
+          }
+        }
+        gen.writeEndObject();
+      }
+      return sw.toString();
+    } catch (IOException e) {
+      throw new SQLException("Failed to serialize EventDataValues to JSON", e);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
@@ -35,12 +35,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -83,6 +82,53 @@ final class JdbcBatchSupport {
   }
 
   /**
+   * Extracts one column value from a row. Allows {@link SQLException} so JSON serializers ({@link
+   * #toJson}, {@link #toEventDataValuesJson}) can be used directly as extractors.
+   */
+  @FunctionalInterface
+  interface RowExtractor<E, R> {
+    R apply(E row) throws SQLException;
+  }
+
+  /**
+   * Builds a SQL {@code bigint[]} from one column of {@code rows} for binding into a {@code
+   * ?::bigint[]} parameter of a constant-text {@code INSERT ... SELECT unnest(...)} statement. Null
+   * elements (e.g. nullable FKs) become SQL NULLs.
+   */
+  static <E> Array bigintArray(Connection conn, List<E> rows, RowExtractor<E, Long> extractor)
+      throws SQLException {
+    Long[] values = new Long[rows.size()];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = extractor.apply(rows.get(i));
+    }
+    return conn.createArrayOf("bigint", values);
+  }
+
+  /**
+   * Builds a SQL {@code text[]} from one column of {@code rows}. Used both for genuine text columns
+   * ({@code ?::text[]}) and for timestamps formatted via {@link #toTimestamptz} ({@code
+   * ?::timestamptz[]}), mirroring the unnest UPDATE binding.
+   */
+  static <E> Array textArray(Connection conn, List<E> rows, RowExtractor<E, String> extractor)
+      throws SQLException {
+    String[] values = new String[rows.size()];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = extractor.apply(rows.get(i));
+    }
+    return conn.createArrayOf("text", values);
+  }
+
+  /** Builds a SQL {@code boolean[]} from one column of {@code rows}. */
+  static <E> Array booleanArray(Connection conn, List<E> rows, RowExtractor<E, Boolean> extractor)
+      throws SQLException {
+    Boolean[] values = new Boolean[rows.size()];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = extractor.apply(rows.get(i));
+    }
+    return conn.createArrayOf("boolean", values);
+  }
+
+  /**
    * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
    * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
    * a {@code regclass}; the value is always a static literal controlled by us.
@@ -106,23 +152,6 @@ final class JdbcBatchSupport {
     return ids;
   }
 
-  static String buildMultiRowInsertSql(String prefix, String rowPlaceholders, int rowCount) {
-    StringBuilder sb =
-        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
-    sb.append(prefix);
-    for (int i = 0; i < rowCount; i++) {
-      if (i > 0) {
-        sb.append(", ");
-      }
-      sb.append(rowPlaceholders);
-    }
-    return sb.toString();
-  }
-
-  static Timestamp toTimestamp(Date date) {
-    return date != null ? new Timestamp(date.getTime()) : null;
-  }
-
   /**
    * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
    * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
@@ -130,8 +159,7 @@ final class JdbcBatchSupport {
    * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
    * under the session {@code TimeZone} -- skewing every value when the session zone differs from
    * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
-   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
-   * (pgjdbc appends the JVM zone offset there).
+   * offset makes the parse unambiguous.
    */
   static String toTimestamptz(Date date) {
     return date != null
@@ -139,20 +167,12 @@ final class JdbcBatchSupport {
         : null;
   }
 
-  static void setNullableTimestamp(PreparedStatement ps, int index, Date date) throws SQLException {
-    if (date != null) {
-      ps.setTimestamp(index, new Timestamp(date.getTime()));
-    } else {
-      ps.setNull(index, Types.TIMESTAMP);
-    }
-  }
-
-  static void setNullableString(PreparedStatement ps, int index, String value) throws SQLException {
-    if (value != null) {
-      ps.setString(index, value);
-    } else {
-      ps.setNull(index, Types.VARCHAR);
-    }
+  /**
+   * The WKT text of a geometry, or {@code null}. Bound into a {@code ?::text[]} array and converted
+   * back by {@code ST_GeomFromText} in the INSERT/UPDATE projection.
+   */
+  static String geometryText(org.locationtech.jts.geom.Geometry geometry) {
+    return geometry != null ? geometry.toText() : null;
   }
 
   static <T> void truncate(List<T> list, int size) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/JdbcBatchSupport.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.ObjectStyle;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType;
+import org.hisp.dhis.program.UserInfoSnapshot;
+
+/**
+ * Shared JDBC mechanics for the per-entity {@code *Writer} classes that make up {@link
+ * EntityWriteBatch}: id pre-allocation, multi-row INSERT SQL assembly, chunking, nullable binds,
+ * date/timestamp formatting, list truncation and the JSON serializers. Centralising the serializers
+ * here also centralises the invariant that {@code eventdatavalues} / {@code ObjectStyle} must be
+ * written with {@link JsonBinaryType#MAPPER} (a different {@code ObjectMapper} drops fields like
+ * {@code UserInfoSnapshot.id} that the JDBC reader requires).
+ */
+final class JdbcBatchSupport {
+
+  private JdbcBatchSupport() {}
+
+  /** Cap on rows per multi-row INSERT/UPDATE statement, to bound peak array memory per chunk. */
+  static final int BATCH_SIZE = 128;
+
+  static final int SRID = 4326;
+
+  /** Body invoked once per {@code BATCH_SIZE}-sized chunk of a list. */
+  @FunctionalInterface
+  interface ChunkConsumer<T> {
+    void accept(List<T> chunk) throws SQLException;
+  }
+
+  /** Invokes {@code consumer} on successive {@link #BATCH_SIZE}-sized sublists of {@code list}. */
+  static <T> void forEachChunk(List<T> list, ChunkConsumer<T> consumer) throws SQLException {
+    for (int from = 0; from < list.size(); from += BATCH_SIZE) {
+      int to = Math.min(from + BATCH_SIZE, list.size());
+      consumer.accept(list.subList(from, to));
+    }
+  }
+
+  /**
+   * Fetches {@code count} ids from {@code sequenceName} in a single round-trip. The sequence name
+   * is interpolated into the SQL (not a bind parameter) because PostgreSQL's {@code nextval} takes
+   * a {@code regclass}; the value is always a static literal controlled by us.
+   */
+  static long[] allocateIds(Connection conn, String sequenceName, int count) throws SQLException {
+    long[] ids = new long[count];
+    String sql = "select nextval('" + sequenceName + "') from generate_series(1, ?)";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setInt(1, count);
+      try (ResultSet rs = ps.executeQuery()) {
+        int i = 0;
+        while (rs.next()) {
+          ids[i++] = rs.getLong(1);
+        }
+        if (i != count) {
+          throw new SQLException(
+              "Allocated " + i + " ids from " + sequenceName + ", expected " + count);
+        }
+      }
+    }
+    return ids;
+  }
+
+  static String buildMultiRowInsertSql(String prefix, String rowPlaceholders, int rowCount) {
+    StringBuilder sb =
+        new StringBuilder(prefix.length() + rowPlaceholders.length() * rowCount + 16);
+    sb.append(prefix);
+    for (int i = 0; i < rowCount; i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(rowPlaceholders);
+    }
+    return sb.toString();
+  }
+
+  static Timestamp toTimestamp(Date date) {
+    return date != null ? new Timestamp(date.getTime()) : null;
+  }
+
+  /**
+   * Formats a date as an ISO-8601 instant with explicit UTC offset, for binding into a {@code
+   * ?::timestamptz[]} parameter as a text array. Binding {@code createArrayOf("timestamptz",
+   * Timestamp[])} is not safe: pgjdbc stringifies each element via {@code Timestamp.toString()},
+   * which renders the JVM-local wall-clock time without an offset, so the server re-interprets it
+   * under the session {@code TimeZone} -- skewing every value when the session zone differs from
+   * the JVM zone (e.g. {@code options=-c TimeZone=UTC}) and in the DST fall-back hour. An explicit
+   * offset makes the parse unambiguous. Single-value {@code setTimestamp} binds are unaffected
+   * (pgjdbc appends the JVM zone offset there).
+   */
+  static String toTimestamptz(Date date) {
+    return date != null
+        ? OffsetDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).toString()
+        : null;
+  }
+
+  static void setNullableTimestamp(PreparedStatement ps, int index, Date date) throws SQLException {
+    if (date != null) {
+      ps.setTimestamp(index, new Timestamp(date.getTime()));
+    } else {
+      ps.setNull(index, Types.TIMESTAMP);
+    }
+  }
+
+  static void setNullableString(PreparedStatement ps, int index, String value) throws SQLException {
+    if (value != null) {
+      ps.setString(index, value);
+    } else {
+      ps.setNull(index, Types.VARCHAR);
+    }
+  }
+
+  static <T> void truncate(List<T> list, int size) {
+    if (list.size() > size) {
+      list.subList(size, list.size()).clear();
+    }
+  }
+
+  static String toJson(ObjectMapper objectMapper, UserInfoSnapshot info) throws SQLException {
+    if (info == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(info);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize UserInfoSnapshot to JSON", e);
+    }
+  }
+
+  // Must mirror JsonEventDataValueSetBinaryType exactly: same MAPPER (configured with
+  // IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector, NON_NULL inclusion, etc.) and
+  // same per-value writer. Using a different ObjectMapper (e.g. the Spring-injected default) drops
+  // fields like UserInfoSnapshot.id that the JDBC reader requires.
+  private static final ObjectWriter EVENT_DATA_VALUE_WRITER =
+      JsonBinaryType.MAPPER.writerFor(EventDataValue.class);
+
+  /**
+   * Serializes the EventDataValues set as a JSON object keyed by {@code dataElement} uid, matching
+   * the on-disk shape produced by {@code JsonEventDataValueSetBinaryType}. An empty or null set is
+   * serialized as {@code "{}"} to match the column's NOT NULL default.
+   */
+  static String toEventDataValuesJson(Set<EventDataValue> values) throws SQLException {
+    try {
+      StringWriter sw = new StringWriter();
+      try (JsonGenerator gen = JsonBinaryType.MAPPER.getFactory().createGenerator(sw)) {
+        gen.writeStartObject();
+        if (values != null) {
+          for (EventDataValue edv : values) {
+            gen.writeFieldName(edv.getDataElement());
+            EVENT_DATA_VALUE_WRITER.writeValue(gen, edv);
+          }
+        }
+        gen.writeEndObject();
+      }
+      return sw.toString();
+    } catch (IOException e) {
+      throw new SQLException("Failed to serialize EventDataValues to JSON", e);
+    }
+  }
+
+  /**
+   * Serializes the relationship's {@link ObjectStyle} via {@link JsonBinaryType#MAPPER} to match
+   * the Hibernate {@code jbObjectStyle} UserType. Returns {@code null} for a null style so the
+   * caller can pass it straight to a {@code ?::jsonb} parameter as SQL NULL.
+   */
+  static String toObjectStyleJson(ObjectStyle style) throws SQLException {
+    if (style == null) {
+      return null;
+    }
+    try {
+      return JsonBinaryType.MAPPER.writeValueAsString(style);
+    } catch (JsonProcessingException e) {
+      throw new SQLException("Failed to serialize ObjectStyle to JSON", e);
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
@@ -30,14 +30,14 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -60,20 +60,39 @@ import org.hisp.dhis.note.Note;
  */
 final class NoteCascadeWriter {
 
-  private static final String NOTE_INSERT_PREFIX =
-      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
-  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
-
-  private static final String JOIN_INSERT_ROW = "(?, ?, ?)";
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count.
+  private static final String NOTE_INSERT_SQL =
+      "insert into note (noteid, uid, created, lastupdatedby, notetext)"
+          + " select noteid, uid, created, lastupdatedby, notetext"
+          + " from ( select"
+          + " unnest(?::bigint[]) as noteid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::bigint[]) as lastupdatedby,"
+          + " unnest(?::text[]) as notetext"
+          + " ) v";
 
   /** A new {@link Note} to insert for a given owner row, with its 1-based sort order. */
   record NoteRow(long ownerId, Note note, int sortOrder) {}
 
-  private final String joinInsertPrefix;
+  // Constant per join table (the table and owner-id column vary by instance), built once here so
+  // each NoteCascadeWriter has a single cacheable join INSERT statement.
+  private final String joinInsertSql;
 
   NoteCascadeWriter(String joinTable, String ownerIdColumn) {
-    this.joinInsertPrefix =
-        "insert into " + joinTable + " (" + ownerIdColumn + ", noteid, sort_order) values ";
+    this.joinInsertSql =
+        "insert into "
+            + joinTable
+            + " ("
+            + ownerIdColumn
+            + ", noteid, sort_order)"
+            + " select owner_id, note_id, sort_order"
+            + " from ( select"
+            + " unnest(?::bigint[]) as owner_id,"
+            + " unnest(?::bigint[]) as note_id,"
+            + " unnest(?::bigint[]) as sort_order"
+            + " ) v";
   }
 
   /**
@@ -127,42 +146,31 @@ final class NoteCascadeWriter {
     forEachChunk(
         newNotes,
         chunk -> {
-          String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          try (PreparedStatement ps = conn.prepareStatement(NOTE_INSERT_SQL)) {
             int p = 1;
-            for (NoteRow item : chunk) {
-              Note n = item.note();
-              ps.setLong(p++, n.getId());
-              ps.setString(p++, n.getUid());
-              ps.setTimestamp(p++, toTimestamp(n.getCreated()));
-              if (n.getLastUpdatedBy() != null) {
-                ps.setLong(p++, n.getLastUpdatedBy().getId());
-              } else {
-                ps.setNull(p++, Types.BIGINT);
-              }
-              if (n.getNoteText() != null) {
-                ps.setString(p++, n.getNoteText());
-              } else {
-                ps.setNull(p++, Types.VARCHAR);
-              }
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, nr -> nr.note().getId()));
+            ps.setArray(p++, textArray(conn, chunk, nr -> nr.note().getUid()));
+            ps.setArray(p++, textArray(conn, chunk, nr -> toTimestamptz(nr.note().getCreated())));
+            ps.setArray(p++, bigintArray(conn, chunk, nr -> lastUpdatedById(nr.note())));
+            ps.setArray(p++, textArray(conn, chunk, nr -> nr.note().getNoteText()));
             ps.executeUpdate();
           }
         });
+  }
+
+  private static Long lastUpdatedById(Note note) {
+    return note.getLastUpdatedBy() != null ? note.getLastUpdatedBy().getId() : null;
   }
 
   private void insertJoinRows(Connection conn, List<NoteRow> newNotes) throws SQLException {
     forEachChunk(
         newNotes,
         chunk -> {
-          String sql = buildMultiRowInsertSql(joinInsertPrefix, JOIN_INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          try (PreparedStatement ps = conn.prepareStatement(joinInsertSql)) {
             int p = 1;
-            for (NoteRow item : chunk) {
-              ps.setLong(p++, item.ownerId());
-              ps.setLong(p++, item.note().getId());
-              ps.setInt(p++, item.sortOrder());
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, NoteRow::ownerId));
+            ps.setArray(p++, bigintArray(conn, chunk, nr -> nr.note().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, nr -> (long) nr.sortOrder()));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import org.hisp.dhis.note.Note;
+
+/**
+ * Cascade-inserts new {@link Note}s for an entity type that carries notes (Enrollment,
+ * TrackerEvent, SingleEvent), replacing Hibernate's {@code @OneToMany(cascade=ALL)} behaviour.
+ * Mirrors what Hibernate did on the owning collection: allocate ids for the new {@code note} rows
+ * from {@code note_sequence}, insert the {@code note} rows, then insert the join rows in the
+ * owner's notes join table ({@code enrollment_notes} / {@code trackerevent_notes} / {@code
+ * singleevent_notes}) with {@code sort_order} taken from the 1-based list position (per
+ * {@code @ListIndexBase(1)}).
+ *
+ * <p>On INSERT every Note is new; on UPDATE only Notes with {@code id == 0} are new (existing ones
+ * were loaded by the preheat). Notes are append-only on UPDATE.
+ *
+ * <p>One instance is configured per join table; the three entity writers each compose one.
+ */
+final class NoteCascadeWriter {
+
+  private static final String NOTE_INSERT_PREFIX =
+      "insert into note (noteid, uid, created, lastupdatedby, notetext) values ";
+  private static final String NOTE_INSERT_ROW = "(?, ?, ?, ?, ?)";
+
+  private static final String JOIN_INSERT_ROW = "(?, ?, ?)";
+
+  /** A new {@link Note} to insert for a given owner row, with its 1-based sort order. */
+  record NoteRow(long ownerId, Note note, int sortOrder) {}
+
+  private final String joinInsertPrefix;
+
+  NoteCascadeWriter(String joinTable, String ownerIdColumn) {
+    this.joinInsertPrefix =
+        "insert into " + joinTable + " (" + ownerIdColumn + ", noteid, sort_order) values ";
+  }
+
+  /**
+   * Collects the new notes (no DB id) from the given inserted and updated owners and
+   * cascade-inserts them. {@code ownerId} extracts the owner's pre-allocated/persisted id; {@code
+   * notesGetter} returns the owner's notes list (may be {@code null}).
+   */
+  <E> void cascade(
+      Connection conn,
+      List<E> inserts,
+      List<E> updates,
+      ToLongFunction<E> ownerId,
+      Function<E, List<Note>> notesGetter)
+      throws SQLException {
+    List<NoteRow> newNotes = new ArrayList<>();
+    collectNewNotes(inserts, ownerId, notesGetter, newNotes);
+    collectNewNotes(updates, ownerId, notesGetter, newNotes);
+    if (newNotes.isEmpty()) {
+      return;
+    }
+
+    long[] noteIds = allocateIds(conn, "note_sequence", newNotes.size());
+    for (int i = 0; i < newNotes.size(); i++) {
+      newNotes.get(i).note().setId(noteIds[i]);
+    }
+
+    insertNoteRows(conn, newNotes);
+    insertJoinRows(conn, newNotes);
+  }
+
+  private static <E> void collectNewNotes(
+      List<E> owners,
+      ToLongFunction<E> ownerId,
+      Function<E, List<Note>> notesGetter,
+      List<NoteRow> out) {
+    for (E owner : owners) {
+      List<Note> notes = notesGetter.apply(owner);
+      if (notes == null) {
+        continue;
+      }
+      for (int i = 0; i < notes.size(); i++) {
+        Note n = notes.get(i);
+        if (n.getId() == 0) {
+          out.add(new NoteRow(ownerId.applyAsLong(owner), n, i + 1));
+        }
+      }
+    }
+  }
+
+  private void insertNoteRows(Connection conn, List<NoteRow> newNotes) throws SQLException {
+    forEachChunk(
+        newNotes,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(NOTE_INSERT_PREFIX, NOTE_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (NoteRow item : chunk) {
+              Note n = item.note();
+              ps.setLong(p++, n.getId());
+              ps.setString(p++, n.getUid());
+              ps.setTimestamp(p++, toTimestamp(n.getCreated()));
+              if (n.getLastUpdatedBy() != null) {
+                ps.setLong(p++, n.getLastUpdatedBy().getId());
+              } else {
+                ps.setNull(p++, Types.BIGINT);
+              }
+              if (n.getNoteText() != null) {
+                ps.setString(p++, n.getNoteText());
+              } else {
+                ps.setNull(p++, Types.VARCHAR);
+              }
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void insertJoinRows(Connection conn, List<NoteRow> newNotes) throws SQLException {
+    forEachChunk(
+        newNotes,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(joinInsertPrefix, JOIN_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (NoteRow item : chunk) {
+              ps.setLong(p++, item.ownerId());
+              ps.setLong(p++, item.note().getId());
+              ps.setInt(p++, item.sortOrder());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/NoteCascadeWriter.java
@@ -63,13 +63,14 @@ final class NoteCascadeWriter {
   // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
   // regardless of row count.
   private static final String NOTE_INSERT_SQL =
-      "insert into note (noteid, uid, created, lastupdatedby, notetext)"
-          + " select noteid, uid, created, lastupdatedby, notetext"
+      "insert into note (noteid, uid, created, lastupdatedby, creator, notetext)"
+          + " select noteid, uid, created, lastupdatedby, creator, notetext"
           + " from ( select"
           + " unnest(?::bigint[]) as noteid,"
           + " unnest(?::text[]) as uid,"
           + " unnest(?::timestamptz[]) as created,"
           + " unnest(?::bigint[]) as lastupdatedby,"
+          + " unnest(?::text[]) as creator,"
           + " unnest(?::text[]) as notetext"
           + " ) v";
 
@@ -152,6 +153,7 @@ final class NoteCascadeWriter {
             ps.setArray(p++, textArray(conn, chunk, nr -> nr.note().getUid()));
             ps.setArray(p++, textArray(conn, chunk, nr -> toTimestamptz(nr.note().getCreated())));
             ps.setArray(p++, bigintArray(conn, chunk, nr -> lastUpdatedById(nr.note())));
+            ps.setArray(p++, textArray(conn, chunk, nr -> nr.note().getCreator()));
             ps.setArray(p++, textArray(conn, chunk, nr -> nr.note().getNoteText()));
             ps.executeUpdate();
           }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
@@ -78,6 +79,7 @@ public class RelationshipPersister
 
   @Override
   protected void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -65,6 +65,23 @@ public class RelationshipPersister
   }
 
   @Override
+  protected void assignId(org.hisp.dhis.tracker.model.Relationship entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(
+      org.hisp.dhis.tracker.model.Relationship entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(
+      org.hisp.dhis.tracker.model.Relationship entity, EntityWriteBatch batch) {
+    throw new UnsupportedOperationException("Relationships are not updated");
+  }
+
+  @Override
   protected org.hisp.dhis.tracker.model.Relationship convert(
       TrackerBundle bundle, Relationship trackerDto) {
     if (bundle.getStrategy(trackerDto) == TrackerImportStrategy.UPDATE) {
@@ -106,7 +123,8 @@ public class RelationshipPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       Relationship trackerDto,
-      org.hisp.dhis.tracker.model.Relationship entity) {
+      org.hisp.dhis.tracker.model.Relationship entity,
+      EntityWriteBatch batch) {
     // NOTHING TO DO
 
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -30,8 +30,8 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
@@ -40,8 +40,10 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -93,13 +95,13 @@ public class RelationshipPersister
 
   @Override
   protected void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     // NOTHING TO DO
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -70,7 +70,8 @@ public class RelationshipPersister
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // NOTHING TO DO
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -58,7 +58,12 @@ public class RelationshipPersister
 
   @Override
   protected String sequenceName() {
-    return null;
+    // Shared with every other entity that uses Hibernate's `<generator class="native"/>`. No
+    // dedicated relationship_sequence was provisioned in any Flyway migration. The 2
+    // RelationshipItem
+    // ids per Relationship are allocated separately inside
+    // EntityWriteBatch.insertRelationshipItems.
+    return "hibernate_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -59,12 +59,9 @@ public class RelationshipPersister
 
   @Override
   protected String sequenceName() {
-    // Shared with every other entity that uses Hibernate's `<generator class="native"/>`. No
-    // dedicated relationship_sequence was provisioned in any Flyway migration. The 2
-    // RelationshipItem
-    // ids per Relationship are allocated separately inside
-    // EntityWriteBatch.insertRelationshipItems.
-    return "hibernate_sequence";
+    // The 2 RelationshipItem ids per Relationship are allocated separately from
+    // relationshipitem_sequence inside EntityWriteBatch.insertRelationshipItems.
+    return "relationship_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
@@ -47,6 +48,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.tracker.model.Relationship> {
+
+  public RelationshipPersister(DataSource dataSource) {
+    super(dataSource);
+  }
 
   @Override
   protected org.hisp.dhis.tracker.model.Relationship convert(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
@@ -49,8 +50,8 @@ import org.springframework.stereotype.Component;
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.tracker.model.Relationship> {
 
-  public RelationshipPersister(DataSource dataSource) {
-    super(dataSource);
+  public RelationshipPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
+    super(dataSource, fileResourceStore);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
@@ -61,7 +60,6 @@ public class RelationshipPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship hibernateEntity,
@@ -97,7 +95,6 @@ public class RelationshipPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Relationship trackerDto,
       org.hisp.dhis.tracker.model.Relationship payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipPersister.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
@@ -50,8 +51,14 @@ import org.springframework.stereotype.Component;
 public class RelationshipPersister
     extends AbstractTrackerPersister<Relationship, org.hisp.dhis.tracker.model.Relationship> {
 
-  public RelationshipPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
-    super(dataSource, fileResourceStore);
+  public RelationshipPersister(
+      DataSource dataSource, FileResourceStore fileResourceStore, ObjectMapper objectMapper) {
+    super(dataSource, fileResourceStore, objectMapper);
+  }
+
+  @Override
+  protected String sequenceName() {
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
@@ -30,17 +30,17 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.booleanArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toObjectStyleJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.tracker.model.Relationship;
@@ -58,23 +58,46 @@ import org.hisp.dhis.tracker.model.RelationshipItem;
  */
 final class RelationshipWriter {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count. from/to_relationshipitemid are written as NULL on this parent INSERT
+  // and filled in by updateFromTo after the items are inserted.
+  private static final String INSERT_SQL =
       "insert into relationship ("
           + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
-          + " style, relationshiptypeid,"
-          + " from_relationshipitemid, to_relationshipitemid,"
-          + " key, inverted_key, deleted, createdatclient) values ";
+          + " style, relationshiptypeid, from_relationshipitemid, to_relationshipitemid,"
+          + " key, inverted_key, deleted, createdatclient)"
+          + " select relationshipid, uid, code, created, lastupdated, lastupdatedby,"
+          + " style::jsonb, relationshiptypeid, null, null,"
+          + " key, inverted_key, deleted, createdatclient"
+          + " from ( select"
+          + " unnest(?::bigint[]) as relationshipid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::text[]) as code,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::bigint[]) as lastupdatedby,"
+          + " unnest(?::text[]) as style,"
+          + " unnest(?::bigint[]) as relationshiptypeid,"
+          + " unnest(?::text[]) as key,"
+          + " unnest(?::text[]) as inverted_key,"
+          + " unnest(?::boolean[]) as deleted,"
+          + " unnest(?::timestamptz[]) as createdatclient"
+          + " ) v";
 
-  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
-  // updateFromTo after the items are inserted.
-  private static final String INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
-
-  private static final String ITEM_INSERT_PREFIX =
+  private static final String ITEM_INSERT_SQL =
       "insert into relationshipitem ("
           + "relationshipitemid, relationshipid,"
-          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
-  private static final String ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+          + " trackedentityid, enrollmentid, trackereventid, singleeventid)"
+          + " select relationshipitemid, relationshipid,"
+          + " trackedentityid, enrollmentid, trackereventid, singleeventid"
+          + " from ( select"
+          + " unnest(?::bigint[]) as relationshipitemid,"
+          + " unnest(?::bigint[]) as relationshipid,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::bigint[]) as trackereventid,"
+          + " unnest(?::bigint[]) as singleeventid"
+          + " ) v";
 
   private static final String UPDATE_FROM_TO_SQL =
       "update relationship r set"
@@ -125,18 +148,33 @@ final class RelationshipWriter {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          for (Relationship r : chunk) {
+            requirePreallocatedId(r);
+          }
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (Relationship r : chunk) {
-              p = bindRow(ps, p, r);
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, Relationship::getId));
+            ps.setArray(p++, textArray(conn, chunk, Relationship::getUid));
+            ps.setArray(p++, textArray(conn, chunk, Relationship::getCode));
+            ps.setArray(p++, textArray(conn, chunk, r -> toTimestamptz(r.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, r -> toTimestamptz(r.getLastUpdated())));
+            ps.setArray(p++, bigintArray(conn, chunk, RelationshipWriter::lastUpdatedById));
+            ps.setArray(p++, textArray(conn, chunk, r -> toObjectStyleJson(r.getStyle())));
+            ps.setArray(p++, bigintArray(conn, chunk, r -> r.getRelationshipType().getId()));
+            ps.setArray(p++, textArray(conn, chunk, Relationship::getKey));
+            ps.setArray(p++, textArray(conn, chunk, Relationship::getInvertedKey));
+            ps.setArray(p++, booleanArray(conn, chunk, Relationship::isDeleted));
+            ps.setArray(p++, textArray(conn, chunk, r -> toTimestamptz(r.getCreatedAtClient())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
+  private static Long lastUpdatedById(Relationship r) {
+    return r.getLastUpdatedBy() != null ? r.getLastUpdatedBy().getId() : null;
+  }
+
+  private static void requirePreallocatedId(Relationship r) throws SQLException {
     if (r.getId() == 0) {
       throw new SQLException(
           "Relationship "
@@ -144,27 +182,6 @@ final class RelationshipWriter {
               + " has no pre-allocated id; AbstractTrackerPersister"
               + " must pre-allocate ids when sequenceName() is non-null.");
     }
-    ps.setLong(p++, r.getId());
-    ps.setString(p++, r.getUid());
-    if (r.getCode() != null) {
-      ps.setString(p++, r.getCode());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
-    if (r.getLastUpdatedBy() != null) {
-      ps.setLong(p++, r.getLastUpdatedBy().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toObjectStyleJson(r.getStyle()));
-    ps.setLong(p++, r.getRelationshipType().getId());
-    ps.setString(p++, r.getKey());
-    ps.setString(p++, r.getInvertedKey());
-    ps.setBoolean(p++, r.isDeleted());
-    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
-    return p;
   }
 
   /** Flattened from/to item with its pre-allocated id and parent relationship id. */
@@ -193,49 +210,31 @@ final class RelationshipWriter {
       rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
     }
 
+    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
+    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
+    // non-null because a given UID exists in exactly one of the two event tables.
     forEachChunk(
         rows,
         chunk -> {
-          String sql = buildMultiRowInsertSql(ITEM_INSERT_PREFIX, ITEM_INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          try (PreparedStatement ps = conn.prepareStatement(ITEM_INSERT_SQL)) {
             int p = 1;
-            for (ItemRow row : chunk) {
-              p = bindItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, ItemRow::itemId));
+            ps.setArray(p++, bigintArray(conn, chunk, ItemRow::relationshipId));
+            ps.setArray(
+                p++, bigintArray(conn, chunk, row -> itemRefId(row.item().getTrackedEntity())));
+            ps.setArray(
+                p++, bigintArray(conn, chunk, row -> itemRefId(row.item().getEnrollment())));
+            ps.setArray(
+                p++, bigintArray(conn, chunk, row -> itemRefId(row.item().getTrackerEvent())));
+            ps.setArray(
+                p++, bigintArray(conn, chunk, row -> itemRefId(row.item().getSingleEvent())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindItemRow(
-      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
-      throws SQLException {
-    ps.setLong(p++, itemId);
-    ps.setLong(p++, relationshipId);
-    if (item.getTrackedEntity() != null) {
-      ps.setLong(p++, item.getTrackedEntity().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getEnrollment() != null) {
-      ps.setLong(p++, item.getEnrollment().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
-    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
-    // non-null because a given UID exists in exactly one of the two event tables.
-    if (item.getTrackerEvent() != null) {
-      ps.setLong(p++, item.getTrackerEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    if (item.getSingleEvent() != null) {
-      ps.setLong(p++, item.getSingleEvent().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    return p;
+  private static Long itemRefId(org.hisp.dhis.common.IdentifiableObject ref) {
+    return ref != null ? ref.getId() : null;
   }
 
   /**

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/RelationshipWriter.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toObjectStyleJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import org.hisp.dhis.tracker.model.Relationship;
+import org.hisp.dhis.tracker.model.RelationshipItem;
+
+/**
+ * Flushes staged {@link Relationship} inserts via three JDBC statements -- a multi-row INSERT into
+ * {@code relationship} with {@code from/to_relationshipitemid} left NULL, a multi-row INSERT into
+ * {@code relationshipitem} for the (from + to) items, and an unnest UPDATE on {@code relationship}
+ * to set the from/to FKs. The three-step shape breaks the circular, non-deferrable FK between the
+ * two tables. Ids come from {@code relationship_sequence} and {@code relationshipitem_sequence}.
+ *
+ * <p>Relationship is INSERT-only in tracker imports ({@code RelationshipPersister.convert} returns
+ * null on UPDATE strategy), so there is no update list and no L1 detach/refresh.
+ */
+final class RelationshipWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into relationship ("
+          + "relationshipid, uid, code, created, lastupdated, lastupdatedby,"
+          + " style, relationshiptypeid,"
+          + " from_relationshipitemid, to_relationshipitemid,"
+          + " key, inverted_key, deleted, createdatclient) values ";
+
+  // from/to_relationshipitemid are written as NULL on the parent INSERT and filled in by
+  // updateFromTo after the items are inserted.
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?, NULL, NULL, ?, ?, ?, ?)";
+
+  private static final String ITEM_INSERT_PREFIX =
+      "insert into relationshipitem ("
+          + "relationshipitemid, relationshipid,"
+          + " trackedentityid, enrollmentid, trackereventid, singleeventid) values ";
+  private static final String ITEM_INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  private static final String UPDATE_FROM_TO_SQL =
+      "update relationship r set"
+          + " from_relationshipitemid = v.from_id,"
+          + " to_relationshipitemid = v.to_id"
+          + " from ( select"
+          + " unnest(?::bigint[]) as relationshipid,"
+          + " unnest(?::bigint[]) as from_id,"
+          + " unnest(?::bigint[]) as to_id"
+          + " ) v where r.relationshipid = v.relationshipid";
+
+  private final List<Relationship> inserts = new ArrayList<>();
+
+  /**
+   * Relationships are never updated -- {@link AbstractTrackerPersister} ignores update payloads.
+   */
+  void stageInsert(Relationship relationship) {
+    inserts.add(relationship);
+  }
+
+  int mark() {
+    return inserts.size();
+  }
+
+  void rollbackTo(int mark) {
+    truncate(inserts, mark);
+  }
+
+  void clear() {
+    inserts.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    insertRelationships(conn);
+    insertRelationshipItems(conn);
+    updateFromTo(conn);
+  }
+
+  /**
+   * Inserts the parent {@code relationship} rows with from/to FKs left NULL (filled in by {@link
+   * #updateFromTo} once the item rows exist, since neither FK constraint is deferrable).
+   */
+  private void insertRelationships(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (Relationship r : chunk) {
+              p = bindRow(ps, p, r);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, Relationship r) throws SQLException {
+    if (r.getId() == 0) {
+      throw new SQLException(
+          "Relationship "
+              + r.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, r.getId());
+    ps.setString(p++, r.getUid());
+    if (r.getCode() != null) {
+      ps.setString(p++, r.getCode());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setTimestamp(p++, toTimestamp(r.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(r.getLastUpdated()));
+    if (r.getLastUpdatedBy() != null) {
+      ps.setLong(p++, r.getLastUpdatedBy().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toObjectStyleJson(r.getStyle()));
+    ps.setLong(p++, r.getRelationshipType().getId());
+    ps.setString(p++, r.getKey());
+    ps.setString(p++, r.getInvertedKey());
+    ps.setBoolean(p++, r.isDeleted());
+    setNullableTimestamp(ps, p++, r.getCreatedAtClient());
+    return p;
+  }
+
+  /** Flattened from/to item with its pre-allocated id and parent relationship id. */
+  private record ItemRow(long itemId, long relationshipId, RelationshipItem item) {}
+
+  /**
+   * Inserts the {@code relationshipitem} rows. Each Relationship has exactly two items (from + to);
+   * we allocate {@code 2 * relationships.size()} ids from {@code relationshipitem_sequence} in one
+   * round-trip, assign them to the in-memory items (so {@link #updateFromTo} can read them back),
+   * then flatten the from/to items into a single multi-row INSERT.
+   */
+  private void insertRelationshipItems(Connection conn) throws SQLException {
+    if (inserts.isEmpty()) {
+      return;
+    }
+    long[] itemIds = allocateIds(conn, "relationshipitem_sequence", 2 * inserts.size());
+    int cursor = 0;
+    for (Relationship r : inserts) {
+      r.getFrom().setId((int) itemIds[cursor++]);
+      r.getTo().setId((int) itemIds[cursor++]);
+    }
+
+    List<ItemRow> rows = new ArrayList<>(2 * inserts.size());
+    for (Relationship r : inserts) {
+      rows.add(new ItemRow(r.getFrom().getId(), r.getId(), r.getFrom()));
+      rows.add(new ItemRow(r.getTo().getId(), r.getId(), r.getTo()));
+    }
+
+    forEachChunk(
+        rows,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(ITEM_INSERT_PREFIX, ITEM_INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (ItemRow row : chunk) {
+              p = bindItemRow(ps, p, row.itemId(), row.relationshipId(), row.item());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindItemRow(
+      PreparedStatement ps, int p, long itemId, long relationshipId, RelationshipItem item)
+      throws SQLException {
+    ps.setLong(p++, itemId);
+    ps.setLong(p++, relationshipId);
+    if (item.getTrackedEntity() != null) {
+      ps.setLong(p++, item.getTrackedEntity().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getEnrollment() != null) {
+      ps.setLong(p++, item.getEnrollment().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    // For PROGRAM_STAGE_INSTANCE endpoints the mapper sets BOTH trackerEvent and singleEvent from
+    // preheat (TrackerObjectsMapper.java:350-353,366-369), but only the matching one resolves to
+    // non-null because a given UID exists in exactly one of the two event tables.
+    if (item.getTrackerEvent() != null) {
+      ps.setLong(p++, item.getTrackerEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    if (item.getSingleEvent() != null) {
+      ps.setLong(p++, item.getSingleEvent().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    return p;
+  }
+
+  /**
+   * Sets {@code relationship.from_relationshipitemid} and {@code to_relationshipitemid} once the
+   * item rows have been inserted by {@link #insertRelationshipItems}.
+   */
+  private void updateFromTo(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          Long[] fromIds = new Long[n];
+          Long[] toIds = new Long[n];
+
+          for (int i = 0; i < n; i++) {
+            Relationship r = chunk.get(i);
+            ids[i] = r.getId();
+            fromIds[i] = (long) r.getFrom().getId();
+            toIds[i] = (long) r.getTo().getId();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_FROM_TO_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("bigint", fromIds));
+            ps.setArray(3, conn.createArrayOf("bigint", toIds));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -62,10 +61,12 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
 import org.hisp.dhis.tracker.model.SingleEvent;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -172,13 +173,13 @@ public class SingleEventPersister
 
   @Override
   protected void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -74,8 +75,14 @@ import org.springframework.stereotype.Component;
 public class SingleEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.SingleEvent, SingleEvent> {
-  public SingleEventPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
-    super(dataSource, fileResourceStore);
+  public SingleEventPersister(
+      DataSource dataSource, FileResourceStore fileResourceStore, ObjectMapper objectMapper) {
+    super(dataSource, fileResourceStore, objectMapper);
+  }
+
+  @Override
+  protected String sequenceName() {
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
@@ -72,6 +73,9 @@ import org.springframework.stereotype.Component;
 public class SingleEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.SingleEvent, SingleEvent> {
+  public SingleEventPersister(DataSource dataSource) {
+    super(dataSource);
+  }
 
   @Override
   protected void updatePreheat(TrackerPreheat preheat, SingleEvent event) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -82,7 +82,7 @@ public class SingleEventPersister
 
   @Override
   protected String sequenceName() {
-    return null;
+    return "singleevent_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -145,7 +144,6 @@ public class SingleEventPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,
@@ -156,20 +154,17 @@ public class SingleEventPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent payloadEntity,
       SingleEvent currentEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleDataValues(
-        entityManager, preheat, event.getDataValues(), payloadEntity, user, changeLogs);
+    handleDataValues(preheat, event.getDataValues(), payloadEntity, user, changeLogs);
     logFieldChanges(currentEntity, payloadEntity, user.getUsername(), changeLogs);
   }
 
   private void handleDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
       SingleEvent event,
@@ -188,7 +183,7 @@ public class SingleEventPersister
           if (isNewDataValue(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event, dataElement, program, null, dataValue.getValue(), CREATE, username);
-            saveDataValue(dataValue, event, dataElement, user, entityManager, preheat);
+            saveDataValue(dataValue, event, dataElement, user, preheat);
           } else if (isUpdate(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event,
@@ -198,12 +193,11 @@ public class SingleEventPersister
                 dataValue.getValue(),
                 UPDATE,
                 username);
-            updateDataValue(
-                dbDataValue, dataValue, event, dataElement, user, entityManager, preheat);
+            updateDataValue(dbDataValue, dataValue, event, dataElement, user, preheat);
           } else if (isDeletion(dbDataValue, dataValue)) {
             changeLogs.addSingleEventChangeLog(
                 event, dataElement, program, dbDataValue.getValue(), null, DELETE, username);
-            deleteDataValue(dbDataValue, event, dataElement, entityManager, preheat);
+            deleteDataValue(dbDataValue, event, dataElement, preheat);
           }
         });
   }
@@ -213,7 +207,6 @@ public class SingleEventPersister
       SingleEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     EventDataValue eventDataValue = new EventDataValue();
     eventDataValue.setDataElement(dataElement.getUid());
@@ -228,7 +221,7 @@ public class SingleEventPersister
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
 
     if (dataElement.isFileType()) {
-      assignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().add(eventDataValue);
@@ -240,14 +233,13 @@ public class SingleEventPersister
       SingleEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     eventDataValue.setLastUpdated(new Date());
     eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
-      assignFileResource(entityManager, preheat, event.getUid(), dv.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), dv.getValue());
     }
 
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
@@ -258,10 +250,9 @@ public class SingleEventPersister
       EventDataValue eventDataValue,
       SingleEvent event,
       DataElement dataElement,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().remove(eventDataValue);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.NotificationTrigger;
@@ -73,8 +74,8 @@ import org.springframework.stereotype.Component;
 public class SingleEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.SingleEvent, SingleEvent> {
-  public SingleEventPersister(DataSource dataSource) {
-    super(dataSource);
+  public SingleEventPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
+    super(dataSource, fileResourceStore);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -153,7 +153,8 @@ public class SingleEventPersister
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -156,6 +157,7 @@ public class SingleEventPersister
 
   @Override
   protected void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.SingleEvent event,
       SingleEvent hibernateEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventPersister.java
@@ -87,6 +87,21 @@ public class SingleEventPersister
   }
 
   @Override
+  protected void assignId(SingleEvent entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(SingleEvent entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(SingleEvent entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updatePreheat(TrackerPreheat preheat, SingleEvent event) {
     preheat.putSingleEvents(Collections.singletonList(event));
   }
@@ -277,7 +292,8 @@ public class SingleEventPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.SingleEvent trackerDto,
-      SingleEvent entity) {
+      SingleEvent entity,
+      EntityWriteBatch batch) {
     // DO NOTHING. Event creation does not create ownership records.
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
@@ -36,10 +36,8 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.fo
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -134,11 +132,11 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
           + " unnest(?::text[]) as geometry"
           + " ) v where ev.eventid = v.eventid";
 
-  private final ObjectMapper objectMapper;
+  private final UserInfoJsonCache userInfo;
   private final NoteCascadeWriter notes = new NoteCascadeWriter("singleevent_notes", "eventid");
 
-  SingleEventWriter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  SingleEventWriter(UserInfoJsonCache userInfo) {
+    this.userInfo = userInfo;
   }
 
   @Override
@@ -165,10 +163,9 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
             ps.setArray(
                 p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
             ps.setArray(
-                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getCreatedByUserInfo())));
             ps.setArray(
-                p++,
-                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getLastUpdatedByUserInfo())));
             ps.setArray(p++, textArray(conn, chunk, e -> e.getStatus().name()));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCompletedDate())));
@@ -229,7 +226,7 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
             lastUpdated[i] = toTimestamptz(e.getLastUpdated());
             createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
             lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            lastUpdatedByUserInfo[i] = userInfo.toJson(e.getLastUpdatedByUserInfo());
             programStageIds[i] = e.getProgramStage().getId();
             organisationUnitIds[i] = e.getOrganisationUnit().getId();
             attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
@@ -60,7 +60,7 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
           + " createdbyuserinfo, lastupdatedbyuserinfo, status, occurreddate, completeddate,"
           + " completedby, deleted, lastsynchronized,"
           + " programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry)"
+          + " assigneduserid, eventdatavalues, geometry, storedby)"
           + " select eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, status, occurreddate,"
           + " completeddate, completedby, deleted, lastsynchronized,"
@@ -68,7 +68,8 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
           + " assigneduserid, eventdatavalues::jsonb,"
           + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + ") end"
+          + ") end,"
+          + " storedby"
           + " from ( select"
           + " unnest(?::bigint[]) as eventid,"
           + " unnest(?::text[]) as uid,"
@@ -89,7 +90,8 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
           + " unnest(?::bigint[]) as attributeoptioncomboid,"
           + " unnest(?::bigint[]) as assigneduserid,"
           + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
+          + " unnest(?::text[]) as geometry,"
+          + " unnest(?::text[]) as storedby"
           + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch. Insert-
@@ -179,6 +181,7 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
             ps.setArray(
                 p++, textArray(conn, chunk, e -> toEventDataValuesJson(e.getEventDataValues())));
             ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
+            ps.setArray(p++, textArray(conn, chunk, SingleEvent::getStoredBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
@@ -30,19 +30,19 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.booleanArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import org.hisp.dhis.tracker.model.SingleEvent;
 
 /**
@@ -53,21 +53,46 @@ import org.hisp.dhis.tracker.model.SingleEvent;
  */
 final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count. INSERT column order, the SELECT projection and the unnest aliases are
+  // kept in lockstep.
+  private static final String INSERT_SQL =
       "insert into singleevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
+          + "eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo, status, occurreddate, completeddate,"
+          + " completedby, deleted, lastsynchronized,"
           + " programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
+          + " assigneduserid, eventdatavalues, geometry)"
+          + " select eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, status, occurreddate,"
+          + " completeddate, completedby, deleted, lastsynchronized,"
+          + " programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues::jsonb,"
+          + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + "))";
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as createdbyuserinfo,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::boolean[]) as deleted,"
+          + " unnest(?::timestamptz[]) as lastsynchronized,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch. Insert-
   // only columns (uid, created, createdbyuserinfo, deleted) and columns owned by other code paths
@@ -127,18 +152,46 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          for (SingleEvent e : chunk) {
+            requirePreallocatedId(e);
+          }
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (SingleEvent e : chunk) {
-              p = bindRow(ps, p, e);
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, SingleEvent::getId));
+            ps.setArray(p++, textArray(conn, chunk, SingleEvent::getUid));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+            ps.setArray(
+                p++,
+                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+            ps.setArray(p++, textArray(conn, chunk, e -> e.getStatus().name()));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCompletedDate())));
+            ps.setArray(p++, textArray(conn, chunk, SingleEvent::getCompletedBy));
+            ps.setArray(p++, booleanArray(conn, chunk, SingleEvent::isDeleted));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastSynchronized())));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getProgramStage().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getOrganisationUnit().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getAttributeOptionCombo().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, SingleEventWriter::assignedUserId));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toEventDataValuesJson(e.getEventDataValues())));
+            ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
+  private static Long assignedUserId(SingleEvent e) {
+    return e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+  }
+
+  private static void requirePreallocatedId(SingleEvent e) throws SQLException {
     if (e.getId() == 0) {
       throw new SQLException(
           "SingleEvent "
@@ -146,39 +199,6 @@ final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
               + " has no pre-allocated id; AbstractTrackerPersister"
               + " must pre-allocate ids when sequenceName() is non-null.");
     }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
   }
 
   private void update(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/SingleEventWriter.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.SingleEvent;
+
+/**
+ * Flushes staged {@link SingleEvent} writes. Mirrors {@link TrackerEventWriter} but writes to
+ * {@code singleevent} (no {@code enrollmentid}, no {@code scheduleddate}); ids are pre-allocated
+ * from {@code singleevent_sequence}. New notes cascade into {@code note} + {@code
+ * singleevent_notes}.
+ */
+final class SingleEventWriter extends UpsertTableWriter<SingleEvent> {
+
+  private static final String INSERT_PREFIX =
+      "insert into singleevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.mapSingleEvent outside the new-entity branch. Insert-
+  // only columns (uid, created, createdbyuserinfo, deleted) and columns owned by other code paths
+  // (lastsynchronized) are excluded.
+  private static final String UPDATE_SQL =
+      "update singleevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("singleevent_notes", "eventid");
+
+  SingleEventWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, SingleEvent::getId, SingleEvent::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (SingleEvent e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, SingleEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "SingleEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] programStageIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] status = new String[n];
+          String[] occurredDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          Long[] assignedUserIds = new Long[n];
+          String[] eventDataValues = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            SingleEvent e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            programStageIds[i] = e.getProgramStage().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            status[i] = e.getStatus().name();
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+            eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", programStageIds));
+            ps.setArray(7, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(8, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(9, conn.createArrayOf("text", status));
+            ps.setArray(10, conn.createArrayOf("text", occurredDate));
+            ps.setArray(11, conn.createArrayOf("text", completedDate));
+            ps.setArray(12, conn.createArrayOf("text", completedBy));
+            ps.setArray(13, conn.createArrayOf("bigint", assignedUserIds));
+            ps.setArray(14, conn.createArrayOf("text", eventDataValues));
+            ps.setArray(15, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
@@ -29,10 +29,9 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableString;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
 
@@ -41,8 +40,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
-import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 
 /**
@@ -55,11 +52,20 @@ import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
  */
 final class TeavWriter {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count.
+  private static final String INSERT_SQL =
       "insert into trackedentityattributevalue ("
-          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
-          + " value, storedby) values ";
-  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+          + "trackedentityid, trackedentityattributeid, created, lastupdated, value, storedby)"
+          + " select trackedentityid, trackedentityattributeid, created, lastupdated, value, storedby"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::text[]) as value,"
+          + " unnest(?::text[]) as storedby"
+          + " ) v";
 
   // `created` is insert-only and deliberately excluded from the UPDATE column set.
   private static final String UPDATE_SQL =
@@ -102,19 +108,6 @@ final class TeavWriter {
     deletes.add(value);
   }
 
-  /**
-   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
-   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
-   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
-   * each carrying the same attribute value -- so it can fold the second occurrence into the first
-   * staged instance instead of staging a second INSERT for the same composite key, which would
-   * violate the primary key at flush.
-   */
-  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
-    return Stream.concat(inserts.stream(), updates.stream())
-        .filter(v -> v.getTrackedEntity() == trackedEntity);
-  }
-
   Mark mark() {
     return new Mark(inserts.size(), updates.size(), deletes.size());
   }
@@ -145,17 +138,14 @@ final class TeavWriter {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (TrackedEntityAttributeValue v : chunk) {
-              ps.setLong(p++, v.getTrackedEntity().getId());
-              ps.setLong(p++, v.getAttribute().getId());
-              ps.setTimestamp(p++, toTimestamp(v.getCreated()));
-              ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
-              setNullableString(ps, p++, v.getValue());
-              setNullableString(ps, p++, v.getStoredBy());
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, v -> v.getTrackedEntity().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, v -> v.getAttribute().getId()));
+            ps.setArray(p++, textArray(conn, chunk, v -> toTimestamptz(v.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, v -> toTimestamptz(v.getLastUpdated())));
+            ps.setArray(p++, textArray(conn, chunk, TrackedEntityAttributeValue::getValue));
+            ps.setArray(p++, textArray(conn, chunk, TrackedEntityAttributeValue::getStoredBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TeavWriter.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableString;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
+
+/**
+ * Flushes staged {@link TrackedEntityAttributeValue} writes via JDBC against {@code
+ * trackedentityattributevalue}: a multi-row INSERT, a single unnest UPDATE keyed on the composite
+ * ({@code trackedentityid}, {@code trackedentityattributeid}) PK, and a single unnest DELETE on the
+ * same key. TEAV has a composite PK and no sequence, so no id pre-allocation is needed.
+ * Confidential attributes (and the {@code encryptedvalue} column) were removed in DHIS2-21518, so
+ * the value is stored as plain text in {@code value}.
+ */
+final class TeavWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentityattributevalue ("
+          + "trackedentityid, trackedentityattributeid, created, lastupdated,"
+          + " value, storedby) values ";
+  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?)";
+
+  // `created` is insert-only and deliberately excluded from the UPDATE column set.
+  private static final String UPDATE_SQL =
+      "update trackedentityattributevalue teav set"
+          + " lastupdated = v.lastupdated,"
+          + " value = v.value,"
+          + " storedby = v.storedby"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::text[]) as value,"
+          + " unnest(?::text[]) as storedby"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
+  // Unnest DELETE on the composite key, mirroring the unnest UPDATE shape rather than an
+  // IN (VALUES ...) form, to stay consistent with the other batch statements and avoid dynamic SQL.
+  private static final String DELETE_SQL =
+      "delete from trackedentityattributevalue teav"
+          + " using ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as trackedentityattributeid"
+          + " ) v where teav.trackedentityid = v.trackedentityid"
+          + " and teav.trackedentityattributeid = v.trackedentityattributeid";
+
+  private final List<TrackedEntityAttributeValue> inserts = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> updates = new ArrayList<>();
+  private final List<TrackedEntityAttributeValue> deletes = new ArrayList<>();
+
+  void stageInsert(TrackedEntityAttributeValue value) {
+    inserts.add(value);
+  }
+
+  void stageUpdate(TrackedEntityAttributeValue value) {
+    updates.add(value);
+  }
+
+  void stageDelete(TrackedEntityAttributeValue value) {
+    deletes.add(value);
+  }
+
+  /**
+   * TEAVs already staged for insert or update against the given TrackedEntity. Used by the
+   * attribute-handling code to detect when the same logical TEAV (composite key {@code te + attr})
+   * is being processed twice within one persister run -- e.g. two enrollments under the same TE
+   * each carrying the same attribute value -- so it can fold the second occurrence into the first
+   * staged instance instead of staging a second INSERT for the same composite key, which would
+   * violate the primary key at flush.
+   */
+  Stream<TrackedEntityAttributeValue> stagedFor(TrackedEntity trackedEntity) {
+    return Stream.concat(inserts.stream(), updates.stream())
+        .filter(v -> v.getTrackedEntity() == trackedEntity);
+  }
+
+  Mark mark() {
+    return new Mark(inserts.size(), updates.size(), deletes.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    truncate(inserts, mark.inserts());
+    truncate(updates, mark.updates());
+    truncate(deletes, mark.deletes());
+  }
+
+  void clear() {
+    inserts.clear();
+    updates.clear();
+    deletes.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty() && updates.isEmpty() && deletes.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    delete(conn);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntityAttributeValue v : chunk) {
+              ps.setLong(p++, v.getTrackedEntity().getId());
+              ps.setLong(p++, v.getAttribute().getId());
+              ps.setTimestamp(p++, toTimestamp(v.getCreated()));
+              ps.setTimestamp(p++, toTimestamp(v.getLastUpdated()));
+              setNullableString(ps, p++, v.getValue());
+              setNullableString(ps, p++, v.getStoredBy());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] trackedEntityIds = new Long[n];
+          Long[] attributeIds = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] value = new String[n];
+          String[] storedBy = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackedEntityAttributeValue v = chunk.get(i);
+            trackedEntityIds[i] = v.getTrackedEntity().getId();
+            attributeIds[i] = v.getAttribute().getId();
+            lastUpdated[i] = toTimestamptz(v.getLastUpdated());
+            value[i] = v.getValue();
+            storedBy[i] = v.getStoredBy();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+            ps.setArray(3, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(4, conn.createArrayOf("text", value));
+            ps.setArray(5, conn.createArrayOf("text", storedBy));
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private void delete(Connection conn) throws SQLException {
+    forEachChunk(
+        deletes,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] trackedEntityIds = new Long[n];
+          Long[] attributeIds = new Long[n];
+          for (int i = 0; i < n; i++) {
+            TrackedEntityAttributeValue v = chunk.get(i);
+            trackedEntityIds[i] = v.getTrackedEntity().getId();
+            attributeIds[i] = v.getAttribute().getId();
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(DELETE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", trackedEntityIds));
+            ps.setArray(2, conn.createArrayOf("bigint", attributeIds));
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  record Mark(int inserts, int updates, int deletes) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -61,8 +61,10 @@ public class TrackedEntityPersister
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
-    handleTrackedEntityAttributeValues(preheat, trackerDto.getAttributes(), te, user, changeLogs);
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
+    handleTrackedEntityAttributeValues(
+        preheat, trackerDto.getAttributes(), te, user, changeLogs, batch);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
@@ -48,6 +49,10 @@ import org.springframework.stereotype.Component;
 public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
+
+  public TrackedEntityPersister(DataSource dataSource) {
+    super(dataSource);
+  }
 
   @Override
   protected void updateAttributes(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -64,6 +65,7 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
@@ -71,7 +73,7 @@ public class TrackedEntityPersister
       ChangeLogAccumulator changeLogs,
       EntityWriteBatch batch) {
     handleTrackedEntityAttributeValues(
-        preheat, trackerDto.getAttributes(), te, user, changeLogs, batch);
+        connection, preheat, trackerDto.getAttributes(), te, user, changeLogs, batch);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -60,7 +60,7 @@ public class TrackedEntityPersister
 
   @Override
   protected String sequenceName() {
-    return "trackedentityinstance_sequence";
+    return "trackedentity_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -52,14 +51,12 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleTrackedEntityAttributeValues(
-        entityManager, preheat, trackerDto.getAttributes(), te, user, changeLogs);
+    handleTrackedEntityAttributeValues(preheat, trackerDto.getAttributes(), te, user, changeLogs);
   }
 
   @Override
@@ -95,7 +92,6 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity payloadEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -51,8 +52,14 @@ public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
 
-  public TrackedEntityPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
-    super(dataSource, fileResourceStore);
+  public TrackedEntityPersister(
+      DataSource dataSource, FileResourceStore fileResourceStore, ObjectMapper objectMapper) {
+    super(dataSource, fileResourceStore, objectMapper);
+  }
+
+  @Override
+  protected String sequenceName() {
+    return "trackedentityinstance_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
@@ -50,8 +51,8 @@ public class TrackedEntityPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackedEntity, TrackedEntity> {
 
-  public TrackedEntityPersister(DataSource dataSource) {
-    super(dataSource);
+  public TrackedEntityPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
+    super(dataSource, fileResourceStore);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -64,6 +64,21 @@ public class TrackedEntityPersister
   }
 
   @Override
+  protected void assignId(TrackedEntity entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(TrackedEntity entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(TrackedEntity entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updateAttributes(
       Connection connection,
       TrackerPreheat preheat,
@@ -102,7 +117,8 @@ public class TrackedEntityPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
-      TrackedEntity entity) {
+      TrackedEntity entity,
+      EntityWriteBatch batch) {
     // DO NOTHING, TE alone does not have ownership records
 
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityPersister.java
@@ -30,18 +30,21 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.model.TrackedEntity;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -80,15 +83,21 @@ public class TrackedEntityPersister
 
   @Override
   protected void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackerDto,
       TrackedEntity te,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     handleTrackedEntityAttributeValues(
-        connection, preheat, trackerDto.getAttributes(), te, user, changeLogs, batch);
+        preheat, trackerDto.getAttributes(), te, user, changeLogs, batch, existingAttributeValues);
+  }
+
+  @Override
+  protected Set<String> trackedEntityUidsForAttributeLoad(
+      List<org.hisp.dhis.tracker.imports.domain.TrackedEntity> dtos) {
+    return dtos.stream().map(te -> te.getUID().getValue()).collect(Collectors.toSet());
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
@@ -30,9 +30,10 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
 
 import java.sql.Connection;
@@ -58,11 +59,23 @@ import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
  */
 final class TrackedEntityProgramOwnerWriter {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count.
+  private static final String INSERT_SQL =
       "insert into trackedentityprogramowner ("
           + "trackedentityprogramownerid, trackedentityid, programid,"
-          + " created, lastupdated, organisationunitid, createdby) values ";
-  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?, ?)";
+          + " created, lastupdated, organisationunitid, createdby)"
+          + " select trackedentityprogramownerid, trackedentityid, programid,"
+          + " created, lastupdated, organisationunitid, createdby"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityprogramownerid,"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::bigint[]) as programid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::text[]) as createdby"
+          + " ) v";
 
   private final List<TrackedEntityProgramOwner> inserts = new ArrayList<>();
 
@@ -99,18 +112,15 @@ final class TrackedEntityProgramOwnerWriter {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (TrackedEntityProgramOwner owner : chunk) {
-              ps.setLong(p++, owner.getId());
-              ps.setLong(p++, owner.getTrackedEntity().getId());
-              ps.setLong(p++, owner.getProgram().getId());
-              ps.setTimestamp(p++, toTimestamp(owner.getCreated()));
-              ps.setTimestamp(p++, toTimestamp(owner.getLastUpdated()));
-              ps.setLong(p++, owner.getOrganisationUnit().getId());
-              ps.setString(p++, owner.getCreatedBy());
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, o -> (long) o.getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, o -> o.getTrackedEntity().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, o -> o.getProgram().getId()));
+            ps.setArray(p++, textArray(conn, chunk, o -> toTimestamptz(o.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, o -> toTimestamptz(o.getLastUpdated())));
+            ps.setArray(p++, bigintArray(conn, chunk, o -> o.getOrganisationUnit().getId()));
+            ps.setArray(p++, textArray(conn, chunk, TrackedEntityProgramOwner::getCreatedBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityProgramOwnerWriter.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.allocateIds;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
+
+/**
+ * Flushes staged {@link TrackedEntityProgramOwner} rows via a single batched, multi-row JDBC INSERT
+ * into {@code trackedentityprogramowner}, replacing the per-new-enrollment Hibernate {@code save()}
+ * in {@code EnrollmentPersister.persistOwnership} (one {@code nextval} round-trip + one single-row
+ * INSERT each).
+ *
+ * <p>Ids are pre-allocated from {@code trackedentityprogramowner_sequence} (added in {@code
+ * V2_44_14}), the dedicated sequence the entity's {@code <generator class="sequence"/>} mapping now
+ * draws from. Both this JDBC import path and the remaining Hibernate insert paths for this table
+ * (ownership create-or-update and transfer) share that one sequence, so they cannot collide.
+ *
+ * <p>Ownership is INSERT-only here; the persister guards against duplicates against the preheat
+ * before staging, and the {@code (trackedentityid, programid)} unique key backstops it.
+ */
+final class TrackedEntityProgramOwnerWriter {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentityprogramowner ("
+          + "trackedentityprogramownerid, trackedentityid, programid,"
+          + " created, lastupdated, organisationunitid, createdby) values ";
+  private static final String INSERT_ROW = "(?, ?, ?, ?, ?, ?, ?)";
+
+  private final List<TrackedEntityProgramOwner> inserts = new ArrayList<>();
+
+  void stageInsert(TrackedEntityProgramOwner owner) {
+    inserts.add(owner);
+  }
+
+  int mark() {
+    return inserts.size();
+  }
+
+  void rollbackTo(int mark) {
+    truncate(inserts, mark);
+  }
+
+  void clear() {
+    inserts.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty();
+  }
+
+  void flush(Connection conn) throws SQLException {
+    if (inserts.isEmpty()) {
+      return;
+    }
+    long[] ids = allocateIds(conn, "trackedentityprogramowner_sequence", inserts.size());
+    int cursor = 0;
+    for (TrackedEntityProgramOwner owner : inserts) {
+      owner.setId((int) ids[cursor++]);
+    }
+
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntityProgramOwner owner : chunk) {
+              ps.setLong(p++, owner.getId());
+              ps.setLong(p++, owner.getTrackedEntity().getId());
+              ps.setLong(p++, owner.getProgram().getId());
+              ps.setTimestamp(p++, toTimestamp(owner.getCreated()));
+              ps.setTimestamp(p++, toTimestamp(owner.getLastUpdated()));
+              ps.setLong(p++, owner.getOrganisationUnit().getId());
+              ps.setString(p++, owner.getCreatedBy());
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
@@ -30,17 +30,18 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.booleanArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 
 /**
@@ -50,16 +51,40 @@ import org.hisp.dhis.tracker.model.TrackedEntity;
  */
 final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...): one cacheable statement regardless of row count,
+  // so pgjdbc's server-side prepared-statement cache engages (a multi-row VALUES list has distinct
+  // text per row count). INSERT column order, the SELECT projection and the unnest aliases below
+  // are kept in lockstep.
+  private static final String INSERT_SQL =
       "insert into trackedentity ("
-          + "trackedentityid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
+          + "trackedentityid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " inactive, deleted, lastsynchronized, potentialduplicate,"
+          + " organisationunitid, trackedentitytypeid, geometry, createdbyuserinfo,"
+          + " lastupdatedbyuserinfo)"
+          + " select trackedentityid, uid, created, lastupdated, createdatclient,"
+          + " lastupdatedatclient, inactive, deleted, lastsynchronized, potentialduplicate,"
           + " organisationunitid, trackedentitytypeid,"
-          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
-
-  private static final String INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, " + SRID + "), ?::jsonb, ?::jsonb)";
+          + " case when geometry is null then null else ST_GeomFromText(geometry, "
+          + SRID
+          + ") end,"
+          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::boolean[]) as inactive,"
+          + " unnest(?::boolean[]) as deleted,"
+          + " unnest(?::timestamptz[]) as lastsynchronized,"
+          + " unnest(?::boolean[]) as potentialduplicate,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as trackedentitytypeid,"
+          + " unnest(?::text[]) as geometry,"
+          + " unnest(?::text[]) as createdbyuserinfo,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo"
+          + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch. Insert-only columns (uid,
   // created, createdbyuserinfo) and columns owned by other code paths (deleted, lastsynchronized --
@@ -108,18 +133,36 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          for (TrackedEntity te : chunk) {
+            requirePreallocatedId(te);
+          }
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (TrackedEntity te : chunk) {
-              p = bindRow(ps, p, te);
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, TrackedEntity::getId));
+            ps.setArray(p++, textArray(conn, chunk, TrackedEntity::getUid));
+            ps.setArray(p++, textArray(conn, chunk, te -> toTimestamptz(te.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, te -> toTimestamptz(te.getLastUpdated())));
+            ps.setArray(p++, textArray(conn, chunk, te -> toTimestamptz(te.getCreatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, te -> toTimestamptz(te.getLastUpdatedAtClient())));
+            ps.setArray(p++, booleanArray(conn, chunk, TrackedEntity::isInactive));
+            ps.setArray(p++, booleanArray(conn, chunk, TrackedEntity::isDeleted));
+            ps.setArray(p++, textArray(conn, chunk, te -> toTimestamptz(te.getLastSynchronized())));
+            ps.setArray(p++, booleanArray(conn, chunk, TrackedEntity::isPotentialDuplicate));
+            ps.setArray(p++, bigintArray(conn, chunk, te -> te.getOrganisationUnit().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, te -> te.getTrackedEntityType().getId()));
+            ps.setArray(p++, textArray(conn, chunk, te -> geometryText(te.getGeometry())));
+            ps.setArray(
+                p++, textArray(conn, chunk, te -> toJson(objectMapper, te.getCreatedByUserInfo())));
+            ps.setArray(
+                p++,
+                textArray(conn, chunk, te -> toJson(objectMapper, te.getLastUpdatedByUserInfo())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindRow(PreparedStatement ps, int p, TrackedEntity te) throws SQLException {
+  private static void requirePreallocatedId(TrackedEntity te) throws SQLException {
     if (te.getId() == 0) {
       throw new SQLException(
           "TrackedEntity "
@@ -127,26 +170,6 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
               + " has no pre-allocated id; AbstractTrackerPersister"
               + " must pre-allocate ids when sequenceName() is non-null.");
     }
-    ps.setLong(p++, te.getId());
-    ps.setString(p++, te.getUid());
-    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
-    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getCreatedAtClient());
-    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
-    ps.setBoolean(p++, te.isInactive());
-    ps.setBoolean(p++, te.isDeleted());
-    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
-    ps.setBoolean(p++, te.isPotentialDuplicate());
-    ps.setLong(p++, te.getOrganisationUnit().getId());
-    ps.setLong(p++, te.getTrackedEntityType().getId());
-    if (te.getGeometry() != null) {
-      ps.setString(p++, te.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setString(p++, toJson(objectMapper, te.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(objectMapper, te.getLastUpdatedByUserInfo()));
-    return p;
   }
 
   private void update(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.TrackedEntity;
+
+/**
+ * Flushes staged {@link TrackedEntity} writes: a multi-row JDBC INSERT against {@code
+ * trackedentity} (ids pre-allocated from {@code trackedentity_sequence}) and a single unnest UPDATE
+ * writing only the columns mutated by {@code TrackerObjectsMapper.map} on the update branch.
+ */
+final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackedentity ("
+          + "trackedentityid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " inactive, deleted, lastsynchronized, potentialduplicate,"
+          + " organisationunitid, trackedentitytypeid,"
+          + " geometry, createdbyuserinfo, lastupdatedbyuserinfo) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ST_GeomFromText(?, " + SRID + "), ?::jsonb, ?::jsonb)";
+
+  // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch. Insert-only columns (uid,
+  // created, createdbyuserinfo) and columns owned by other code paths (deleted, lastsynchronized --
+  // the latter is bulk-updated by DefaultTrackerBundleService.postCommit) are deliberately
+  // excluded.
+  private static final String UPDATE_SQL =
+      "update trackedentity te set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " organisationunitid = v.organisationunitid,"
+          + " trackedentitytypeid = v.trackedentitytypeid,"
+          + " potentialduplicate = v.potentialduplicate,"
+          + " inactive = v.inactive,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as trackedentityid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as trackedentitytypeid,"
+          + " unnest(?::boolean[]) as potentialduplicate,"
+          + " unnest(?::boolean[]) as inactive,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where te.trackedentityid = v.trackedentityid";
+
+  private final ObjectMapper objectMapper;
+
+  TrackedEntityWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackedEntity te : chunk) {
+              p = bindRow(ps, p, te);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, TrackedEntity te) throws SQLException {
+    if (te.getId() == 0) {
+      throw new SQLException(
+          "TrackedEntity "
+              + te.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, te.getId());
+    ps.setString(p++, te.getUid());
+    ps.setTimestamp(p++, toTimestamp(te.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(te.getLastUpdated()));
+    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getCreatedAtClient());
+    JdbcBatchSupport.setNullableTimestamp(ps, p++, te.getLastUpdatedAtClient());
+    ps.setBoolean(p++, te.isInactive());
+    ps.setBoolean(p++, te.isDeleted());
+    ps.setTimestamp(p++, toTimestamp(te.getLastSynchronized()));
+    ps.setBoolean(p++, te.isPotentialDuplicate());
+    ps.setLong(p++, te.getOrganisationUnit().getId());
+    ps.setLong(p++, te.getTrackedEntityType().getId());
+    if (te.getGeometry() != null) {
+      ps.setString(p++, te.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setString(p++, toJson(objectMapper, te.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, te.getLastUpdatedByUserInfo()));
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] trackedEntityTypeIds = new Long[n];
+          Boolean[] potentialDuplicate = new Boolean[n];
+          Boolean[] inactive = new Boolean[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackedEntity te = chunk.get(i);
+            ids[i] = te.getId();
+            lastUpdated[i] = toTimestamptz(te.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(te.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(te.getLastUpdatedAtClient());
+            organisationUnitIds[i] = te.getOrganisationUnit().getId();
+            trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
+            potentialDuplicate[i] = te.isPotentialDuplicate();
+            inactive[i] = te.isInactive();
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, te.getLastUpdatedByUserInfo());
+            geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(6, conn.createArrayOf("bigint", trackedEntityTypeIds));
+            ps.setArray(7, conn.createArrayOf("boolean", potentialDuplicate));
+            ps.setArray(8, conn.createArrayOf("boolean", inactive));
+            ps.setArray(9, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(10, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
@@ -35,10 +35,8 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bo
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -117,10 +115,10 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
           + " unnest(?::text[]) as geometry"
           + " ) v where te.trackedentityid = v.trackedentityid";
 
-  private final ObjectMapper objectMapper;
+  private final UserInfoJsonCache userInfo;
 
-  TrackedEntityWriter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  TrackedEntityWriter(UserInfoJsonCache userInfo) {
+    this.userInfo = userInfo;
   }
 
   @Override
@@ -153,10 +151,9 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
             ps.setArray(p++, bigintArray(conn, chunk, te -> te.getTrackedEntityType().getId()));
             ps.setArray(p++, textArray(conn, chunk, te -> geometryText(te.getGeometry())));
             ps.setArray(
-                p++, textArray(conn, chunk, te -> toJson(objectMapper, te.getCreatedByUserInfo())));
+                p++, textArray(conn, chunk, te -> userInfo.toJson(te.getCreatedByUserInfo())));
             ps.setArray(
-                p++,
-                textArray(conn, chunk, te -> toJson(objectMapper, te.getLastUpdatedByUserInfo())));
+                p++, textArray(conn, chunk, te -> userInfo.toJson(te.getLastUpdatedByUserInfo())));
             ps.executeUpdate();
           }
         });
@@ -199,7 +196,7 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
             trackedEntityTypeIds[i] = te.getTrackedEntityType().getId();
             potentialDuplicate[i] = te.isPotentialDuplicate();
             inactive[i] = te.isInactive();
-            lastUpdatedByUserInfo[i] = toJson(objectMapper, te.getLastUpdatedByUserInfo());
+            lastUpdatedByUserInfo[i] = userInfo.toJson(te.getLastUpdatedByUserInfo());
             geometry[i] = te.getGeometry() != null ? te.getGeometry().toText() : null;
           }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackedEntityWriter.java
@@ -58,14 +58,14 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
           + "trackedentityid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " inactive, deleted, lastsynchronized, potentialduplicate,"
           + " organisationunitid, trackedentitytypeid, geometry, createdbyuserinfo,"
-          + " lastupdatedbyuserinfo)"
+          + " lastupdatedbyuserinfo, storedby)"
           + " select trackedentityid, uid, created, lastupdated, createdatclient,"
           + " lastupdatedatclient, inactive, deleted, lastsynchronized, potentialduplicate,"
           + " organisationunitid, trackedentitytypeid,"
           + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
           + ") end,"
-          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb"
+          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, storedby"
           + " from ( select"
           + " unnest(?::bigint[]) as trackedentityid,"
           + " unnest(?::text[]) as uid,"
@@ -81,7 +81,8 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
           + " unnest(?::bigint[]) as trackedentitytypeid,"
           + " unnest(?::text[]) as geometry,"
           + " unnest(?::text[]) as createdbyuserinfo,"
-          + " unnest(?::text[]) as lastupdatedbyuserinfo"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as storedby"
           + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map() on the UPDATE branch. Insert-only columns (uid,
@@ -154,6 +155,7 @@ final class TrackedEntityWriter extends UpsertTableWriter<TrackedEntity> {
                 p++, textArray(conn, chunk, te -> userInfo.toJson(te.getCreatedByUserInfo())));
             ps.setArray(
                 p++, textArray(conn, chunk, te -> userInfo.toJson(te.getLastUpdatedByUserInfo())));
+            ps.setArray(p++, textArray(conn, chunk, TrackedEntity::getStoredBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.fileresource.FileResourceStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.NotificationTrigger;
@@ -74,8 +75,8 @@ import org.springframework.stereotype.Component;
 public class TrackerEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackerEvent, TrackerEvent> {
-  public TrackerEventPersister(DataSource dataSource) {
-    super(dataSource);
+  public TrackerEventPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
+    super(dataSource, fileResourceStore);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -63,9 +62,11 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.bundle.TrackerObjectsMapper;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.programrule.engine.Notification;
+import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.model.TrackerEvent;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
@@ -175,13 +176,13 @@ public class TrackerEventPersister
 
   @Override
   protected void updateAttributes(
-      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs,
-      EntityWriteBatch batch) {
+      EntityWriteBatch batch,
+      Map<Long, Map<MetadataIdentifier, TrackedEntityAttributeValue>> existingAttributeValues) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -83,7 +83,7 @@ public class TrackerEventPersister
 
   @Override
   protected String sequenceName() {
-    return null;
+    return "trackerevent_sequence";
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -75,8 +76,14 @@ import org.springframework.stereotype.Component;
 public class TrackerEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackerEvent, TrackerEvent> {
-  public TrackerEventPersister(DataSource dataSource, FileResourceStore fileResourceStore) {
-    super(dataSource, fileResourceStore);
+  public TrackerEventPersister(
+      DataSource dataSource, FileResourceStore fileResourceStore, ObjectMapper objectMapper) {
+    super(dataSource, fileResourceStore, objectMapper);
+  }
+
+  @Override
+  protected String sequenceName() {
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -156,7 +156,8 @@ public class TrackerEventPersister
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,
       UserDetails user,
-      ChangeLogAccumulator changeLogs) {
+      ChangeLogAccumulator changeLogs,
+      EntityWriteBatch batch) {
     // DO NOTHING - EVENT HAVE NO ATTRIBUTES
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -88,6 +88,21 @@ public class TrackerEventPersister
   }
 
   @Override
+  protected void assignId(TrackerEvent entity, long id) {
+    entity.setId(id);
+  }
+
+  @Override
+  protected void stageInsert(TrackerEvent entity, EntityWriteBatch batch) {
+    batch.stageInsert(entity);
+  }
+
+  @Override
+  protected void stageUpdate(TrackerEvent entity, EntityWriteBatch batch) {
+    batch.stageUpdate(entity);
+  }
+
+  @Override
   protected void updatePreheat(TrackerPreheat preheat, TrackerEvent event) {
     preheat.putTrackerEvents(Collections.singletonList(event));
   }
@@ -335,7 +350,8 @@ public class TrackerEventPersister
   protected void persistOwnership(
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent trackerDto,
-      TrackerEvent entity) {
+      TrackerEvent entity,
+      EntityWriteBatch batch) {
     // DO NOTHING. Event creation does not create ownership records.
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.changelog.ChangeLogType.CREATE;
 import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -148,7 +147,6 @@ public class TrackerEventPersister
 
   @Override
   protected void updateAttributes(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,
@@ -159,20 +157,17 @@ public class TrackerEventPersister
 
   @Override
   protected void updateDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent payloadEntity,
       TrackerEvent currentEntity,
       UserDetails user,
       ChangeLogAccumulator changeLogs) {
-    handleDataValues(
-        entityManager, preheat, event.getDataValues(), payloadEntity, user, changeLogs);
+    handleDataValues(preheat, event.getDataValues(), payloadEntity, user, changeLogs);
     logFieldChanges(currentEntity, payloadEntity, user.getUsername(), changeLogs);
   }
 
   private void handleDataValues(
-      EntityManager entityManager,
       TrackerPreheat preheat,
       Set<DataValue> payloadDataValues,
       TrackerEvent event,
@@ -191,7 +186,7 @@ public class TrackerEventPersister
           if (isNewDataValue(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event, dataElement, program, null, dataValue.getValue(), CREATE, username);
-            saveDataValue(dataValue, event, dataElement, user, entityManager, preheat);
+            saveDataValue(dataValue, event, dataElement, user, preheat);
           } else if (isUpdate(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event,
@@ -201,12 +196,11 @@ public class TrackerEventPersister
                 dataValue.getValue(),
                 UPDATE,
                 username);
-            updateDataValue(
-                dbDataValue, dataValue, event, dataElement, user, entityManager, preheat);
+            updateDataValue(dbDataValue, dataValue, event, dataElement, user, preheat);
           } else if (isDeletion(dbDataValue, dataValue)) {
             changeLogs.addTrackerEventChangeLog(
                 event, dataElement, program, dbDataValue.getValue(), null, DELETE, username);
-            deleteDataValue(dbDataValue, event, dataElement, entityManager, preheat);
+            deleteDataValue(dbDataValue, event, dataElement, preheat);
           }
         });
   }
@@ -271,7 +265,6 @@ public class TrackerEventPersister
       TrackerEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     EventDataValue eventDataValue = new EventDataValue();
     eventDataValue.setDataElement(dataElement.getUid());
@@ -286,7 +279,7 @@ public class TrackerEventPersister
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
 
     if (dataElement.isFileType()) {
-      assignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().add(eventDataValue);
@@ -298,14 +291,13 @@ public class TrackerEventPersister
       TrackerEvent event,
       DataElement dataElement,
       UserDetails user,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     eventDataValue.setLastUpdated(new Date());
     eventDataValue.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
-      assignFileResource(entityManager, preheat, event.getUid(), dv.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
+      assignFileResource(preheat, event.getUid(), dv.getValue());
     }
 
     eventDataValue.setProvidedElsewhere(dv.isProvidedElsewhere());
@@ -316,10 +308,9 @@ public class TrackerEventPersister
       EventDataValue eventDataValue,
       TrackerEvent event,
       DataElement dataElement,
-      EntityManager entityManager,
       TrackerPreheat preheat) {
     if (dataElement.isFileType()) {
-      unassignFileResource(entityManager, preheat, event.getUid(), eventDataValue.getValue());
+      unassignFileResource(preheat, event.getUid(), eventDataValue.getValue());
     }
 
     event.getEventDataValues().remove(eventDataValue);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.UID;
@@ -73,6 +74,9 @@ import org.springframework.stereotype.Component;
 public class TrackerEventPersister
     extends AbstractTrackerPersister<
         org.hisp.dhis.tracker.imports.domain.TrackerEvent, TrackerEvent> {
+  public TrackerEventPersister(DataSource dataSource) {
+    super(dataSource);
+  }
 
   @Override
   protected void updatePreheat(TrackerPreheat preheat, TrackerEvent event) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventPersister.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.changelog.ChangeLogType.DELETE;
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -159,6 +160,7 @@ public class TrackerEventPersister
 
   @Override
   protected void updateAttributes(
+      Connection connection,
       TrackerPreheat preheat,
       org.hisp.dhis.tracker.imports.domain.TrackerEvent event,
       TrackerEvent hibernateEntity,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
@@ -36,10 +36,8 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.fo
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -141,11 +139,11 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
           + " unnest(?::text[]) as geometry"
           + " ) v where ev.eventid = v.eventid";
 
-  private final ObjectMapper objectMapper;
+  private final UserInfoJsonCache userInfo;
   private final NoteCascadeWriter notes = new NoteCascadeWriter("trackerevent_notes", "eventid");
 
-  TrackerEventWriter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  TrackerEventWriter(UserInfoJsonCache userInfo) {
+    this.userInfo = userInfo;
   }
 
   @Override
@@ -172,10 +170,9 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
             ps.setArray(
                 p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
             ps.setArray(
-                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getCreatedByUserInfo())));
             ps.setArray(
-                p++,
-                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+                p++, textArray(conn, chunk, e -> userInfo.toJson(e.getLastUpdatedByUserInfo())));
             ps.setArray(p++, textArray(conn, chunk, e -> e.getStatus().name()));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
             ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getScheduledDate())));
@@ -240,7 +237,7 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
             lastUpdated[i] = toTimestamptz(e.getLastUpdated());
             createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
             lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
-            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            lastUpdatedByUserInfo[i] = userInfo.toJson(e.getLastUpdatedByUserInfo());
             enrollmentIds[i] = e.getEnrollment().getId();
             programStageIds[i] = e.getProgramStage().getId();
             organisationUnitIds[i] = e.getOrganisationUnit().getId();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
@@ -30,19 +30,19 @@
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.bigintArray;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.booleanArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.geometryText;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.textArray;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
-import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
 import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Types;
 import org.hisp.dhis.tracker.model.TrackerEvent;
 
 /**
@@ -53,21 +53,48 @@ import org.hisp.dhis.tracker.model.TrackerEvent;
  */
 final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
 
-  private static final String INSERT_PREFIX =
+  // Constant-text INSERT ... SELECT unnest(...) so pgjdbc's prepared-statement cache engages
+  // regardless of row count. INSERT column order, the SELECT projection and the unnest aliases are
+  // kept in lockstep.
+  private static final String INSERT_SQL =
       "insert into trackerevent ("
-          + "eventid, uid, created, lastupdated,"
-          + " createdatclient, lastupdatedatclient,"
-          + " createdbyuserinfo, lastupdatedbyuserinfo,"
-          + " status, occurreddate, scheduleddate, completeddate, completedby,"
-          + " deleted, lastsynchronized,"
+          + "eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo, status, occurreddate, scheduleddate,"
+          + " completeddate, completedby, deleted, lastsynchronized,"
           + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry) values ";
-
-  private static final String INSERT_ROW =
-      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
-          + "ST_GeomFromText(?, "
+          + " assigneduserid, eventdatavalues, geometry)"
+          + " select eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, status, occurreddate,"
+          + " scheduleddate, completeddate, completedby, deleted, lastsynchronized,"
+          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues::jsonb,"
+          + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + "))";
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::text[]) as uid,"
+          + " unnest(?::timestamptz[]) as created,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as createdbyuserinfo,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as scheduleddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::boolean[]) as deleted,"
+          + " unnest(?::timestamptz[]) as lastsynchronized,"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch.
   // Insert-
@@ -132,18 +159,48 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
     forEachChunk(
         inserts,
         chunk -> {
-          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
-          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+          for (TrackerEvent e : chunk) {
+            requirePreallocatedId(e);
+          }
+          try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
             int p = 1;
-            for (TrackerEvent e : chunk) {
-              p = bindRow(ps, p, e);
-            }
+            ps.setArray(p++, bigintArray(conn, chunk, TrackerEvent::getId));
+            ps.setArray(p++, textArray(conn, chunk, TrackerEvent::getUid));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdated())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCreatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastUpdatedAtClient())));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toJson(objectMapper, e.getCreatedByUserInfo())));
+            ps.setArray(
+                p++,
+                textArray(conn, chunk, e -> toJson(objectMapper, e.getLastUpdatedByUserInfo())));
+            ps.setArray(p++, textArray(conn, chunk, e -> e.getStatus().name()));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getOccurredDate())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getScheduledDate())));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getCompletedDate())));
+            ps.setArray(p++, textArray(conn, chunk, TrackerEvent::getCompletedBy));
+            ps.setArray(p++, booleanArray(conn, chunk, TrackerEvent::isDeleted));
+            ps.setArray(p++, textArray(conn, chunk, e -> toTimestamptz(e.getLastSynchronized())));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getEnrollment().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getProgramStage().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getOrganisationUnit().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, e -> e.getAttributeOptionCombo().getId()));
+            ps.setArray(p++, bigintArray(conn, chunk, TrackerEventWriter::assignedUserId));
+            ps.setArray(
+                p++, textArray(conn, chunk, e -> toEventDataValuesJson(e.getEventDataValues())));
+            ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
             ps.executeUpdate();
           }
         });
   }
 
-  private int bindRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
+  private static Long assignedUserId(TrackerEvent e) {
+    return e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+  }
+
+  private static void requirePreallocatedId(TrackerEvent e) throws SQLException {
     if (e.getId() == 0) {
       throw new SQLException(
           "TrackerEvent "
@@ -151,41 +208,6 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
               + " has no pre-allocated id; AbstractTrackerPersister"
               + " must pre-allocate ids when sequenceName() is non-null.");
     }
-    ps.setLong(p++, e.getId());
-    ps.setString(p++, e.getUid());
-    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
-    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
-    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
-    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
-    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
-    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
-    ps.setString(p++, e.getStatus().name());
-    setNullableTimestamp(ps, p++, e.getOccurredDate());
-    setNullableTimestamp(ps, p++, e.getScheduledDate());
-    setNullableTimestamp(ps, p++, e.getCompletedDate());
-    if (e.getCompletedBy() != null) {
-      ps.setString(p++, e.getCompletedBy());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    ps.setBoolean(p++, e.isDeleted());
-    setNullableTimestamp(ps, p++, e.getLastSynchronized());
-    ps.setLong(p++, e.getEnrollment().getId());
-    ps.setLong(p++, e.getProgramStage().getId());
-    ps.setLong(p++, e.getOrganisationUnit().getId());
-    ps.setLong(p++, e.getAttributeOptionCombo().getId());
-    if (e.getAssignedUser() != null) {
-      ps.setLong(p++, e.getAssignedUser().getId());
-    } else {
-      ps.setNull(p++, Types.BIGINT);
-    }
-    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
-    if (e.getGeometry() != null) {
-      ps.setString(p++, e.getGeometry().toText());
-    } else {
-      ps.setNull(p++, Types.VARCHAR);
-    }
-    return p;
   }
 
   private void update(Connection conn) throws SQLException {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
@@ -60,7 +60,7 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
           + " createdbyuserinfo, lastupdatedbyuserinfo, status, occurreddate, scheduleddate,"
           + " completeddate, completedby, deleted, lastsynchronized,"
           + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
-          + " assigneduserid, eventdatavalues, geometry)"
+          + " assigneduserid, eventdatavalues, geometry, storedby)"
           + " select eventid, uid, created, lastupdated, createdatclient, lastupdatedatclient,"
           + " createdbyuserinfo::jsonb, lastupdatedbyuserinfo::jsonb, status, occurreddate,"
           + " scheduleddate, completeddate, completedby, deleted, lastsynchronized,"
@@ -68,7 +68,8 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
           + " assigneduserid, eventdatavalues::jsonb,"
           + " case when geometry is null then null else ST_GeomFromText(geometry, "
           + SRID
-          + ") end"
+          + ") end,"
+          + " storedby"
           + " from ( select"
           + " unnest(?::bigint[]) as eventid,"
           + " unnest(?::text[]) as uid,"
@@ -91,7 +92,8 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
           + " unnest(?::bigint[]) as attributeoptioncomboid,"
           + " unnest(?::bigint[]) as assigneduserid,"
           + " unnest(?::text[]) as eventdatavalues,"
-          + " unnest(?::text[]) as geometry"
+          + " unnest(?::text[]) as geometry,"
+          + " unnest(?::text[]) as storedby"
           + " ) v";
 
   // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch.
@@ -188,6 +190,7 @@ final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
             ps.setArray(
                 p++, textArray(conn, chunk, e -> toEventDataValuesJson(e.getEventDataValues())));
             ps.setArray(p++, textArray(conn, chunk, e -> geometryText(e.getGeometry())));
+            ps.setArray(p++, textArray(conn, chunk, TrackerEvent::getStoredBy));
             ps.executeUpdate();
           }
         });

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerEventWriter.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.SRID;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.buildMultiRowInsertSql;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.forEachChunk;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.setNullableTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toEventDataValuesJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toJson;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamp;
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.toTimestamptz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hisp.dhis.tracker.model.TrackerEvent;
+
+/**
+ * Flushes staged {@link TrackerEvent} writes: a multi-row JDBC INSERT against {@code trackerevent}
+ * (ids pre-allocated from {@code trackerevent_sequence}; {@code eventdatavalues} jsonb serialized
+ * as a JSON object keyed by dataElement uid), a single unnest UPDATE, and a cascade insert of any
+ * new notes into {@code note} + {@code trackerevent_notes}.
+ */
+final class TrackerEventWriter extends UpsertTableWriter<TrackerEvent> {
+
+  private static final String INSERT_PREFIX =
+      "insert into trackerevent ("
+          + "eventid, uid, created, lastupdated,"
+          + " createdatclient, lastupdatedatclient,"
+          + " createdbyuserinfo, lastupdatedbyuserinfo,"
+          + " status, occurreddate, scheduleddate, completeddate, completedby,"
+          + " deleted, lastsynchronized,"
+          + " enrollmentid, programstageid, organisationunitid, attributeoptioncomboid,"
+          + " assigneduserid, eventdatavalues, geometry) values ";
+
+  private static final String INSERT_ROW =
+      "(?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, "
+          + "ST_GeomFromText(?, "
+          + SRID
+          + "))";
+
+  // Columns mutated by TrackerObjectsMapper.map(TrackerEvent) outside the new-entity branch.
+  // Insert-
+  // only columns (uid, created, createdbyuserinfo, deleted) and columns owned by other code paths
+  // (lastsynchronized) are excluded.
+  private static final String UPDATE_SQL =
+      "update trackerevent ev set"
+          + " lastupdated = v.lastupdated,"
+          + " createdatclient = v.createdatclient,"
+          + " lastupdatedatclient = v.lastupdatedatclient,"
+          + " lastupdatedbyuserinfo = v.lastupdatedbyuserinfo::jsonb,"
+          + " enrollmentid = v.enrollmentid,"
+          + " programstageid = v.programstageid,"
+          + " organisationunitid = v.organisationunitid,"
+          + " attributeoptioncomboid = v.attributeoptioncomboid,"
+          + " status = v.status,"
+          + " occurreddate = v.occurreddate,"
+          + " scheduleddate = v.scheduleddate,"
+          + " completeddate = v.completeddate,"
+          + " completedby = v.completedby,"
+          + " assigneduserid = v.assigneduserid,"
+          + " eventdatavalues = v.eventdatavalues::jsonb,"
+          + " geometry = case when v.geometry is null then null"
+          + " else ST_GeomFromText(v.geometry, "
+          + SRID
+          + ") end"
+          + " from ( select"
+          + " unnest(?::bigint[]) as eventid,"
+          + " unnest(?::timestamptz[]) as lastupdated,"
+          + " unnest(?::timestamptz[]) as createdatclient,"
+          + " unnest(?::timestamptz[]) as lastupdatedatclient,"
+          + " unnest(?::text[]) as lastupdatedbyuserinfo,"
+          + " unnest(?::bigint[]) as enrollmentid,"
+          + " unnest(?::bigint[]) as programstageid,"
+          + " unnest(?::bigint[]) as organisationunitid,"
+          + " unnest(?::bigint[]) as attributeoptioncomboid,"
+          + " unnest(?::text[]) as status,"
+          + " unnest(?::timestamptz[]) as occurreddate,"
+          + " unnest(?::timestamptz[]) as scheduleddate,"
+          + " unnest(?::timestamptz[]) as completeddate,"
+          + " unnest(?::text[]) as completedby,"
+          + " unnest(?::bigint[]) as assigneduserid,"
+          + " unnest(?::text[]) as eventdatavalues,"
+          + " unnest(?::text[]) as geometry"
+          + " ) v where ev.eventid = v.eventid";
+
+  private final ObjectMapper objectMapper;
+  private final NoteCascadeWriter notes = new NoteCascadeWriter("trackerevent_notes", "eventid");
+
+  TrackerEventWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  void flush(Connection conn) throws SQLException {
+    insert(conn);
+    update(conn);
+    notes.cascade(conn, inserts, updates, TrackerEvent::getId, TrackerEvent::getNotes);
+  }
+
+  private void insert(Connection conn) throws SQLException {
+    forEachChunk(
+        inserts,
+        chunk -> {
+          String sql = buildMultiRowInsertSql(INSERT_PREFIX, INSERT_ROW, chunk.size());
+          try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int p = 1;
+            for (TrackerEvent e : chunk) {
+              p = bindRow(ps, p, e);
+            }
+            ps.executeUpdate();
+          }
+        });
+  }
+
+  private int bindRow(PreparedStatement ps, int p, TrackerEvent e) throws SQLException {
+    if (e.getId() == 0) {
+      throw new SQLException(
+          "TrackerEvent "
+              + e.getUid()
+              + " has no pre-allocated id; AbstractTrackerPersister"
+              + " must pre-allocate ids when sequenceName() is non-null.");
+    }
+    ps.setLong(p++, e.getId());
+    ps.setString(p++, e.getUid());
+    ps.setTimestamp(p++, toTimestamp(e.getCreated()));
+    ps.setTimestamp(p++, toTimestamp(e.getLastUpdated()));
+    setNullableTimestamp(ps, p++, e.getCreatedAtClient());
+    setNullableTimestamp(ps, p++, e.getLastUpdatedAtClient());
+    ps.setString(p++, toJson(objectMapper, e.getCreatedByUserInfo()));
+    ps.setString(p++, toJson(objectMapper, e.getLastUpdatedByUserInfo()));
+    ps.setString(p++, e.getStatus().name());
+    setNullableTimestamp(ps, p++, e.getOccurredDate());
+    setNullableTimestamp(ps, p++, e.getScheduledDate());
+    setNullableTimestamp(ps, p++, e.getCompletedDate());
+    if (e.getCompletedBy() != null) {
+      ps.setString(p++, e.getCompletedBy());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    ps.setBoolean(p++, e.isDeleted());
+    setNullableTimestamp(ps, p++, e.getLastSynchronized());
+    ps.setLong(p++, e.getEnrollment().getId());
+    ps.setLong(p++, e.getProgramStage().getId());
+    ps.setLong(p++, e.getOrganisationUnit().getId());
+    ps.setLong(p++, e.getAttributeOptionCombo().getId());
+    if (e.getAssignedUser() != null) {
+      ps.setLong(p++, e.getAssignedUser().getId());
+    } else {
+      ps.setNull(p++, Types.BIGINT);
+    }
+    ps.setString(p++, toEventDataValuesJson(e.getEventDataValues()));
+    if (e.getGeometry() != null) {
+      ps.setString(p++, e.getGeometry().toText());
+    } else {
+      ps.setNull(p++, Types.VARCHAR);
+    }
+    return p;
+  }
+
+  private void update(Connection conn) throws SQLException {
+    forEachChunk(
+        updates,
+        chunk -> {
+          int n = chunk.size();
+
+          Long[] ids = new Long[n];
+          String[] lastUpdated = new String[n];
+          String[] createdAtClient = new String[n];
+          String[] lastUpdatedAtClient = new String[n];
+          String[] lastUpdatedByUserInfo = new String[n];
+          Long[] enrollmentIds = new Long[n];
+          Long[] programStageIds = new Long[n];
+          Long[] organisationUnitIds = new Long[n];
+          Long[] attributeOptionComboIds = new Long[n];
+          String[] status = new String[n];
+          String[] occurredDate = new String[n];
+          String[] scheduledDate = new String[n];
+          String[] completedDate = new String[n];
+          String[] completedBy = new String[n];
+          Long[] assignedUserIds = new Long[n];
+          String[] eventDataValues = new String[n];
+          String[] geometry = new String[n];
+
+          for (int i = 0; i < n; i++) {
+            TrackerEvent e = chunk.get(i);
+            ids[i] = e.getId();
+            lastUpdated[i] = toTimestamptz(e.getLastUpdated());
+            createdAtClient[i] = toTimestamptz(e.getCreatedAtClient());
+            lastUpdatedAtClient[i] = toTimestamptz(e.getLastUpdatedAtClient());
+            lastUpdatedByUserInfo[i] = toJson(objectMapper, e.getLastUpdatedByUserInfo());
+            enrollmentIds[i] = e.getEnrollment().getId();
+            programStageIds[i] = e.getProgramStage().getId();
+            organisationUnitIds[i] = e.getOrganisationUnit().getId();
+            attributeOptionComboIds[i] = e.getAttributeOptionCombo().getId();
+            status[i] = e.getStatus().name();
+            occurredDate[i] = toTimestamptz(e.getOccurredDate());
+            scheduledDate[i] = toTimestamptz(e.getScheduledDate());
+            completedDate[i] = toTimestamptz(e.getCompletedDate());
+            completedBy[i] = e.getCompletedBy();
+            assignedUserIds[i] = e.getAssignedUser() != null ? e.getAssignedUser().getId() : null;
+            eventDataValues[i] = toEventDataValuesJson(e.getEventDataValues());
+            geometry[i] = e.getGeometry() != null ? e.getGeometry().toText() : null;
+          }
+
+          try (PreparedStatement ps = conn.prepareStatement(UPDATE_SQL)) {
+            ps.setArray(1, conn.createArrayOf("bigint", ids));
+            ps.setArray(2, conn.createArrayOf("text", lastUpdated));
+            ps.setArray(3, conn.createArrayOf("text", createdAtClient));
+            ps.setArray(4, conn.createArrayOf("text", lastUpdatedAtClient));
+            ps.setArray(5, conn.createArrayOf("text", lastUpdatedByUserInfo));
+            ps.setArray(6, conn.createArrayOf("bigint", enrollmentIds));
+            ps.setArray(7, conn.createArrayOf("bigint", programStageIds));
+            ps.setArray(8, conn.createArrayOf("bigint", organisationUnitIds));
+            ps.setArray(9, conn.createArrayOf("bigint", attributeOptionComboIds));
+            ps.setArray(10, conn.createArrayOf("text", status));
+            ps.setArray(11, conn.createArrayOf("text", occurredDate));
+            ps.setArray(12, conn.createArrayOf("text", scheduledDate));
+            ps.setArray(13, conn.createArrayOf("text", completedDate));
+            ps.setArray(14, conn.createArrayOf("text", completedBy));
+            ps.setArray(15, conn.createArrayOf("bigint", assignedUserIds));
+            ps.setArray(16, conn.createArrayOf("text", eventDataValues));
+            ps.setArray(17, conn.createArrayOf("text", geometry));
+            ps.executeUpdate();
+          }
+        });
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerPersister.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.tracker.imports.bundle.persister;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
@@ -49,9 +48,8 @@ public interface TrackerPersister<T extends TrackerDto, V> {
    * Persist one of the collections in the provided Tracker Bundle. Each class implementing this
    * method should be responsible to persist one collection of the TrackerBundle (e.g. Enrollments)
    *
-   * @param entityManager a valid EntityManager
    * @param bundle the Bundle to persist
    * @return a {@link PersistResult} containing the report and any notifications
    */
-  PersistResult persist(EntityManager entityManager, TrackerBundle bundle);
+  PersistResult persist(TrackerBundle bundle);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
@@ -55,11 +55,6 @@ abstract class UpsertTableWriter<E> {
     updates.add(entity);
   }
 
-  /** Whether the given entity is staged for insert (no DB row yet) in this batch. */
-  boolean isStagedAsInsert(E entity) {
-    return inserts.contains(entity);
-  }
-
   Mark mark() {
     return new Mark(inserts.size(), updates.size());
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.truncate;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Base for the per-entity writers that stage inserts and updates of a single top-level entity type
+ * (TrackedEntity, Enrollment, TrackerEvent, SingleEvent). Owns the two staging lists and the
+ * mark/rollback/clear lifecycle shared with {@link ChangeLogAccumulator}; subclasses supply the
+ * type-specific {@link #flush(Connection)} (multi-row INSERT, unnest UPDATE and any notes cascade).
+ */
+abstract class UpsertTableWriter<E> {
+
+  protected final List<E> inserts = new ArrayList<>();
+  protected final List<E> updates = new ArrayList<>();
+
+  // Membership index over `inserts` for O(1) isStagedAsInsert, which is called once per tracked
+  // entity during attribute handling -- a List.contains scan there is O(n) and turns a large
+  // insert batch quadratic. Identity-based: the instance staged is the same instance queried.
+  private final Set<E> insertSet = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  void stageInsert(E entity) {
+    inserts.add(entity);
+    insertSet.add(entity);
+  }
+
+  void stageUpdate(E entity) {
+    updates.add(entity);
+  }
+
+  /** Whether the given entity is staged for insert (no DB row yet) in this batch. */
+  boolean isStagedAsInsert(E entity) {
+    return insertSet.contains(entity);
+  }
+
+  Mark mark() {
+    return new Mark(inserts.size(), updates.size());
+  }
+
+  void rollbackTo(Mark mark) {
+    for (int i = mark.inserts(); i < inserts.size(); i++) {
+      insertSet.remove(inserts.get(i));
+    }
+    truncate(inserts, mark.inserts());
+    truncate(updates, mark.updates());
+  }
+
+  void clear() {
+    inserts.clear();
+    insertSet.clear();
+    updates.clear();
+  }
+
+  boolean isEmpty() {
+    return inserts.isEmpty() && updates.isEmpty();
+  }
+
+  /** Applies the staged inserts and updates via JDBC on {@code conn}. */
+  abstract void flush(Connection conn) throws SQLException;
+
+  record Mark(int inserts, int updates) {}
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UpsertTableWriter.java
@@ -34,10 +34,7 @@ import static org.hisp.dhis.tracker.imports.bundle.persister.JdbcBatchSupport.tr
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Base for the per-entity writers that stage inserts and updates of a single top-level entity type
@@ -50,14 +47,8 @@ abstract class UpsertTableWriter<E> {
   protected final List<E> inserts = new ArrayList<>();
   protected final List<E> updates = new ArrayList<>();
 
-  // Membership index over `inserts` for O(1) isStagedAsInsert, which is called once per tracked
-  // entity during attribute handling -- a List.contains scan there is O(n) and turns a large
-  // insert batch quadratic. Identity-based: the instance staged is the same instance queried.
-  private final Set<E> insertSet = Collections.newSetFromMap(new IdentityHashMap<>());
-
   void stageInsert(E entity) {
     inserts.add(entity);
-    insertSet.add(entity);
   }
 
   void stageUpdate(E entity) {
@@ -66,7 +57,7 @@ abstract class UpsertTableWriter<E> {
 
   /** Whether the given entity is staged for insert (no DB row yet) in this batch. */
   boolean isStagedAsInsert(E entity) {
-    return insertSet.contains(entity);
+    return inserts.contains(entity);
   }
 
   Mark mark() {
@@ -74,16 +65,12 @@ abstract class UpsertTableWriter<E> {
   }
 
   void rollbackTo(Mark mark) {
-    for (int i = mark.inserts(); i < inserts.size(); i++) {
-      insertSet.remove(inserts.get(i));
-    }
     truncate(inserts, mark.inserts());
     truncate(updates, mark.updates());
   }
 
   void clear() {
     inserts.clear();
-    insertSet.clear();
     updates.clear();
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UserInfoJsonCache.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/UserInfoJsonCache.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.bundle.persister;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import org.hisp.dhis.program.UserInfoSnapshot;
+
+/**
+ * Memoizes {@link UserInfoSnapshot} JSON serialization for the lifetime of a single {@link
+ * EntityWriteBatch}. {@code TrackerObjectsMapper} stamps a fresh {@code UserInfoSnapshot} of the
+ * importing user onto the created/lastUpdated columns of every row, so without caching the same
+ * string is serialized once per row per column. The importing user is constant across an import, so
+ * the snapshots are equal by value ({@link UserInfoSnapshot} inherits {@code equals}/{@code
+ * hashCode} on id/code/uid from {@code IdentifiableObjectSnapshot}) and collapse to a single cache
+ * entry, leaving essentially one serialization per batch.
+ *
+ * <p>Intentionally batch-scoped (one instance per persist() call) and not thread-safe: this bounds
+ * the cache and prevents one request's user JSON from being reused by another.
+ */
+final class UserInfoJsonCache {
+  private final ObjectMapper objectMapper;
+  private final Map<UserInfoSnapshot, String> cache = new HashMap<>();
+
+  UserInfoJsonCache(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  String toJson(UserInfoSnapshot info) throws SQLException {
+    if (info == null) {
+      return null;
+    }
+    String cached = cache.get(info);
+    if (cached != null) {
+      return cached;
+    }
+    String json = JdbcBatchSupport.toJson(objectMapper, info);
+    cache.put(info, json);
+    return json;
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateEnrollmentStore.java
@@ -49,7 +49,9 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher,
       AclService aclService) {
-    super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, true);
+    // cacheable=false: enrollments are written via raw JDBC in the importer, which bypasses
+    // Hibernate's query-cache invalidation -- cached results would go stale across imports.
+    super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, false);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
@@ -92,10 +92,10 @@ public class Enrollment extends BaseTrackerObject
 
   @Id
   @Column(name = "enrollmentid")
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "programinstance_sequence")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "enrollment_sequence")
   @SequenceGenerator(
-      name = "programinstance_sequence",
-      sequenceName = "programinstance_sequence",
+      name = "enrollment_sequence",
+      sequenceName = "enrollment_sequence",
       allocationSize = 1)
   private long id;
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/Enrollment.java
@@ -56,8 +56,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ListIndexBase;
 import org.hibernate.annotations.Type;
 import org.hisp.dhis.attribute.AttributeValues;
@@ -87,7 +85,6 @@ import org.locationtech.jts.geom.Geometry;
  */
 @Entity
 @Table(name = "enrollment")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Auditable(scope = AuditScope.TRACKER)
 @Data
 public class Enrollment extends BaseTrackerObject

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
@@ -40,7 +40,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
@@ -82,10 +81,6 @@ import org.locationtech.jts.geom.Geometry;
 @Setter
 @Getter
 @Table(name = "trackedentity")
-@NamedNativeQuery(
-    name = "updateTrackedEntitiesLastUpdated",
-    query =
-        "update trackedentity set lastUpdated = :lastUpdated, lastupdatedbyuserinfo = CAST(:lastupdatedbyuserinfo as jsonb) WHERE uid in :trackedEntities")
 @Auditable(scope = AuditScope.TRACKER)
 public class TrackedEntity extends BaseTrackerObject
     implements IdentifiableObject, SoftDeletableEntity {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/model/TrackedEntity.java
@@ -86,9 +86,12 @@ public class TrackedEntity extends BaseTrackerObject
     implements IdentifiableObject, SoftDeletableEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
-  @SequenceGenerator(sequenceName = "trackedentityinstance_sequence")
   @Column(name = "trackedentityid")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trackedentity_sequence")
+  @SequenceGenerator(
+      name = "trackedentity_sequence",
+      sequenceName = "trackedentity_sequence",
+      allocationSize = 1)
   private long id;
 
   private boolean deleted = false;


### PR DESCRIPTION
Backport of https://dhis2.atlassian.net/browse/DHIS2-21378

This backport carries the DHIS2-21378 tracker import work (Hibernate → JDBC) to 2.43. To validate it, I ran the `performance-tests-compare` workflow three times — same `TrackerTest` simulation on the `sierra-leone` dataset — comparing **2.43.0** (`dhis2/core:2.43.0`) against **2.43 + this backport** (`core-pr:24286`). Each run profiled a different async-profiler event:

- [CPU run](https://github.com/dhis2/dhis2-core/actions/runs/28354445478) (`-e cpu`)
- [Wall run](https://github.com/dhis2/dhis2-core/actions/runs/28354454017) (`-e wall`)
- [Allocation run](https://github.com/dhis2/dhis2-core/actions/runs/28354097637) (`-e alloc`)

### Response time (p95)

Import endpoints are roughly **twice as fast**, consistently across all three runs, while the candidate also sustained **~2.4× the throughput** (req/s). Login is within noise (small sample).

| Request | CPU run | Wall run | Alloc run |
|---|---|---|---|
| MNCH import | −49% (1213 → 614 ms) | −53% (1281 → 599 ms) | −56% (1268 → 555 ms) |
| Child Programme import | −52% (554 → 265 ms) | −44% (500 → 278 ms) | −35% (569 → 371 ms) |
| ANC import | −51% (430 → 213 ms) | −58% (410 → 173 ms) | −53% (423 → 197 ms) |
| Login | +5% | −18% | +8% |

### CPU / Wall / Allocation (whole-JVM totals over the full run)

| Metric | Baseline (2.43.0) | Candidate (backport) | Change |
|---|---|---|---|
| CPU (samples) | 6,433 | 3,327 | **−48%** |
| Wall (samples) | 92,775 | 50,919 | **−45%** |
| Allocation (bytes) | 14.3 GB | 8.2 GB | **−43%** |

**Allocation −43%** is the headline win: allocated bytes scale with the work done (not run duration), so the backport allocates ~40% less memory to process the identical import workload — less GC pressure and fewer round-trips, which drives the latency and throughput gains. The CPU/wall totals span the full run, so part of their drop reflects the shorter run duration; but since the workload is fixed, halving total CPU/wall samples means it genuinely costs ~half the CPU and wall time to do the same imports.