### PR TITLE
fix: Run sync request synchronously [DHIS2-21606][2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
@@ -104,6 +104,39 @@ public class SyncUtils {
     return false;
   }
 
+  public static <T> Optional<T> runSyncRequest(
+      RestTemplate restTemplate,
+      RequestCallback requestCallback,
+      ResponseExtractor<T> responseExtractor,
+      String syncUrl,
+      int maxSyncAttempts) {
+    boolean networkErrorOccurred = true;
+    int syncAttemptsDone = 0;
+    T responseSummary = null;
+
+    while (networkErrorOccurred) {
+      networkErrorOccurred = false;
+      syncAttemptsDone++;
+      try {
+        responseSummary =
+            restTemplate.execute(syncUrl, HttpMethod.POST, requestCallback, responseExtractor);
+      } catch (HttpServerErrorException ex) {
+        log.error(
+            "Internal error happened during sync request: {}", ex.getResponseBodyAsString(), ex);
+        if (syncAttemptsDone <= maxSyncAttempts) {
+          networkErrorOccurred = true;
+        } else {
+          throw ex;
+        }
+      } catch (ResourceAccessException ex) {
+        log.error("Exception during sync request: {}", ex.getMessage(), ex);
+        throw ex;
+      }
+    }
+
+    return Optional.ofNullable(responseSummary);
+  }
+
   public static Optional<WebMessageResponse> runSyncRequest(
       RestTemplate restTemplate,
       RequestCallback requestCallback,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
@@ -104,15 +104,15 @@ public class SyncUtils {
     return false;
   }
 
-  public static <T> Optional<T> runSyncRequest(
+  public static Optional<ImportSummary> runSyncRequest(
       RestTemplate restTemplate,
       RequestCallback requestCallback,
-      ResponseExtractor<T> responseExtractor,
+      ResponseExtractor<ImportSummary> responseExtractor,
       String syncUrl,
       int maxSyncAttempts) {
     boolean networkErrorOccurred = true;
     int syncAttemptsDone = 0;
-    T responseSummary = null;
+    ImportSummary responseSummary = null;
 
     while (networkErrorOccurred) {
       networkErrorOccurred = false;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
@@ -174,10 +174,25 @@ class PersistablesFilter {
 
   private <T extends TrackerDto> void collectDeletables(Class<T> type, List<T> entities) {
     for (T entity : entities) {
-      if (isValid(entity)) {
+      if (isValid(entity) && !isAlreadyDeleted(entity)) {
         collectPersistable(type, entity);
       }
     }
+  }
+
+  private boolean isAlreadyDeleted(TrackerDto entity) {
+    if (entity instanceof Event ev) {
+      org.hisp.dhis.program.Event existing = preheat.getEvent(ev.getEvent());
+      return existing != null && existing.isDeleted();
+    } else if (entity instanceof Enrollment en) {
+      org.hisp.dhis.program.Enrollment existing = preheat.getEnrollment(en.getEnrollment());
+      return existing != null && existing.isDeleted();
+    } else if (entity instanceof TrackedEntity te) {
+      org.hisp.dhis.trackedentity.TrackedEntity existing =
+          preheat.getTrackedEntity(te.getTrackedEntity());
+      return existing != null && existing.isDeleted();
+    }
+    return false;
   }
 
   private <T extends TrackerDto> void collectPersistables(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/ExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/ExistenceValidator.java
@@ -50,10 +50,12 @@ class ExistenceValidator implements Validator<org.hisp.dhis.tracker.imports.doma
 
     Event existingEvent = bundle.getPreheat().getEvent(event.getEvent());
 
-    // If the event is soft-deleted no operation is allowed
     if (existingEvent != null && existingEvent.isDeleted()) {
-      reporter.addError(event, E1082, event.getEvent());
-      return;
+      if (importStrategy.isDelete()) {
+        reporter.addWarning(event, E1082, event.getEvent());
+      } else {
+        reporter.addError(event, E1082, event.getEvent());
+      }
     }
 
     if (existingEvent != null && importStrategy.isCreate()) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller.tracker.sync;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.dxf2.sync.SyncUtils.runSyncRequest;
 import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -70,11 +71,9 @@ import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.tracker.imports.report.Stats;
 import org.hisp.dhis.webapi.controller.tracker.export.event.EventMapper;
 import org.mapstruct.factory.Mappers;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RequestCallback;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -97,9 +96,10 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   @Getter
   private static final class EventSynchronizationContext extends PagedDataSynchronisationContext {
     private final Map<String, Set<String>> skipSyncDataElementsByProgramStage;
+    private final int maxAttempts;
 
     public EventSynchronizationContext(Date skipChangedBefore, int pageSize) {
-      this(skipChangedBefore, 0, null, pageSize, Map.of());
+      this(skipChangedBefore, 0, null, pageSize, Map.of(), 1);
     }
 
     public EventSynchronizationContext(
@@ -107,9 +107,11 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
         long objectsToSynchronize,
         SystemInstance instance,
         int pageSize,
-        Map<String, Set<String>> skipSyncDataElementsByProgramStage) {
+        Map<String, Set<String>> skipSyncDataElementsByProgramStage,
+        int maxAttempts) {
       super(skipChangedBefore, objectsToSynchronize, instance, pageSize);
       this.skipSyncDataElementsByProgramStage = skipSyncDataElementsByProgramStage;
+      this.maxAttempts = maxAttempts;
     }
 
     public boolean hasNoObjectsToSynchronize() {
@@ -165,7 +167,12 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
         getSkipSyncProgramStageDataElements();
 
     return new EventSynchronizationContext(
-        skipChangedBefore, eventCount, instance, pageSize, skipSyncProgramStageDataElements);
+        skipChangedBefore,
+        eventCount,
+        instance,
+        pageSize,
+        skipSyncProgramStageDataElements,
+        settings.getSyncMaxAttempts());
   }
 
   private long countEventsForSynchronization(Date skipChangedBefore)
@@ -248,17 +255,23 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
       List<Event> activeEvents, List<Event> deletedEvents, EventSynchronizationContext context) {
     Date syncTime = context.getStartTime();
     SystemInstance instance = context.getInstance();
+    int maxAttempts = context.getMaxAttempts();
 
     if (!activeEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> activeEventDtos =
           activeEvents.stream().map(EVENT_MAPPER::map).toList();
-      syncEvents(activeEventDtos, instance, syncTime, TrackerImportStrategy.CREATE_AND_UPDATE);
+      syncEvents(
+          activeEventDtos,
+          instance,
+          syncTime,
+          TrackerImportStrategy.CREATE_AND_UPDATE,
+          maxAttempts);
     }
 
     if (!deletedEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> deletedEventDtos =
           deletedEvents.stream().map(this::toMinimalEvent).toList();
-      syncEvents(deletedEventDtos, instance, syncTime, TrackerImportStrategy.DELETE);
+      syncEvents(deletedEventDtos, instance, syncTime, TrackerImportStrategy.DELETE, maxAttempts);
     }
   }
 
@@ -266,10 +279,11 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
       Date syncTime,
-      TrackerImportStrategy importStrategy) {
+      TrackerImportStrategy importStrategy,
+      int maxAttempts) {
     String url = instance.getUrl() + "?importStrategy=" + importStrategy;
 
-    ImportSummary summary = sendTrackerRequest(events, instance, url);
+    ImportSummary summary = sendTrackerRequest(events, instance, url, maxAttempts);
 
     if (summary == null || summary.getStatus() != ImportStatus.SUCCESS) {
       throw new MetadataSyncServiceException(
@@ -287,22 +301,18 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   private ImportSummary sendTrackerRequest(
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
-      String url) {
+      String url,
+      int maxAttempts) {
     RequestCallback requestCallback = createRequestCallback(events, instance);
     String syncUrl = url + "&async=false";
-    try {
-      return restTemplate.execute(
-          syncUrl,
-          HttpMethod.POST,
-          requestCallback,
-          response -> {
-            ImportReport report = JSON_MAPPER.readValue(response.getBody(), ImportReport.class);
-            return toImportSummary(report);
-          });
-    } catch (RestClientException ex) {
-      log.error("Failed to POST single event sync payload: {}", ex.getMessage(), ex);
-      return null;
-    }
+    return runSyncRequest(
+            restTemplate,
+            requestCallback,
+            response ->
+                toImportSummary(JSON_MAPPER.readValue(response.getBody(), ImportReport.class)),
+            syncUrl,
+            maxAttempts)
+        .orElse(null);
   }
 
   static ImportSummary toImportSummary(ImportReport report) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
@@ -30,13 +30,12 @@
 package org.hisp.dhis.webapi.controller.tracker.sync;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.dxf2.sync.SyncUtils.runSyncRequest;
 import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -44,6 +43,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
+import org.hisp.dhis.dxf2.importsummary.ImportCount;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
@@ -65,12 +66,15 @@ import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.tracker.imports.report.Stats;
 import org.hisp.dhis.webapi.controller.tracker.export.event.EventMapper;
-import org.hisp.dhis.webmessage.WebMessageResponse;
 import org.mapstruct.factory.Mappers;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RequestCallback;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -82,6 +86,7 @@ import org.springframework.web.client.RestTemplate;
 public class SingleEventDataSynchronizationService extends TrackerDataSynchronizationWithPaging {
   private static final String PROCESS_NAME = "Single event programs data synchronization";
   private static final EventMapper EVENT_MAPPER = Mappers.getMapper(EventMapper.class);
+  private static final ObjectMapper JSON_MAPPER = JacksonObjectMapperConfig.staticJsonMapper();
 
   private final EventService eventService;
   private final SystemSettingsService systemSettingsService;
@@ -130,7 +135,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
       return endProcess(progress, "No events to synchronize", PROCESS_NAME);
     }
 
-    boolean success = executeSynchronizationWithPaging(context, progress, settings);
+    boolean success = executeSynchronizationWithPaging(context, progress);
 
     return success
         ? endProcess(progress, "Completed successfully", PROCESS_NAME)
@@ -180,7 +185,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   }
 
   private boolean executeSynchronizationWithPaging(
-      EventSynchronizationContext context, JobProgress progress, SystemSettings settings) {
+      EventSynchronizationContext context, JobProgress progress) {
     String stageDescription =
         format(
             "Found %d single events. Remote: %s. Pages: %d (size %d)",
@@ -194,15 +199,14 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     progress.runStage(
         IntStream.range(1, context.getPages() + 1).boxed(),
         page -> format("Syncing page %d (size %d)", page, context.getPageSize()),
-        page -> synchronizePageSafely(page, context, settings));
+        page -> synchronizePageSafely(page, context));
 
     return !progress.isSkipCurrentStage();
   }
 
-  private void synchronizePageSafely(
-      int page, EventSynchronizationContext context, SystemSettings settings) {
+  private void synchronizePageSafely(int page, EventSynchronizationContext context) {
     try {
-      synchronizePage(page, context, settings);
+      synchronizePage(page, context);
     } catch (Exception ex) {
       log.error("Failed to synchronize page {}", page, ex);
       throw new RuntimeException(
@@ -210,8 +214,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     }
   }
 
-  private void synchronizePage(
-      int page, EventSynchronizationContext context, SystemSettings settings)
+  private void synchronizePage(int page, EventSynchronizationContext context)
       throws ForbiddenException, BadRequestException {
     List<Event> events = fetchEventsForPage(page, context);
 
@@ -219,7 +222,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     List<Event> deletedEvents = partitionedEvents.get(true);
     List<Event> activeEvents = partitionedEvents.get(false);
 
-    syncEventsByDeletionStatus(activeEvents, deletedEvents, context, settings);
+    syncEventsByDeletionStatus(activeEvents, deletedEvents, context);
   }
 
   private List<Event> fetchEventsForPage(int page, EventSynchronizationContext context)
@@ -242,36 +245,31 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   }
 
   private void syncEventsByDeletionStatus(
-      List<Event> activeEvents,
-      List<Event> deletedEvents,
-      EventSynchronizationContext context,
-      SystemSettings settings) {
+      List<Event> activeEvents, List<Event> deletedEvents, EventSynchronizationContext context) {
     Date syncTime = context.getStartTime();
     SystemInstance instance = context.getInstance();
 
     if (!activeEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> activeEventDtos =
           activeEvents.stream().map(EVENT_MAPPER::map).toList();
-      syncEvents(
-          activeEventDtos, instance, settings, syncTime, TrackerImportStrategy.CREATE_AND_UPDATE);
+      syncEvents(activeEventDtos, instance, syncTime, TrackerImportStrategy.CREATE_AND_UPDATE);
     }
 
     if (!deletedEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> deletedEventDtos =
           deletedEvents.stream().map(this::toMinimalEvent).toList();
-      syncEvents(deletedEventDtos, instance, settings, syncTime, TrackerImportStrategy.DELETE);
+      syncEvents(deletedEventDtos, instance, syncTime, TrackerImportStrategy.DELETE);
     }
   }
 
   private void syncEvents(
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
-      SystemSettings settings,
       Date syncTime,
       TrackerImportStrategy importStrategy) {
     String url = instance.getUrl() + "?importStrategy=" + importStrategy;
 
-    ImportSummary summary = sendTrackerRequest(events, instance, settings, url);
+    ImportSummary summary = sendTrackerRequest(events, instance, url);
 
     if (summary == null || summary.getStatus() != ImportStatus.SUCCESS) {
       throw new MetadataSyncServiceException(
@@ -289,19 +287,39 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   private ImportSummary sendTrackerRequest(
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
-      SystemSettings settings,
       String url) {
     RequestCallback requestCallback = createRequestCallback(events, instance);
+    String syncUrl = url + "&async=false";
+    try {
+      return restTemplate.execute(
+          syncUrl,
+          HttpMethod.POST,
+          requestCallback,
+          response -> {
+            ImportReport report = JSON_MAPPER.readValue(response.getBody(), ImportReport.class);
+            return toImportSummary(report);
+          });
+    } catch (RestClientException ex) {
+      log.error("Failed to POST single event sync payload: {}", ex.getMessage(), ex);
+      return null;
+    }
+  }
 
-    Optional<WebMessageResponse> response =
-        runSyncRequest(
-            restTemplate,
-            requestCallback,
-            SyncEndpoint.TRACKER_IMPORT.getKlass(),
-            url,
-            settings.getSyncMaxAttempts());
-
-    return response.map(ImportSummary.class::cast).orElse(null);
+  static ImportSummary toImportSummary(ImportReport report) {
+    ImportSummary summary = new ImportSummary();
+    summary.setStatus(
+        switch (report.getStatus()) {
+          case OK -> ImportStatus.SUCCESS;
+          case WARNING -> ImportStatus.WARNING;
+          case ERROR -> ImportStatus.ERROR;
+        });
+    Stats stats = report.getStats();
+    if (stats != null) {
+      summary.setImportCount(
+          new ImportCount(
+              stats.getCreated(), stats.getUpdated(), stats.getIgnored(), stats.getDeleted()));
+    }
+    return summary;
   }
 
   private RequestCallback createRequestCallback(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
@@ -96,10 +96,9 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   @Getter
   private static final class EventSynchronizationContext extends PagedDataSynchronisationContext {
     private final Map<String, Set<String>> skipSyncDataElementsByProgramStage;
-    private final int maxAttempts;
 
     public EventSynchronizationContext(Date skipChangedBefore, int pageSize) {
-      this(skipChangedBefore, 0, null, pageSize, Map.of(), 1);
+      this(skipChangedBefore, 0, null, pageSize, Map.of());
     }
 
     public EventSynchronizationContext(
@@ -107,11 +106,9 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
         long objectsToSynchronize,
         SystemInstance instance,
         int pageSize,
-        Map<String, Set<String>> skipSyncDataElementsByProgramStage,
-        int maxAttempts) {
+        Map<String, Set<String>> skipSyncDataElementsByProgramStage) {
       super(skipChangedBefore, objectsToSynchronize, instance, pageSize);
       this.skipSyncDataElementsByProgramStage = skipSyncDataElementsByProgramStage;
-      this.maxAttempts = maxAttempts;
     }
 
     public boolean hasNoObjectsToSynchronize() {
@@ -137,7 +134,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
       return endProcess(progress, "No events to synchronize", PROCESS_NAME);
     }
 
-    boolean success = executeSynchronizationWithPaging(context, progress);
+    boolean success = executeSynchronizationWithPaging(context, progress, settings);
 
     return success
         ? endProcess(progress, "Completed successfully", PROCESS_NAME)
@@ -167,12 +164,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
         getSkipSyncProgramStageDataElements();
 
     return new EventSynchronizationContext(
-        skipChangedBefore,
-        eventCount,
-        instance,
-        pageSize,
-        skipSyncProgramStageDataElements,
-        settings.getSyncMaxAttempts());
+        skipChangedBefore, eventCount, instance, pageSize, skipSyncProgramStageDataElements);
   }
 
   private long countEventsForSynchronization(Date skipChangedBefore)
@@ -192,7 +184,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   }
 
   private boolean executeSynchronizationWithPaging(
-      EventSynchronizationContext context, JobProgress progress) {
+      EventSynchronizationContext context, JobProgress progress, SystemSettings settings) {
     String stageDescription =
         format(
             "Found %d single events. Remote: %s. Pages: %d (size %d)",
@@ -206,14 +198,15 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     progress.runStage(
         IntStream.range(1, context.getPages() + 1).boxed(),
         page -> format("Syncing page %d (size %d)", page, context.getPageSize()),
-        page -> synchronizePageSafely(page, context));
+        page -> synchronizePageSafely(page, context, settings));
 
     return !progress.isSkipCurrentStage();
   }
 
-  private void synchronizePageSafely(int page, EventSynchronizationContext context) {
+  private void synchronizePageSafely(
+      int page, EventSynchronizationContext context, SystemSettings settings) {
     try {
-      synchronizePage(page, context);
+      synchronizePage(page, context, settings);
     } catch (Exception ex) {
       log.error("Failed to synchronize page {}", page, ex);
       throw new RuntimeException(
@@ -221,7 +214,8 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     }
   }
 
-  private void synchronizePage(int page, EventSynchronizationContext context)
+  private void synchronizePage(
+      int page, EventSynchronizationContext context, SystemSettings settings)
       throws ForbiddenException, BadRequestException {
     List<Event> events = fetchEventsForPage(page, context);
 
@@ -229,7 +223,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
     List<Event> deletedEvents = partitionedEvents.get(true);
     List<Event> activeEvents = partitionedEvents.get(false);
 
-    syncEventsByDeletionStatus(activeEvents, deletedEvents, context);
+    syncEventsByDeletionStatus(activeEvents, deletedEvents, context, settings);
   }
 
   private List<Event> fetchEventsForPage(int page, EventSynchronizationContext context)
@@ -252,38 +246,36 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   }
 
   private void syncEventsByDeletionStatus(
-      List<Event> activeEvents, List<Event> deletedEvents, EventSynchronizationContext context) {
+      List<Event> activeEvents,
+      List<Event> deletedEvents,
+      EventSynchronizationContext context,
+      SystemSettings settings) {
     Date syncTime = context.getStartTime();
     SystemInstance instance = context.getInstance();
-    int maxAttempts = context.getMaxAttempts();
 
     if (!activeEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> activeEventDtos =
           activeEvents.stream().map(EVENT_MAPPER::map).toList();
       syncEvents(
-          activeEventDtos,
-          instance,
-          syncTime,
-          TrackerImportStrategy.CREATE_AND_UPDATE,
-          maxAttempts);
+          activeEventDtos, instance, settings, syncTime, TrackerImportStrategy.CREATE_AND_UPDATE);
     }
 
     if (!deletedEvents.isEmpty()) {
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> deletedEventDtos =
           deletedEvents.stream().map(this::toMinimalEvent).toList();
-      syncEvents(deletedEventDtos, instance, syncTime, TrackerImportStrategy.DELETE, maxAttempts);
+      syncEvents(deletedEventDtos, instance, settings, syncTime, TrackerImportStrategy.DELETE);
     }
   }
 
   private void syncEvents(
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
+      SystemSettings settings,
       Date syncTime,
-      TrackerImportStrategy importStrategy,
-      int maxAttempts) {
+      TrackerImportStrategy importStrategy) {
     String url = instance.getUrl() + "?importStrategy=" + importStrategy;
 
-    ImportSummary summary = sendTrackerRequest(events, instance, url, maxAttempts);
+    ImportSummary summary = sendTrackerRequest(events, instance, settings, url);
 
     if (summary == null || summary.getStatus() != ImportStatus.SUCCESS) {
       throw new MetadataSyncServiceException(
@@ -301,8 +293,8 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
   private ImportSummary sendTrackerRequest(
       List<org.hisp.dhis.webapi.controller.tracker.view.Event> events,
       SystemInstance instance,
-      String url,
-      int maxAttempts) {
+      SystemSettings settings,
+      String url) {
     RequestCallback requestCallback = createRequestCallback(events, instance);
     String syncUrl = url + "&async=false";
     return runSyncRequest(
@@ -311,7 +303,7 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
             response ->
                 toImportSummary(JSON_MAPPER.readValue(response.getBody(), ImportReport.class)),
             syncUrl,
-            maxAttempts)
+            settings.getSyncMaxAttempts())
         .orElse(null);
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.tracker.imports.report.Stats;
+import org.hisp.dhis.tracker.imports.report.Status;
+import org.junit.jupiter.api.Test;
+
+class SingleEventDataSynchronizationServiceTest {
+
+  @Test
+  void shouldMapOkStatusToSuccess() {
+    ImportReport report = ImportReport.builder().status(Status.OK).build();
+
+    ImportSummary summary = SingleEventDataSynchronizationService.toImportSummary(report);
+
+    assertEquals(ImportStatus.SUCCESS, summary.getStatus());
+  }
+
+  @Test
+  void shouldMapWarningStatusToWarning() {
+    ImportReport report = ImportReport.builder().status(Status.WARNING).build();
+
+    ImportSummary summary = SingleEventDataSynchronizationService.toImportSummary(report);
+
+    assertEquals(ImportStatus.WARNING, summary.getStatus());
+  }
+
+  @Test
+  void shouldMapErrorStatusToError() {
+    ImportReport report = ImportReport.builder().status(Status.ERROR).build();
+
+    ImportSummary summary = SingleEventDataSynchronizationService.toImportSummary(report);
+
+    assertEquals(ImportStatus.ERROR, summary.getStatus());
+  }
+
+  @Test
+  void shouldMapStats() {
+    Stats stats = Stats.builder().created(1).updated(2).deleted(3).ignored(4).build();
+    ImportReport report = ImportReport.builder().status(Status.OK).stats(stats).build();
+
+    ImportSummary summary = SingleEventDataSynchronizationService.toImportSummary(report);
+
+    assertEquals(1, summary.getImportCount().getImported());
+    assertEquals(2, summary.getImportCount().getUpdated());
+    assertEquals(3, summary.getImportCount().getDeleted());
+    assertEquals(4, summary.getImportCount().getIgnored());
+  }
+
+  @Test
+  void shouldLeaveImportCountZeroedWhenStatsAbsent() {
+    ImportReport report = ImportReport.builder().status(Status.OK).build();
+
+    ImportSummary summary = SingleEventDataSynchronizationService.toImportSummary(report);
+
+    assertEquals(0, summary.getImportCount().getImported());
+    assertEquals(0, summary.getImportCount().getUpdated());
+    assertEquals(0, summary.getImportCount().getDeleted());
+    assertEquals(0, summary.getImportCount().getIgnored());
+  }
+}


### PR DESCRIPTION
When syncing single events to a remote instance, two issues could cause unnecessary failures:

- **Already deleted events**: If the target had already processed an event deletion, importing the same deletion again raised error `E1082`, causing the sync to fail. This error is now downgraded to a warning for `DELETE` imports. Additionally, `PersistablesFilter` skips persisting entities that are already marked as deleted in the preheat, avoiding redundant write attempts.

- **Run the request synchronously**: The sync request was executed asynchronously, but its status was never polled. Instead, it was always assumed to have succeeded. As a result, single events could be marked as synchronized even if the import had failed, leaving the source and target instances out of sync without detection. The request is now executed synchronously (matching the platform behavior), and single events are marked as synchronized only if the remote import completes successfully.

The overload of `SyncUtils.runSyncRequest` is added to accept a caller-supplied `ResponseExtractor<T>`. The existing overload only handled `ImportSummary`/`ImportSummaries` (the old DXF2 format), but the tracker endpoint returns `ImportReport`, making it incompatible. The new overload preserves the retry-on-5xx behavior while letting callers deserialize the response into any type. It will be reused in a follow up PR that applies the same fix to `TrackerDataSynchronizationService`.