### PR TITLE
fix: Do not save null values for TEAV [DHIS2-21599]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentityattributevalue/hibernate/TrackedEntityAttributeValue.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentityattributevalue/hibernate/TrackedEntityAttributeValue.hbm.xml
@@ -21,7 +21,7 @@
 
     <property name="lastUpdated" type="timestamp" not-null="true" />
 
-    <property name="value" column="value" access="property" length="1200" />
+    <property name="value" column="value" access="property" length="1200" not-null="true" />
 
     <property name="updatedBy" column="updatedby" not-null="false" />
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_15__teav_value_not_null.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_15__teav_value_not_null.sql
@@ -1,0 +1,15 @@
+-- Enforce NOT NULL on trackedentityattributevalue.value.
+--
+-- A tracked entity attribute value row is meaningful only because of its value, so a row with a
+-- NULL value carries no information and is not a state the application produces: the tracker
+-- importer deletes the row when a value is cleared (it never stores NULL), and the legacy
+-- TrackedEntityAttributeValueService skips the save when the value is NULL. The dual-column
+-- encryption storage that historically left `value` NULL (with the ciphertext in `encryptedvalue`)
+-- was removed in 2.44 (V2_44_6__remove_confidential_from_tea.sql). The only remaining NULL rows are
+-- therefore legacy/orphan data, which we remove before adding the constraint. Empty string ('') is
+-- intentionally left allowed.
+DELETE FROM trackedentityattributevalue
+WHERE value IS NULL;
+
+ALTER TABLE trackedentityattributevalue
+ALTER COLUMN value SET NOT NULL;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityAttributeTest.java
@@ -195,6 +195,77 @@ class TrackedEntityAttributeTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldNotPersistAttributeValueWhenImportingEmptyValueForAttributeNotInDb() {
+    UID te = UID.generate();
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder()
+            .trackedEntities(
+                List.of(
+                    org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
+                        .trackedEntity(te)
+                        .trackedEntityType(MetadataIdentifier.ofUid("KrYIdvLxkMb"))
+                        .orgUnit(MetadataIdentifier.ofUid("cNEZTkdAvmg"))
+                        .attributes(
+                            List.of(
+                                Attribute.builder()
+                                    .attribute(MetadataIdentifier.ofUid("sYn3tkL3XKa"))
+                                    .value("123")
+                                    .build(),
+                                Attribute.builder()
+                                    .attribute(MetadataIdentifier.ofUid("TsfP85GKsU5"))
+                                    .value("")
+                                    .build()))
+                        .build()))
+            .build();
+
+    assertNoErrors(
+        trackerImportService.importTracker(TrackerImportParams.builder().build(), trackerObjects));
+    clearSession();
+
+    TrackedEntity trackedEntity = manager.get(TrackedEntity.class, te.getValue());
+    List<TrackedEntityAttributeValue> attributeValues =
+        trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
+    assertContainsOnly(
+        List.of("sYn3tkL3XKa"),
+        attributeValues.stream().map(av -> av.getAttribute().getUid()).toList());
+  }
+
+  @Test
+  void shouldDeleteAttributeValueWhenImportingEmptyValueForExistingAttribute() throws IOException {
+    testSetup.importTrackerData("tracker/te_with_tea_data.json");
+    clearSession();
+
+    TrackerObjects update =
+        TrackerObjects.builder()
+            .trackedEntities(
+                List.of(
+                    org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
+                        .trackedEntity(UID.of("CLR1fvPj4ic"))
+                        .trackedEntityType(MetadataIdentifier.ofUid("KrYIdvLxkMb"))
+                        .orgUnit(MetadataIdentifier.ofUid("cNEZTkdAvmg"))
+                        .attributes(
+                            List.of(
+                                Attribute.builder()
+                                    .attribute(MetadataIdentifier.ofUid("TsfP85GKsU5"))
+                                    .value("")
+                                    .build()))
+                        .build()))
+            .build();
+    TrackerImportParams params =
+        TrackerImportParams.builder().importStrategy(TrackerImportStrategy.UPDATE).build();
+
+    assertNoErrors(trackerImportService.importTracker(params, update));
+    clearSession();
+
+    TrackedEntity trackedEntity = manager.get(TrackedEntity.class, "CLR1fvPj4ic");
+    List<TrackedEntityAttributeValue> attributeValues =
+        trackedEntityAttributeValueService.getTrackedEntityAttributeValues(trackedEntity);
+    assertContainsOnly(
+        List.of("sYn3tkL3XKa", "sTGqP5JNy6E"),
+        attributeValues.stream().map(av -> av.getAttribute().getUid()).toList());
+  }
+
+  @Test
   void shouldSetMinCharactersToSearchFromImportOrDefaultToZeroIfNotSpecified() {
     List<TrackedEntityAttribute> trackedEntityAttributes =
         trackedEntityAttributeService.getAllTrackedEntityAttributes();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -525,7 +525,17 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           String previousValue = isNew ? null : currentValue.getValue();
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
-          if (isDelete && !isNew) {
+if (isDelete) {
+  if (!isNew) {
+    delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
+
+    // Leave the entry in the map: the DELETE is not flushed until the end of
+    // the run, so a later occurrence of the same TE+attribute in this run must
+    // still see it as existing (matching the pre-batch DB-read behaviour).
+  }
+
+  // If the value doesn't exist yet, deleting it is a no-op.
+}
             delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
             // Leave the entry in the map: the DELETE is not flushed until the end of the run, so a
             // later occurrence of the same TE+attribute in this run must still see it as existing

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -530,6 +530,8 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
             // Leave the entry in the map: the DELETE is not flushed until the end of the run, so a
             // later occurrence of the same TE+attribute in this run must still see it as existing
             // (matching the pre-batch DB-read behaviour).
+          } else if (isDelete && isNew) {
+            // If user is trying to delete a value not present in DB: do nothing.
           } else if (valueChanged) {
             TrackedEntityAttributeValue persisted =
                 saveOrUpdateAttributeValue(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -525,23 +525,16 @@ public abstract class AbstractTrackerPersister<T extends TrackerDto, V extends I
           String previousValue = isNew ? null : currentValue.getValue();
           boolean valueChanged = isNew || !Objects.equals(previousValue, attribute.getValue());
 
-if (isDelete) {
-  if (!isNew) {
-    delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
+          if (isDelete) {
+            if (!isNew) {
+              delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
 
-    // Leave the entry in the map: the DELETE is not flushed until the end of
-    // the run, so a later occurrence of the same TE+attribute in this run must
-    // still see it as existing (matching the pre-batch DB-read behaviour).
-  }
+              // Leave the entry in the map: the DELETE is not flushed until the end of
+              // the run, so a later occurrence of the same TE+attribute in this run must
+              // still see it as existing (matching the pre-batch DB-read behaviour).
+            }
 
-  // If the value doesn't exist yet, deleting it is a no-op.
-}
-            delete(preheat, currentValue, trackedEntity, user, changeLogs, batch);
-            // Leave the entry in the map: the DELETE is not flushed until the end of the run, so a
-            // later occurrence of the same TE+attribute in this run must still see it as existing
-            // (matching the pre-batch DB-read behaviour).
-          } else if (isDelete && isNew) {
-            // If user is trying to delete a value not present in DB: do nothing.
+            // If the value doesn't exist yet, deleting it is a no-op.
           } else if (valueChanged) {
             TrackedEntityAttributeValue persisted =
                 saveOrUpdateAttributeValue(


### PR DESCRIPTION
## Summary

Prevents the tracker importer from persisting tracked entity attribute values with a `null`/empty `value`, and enforces this at the database level by making `trackedentityattributevalue.value` `NOT NULL`. Previously, importing an empty value for an attribute that did not yet exist on the tracked entity inserted a meaningless row with a null/empty value instead of doing nothing.

## Changes

- `AbstractTrackerPersister.handleTrackedEntityAttributeValues`: adds the `isDelete && isNew` branch so that sending an empty value for an attribute with no existing value is a no-op. Before this, `valueChanged` was `true` for new entries, so the empty value fell through to `saveOrUpdateAttributeValue` and inserted a row with a null/empty `value`.
- `TrackedEntityAttributeValue.hbm.xml`: marks the `value` property `not-null="true"`, aligning the Hibernate mapping with the new DB constraint.
- New migration `2.44/V2_44_15__teav_value_not_null.sql`: deletes any pre-existing rows where `value IS NULL` (legacy/orphan data — the encryption `encryptedvalue` column was already removed in `V2_44_6`), then applies `ALTER COLUMN value SET NOT NULL`. Empty string (`''`) is intentionally still allowed.
- `TrackedEntityAttributeTest`: adds two regression tests — one asserting that importing an empty value for an attribute not in the DB persists no row (`isDelete && isNew`), and a companion asserting that importing an empty value for an existing attribute deletes its row while leaving the others untouched (`isDelete && !isNew`).
