### PR TITLE
fix: Bucket stage date dimension by period in enrol. aggregate [DHIS2 21697]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssembler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssembler.java
@@ -46,18 +46,20 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.CteDefinition;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam.StaticDimension;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentDateHeaderResolver;
 import org.hisp.dhis.analytics.event.data.aggregate.AggregatedEnrollmentHeaderColumnResolver;
+import org.hisp.dhis.analytics.event.data.stage.StageDatePeriodBucketSqlRenderer;
 import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
 import org.hisp.dhis.analytics.util.sql.SqlColumnParser;
+import org.hisp.dhis.common.AnalyticsCustomHeader;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.program.AnalyticsType;
@@ -69,7 +71,6 @@ import org.springframework.stereotype.Component;
  * columns with optional shadow-CTE alias rewriting).
  */
 @Component
-@RequiredArgsConstructor
 public class AggregatedEnrollmentQueryAssembler {
 
   private static final AnalyticsType ANALYTICS_TYPE = AnalyticsType.ENROLLMENT;
@@ -87,8 +88,17 @@ public class AggregatedEnrollmentQueryAssembler {
   private final AggregatedEnrollmentDateHeaderResolver dateHeaderResolver =
       new AggregatedEnrollmentDateHeaderResolver();
 
-  private final AggregatedEnrollmentHeaderColumnResolver headerColumnResolver =
-      new AggregatedEnrollmentHeaderColumnResolver(stageHeaderClassifier);
+  private final AggregatedEnrollmentHeaderColumnResolver headerColumnResolver;
+
+  public AggregatedEnrollmentQueryAssembler(
+      AnalyticsSqlBuilder sqlBuilder,
+      DateFieldPeriodBucketColumnResolver dateFieldPeriodBucketColumnResolver,
+      StageDatePeriodBucketSqlRenderer dateRenderer) {
+    this.sqlBuilder = sqlBuilder;
+    this.dateFieldPeriodBucketColumnResolver = dateFieldPeriodBucketColumnResolver;
+    this.headerColumnResolver =
+        new AggregatedEnrollmentHeaderColumnResolver(stageHeaderClassifier, dateRenderer);
+  }
 
   /** A response key paired with the optional bucketed expression that produces it. */
   public record PeriodProjection(
@@ -223,8 +233,25 @@ public class AggregatedEnrollmentQueryAssembler {
     }
 
     Map<String, CteDefinition> cteDefinitionMap = collectCteDefinitions(cteContext);
+    Map<String, QueryItem> stageDateItems = collectStageDateItems(params);
     headerColumnResolver.addHeaderColumns(
-        headerColumns, cteContext, sb, cteDefinitionMap, this::quote);
+        headerColumns, cteContext, sb, cteDefinitionMap, stageDateItems, this::quote);
+  }
+
+  /**
+   * Indexes query items carrying a custom stage header (e.g. {@code stageUid.EVENT_DATE}) by their
+   * analytics header key (e.g. {@code stageUid.eventdate}) so the header-column resolver can bucket
+   * a stage date column by the item's requested period.
+   */
+  private Map<String, QueryItem> collectStageDateItems(EventQueryParams params) {
+    Map<String, QueryItem> stageDateItems = new HashMap<>();
+    for (QueryItem item : params.getItems()) {
+      if (item.hasCustomHeader()) {
+        AnalyticsCustomHeader customHeader = item.getCustomHeader();
+        stageDateItems.put(customHeader.headerKey(customHeader.key()), item);
+      }
+    }
+    return stageDateItems;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolver.java
@@ -33,14 +33,17 @@ import static org.hisp.dhis.analytics.event.data.AbstractJdbcEventAnalyticsManag
 import static org.hisp.dhis.analytics.util.RepeatableStageParamsHelper.removeRepeatableStageParams;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.CteDefinition;
+import org.hisp.dhis.analytics.event.data.stage.StageDatePeriodBucketSqlRenderer;
 import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier;
 import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier.StageHeaderType;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
 import org.hisp.dhis.analytics.util.sql.SqlColumnParser;
+import org.hisp.dhis.common.QueryItem;
 
 /**
  * Resolves aggregated enrollment header columns into SQL select and group-by expressions, handling
@@ -50,13 +53,19 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
 
   private final StageHeaderClassifier stageHeaderClassifier;
 
+  private final StageDatePeriodBucketSqlRenderer dateRenderer;
+
   /**
-   * Creates a resolver that uses the provided classifier to detect stage-specific headers.
+   * Creates a resolver that uses the provided classifier to detect stage-specific headers and the
+   * renderer to bucket stage date columns by the requested period.
    *
    * @param stageHeaderClassifier classifier for stage-specific header types
+   * @param dateRenderer renderer that buckets a stage date column by the requested period
    */
-  public AggregatedEnrollmentHeaderColumnResolver(StageHeaderClassifier stageHeaderClassifier) {
+  public AggregatedEnrollmentHeaderColumnResolver(
+      StageHeaderClassifier stageHeaderClassifier, StageDatePeriodBucketSqlRenderer dateRenderer) {
     this.stageHeaderClassifier = stageHeaderClassifier;
+    this.dateRenderer = dateRenderer;
   }
 
   /**
@@ -67,6 +76,8 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
    * @param cteContext CTE context with available CTE definitions
    * @param sb select builder to append columns and group-by entries to
    * @param cteDefinitionMap map of header keys to their CTE definitions
+   * @param stageDateItems map of stage date header keys (e.g. {@code stageUid.eventdate}) to their
+   *     {@link QueryItem}, used to bucket the column by the requested period
    * @param quote operator used to quote column aliases
    */
   public void addHeaderColumns(
@@ -74,6 +85,7 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
       CteContext cteContext,
       SelectBuilder sb,
       Map<String, CteDefinition> cteDefinitionMap,
+      Map<String, QueryItem> stageDateItems,
       UnaryOperator<String> quote) {
 
     for (String headerColumn : headerColumns) {
@@ -84,7 +96,7 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
       if (stageHeaderType != StageHeaderType.NOT_STAGE_SPECIFIC) {
         CteDefinition filterCte = findFilterCte(headerColumn, cteContext);
         if (filterCte != null) {
-          String cteCol = resolveCteColumn(filterCte, stageHeaderType, colName);
+          String cteCol = resolveCteColumn(filterCte, stageHeaderType, colName, stageDateItems);
           sb.addColumn(cteCol, "", quotedCol);
           sb.groupBy(cteCol);
           continue;
@@ -119,18 +131,40 @@ public final class AggregatedEnrollmentHeaderColumnResolver {
    * alias convention established by the aggregate filter CTE.
    */
   private String resolveCteColumn(
-      CteDefinition filterCte, StageHeaderType stageHeaderType, String colName) {
+      CteDefinition filterCte,
+      StageHeaderType stageHeaderType,
+      String colName,
+      Map<String, QueryItem> stageDateItems) {
     String alias = filterCte.getAlias();
     String bareCol = extractColumnName(colName);
     return switch (stageHeaderType) {
-      case EVENT_DATE -> alias + ".ev_occurreddate";
-      case SCHEDULED_DATE -> alias + ".ev_scheduleddate";
+      case EVENT_DATE -> resolveStageDateColumn(alias, "ev_occurreddate", colName, stageDateItems);
+      case SCHEDULED_DATE ->
+          resolveStageDateColumn(alias, "ev_scheduleddate", colName, stageDateItems);
       case EVENT_STATUS -> alias + ".ev_eventstatus";
       case OU_NAME -> alias + ".ev_ouname";
       case OU_CODE -> alias + ".ev_oucode";
       case OU, GENERIC_STAGE_ITEM -> alias + ".ev_" + bareCol;
       case NOT_STAGE_SPECIFIC -> alias + "." + bareCol;
     };
+  }
+
+  /**
+   * Resolves a stage date column to a period-bucket expression when the matching {@link QueryItem}
+   * carries period dimension values; otherwise returns the raw {@code <alias>.<dateColumn>}
+   * reference (ranges and no-value cases are unaffected).
+   */
+  private String resolveStageDateColumn(
+      String alias, String dateColumn, String colName, Map<String, QueryItem> stageDateItems) {
+    String rawColumn = alias + "." + dateColumn;
+    QueryItem item = stageDateItems.get(colName);
+    if (item == null) {
+      return rawColumn;
+    }
+    Optional<String> periodBucket = dateRenderer.resolvePeriodBucketColumn(item);
+    return periodBucket
+        .map(bucket -> dateRenderer.renderPeriodBucketExpression(rawColumn, bucket))
+        .orElse(rawColumn);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/DefaultStageDatePeriodBucketSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/DefaultStageDatePeriodBucketSqlRenderer.java
@@ -106,9 +106,7 @@ public class DefaultStageDatePeriodBucketSqlRenderer implements StageDatePeriodB
 
   /** {@inheritDoc} */
   @Override
-  public String renderPeriodBucketExpression(QueryItem item, String periodBucketColumn) {
-    String stageDateColumn = sqlBuilder.quoteAx(item.getItemId());
-
+  public String renderPeriodBucketExpression(String stageDateColumn, String periodBucketColumn) {
     Optional<String> dbExpression =
         sqlBuilder.renderStageDatePeriodBucket(stageDateColumn, periodBucketColumn);
     if (dbExpression.isPresent()) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/DefaultStageQuerySqlFacade.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/DefaultStageQuerySqlFacade.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.ColumnAndAlias;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.db.sql.AnalyticsSqlBuilder;
 import org.hisp.dhis.program.AnalyticsType;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +48,7 @@ public class DefaultStageQuerySqlFacade implements StageQuerySqlFacade {
   private final StageQueryItemClassifier classifier;
   private final StageDatePeriodBucketSqlRenderer dateRenderer;
   private final StageOrgUnitSqlService stageOrgUnitSqlService;
+  private final AnalyticsSqlBuilder sqlBuilder;
 
   /**
    * Creates a stage SQL facade.
@@ -54,14 +56,17 @@ public class DefaultStageQuerySqlFacade implements StageQuerySqlFacade {
    * @param classifier stage query item classifier
    * @param dateRenderer stage date period renderer
    * @param stageOrgUnitSqlService stage org unit SQL service
+   * @param sqlBuilder SQL builder used to quote the event-path stage date column
    */
   public DefaultStageQuerySqlFacade(
       StageQueryItemClassifier classifier,
       StageDatePeriodBucketSqlRenderer dateRenderer,
-      StageOrgUnitSqlService stageOrgUnitSqlService) {
+      StageOrgUnitSqlService stageOrgUnitSqlService,
+      AnalyticsSqlBuilder sqlBuilder) {
     this.classifier = classifier;
     this.dateRenderer = dateRenderer;
     this.stageOrgUnitSqlService = stageOrgUnitSqlService;
+    this.sqlBuilder = sqlBuilder;
   }
 
   /** {@inheritDoc} */
@@ -81,7 +86,9 @@ public class DefaultStageQuerySqlFacade implements StageQuerySqlFacade {
     if (isAggregated && classifier.isStageDate(item)) {
       Optional<String> periodBucket = dateRenderer.resolvePeriodBucketColumn(item);
       if (periodBucket.isPresent()) {
-        String expression = dateRenderer.renderPeriodBucketExpression(item, periodBucket.get());
+        String expression =
+            dateRenderer.renderPeriodBucketExpression(
+                sqlBuilder.quoteAx(item.getItemId()), periodBucket.get());
         return Optional.of(
             isGroupByClause
                 ? ColumnAndAlias.ofColumn(expression)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/StageDatePeriodBucketSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/stage/StageDatePeriodBucketSqlRenderer.java
@@ -49,12 +49,14 @@ public interface StageDatePeriodBucketSqlRenderer {
   Optional<String> resolvePeriodBucketColumn(QueryItem item);
 
   /**
-   * Renders the SQL expression used to derive the period bucket from the stage date column.
+   * Renders the SQL expression used to derive the period bucket from the given stage date column.
    *
-   * @param item the stage date query item
+   * @param stageDateColumn the SQL column holding the stage date (for example {@code
+   *     ax."occurreddate"} on the event path or {@code latest_events_uid.ev_occurreddate} on the
+   *     enrollment-aggregate path)
    * @param periodBucketColumn the target bucket column (for example {@code yearly}, {@code
    *     monthly})
    * @return SQL expression for SELECT/GROUP BY
    */
-  String renderPeriodBucketExpression(QueryItem item, String periodBucketColumn);
+  String renderPeriodBucketExpression(String stageDateColumn, String periodBucketColumn);
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -221,7 +221,8 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
         new DefaultStageQuerySqlFacade(
             new DefaultStageQueryItemClassifier(),
             new DefaultStageDatePeriodBucketSqlRenderer(sqlBuilder),
-            new DefaultStageOrgUnitSqlService(organisationUnitResolver, sqlBuilder));
+            new DefaultStageOrgUnitSqlService(organisationUnitResolver, sqlBuilder),
+            sqlBuilder);
 
     eventSubject =
         new JdbcEventAnalyticsManager(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AggregatedEnrollmentQueryAssemblerTest.java
@@ -53,13 +53,20 @@ import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.CteDefinition;
 import org.hisp.dhis.analytics.common.EndpointItem;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.analytics.event.data.stage.DefaultStageDatePeriodBucketSqlRenderer;
+import org.hisp.dhis.analytics.table.EventAnalyticsColumnName;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
+import org.hisp.dhis.common.AnalyticsCustomHeader;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.ProgramStage;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -74,7 +81,9 @@ class AggregatedEnrollmentQueryAssemblerTest {
 
   private final AggregatedEnrollmentQueryAssembler assembler =
       new AggregatedEnrollmentQueryAssembler(
-          sqlBuilder, new DateFieldPeriodBucketColumnResolver(sqlBuilder));
+          sqlBuilder,
+          new DateFieldPeriodBucketColumnResolver(sqlBuilder),
+          new DefaultStageDatePeriodBucketSqlRenderer(sqlBuilder));
 
   @Test
   void addAggregatedColumnsEmitsCountValue() {
@@ -340,6 +349,48 @@ class AggregatedEnrollmentQueryAssemblerTest {
     assertThat(sql, containsString("ev_occurreddate as \"stage1.eventdate\""));
     assertThat(sql, containsString("group by"));
     assertThat(sql, containsString("ev_occurreddate"));
+  }
+
+  @Test
+  void addHeaderAggregateColumnsBucketsStageDateViaRealQueryItemKey() {
+    // Proves the real collectStageDateItems key path: a QueryItem carrying a stage EVENT_DATE
+    // custom header is indexed under the same analytics header key (stageUid.eventdate) that the
+    // resolver derives from the GridHeader, so its period (202205) buckets the filter-CTE date
+    // column end-to-end through the assembler — no hand-built header->item map.
+    ProgramStage stage = new ProgramStage();
+    stage.setUid("A03MvHHogjR");
+    stage.setName("Birth");
+
+    QueryItem eventDate =
+        new QueryItem(
+            new BaseDimensionalItemObject(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME));
+    eventDate.setValueType(ValueType.DATE);
+    eventDate.setProgramStage(stage);
+    eventDate.withCustomHeader(AnalyticsCustomHeader.forEventDate(stage));
+    eventDate.addDimensionValue("202205");
+
+    EventQueryParams params = new EventQueryParams.Builder().addItem(eventDate).build();
+
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_A03MvHHogjR", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_A03MvHHogjR").getAlias();
+
+    SelectBuilder sb = new SelectBuilder().from("enrollment_aggr_base", "eb");
+
+    assembler.addHeaderAggregateColumns(
+        List.of(new GridHeader("A03MvHHogjR.eventdate")), params, cteContext, sb, List.of());
+
+    String sql = sb.build();
+    String expected =
+        "(select \"monthly\" from analytics_rs_dateperiodstructure as dps_stage where dps_stage."
+            + "\"dateperiod\" = cast("
+            + alias
+            + ".ev_occurreddate as date))";
+
+    assertThat(sql, containsString(expected + " as \"A03MvHHogjR.eventdate\""));
+    assertThat(sql, containsString("group by " + expected));
+    // not the raw (unbucketed) select column that the bug produced
+    assertThat(sql, not(containsString(alias + ".ev_occurreddate as \"A03MvHHogjR.eventdate\"")));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -870,7 +870,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
         new DefaultStageQuerySqlFacade(
             new DefaultStageQueryItemClassifier(),
             new DefaultStageDatePeriodBucketSqlRenderer(builder),
-            new DefaultStageOrgUnitSqlService(organisationUnitResolver, builder));
+            new DefaultStageOrgUnitSqlService(organisationUnitResolver, builder),
+            builder);
 
     DateFieldPeriodBucketColumnResolver bucketResolver =
         new DateFieldPeriodBucketColumnResolver(builder);
@@ -891,7 +892,8 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
         stageQuerySqlFacade,
         bucketResolver,
         new EnrollmentEventSubqueryBuilder(builder, new ProgramStageOffsetSqlBuilder(builder)),
-        new AggregatedEnrollmentQueryAssembler(builder, bucketResolver));
+        new AggregatedEnrollmentQueryAssembler(
+            builder, bucketResolver, new DefaultStageDatePeriodBucketSqlRenderer(builder)));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -151,7 +151,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
         new DefaultStageQuerySqlFacade(
             new DefaultStageQueryItemClassifier(),
             new DefaultStageDatePeriodBucketSqlRenderer(sqlBuilder),
-            new DefaultStageOrgUnitSqlService(organisationUnitResolver, sqlBuilder));
+            new DefaultStageOrgUnitSqlService(organisationUnitResolver, sqlBuilder),
+            sqlBuilder);
 
     DateFieldPeriodBucketColumnResolver bucketResolver =
         new DateFieldPeriodBucketColumnResolver(new PostgreSqlAnalyticsSqlBuilder());
@@ -175,7 +176,10 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             bucketResolver,
             new EnrollmentEventSubqueryBuilder(
                 sqlBuilder, new ProgramStageOffsetSqlBuilder(sqlBuilder)),
-            new AggregatedEnrollmentQueryAssembler(sqlBuilder, bucketResolver));
+            new AggregatedEnrollmentQueryAssembler(
+                sqlBuilder,
+                bucketResolver,
+                new DefaultStageDatePeriodBucketSqlRenderer(sqlBuilder)));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -1507,7 +1507,8 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
         new DefaultStageQuerySqlFacade(
             new DefaultStageQueryItemClassifier(),
             new DefaultStageDatePeriodBucketSqlRenderer(builder),
-            new DefaultStageOrgUnitSqlService(organisationUnitResolver, builder));
+            new DefaultStageOrgUnitSqlService(organisationUnitResolver, builder),
+            builder);
 
     return new JdbcEventAnalyticsManager(
         jdbcTemplate,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/aggregate/AggregatedEnrollmentHeaderColumnResolverTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.analytics.event.data.aggregate;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
@@ -38,14 +39,23 @@ import java.util.Set;
 import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.CteDefinition;
 import org.hisp.dhis.analytics.common.EndpointItem;
+import org.hisp.dhis.analytics.event.data.stage.DefaultStageDatePeriodBucketSqlRenderer;
 import org.hisp.dhis.analytics.event.data.stage.StageHeaderClassifier;
+import org.hisp.dhis.analytics.table.EventAnalyticsColumnName;
 import org.hisp.dhis.analytics.util.sql.SelectBuilder;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
+import org.hisp.dhis.program.ProgramStage;
 import org.junit.jupiter.api.Test;
 
 class AggregatedEnrollmentHeaderColumnResolverTest {
   private final StageHeaderClassifier stageHeaderClassifier = new StageHeaderClassifier();
   private final AggregatedEnrollmentHeaderColumnResolver subject =
-      new AggregatedEnrollmentHeaderColumnResolver(stageHeaderClassifier);
+      new AggregatedEnrollmentHeaderColumnResolver(
+          stageHeaderClassifier,
+          new DefaultStageDatePeriodBucketSqlRenderer(new PostgreSqlAnalyticsSqlBuilder()));
 
   @Test
   void shouldUseFilterCteForStageEventDate() {
@@ -59,6 +69,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         Set.of("\"stage1.eventdate\""),
         cteContext,
         sb,
+        Collections.emptyMap(),
         Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
@@ -80,6 +91,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         cteContext,
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -99,6 +111,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         Set.of("\"stage1.oucode\""),
         cteContext,
         sb,
+        Collections.emptyMap(),
         Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
@@ -120,6 +133,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         cteContext,
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -139,6 +153,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         Set.of("\"stage1.ou\""),
         cteContext,
         sb,
+        Collections.emptyMap(),
         Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
@@ -160,6 +175,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         cteContext,
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -179,6 +195,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         Set.of("`stage1.de1`"),
         cteContext,
         sb,
+        Collections.emptyMap(),
         Collections.emptyMap(),
         column -> "`" + column + "`");
 
@@ -200,6 +217,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         new CteContext(EndpointItem.ENROLLMENT),
         sb,
         cteDefinitionMap,
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -217,6 +235,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         new CteContext(EndpointItem.ENROLLMENT),
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -233,6 +252,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         Set.of("\"stage1.de1\""),
         new CteContext(EndpointItem.ENROLLMENT),
         sb,
+        Collections.emptyMap(),
         Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
@@ -255,6 +275,7 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         cteContext,
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
@@ -276,11 +297,156 @@ class AggregatedEnrollmentHeaderColumnResolverTest {
         cteContext,
         sb,
         Collections.emptyMap(),
+        Collections.emptyMap(),
         column -> "\"" + column + "\"");
 
     String sql = sb.build();
 
     assertThat(sql, containsString("ev_occurreddate as \"stage1.eventdate\""));
     assertThat(sql, containsString("ev_eventstatus as \"stage1.eventstatus\""));
+  }
+
+  @Test
+  void shouldBucketStageEventDateWithPeriodValue() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_stage1").getAlias();
+
+    SelectBuilder sb = new SelectBuilder();
+    sb.from("dummy");
+
+    subject.addHeaderColumns(
+        Set.of("\"stage1.eventdate\""),
+        cteContext,
+        sb,
+        Collections.emptyMap(),
+        Map.of(
+            "stage1.eventdate",
+            stageDateItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME, "202205")),
+        column -> "\"" + column + "\"");
+
+    String sql = sb.build();
+    String expected = monthlyBucket(alias + ".ev_occurreddate");
+
+    assertThat(sql, containsString(expected + " as \"stage1.eventdate\""));
+    assertThat(sql, containsString("group by " + expected));
+  }
+
+  @Test
+  void shouldUseRawColumnForStageEventDateWithoutPeriodValue() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_stage1").getAlias();
+
+    SelectBuilder sb = new SelectBuilder();
+    sb.from("dummy");
+
+    subject.addHeaderColumns(
+        Set.of("\"stage1.eventdate\""),
+        cteContext,
+        sb,
+        Collections.emptyMap(),
+        Map.of(
+            "stage1.eventdate", stageDateItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME)),
+        column -> "\"" + column + "\"");
+
+    String sql = sb.build();
+
+    assertThat(sql, containsString(alias + ".ev_occurreddate as \"stage1.eventdate\""));
+    assertThat(sql, not(containsString("analytics_rs_dateperiodstructure")));
+  }
+
+  @Test
+  void shouldBucketStageScheduledDateWithPeriodValue() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_stage1").getAlias();
+
+    SelectBuilder sb = new SelectBuilder();
+    sb.from("dummy");
+
+    subject.addHeaderColumns(
+        Set.of("\"stage1.scheduleddate\""),
+        cteContext,
+        sb,
+        Collections.emptyMap(),
+        Map.of(
+            "stage1.scheduleddate",
+            stageDateItem(EventAnalyticsColumnName.SCHEDULED_DATE_COLUMN_NAME, "202107")),
+        column -> "\"" + column + "\"");
+
+    String sql = sb.build();
+    String expected = monthlyBucket(alias + ".ev_scheduleddate");
+
+    assertThat(sql, containsString(expected + " as \"stage1.scheduleddate\""));
+    assertThat(sql, containsString("group by " + expected));
+  }
+
+  @Test
+  void shouldBucketStageEventDateWithMultiplePeriodsOfSameType() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_stage1").getAlias();
+
+    SelectBuilder sb = new SelectBuilder();
+    sb.from("dummy");
+
+    subject.addHeaderColumns(
+        Set.of("\"stage1.eventdate\""),
+        cteContext,
+        sb,
+        Collections.emptyMap(),
+        Map.of(
+            "stage1.eventdate",
+            stageDateItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME, "202205", "202206")),
+        column -> "\"" + column + "\"");
+
+    String sql = sb.build();
+
+    assertThat(sql, containsString(monthlyBucket(alias + ".ev_occurreddate")));
+  }
+
+  @Test
+  void shouldUseRawColumnForStageEventDateWithMixedPeriodTypes() {
+    CteContext cteContext = new CteContext(EndpointItem.ENROLLMENT);
+    cteContext.addFilterCte("latest_events_stage1", "select 1");
+    String alias = cteContext.getDefinitionByItemUid("latest_events_stage1").getAlias();
+
+    SelectBuilder sb = new SelectBuilder();
+    sb.from("dummy");
+
+    subject.addHeaderColumns(
+        Set.of("\"stage1.eventdate\""),
+        cteContext,
+        sb,
+        Collections.emptyMap(),
+        Map.of(
+            "stage1.eventdate",
+            stageDateItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME, "202205", "2022")),
+        column -> "\"" + column + "\"");
+
+    String sql = sb.build();
+
+    assertThat(sql, containsString(alias + ".ev_occurreddate as \"stage1.eventdate\""));
+    assertThat(sql, not(containsString("analytics_rs_dateperiodstructure")));
+  }
+
+  private QueryItem stageDateItem(String itemId, String... periodValues) {
+    QueryItem item = new QueryItem(new BaseDimensionalItemObject(itemId));
+    item.setValueType(ValueType.DATE);
+    ProgramStage stage = new ProgramStage();
+    stage.setUid("stage1");
+    item.setProgramStage(stage);
+    for (String value : periodValues) {
+      item.addDimensionValue(value);
+    }
+    return item;
+  }
+
+  private String monthlyBucket(String dateColumn) {
+    return "(select \"monthly\" from analytics_rs_dateperiodstructure as dps_stage where dps_stage."
+        + "\"dateperiod\" = cast("
+        + dateColumn
+        + " as date))";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageDatePeriodBucketSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageDatePeriodBucketSqlRendererTest.java
@@ -96,12 +96,23 @@ class StageDatePeriodBucketSqlRendererTest {
   void shouldRenderPostgresCorrelatedSubquery() {
     DefaultStageDatePeriodBucketSqlRenderer subject =
         new DefaultStageDatePeriodBucketSqlRenderer(new PostgreSqlAnalyticsSqlBuilder());
-    QueryItem item = createItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME);
 
-    String expression = subject.renderPeriodBucketExpression(item, "monthly");
+    String expression = subject.renderPeriodBucketExpression("ax.\"occurreddate\"", "monthly");
 
     assertTrue(expression.contains("analytics_rs_dateperiodstructure"));
     assertTrue(expression.contains("cast(ax.\"occurreddate\" as date)"));
+    assertTrue(expression.contains("\"monthly\""));
+  }
+
+  @Test
+  void shouldRenderPostgresSubqueryOverProvidedColumn() {
+    DefaultStageDatePeriodBucketSqlRenderer subject =
+        new DefaultStageDatePeriodBucketSqlRenderer(new PostgreSqlAnalyticsSqlBuilder());
+
+    String expression =
+        subject.renderPeriodBucketExpression("latest_events_abc.ev_occurreddate", "monthly");
+
+    assertTrue(expression.contains("cast(latest_events_abc.ev_occurreddate as date)"));
     assertTrue(expression.contains("\"monthly\""));
   }
 
@@ -110,9 +121,8 @@ class StageDatePeriodBucketSqlRendererTest {
     DefaultStageDatePeriodBucketSqlRenderer subject =
         new DefaultStageDatePeriodBucketSqlRenderer(
             new DorisAnalyticsSqlBuilder("internal", "doris-jdbc.jar"));
-    QueryItem item = createItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME);
 
-    String expression = subject.renderPeriodBucketExpression(item, "yearly");
+    String expression = subject.renderPeriodBucketExpression("ax.`occurreddate`", "yearly");
 
     assertEquals("date_format(cast(ax.`occurreddate` as date), '%Y')", expression);
   }
@@ -121,9 +131,8 @@ class StageDatePeriodBucketSqlRendererTest {
   void shouldRenderClickHouseExpressionFromScheduledDateColumn() {
     DefaultStageDatePeriodBucketSqlRenderer subject =
         new DefaultStageDatePeriodBucketSqlRenderer(new ClickHouseAnalyticsSqlBuilder("default"));
-    QueryItem item = createItem(EventAnalyticsColumnName.SCHEDULED_DATE_COLUMN_NAME);
 
-    String expression = subject.renderPeriodBucketExpression(item, "monthly");
+    String expression = subject.renderPeriodBucketExpression("ax.\"scheduleddate\"", "monthly");
 
     assertEquals("formatDateTime(toDate(ax.\"scheduleddate\"), '%Y%m')", expression);
   }
@@ -141,9 +150,8 @@ class StageDatePeriodBucketSqlRendererTest {
 
     DefaultStageDatePeriodBucketSqlRenderer subject =
         new DefaultStageDatePeriodBucketSqlRenderer(builder);
-    QueryItem item = createItem(EventAnalyticsColumnName.OCCURRED_DATE_COLUMN_NAME);
 
-    String expression = subject.renderPeriodBucketExpression(item, "monthly");
+    String expression = subject.renderPeriodBucketExpression("ax.\"occurreddate\"", "monthly");
 
     assertEquals("custom_bucket_expr", expression);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageQuerySqlFacadeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/stage/StageQuerySqlFacadeTest.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.ColumnAndAlias;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.ProgramStage;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,8 @@ class StageQuerySqlFacadeTest {
   private final TestDateRenderer dateRenderer = new TestDateRenderer();
   private final TestOrgUnitService orgUnitService = new TestOrgUnitService();
   private final DefaultStageQuerySqlFacade subject =
-      new DefaultStageQuerySqlFacade(classifier, dateRenderer, orgUnitService);
+      new DefaultStageQuerySqlFacade(
+          classifier, dateRenderer, orgUnitService, new PostgreSqlAnalyticsSqlBuilder());
 
   @Test
   void shouldResolveStageOrgUnitSelectColumn() {
@@ -181,7 +183,7 @@ class StageQuerySqlFacadeTest {
     }
 
     @Override
-    public String renderPeriodBucketExpression(QueryItem item, String periodBucketColumn) {
+    public String renderPeriodBucketExpression(String stageDateColumn, String periodBucketColumn) {
       return "bucket_expr_" + periodBucketColumn;
     }
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/aggregate/EnrollmentsAggregate7AutoTest.java
@@ -57,15 +57,16 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     QueryParamsBuilder params =
         new QueryParamsBuilder()
             .add("includeMetadataDetails=true")
-            // .add("displayProperty=NAME")
+            .add("displayProperty=NAME")
             .add("totalPages=false")
             .add("pageSize=100")
-            // .add("outputType=ENROLLMENT")
+            .add("outputType=ENROLLMENT")
             .add("page=1")
             .add("dimension=ou:USER_ORGUNIT,A03MvHHogjR.EVENT_DATE:202205");
 
     // When
     ApiResponse response = actions.aggregate().get("IpHINAT79UW", JSON, JSON, params);
+
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
     //    This helper checks basic counts and dimensions, adapting based on the runtime
@@ -73,7 +74,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        31,
+        1,
         3,
         3); // Pass runtime flag, row count, and expected header counts
 
@@ -85,7 +86,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"endDate\":\"2022-05-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"May 2022\",\"startDate\":\"2022-05-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"202205\"],\"ou\":[\"ImspTQPwCqd\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"May 2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[\"202205\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -118,43 +119,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateRowExists(
         response,
         actualHeaders,
-        Map.of(
-            "value", "24", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-01 00:00:00.0"));
-
-    // Validate row exists with values from original row index 6
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value", "16", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-07 00:00:00.0"));
-
-    // Validate row exists with values from original row index 12
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value", "21", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-13 00:00:00.0"));
-
-    // Validate row exists with values from original row index 18
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value", "19", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-19 00:00:00.0"));
-
-    // Validate row exists with values from original row index 24
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value", "32", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-25 00:00:00.0"));
-
-    // Validate row exists with values from original row index 30
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value", "27", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "2022-05-31 00:00:00.0"));
+        Map.of("value", "702", "ou", "ImspTQPwCqd", "A03MvHHogjR.eventdate", "202205"));
   }
 
   @Test
@@ -547,7 +512,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        30,
+        1,
         3,
         3); // Pass runtime flag, row count, and expected header counts
 
@@ -559,7 +524,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"A03MvHHogjR.scheduleddate\":{\"name\":\"Scheduled date\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202107\":{\"uid\":\"202107\",\"code\":\"202107\",\"endDate\":\"2021-07-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"July 2021\",\"startDate\":\"2021-07-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[\"202107\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR.scheduleddate\":{\"name\":\"Scheduled date\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202107\":{\"uid\":\"202107\",\"code\":\"202107\",\"name\":\"July 2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-07-01T00:00:00.000\",\"endDate\":\"2021-07-31T00:00:00.000\"}},\"dimensions\":{\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.scheduleddate\":[\"202107\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -592,85 +557,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateRowExists(
         response,
         actualHeaders,
-        Map.of(
-            "value",
-            "38",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-01 12:05:00.0"));
-
-    // Validate row exists with values from original row index 5
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "30",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-06 12:05:00.0"));
-
-    // Validate row exists with values from original row index 10
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "31",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-11 12:05:00.0"));
-
-    // Validate row exists with values from original row index 15
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "40",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-16 12:05:00.0"));
-
-    // Validate row exists with values from original row index 20
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "24",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-21 12:05:00.0"));
-
-    // Validate row exists with values from original row index 25
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "42",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-26 12:05:00.0"));
-
-    // Validate row exists with values from original row index 29
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "28",
-            "ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.scheduleddate",
-            "2021-07-30 12:05:00.0"));
+        Map.of("value", "925", "ou", "ImspTQPwCqd", "A03MvHHogjR.scheduleddate", "202107"));
   }
 
   @Test
@@ -767,7 +654,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        62,
+        2,
         5,
         5); // Pass runtime flag, row count, and expected header counts
 
@@ -779,7 +666,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ww8JVblo4SI\":{\"uid\":\"ww8JVblo4SI\",\"code\":\"Others\",\"name\":\"Others\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"Cd0gtHGmlwS\":{\"uid\":\"Cd0gtHGmlwS\",\"code\":\"NVP only\",\"name\":\"NVP only\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"A03MvHHogjR.eventstatus\":{\"name\":\"Event status\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ou\":{\"name\":\"Organisation unit\"},\"A03MvHHogjR.wQLfBvPrXqq\":{\"uid\":\"wQLfBvPrXqq\",\"aggregationType\":\"AVERAGE\",\"code\":\"DE_2008294\",\"valueType\":\"TEXT\",\"name\":\"MCH ARV at birth\",\"description\":\"Onlu used for birth details.\",\"dimensionItemType\":\"DATA_ELEMENT\",\"totalAggregationType\":\"SUM\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"endDate\":\"2022-05-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"May 2022\",\"startDate\":\"2022-05-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"A03MvHHogjR.eventdate\":[\"202205\"],\"A03MvHHogjR.eventstatus\":[],\"A03MvHHogjR.ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.wQLfBvPrXqq\":[\"Cd0gtHGmlwS\",\"ww8JVblo4SI\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ww8JVblo4SI\":{\"uid\":\"ww8JVblo4SI\",\"code\":\"Others\",\"name\":\"Others\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"Cd0gtHGmlwS\":{\"uid\":\"Cd0gtHGmlwS\",\"code\":\"NVP only\",\"name\":\"NVP only\"},\"A03MvHHogjR.eventdate\":{\"name\":\"Report date\"},\"A03MvHHogjR.eventstatus\":{\"name\":\"Event status\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ou\":{\"name\":\"Organisation unit\"},\"A03MvHHogjR.wQLfBvPrXqq\":{\"uid\":\"wQLfBvPrXqq\",\"code\":\"DE_2008294\",\"name\":\"MCH ARV at birth\",\"description\":\"Onlu used for birth details.\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"May 2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"A03MvHHogjR.ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.eventdate\":[\"202205\"],\"A03MvHHogjR.eventstatus\":[],\"A03MvHHogjR.wQLfBvPrXqq\":[\"Cd0gtHGmlwS\",\"ww8JVblo4SI\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -832,7 +719,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
         actualHeaders,
         Map.of(
             "value",
-            "11",
+            "347",
             "A03MvHHogjR.eventstatus",
             "ACTIVE",
             "A03MvHHogjR.ou",
@@ -840,63 +727,15 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
             "A03MvHHogjR.wQLfBvPrXqq",
             "NVP only",
             "A03MvHHogjR.eventdate",
-            "2022-05-01 00:00:00.0"));
+            "202205"));
 
-    // Validate row exists with values from original row index 8
+    // Validate row exists with values from original row index 1
     validateRowExists(
         response,
         actualHeaders,
         Map.of(
             "value",
-            "13",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "NVP only",
-            "A03MvHHogjR.eventdate",
-            "2022-05-09 00:00:00.0"));
-
-    // Validate row exists with values from original row index 16
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "6",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "NVP only",
-            "A03MvHHogjR.eventdate",
-            "2022-05-17 00:00:00.0"));
-
-    // Validate row exists with values from original row index 24
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "14",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "NVP only",
-            "A03MvHHogjR.eventdate",
-            "2022-05-25 00:00:00.0"));
-
-    // Validate row exists with values from original row index 32
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "6",
+            "355",
             "A03MvHHogjR.eventstatus",
             "ACTIVE",
             "A03MvHHogjR.ou",
@@ -904,71 +743,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
             "A03MvHHogjR.wQLfBvPrXqq",
             "Others",
             "A03MvHHogjR.eventdate",
-            "2022-05-02 00:00:00.0"));
-
-    // Validate row exists with values from original row index 40
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "8",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "Others",
-            "A03MvHHogjR.eventdate",
-            "2022-05-10 00:00:00.0"));
-
-    // Validate row exists with values from original row index 48
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "5",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "Others",
-            "A03MvHHogjR.eventdate",
-            "2022-05-18 00:00:00.0"));
-
-    // Validate row exists with values from original row index 56
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "11",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "Others",
-            "A03MvHHogjR.eventdate",
-            "2022-05-26 00:00:00.0"));
-
-    // Validate row exists with values from original row index 61
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "14",
-            "A03MvHHogjR.eventstatus",
-            "ACTIVE",
-            "A03MvHHogjR.ou",
-            "ImspTQPwCqd",
-            "A03MvHHogjR.wQLfBvPrXqq",
-            "Others",
-            "A03MvHHogjR.eventdate",
-            "2022-05-31 00:00:00.0"));
+            "202205"));
   }
 
   @Test
@@ -996,7 +771,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        30,
+        1,
         4,
         4); // Pass runtime flag, row count, and expected header counts
 
@@ -1008,7 +783,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"PUZaKR0Jh2k.eventdate\":{\"name\":\"Date of birth\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"edqlbukwRfQ.eventstatus\":{\"name\":\"Event status\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"endDate\":\"2022-05-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"May 2022\",\"startDate\":\"2022-05-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"PUZaKR0Jh2k.eventdate\":[\"202205\"],\"ou\":[\"ImspTQPwCqd\"],\"edqlbukwRfQ.eventstatus\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"PUZaKR0Jh2k.eventdate\":{\"name\":\"Date of birth\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"edqlbukwRfQ.eventstatus\":{\"name\":\"Event status\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"May 2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"edqlbukwRfQ.eventstatus\":[],\"PUZaKR0Jh2k.eventdate\":[\"202205\"],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -1052,97 +827,13 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
         actualHeaders,
         Map.of(
             "value",
-            "1",
+            "87",
             "ou",
             "ImspTQPwCqd",
             "edqlbukwRfQ.eventstatus",
             "ACTIVE",
             "PUZaKR0Jh2k.eventdate",
-            "2022-05-01 12:05:00.0"));
-
-    // Validate row exists with values from original row index 5
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-06 12:05:00.0"));
-
-    // Validate row exists with values from original row index 10
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-11 12:05:00.0"));
-
-    // Validate row exists with values from original row index 15
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-16 12:05:00.0"));
-
-    // Validate row exists with values from original row index 20
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-21 12:05:00.0"));
-
-    // Validate row exists with values from original row index 25
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "6",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-26 12:05:00.0"));
-
-    // Validate row exists with values from original row index 29
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-30 12:05:00.0"));
+            "202205"));
   }
 
   @Test
@@ -1170,7 +861,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        30,
+        1,
         4,
         4); // Pass runtime flag, row count, and expected header counts
 
@@ -1182,7 +873,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"edqlbukwRfQ.eventdate\":{\"name\":\"Date of visit\"},\"edqlbukwRfQ.eventstatus\":{\"name\":\"Event status\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"endDate\":\"2022-05-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"May 2022\",\"startDate\":\"2022-05-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"ou\":[\"ImspTQPwCqd\"],\"edqlbukwRfQ.eventdate\":[\"202205\"],\"edqlbukwRfQ.eventstatus\":[]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"edqlbukwRfQ.eventdate\":{\"name\":\"Date of visit\"},\"edqlbukwRfQ.eventstatus\":{\"name\":\"Event status\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"May 2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"}},\"dimensions\":{\"edqlbukwRfQ.eventdate\":[\"202205\"],\"edqlbukwRfQ.eventstatus\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -1226,95 +917,11 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
         actualHeaders,
         Map.of(
             "value",
-            "6",
+            "347",
             "ou",
             "ImspTQPwCqd",
             "edqlbukwRfQ.eventdate",
-            "2022-05-01 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 5
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "10",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-06 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 10
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "11",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-11 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 15
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "18",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-16 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 20
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "16",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-21 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 25
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "15",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-26 12:05:00.0",
-            "edqlbukwRfQ.eventstatus",
-            "ACTIVE"));
-
-    // Validate row exists with values from original row index 29
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "12",
-            "ou",
-            "ImspTQPwCqd",
-            "edqlbukwRfQ.eventdate",
-            "2022-05-30 12:05:00.0",
+            "202205",
             "edqlbukwRfQ.eventstatus",
             "ACTIVE"));
   }
@@ -1344,7 +951,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        30,
+        1,
         4,
         4); // Pass runtime flag, row count, and expected header counts
 
@@ -1356,7 +963,7 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
 
     // 3. Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"isLastPage\":true,\"pageSize\":100,\"page\":1},\"items\":{\"PUZaKR0Jh2k.eventdate\":{\"name\":\"Date of birth\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"dimensionType\":\"ORGANISATION_UNIT\",\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"endDate\":\"2022-05-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"May 2022\",\"startDate\":\"2022-05-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"valueType\":\"TEXT\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"totalAggregationType\":\"SUM\"},\"2018\":{\"uid\":\"2018\",\"code\":\"2018\",\"endDate\":\"2018-12-31T00:00:00.000\",\"valueType\":\"TEXT\",\"name\":\"2018\",\"description\":\"2018\",\"startDate\":\"2018-01-01T00:00:00.000\",\"dimensionItemType\":\"PERIOD\",\"totalAggregationType\":\"SUM\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"lastupdated\":{\"name\":\"Last updated\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"PUZaKR0Jh2k.eventdate\":[\"202205\"],\"ou\":[\"ImspTQPwCqd\"],\"lastupdated\":[\"2018\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"PUZaKR0Jh2k.eventdate\":{\"name\":\"Date of birth\"},\"bbKtnxRZKEP\":{\"uid\":\"bbKtnxRZKEP\",\"name\":\"Postpartum care visit\",\"description\":\"Provision of care for the mother for some weeks after delivery\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"edqlbukwRfQ\":{\"uid\":\"edqlbukwRfQ\",\"name\":\"Second antenatal care visit\",\"description\":\"Antenatal care visit\"},\"202205\":{\"uid\":\"202205\",\"code\":\"202205\",\"name\":\"May 2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-05-01T00:00:00.000\",\"endDate\":\"2022-05-31T00:00:00.000\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"2018\":{\"uid\":\"2018\",\"code\":\"2018\",\"name\":\"2018\",\"description\":\"2018\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2018-01-01T00:00:00.000\",\"endDate\":\"2018-12-31T00:00:00.000\"},\"PFDfvmGpsR3\":{\"uid\":\"PFDfvmGpsR3\",\"name\":\"Care at birth\",\"description\":\"Intrapartum care \\/ Childbirth \\/ Labour and delivery\"},\"pe\":{\"uid\":\"pe\",\"dimensionType\":\"PERIOD\"},\"PUZaKR0Jh2k\":{\"uid\":\"PUZaKR0Jh2k\",\"name\":\"Previous deliveries\",\"description\":\"Table for recording earlier deliveries\"},\"WZbXY0S00lP\":{\"uid\":\"WZbXY0S00lP\",\"name\":\"First antenatal care visit\",\"description\":\"First antenatal care visit\"},\"lastupdated\":{\"name\":\"Last updated\"},\"WSGAb5XwJ3Y\":{\"uid\":\"WSGAb5XwJ3Y\",\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"lastupdated\":[\"2018\"],\"PUZaKR0Jh2k.eventdate\":[\"202205\"],\"ou\":[\"ImspTQPwCqd\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -1400,97 +1007,13 @@ public class EnrollmentsAggregate7AutoTest extends AnalyticsApiTest {
         actualHeaders,
         Map.of(
             "value",
-            "1",
+            "92",
             "ou",
             "ImspTQPwCqd",
             "lastupdated",
             "2018",
             "PUZaKR0Jh2k.eventdate",
-            "2022-05-01 12:05:00.0"));
-
-    // Validate row exists with values from original row index 5
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-06 12:05:00.0"));
-
-    // Validate row exists with values from original row index 10
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-11 12:05:00.0"));
-
-    // Validate row exists with values from original row index 15
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-16 12:05:00.0"));
-
-    // Validate row exists with values from original row index 20
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-21 12:05:00.0"));
-
-    // Validate row exists with values from original row index 25
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "6",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-26 12:05:00.0"));
-
-    // Validate row exists with values from original row index 29
-    validateRowExists(
-        response,
-        actualHeaders,
-        Map.of(
-            "value",
-            "3",
-            "ou",
-            "ImspTQPwCqd",
-            "lastupdated",
-            "2018",
-            "PUZaKR0Jh2k.eventdate",
-            "2022-05-30 12:05:00.0"));
+            "202205"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes enrollment **aggregate** analytics so a stage-scoped date dimension
(`<stageUid>.EVENT_DATE:<period>` or `<stageUid>.SCHEDULED_DATE:<period>`) groups rows by the requested period and emits the period code, instead of emitting raw per-day timestamps.

For `dimension=ou:USER_ORGUNIT,A03MvHHogjR.EVENT_DATE:202205` the endpoint previously returned one row **per day** (31 rows) with a raw timestamp cell (`2022-05-01 00:00:00.0`). It now returns a **single period-bucketed** row per org unit with the cell `202205` — matching the behaviour the event-aggregate path already produced.

## Problem

The enrollment-aggregate SELECT/GROUP-BY is assembled by `AggregatedEnrollmentQueryAssembler`, which resolves stage header columns through `AggregatedEnrollmentHeaderColumnResolver.resolveCteColumn`.
That method returned the **raw** per-stage filter-CTE date column (`<alias>.ev_occurreddate` / `ev_scheduleddate`) for both `SELECT` and `GROUP BY`. The requested period was applied only as a `WHERE` filter inside the per-stage filter CTE, so rows were correctly limited to the period but then grouped by the raw day.

The event analytics path does not have this bug — it buckets the date via
`StageDatePeriodBucketSqlRenderer`. The enrollment-aggregate resolver simply never invoked it.
