### PR TITLE
perf: User delete - deletion handler veto improvement [DHIS2-21725]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -920,7 +920,14 @@ public class HibernateIdentifiableObjectStore<T extends IdentifiableObject>
   }
 
   /**
-   * Look up objects which have property createdBy or lastUpdatedBy linked to given {@link User}
+   * Look up objects which have property createdBy or lastUpdatedBy linked to given {@link User}.
+   *
+   * <p>Runs with {@link FlushModeType#COMMIT}, so the JPA auto-flush (a full-session dirty-check)
+   * is skipped before this query. This is safe for the current caller (the read-only deletion veto
+   * phase, which runs before any deletion handler writes), and avoids a per-query flush that
+   * dominates the cost when a large object graph is in the session. If a future caller reads within
+   * a transaction and must observe earlier un-flushed changes, change this method to accept a
+   * flush-mode parameter rather than relaxing the mode for everyone.
    *
    * @param user the {@link User} for filtering
    * @return TRUE of objects found. FALSE otherwise.
@@ -940,10 +947,6 @@ public class HibernateIdentifiableObjectStore<T extends IdentifiableObject>
       return false;
     }
     query.where(builder.or(predicates.toArray(new Predicate[0])));
-    // Read-only existence check: skip the JPA auto-flush (a full-session dirty-check) that would
-    // otherwise run before this query. During user deletion this is invoked once per metadata type
-    // (~44 queries); with a large object graph in the session, that per-query flush dominates the
-    // cost while the query itself is sub-millisecond.
     return !entityManager
         .createQuery(query)
         .setFlushMode(FlushModeType.COMMIT)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.query.JpaQueryUtils.generateHqlQueryForSharingCheck;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -939,7 +940,16 @@ public class HibernateIdentifiableObjectStore<T extends IdentifiableObject>
       return false;
     }
     query.where(builder.or(predicates.toArray(new Predicate[0])));
-    return !entityManager.createQuery(query).setMaxResults(1).getResultList().isEmpty();
+    // Read-only existence check: skip the JPA auto-flush (a full-session dirty-check) that would
+    // otherwise run before this query. During user deletion this is invoked once per metadata type
+    // (~44 queries); with a large object graph in the session, that per-query flush dominates the
+    // cost while the query itself is sub-millisecond.
+    return !entityManager
+        .createQuery(query)
+        .setFlushMode(FlushModeType.COMMIT)
+        .setMaxResults(1)
+        .getResultList()
+        .isEmpty();
   }
 
   /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
@@ -347,6 +347,7 @@ class DataElementStoreTest extends PostgresIntegrationTestBase {
     DataElement dataElementA = createDataElement('A');
     dataElementA.setCreatedBy(userA);
     dataElementStore.save(dataElementA);
+    entityManager.flush();
     assertTrue(dataElementStore.existsByUser(userA, Set.of("createdBy")));
     assertFalse(dataElementStore.existsByUser(userB, Set.of("createdBy")));
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -194,6 +194,7 @@ class UserServiceTest extends PostgresIntegrationTestBase {
     DataElement dataElement = createDataElement('A');
     dataElement.setCreatedBy(userA);
     idObjectManager.save(dataElement);
+    entityManager.flush();
 
     assertThrows(DeleteNotAllowedException.class, () -> userService.deleteUser(userA));
   }
@@ -208,6 +209,7 @@ class UserServiceTest extends PostgresIntegrationTestBase {
 
     dataElement.setDescription("Updated");
     idObjectManager.update(dataElement);
+    entityManager.flush();
 
     assertThrows(DeleteNotAllowedException.class, () -> userService.deleteUser(userA));
   }


### PR DESCRIPTION
# Performance improvement
Change `FlushMode` from `AUTO` (default) to `COMMIT` in `HibernateIdentifiableObjectStore.existsByUser`
- removes needless dirty checks during user deletes
- checks were being run for every entity being checked for user association
- deletion VETOs run first during user delete, so already reading from a correct state (no writes earlier in transaction)
- only 1 caller of this method - `IdObjectDeletionHandler.allowDeleteUser`

2 existing tests now need flush before assertions to ensure reading correct state.

# Tests
Local performance tests run show times almost halved
- `P95` `~1.4s` -> `~0.8s`
- this includes the `platform-perf` DB having the following data associated with users to ensure that deletion handlers are exercised.


| Data | Table(s) | per user | Handler exercised |
| -- | -- | -- | -- |
| User settings | usersetting | 15 | UserSettingDeletionHandler |
| Datastore entries | userkeyjsonvalue | 15 | UserDatastoreDeletionHandler |
| Data-view OUs | userdatavieworgunits | 10 | cascade cleanup |
| TEI-search OUs | userteisearchorgunits | 10 | cascade cleanup |
| Previous passwords | previouspasswords | 3 | cascade cleanup |
| Interpretations | interpretation | 5 | InterpretationDeletionHandler (null-out) |
| Messages | messageconversation +3 | 5 | message handler (sender/recipient) |
| Dashboard items | dashboarditem +_users | 5 | DashboardItemDeletionHandler |


# Next
- User performance test will be updated to reflect new version of `platform-perf` DB with User data for deletion handler triggers
- Upload new version of `platform-perf` DB with user deletion handler data