### PR TITLE
fix: Block update event when block flag on PS [DHIS2-21551]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
@@ -161,6 +161,8 @@ public enum ValidationCode {
   E1323("User: `{0}` has no write access to any program."),
   E1324("User `{0}` has no ownership access to any program for the provided TrackedEntity: `{1}`."),
   E1325("User: `{0}` has no read access to any program."),
+  E1326(
+      "Event `{0}` is completed and its ProgramStage blocks the entry form after completion. Reopen the Event before updating."),
 
   /* Relationship */
   E4000("Relationship: `{0}` cannot link to itself."),

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
@@ -54,15 +54,10 @@ class BlockEntryFormAfterCompletionValidator implements Validator<Event> {
 
     ProgramStage programStage = preheat.getProgramStage(event.getProgramStage());
 
-    if (EventStatus.COMPLETED != event.getStatus()) {
-      return;
+    if (EventStatus.COMPLETED == event.getStatus()
+        && Boolean.TRUE.equals(programStage.getBlockEntryForm())) {
+      reporter.addError(event, E1326, event.getEvent());
     }
-
-    if (!Boolean.TRUE.equals(programStage.getBlockEntryForm())) {
-      return;
-    }
-
-    reporter.addError(event, E1326, event.getEvent());
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.validation.validator.event;
+
+import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1326;
+
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.validation.Reporter;
+import org.hisp.dhis.tracker.imports.validation.Validator;
+
+/**
+ * Rejects updates to a completed event when its {@link ProgramStage} has {@code blockEntryForm}
+ * enabled. With that setting on, the entry form is locked once the event is completed, so the event
+ * must be reopened (its status changed away from {@link EventStatus#COMPLETED}) before it can be
+ * modified.
+ */
+class BlockEntryFormAfterCompletionValidator implements Validator<Event> {
+
+  @Override
+  public void validate(Reporter reporter, TrackerBundle bundle, Event event) {
+    TrackerPreheat preheat = bundle.getPreheat();
+
+    ProgramStage programStage = preheat.getProgramStage(event.getProgramStage());
+
+    if (EventStatus.COMPLETED != event.getStatus()) {
+      return;
+    }
+
+    if (!Boolean.TRUE.equals(programStage.getBlockEntryForm())) {
+      return;
+    }
+
+    reporter.addError(event, E1326, event.getEvent());
+  }
+
+  @Override
+  public boolean needsToRun(TrackerImportStrategy strategy) {
+    return strategy == TrackerImportStrategy.UPDATE;
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventValidator.java
@@ -60,6 +60,7 @@ public class EventValidator implements Validator<TrackerBundle> {
                     new MetaValidator(),
                     new UpdatableFieldsValidator(),
                     new DataRelationsValidator(),
+                    new BlockEntryFormAfterCompletionValidator(),
                     new CategoryOptionComboValidator(),
                     new StatusValidator(),
                     all(

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.validation.validator.event;
+
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1326;
+import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.SingleEvent;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.validation.Reporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Enrico Colasante
+ */
+@ExtendWith(MockitoExtension.class)
+class BlockEntryFormAfterCompletionValidatorTest {
+
+  private static final String PROGRAM_STAGE_UID = "programStageU";
+
+  private BlockEntryFormAfterCompletionValidator validator;
+
+  @Mock private TrackerPreheat preheat;
+
+  @Mock private TrackerBundle bundle;
+
+  private Reporter reporter;
+
+  @BeforeEach
+  void setUp() {
+    validator = new BlockEntryFormAfterCompletionValidator();
+    lenient().when(bundle.getPreheat()).thenReturn(preheat);
+    reporter = new Reporter(TrackerIdSchemeParams.builder().build());
+  }
+
+  @Test
+  void shouldFailWhenTrackerEventIsCompletedAndBlockEntryFormIsEnabled() {
+    stubProgramStage(true);
+    Event event = trackerEvent(EventStatus.COMPLETED);
+
+    validator.validate(reporter, bundle, event);
+
+    assertHasError(reporter, event, E1326);
+  }
+
+  @Test
+  void shouldFailWhenSingleEventIsCompletedAndBlockEntryFormIsEnabled() {
+    stubProgramStage(true);
+    Event event =
+        SingleEvent.builder()
+            .event(UID.generate())
+            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
+            .status(EventStatus.COMPLETED)
+            .build();
+
+    validator.validate(reporter, bundle, event);
+
+    assertHasError(reporter, event, E1326);
+  }
+
+  @Test
+  void shouldPassWhenEventIsCompletedButBlockEntryFormIsDisabled() {
+    stubProgramStage(false);
+    Event event = trackerEvent(EventStatus.COMPLETED);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = EventStatus.class,
+      mode = Mode.EXCLUDE,
+      names = {"COMPLETED"})
+  void shouldPassWhenBlockEntryFormIsEnabledButEventIsNotCompleted(EventStatus status) {
+    stubProgramStage(true);
+    Event event = trackerEvent(status);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldOnlyRunOnUpdate() {
+    assertTrue(validator.needsToRun(TrackerImportStrategy.UPDATE));
+    assertFalse(validator.needsToRun(TrackerImportStrategy.CREATE));
+    assertFalse(validator.needsToRun(TrackerImportStrategy.CREATE_AND_UPDATE));
+    assertFalse(validator.needsToRun(TrackerImportStrategy.DELETE));
+  }
+
+  private void stubProgramStage(boolean blockEntryForm) {
+    ProgramStage programStage = new ProgramStage();
+    programStage.setUid(PROGRAM_STAGE_UID);
+    programStage.setBlockEntryForm(blockEntryForm);
+    when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
+        .thenReturn(programStage);
+  }
+
+  private Event trackerEvent(EventStatus status) {
+    return TrackerEvent.builder()
+        .event(UID.generate())
+        .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
+        .status(status)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

Enforces the "Block entry form after completion" program-stage setting on the tracker import API. Until now `ProgramStage.blockEntryForm` was only honored client-side in Capture, so the API still accepted updates to completed events. This adds a server-side validation that rejects such updates, requiring the event to be reopened first.

## Changes

- `BlockEntryFormAfterCompletionValidator.java` (new): Rejects an event update when the event status is `COMPLETED` and its `ProgramStage` has `blockEntryForm` enabled. Runs only on the `UPDATE` strategy. To modify the event the user must first reopen it (change its status away from `COMPLETED`).
- `EventValidator.java`: Wires the new validator into the event validation chain.
- `ValidationCode.java`: Adds error code `E1326` with a message explaining that the entry form is blocked and the event must be reopened before it can be updated.
- `BlockEntryFormAfterCompletionValidatorTest.java` (new): Covers the failure cases for `TrackerEvent` and `SingleEvent` when completed with the flag enabled, the pass case when the flag is disabled, the pass case for every non-`COMPLETED` status (the reopen path), and that the validator only runs on `UPDATE`.
