### PR TITLE
feat: add GROUP BY support to tracked entity renderable SQL [DHIS2-21728]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/RenderableSqlQuery.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/RenderableSqlQuery.java
@@ -73,6 +73,8 @@ public class RenderableSqlQuery implements Renderable {
 
   private static final String ORDER_BY = "ORDER_BY";
 
+  private static final String GROUP_BY = "GROUP_BY";
+
   private static final String WHERE = "WHERE";
 
   private static final String FROM = "FROM";
@@ -82,6 +84,8 @@ public class RenderableSqlQuery implements Renderable {
   private final boolean countRequested;
 
   @Singular private final List<Field> selectFields;
+
+  @Singular private final List<Field> groupByFields;
 
   private final Table mainTable;
 
@@ -114,10 +118,16 @@ public class RenderableSqlQuery implements Renderable {
   }
 
   private String renderSqlQuery() {
-    return renderParts(select(), from(), where(), order(), limitOffset());
+    return renderParts(select(), from(), where(), groupBy(), order(), limitOffset());
   }
 
   private String renderSqlCountQuery() {
+    String groupBy = groupBy();
+    if (groupBy != null) {
+      return "select count(*) from ("
+          + renderParts(select(), from(), where(), groupBy)
+          + ") subquery";
+    }
     return renderParts(COUNT_1.render(), from(), where());
   }
 
@@ -144,6 +154,25 @@ public class RenderableSqlQuery implements Renderable {
 
   private String select() {
     return getIfPresentOrElse(SELECT, () -> Select.of(nonVirtualSelectFields()).render());
+  }
+
+  private String groupBy() {
+    return getIfPresentOrElse(GROUP_BY, this::renderGroupBy);
+  }
+
+  private String renderGroupBy() {
+    List<Field> fields = nonVirtualGroupByFields();
+    if (fields.isEmpty()) {
+      return null;
+    }
+    return fields.stream().map(Field::render).collect(Collectors.joining(", ", "group by ", ""));
+  }
+
+  private List<Field> nonVirtualGroupByFields() {
+    return groupByFields.stream()
+        .filter(Predicate.not(Field::isVirtual))
+        .filter(distinctByRendered())
+        .toList();
   }
 
   private List<Field> nonVirtualSelectFields() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorService.java
@@ -119,6 +119,7 @@ public class SqlQueryCreatorService {
       RenderableSqlQuery initial, RenderableSqlQuery contribution) {
     RenderableSqlQuery.RenderableSqlQueryBuilder sqlQueryContextBuilder = initial.toBuilder();
     contribution.getSelectFields().forEach(sqlQueryContextBuilder::selectField);
+    contribution.getGroupByFields().forEach(sqlQueryContextBuilder::groupByField);
     contribution.getLeftJoins().forEach(sqlQueryContextBuilder::leftJoin);
     contribution.getGroupableConditions().forEach(sqlQueryContextBuilder::groupableCondition);
     contribution.getOrderClauses().forEach(sqlQueryContextBuilder::orderClause);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/RenderableSqlQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/RenderableSqlQueryTest.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.analytics.common.query.Order;
 import org.hisp.dhis.analytics.common.query.Table;
 import org.hisp.dhis.common.SortDirection;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -77,5 +78,54 @@ class RenderableSqlQueryTest {
                 .orderClause(IndexedOrder.of(1, Order.of(() -> "orderField", SortDirection.ASC)))
                 .groupableCondition(GroupableCondition.of("group", () -> "condition1"))
                 .build()));
+  }
+
+  @Test
+  void testRenderQueryWithGroupByBetweenWhereAndOrder() {
+    RenderableSqlQuery query =
+        RenderableSqlQuery.builder()
+            .selectField(Field.of("t1", () -> "ou", "ou"))
+            .selectField(Field.ofUnquoted("", () -> "count(1)", "value"))
+            .mainTable(Table.of(() -> "table1", () -> "t1"))
+            .groupByField(Field.of("t1", () -> "ou", ""))
+            .groupableCondition(GroupableCondition.of("group", () -> "condition"))
+            .orderClause(IndexedOrder.of(1, Order.of(() -> "orderField", SortDirection.ASC)))
+            .limitOffset(LimitOffset.of(10, 20, false))
+            .build();
+
+    Assertions.assertEquals(
+        """
+        select t1."ou" as "ou", count(1) as "value" from table1 t1 where condition group by t1."ou" order by orderField nulls last limit 10 offset 20""",
+        query.render());
+  }
+
+  @Test
+  void testRenderCountQueryWithGroupByWrapsInSubquery() {
+    RenderableSqlQuery query =
+        RenderableSqlQuery.builder()
+            .selectField(Field.of("t1", () -> "ou", "ou"))
+            .selectField(Field.ofUnquoted("", () -> "count(1)", "value"))
+            .mainTable(Table.of(() -> "table1", () -> "t1"))
+            .groupByField(Field.of("t1", () -> "ou", ""))
+            .groupableCondition(GroupableCondition.of("group", () -> "condition"))
+            .build();
+
+    Assertions.assertEquals(
+        """
+        select count(*) from (select t1."ou" as "ou", count(1) as "value" from table1 t1 where condition group by t1."ou") subquery""",
+        query.forCount().render());
+  }
+
+  @Test
+  void testRenderCountQueryWithoutGroupByUsesCountOne() {
+    RenderableSqlQuery query =
+        RenderableSqlQuery.builder()
+            .selectField(Field.of("t1", () -> "field1", "alias1"))
+            .mainTable(Table.of(() -> "table1", () -> "t1"))
+            .groupableCondition(GroupableCondition.of("group", () -> "condition"))
+            .build();
+
+    Assertions.assertEquals(
+        "select count(1) from table1 t1 where condition", query.forCount().render());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -47,6 +48,7 @@ import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
 import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.DataElementQueryBuilder;
@@ -77,10 +79,12 @@ import org.junit.jupiter.api.Test;
 class SqlQueryCreatorServiceTest extends TestBase {
   private SqlQueryCreatorService sqlQueryCreatorService;
 
+  private List<SqlQueryBuilder> queryBuilders;
+
   @BeforeEach
   void setUp() {
     ProgramIndicatorService programIndicatorService = mock(ProgramIndicatorService.class);
-    List<SqlQueryBuilder> queryBuilders =
+    queryBuilders =
         List.of(
             new DataElementQueryBuilder(),
             new LimitOffsetQueryBuilder(),
@@ -188,6 +192,44 @@ class SqlQueryCreatorServiceTest extends TestBase {
 
     assertTrue(sql.contains("ouname"));
     assertContains("(t_1.\"program1\" or t_1.\"program2\")", sql);
+  }
+
+  @Test
+  void testGroupByFieldsArePropagatedToFinalQuery() {
+    List<SqlQueryBuilder> buildersWithGroupBy = new ArrayList<>(queryBuilders);
+    buildersWithGroupBy.add(new GroupByStubBuilder());
+    SqlQueryCreatorService service = new SqlQueryCreatorService(buildersWithGroupBy);
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().trackedEntityType(createTrackedEntityType('A')).build();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(new CommonRequestParams())
+            .commonParsed(stubSortingCommonParams(null, 1, "ouname"))
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertContains("group by t_1.\"ou\"", sql);
+  }
+
+  /** Stub builder that contributes a group-by field, used to verify group-by propagation. */
+  private static class GroupByStubBuilder implements SqlQueryBuilder {
+    @Override
+    public RenderableSqlQuery buildSqlQuery(
+        QueryContext queryContext,
+        List<DimensionIdentifier<DimensionParam>> acceptedHeaders,
+        List<DimensionIdentifier<DimensionParam>> acceptedDimensions,
+        List<AnalyticsSortingParams> acceptedSortingParams) {
+      return RenderableSqlQuery.builder().groupByField(Field.of("t_1", () -> "ou", "")).build();
+    }
+
+    @Override
+    public boolean alwaysRun() {
+      return true;
+    }
   }
 
   private Program mockProgram(String uid) {


### PR DESCRIPTION
## What

Adds `GROUP BY` capability to the tracked-entity analytics SQL engine - purely at the query-rendering and query-assembly layer. Two focused changes:

- `RenderableSqlQuery` gains a `groupByFields` list and a `groupBy()` renderer. The clause is emitted between `WHERE` and ORDER BY`, only when `group-by` fields are present. The count query is also taught to **count groups** rather than rows: when a group-by is present, `renderSqlCountQuery()` wraps the grouped select as select `count(*)` from (<select … from … where … group by …>) subquery; otherwise it keeps the existing count(1) behaviour unchanged.
- `SqlQueryCreatorService.mergeQueries` propagates each builder's group-by contributions into the final renderable query (one line, mirroring how select fields, joins, and order clauses are already merged).

No API surface, no controller, no service, no new builder - and no change to existing (non-grouped) query behaviour.

## Why

The tracked-entity analytics endpoint (`/api/analytics/trackedEntities/query/{tet}`) is row-level only: one row per tracked entity instance. Unlike events and enrollments, tracked entities have no aggregate query support. Adding that requires the renderable SQL model to be able to express a `GROUP BY` and to count groups for paging — capabilities it does not have today. This PR adds exactly that foundation.

It is deliberately isolated into its own PR because it modifies `RenderableSqlQuery`, a class on the live row-level query path. 

## Groundwork for follow-up work

Sub-task **1** of the tracked-entity aggregate feature (parent DHIS2-21690). The capability added here is unused until later sub-tasks use it:

1. COUNT aggregate, end-to-end — a new `AggregateQueryBuilder` that owns the `SELECT` and feeds the `group-by` fields this PR consumes, plus the params, service, grid, and `aggregate/{tet}` endpoints.
2. Numeric value aggregations - `SUM` / `AVERAGE` / `MIN` / `MAX` / `STDDEV` / `VARIANCE` over a **numeric** tracked-entity attribute.