### PR TITLE
perf: Use new platform-perf DB with more user data for deletion handlers

### DIFF
--- a/.github/workflows/performance-tests-scheduled.yml
+++ b/.github/workflows/performance-tests-scheduled.yml
@@ -40,7 +40,7 @@ jobs:
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
               DB_DIR=dev
               DB_TYPE=platform-perf
-              DB_VERSION=44-2026-06-03
+              DB_VERSION=44-2026-06-30
               WARMUP=2
               MVN_ARGS="-Diterations=10 -Dprofile=smoke"
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
@@ -50,7 +50,7 @@ jobs:
               SIMULATION_CLASS=org.hisp.dhis.test.platform.UsersPerformanceTest
               DB_DIR=dev
               DB_TYPE=platform-perf
-              DB_VERSION=44-2026-06-03
+              DB_VERSION=44-2026-06-30
               MVN_ARGS=-Diterations=30
             slack_webhook_secret: SLACK_WEBHOOK_PLATFORM_PERFORMANCE
     uses: ./.github/workflows/performance-tests.yml

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/UsersPerformanceTest.java
@@ -203,7 +203,7 @@ public class UsersPerformanceTest extends Simulation {
       Map.of(Profile.SMOKE, new Thresholds(150, 160), Profile.LOAD, new Thresholds(150, 300));
 
   private static final Map<Profile, Thresholds> DELETE_THRESH =
-      Map.of(Profile.SMOKE, new Thresholds(250, 260), Profile.LOAD, new Thresholds(250, 280));
+      Map.of(Profile.SMOKE, new Thresholds(1000, 1000), Profile.LOAD, new Thresholds(1000, 1000));
 
   // Timestamp-based offset so each run generates unique usernames
   private static final int RUN_OFFSET = (int) (System.currentTimeMillis() % 10_000_000);


### PR DESCRIPTION
- use new `platform-perf` DB that includes extra user data for deletion handlers (noted below)
  - user data does not contain data that triggers delete not allowed exceptions as this would fail the tests
- update DELETE thresholds to reflect test running against more data
  - previous DELETE test was against users with few associations 
  - detailed in https://github.com/dhis2/dhis2-core/pull/24304 

| Data | Table(s) | per user | Handler exercised |
| -- | -- | -- | -- |
| User settings | usersetting | 15 | UserSettingDeletionHandler |
| Datastore entries | userkeyjsonvalue | 15 | UserDatastoreDeletionHandler |
| Data-view OUs | userdatavieworgunits | 10 | cascade cleanup |
| TEI-search OUs | userteisearchorgunits | 10 | cascade cleanup |
| Previous passwords | previouspasswords | 3 | cascade cleanup |
| Interpretations | interpretation | 5 | InterpretationDeletionHandler (null-out) |
| Messages | messageconversation +3 | 5 | message handler (sender/recipient) |
| Dashboard items | dashboarditem +_users | 5 | DashboardItemDeletionHandler |
