### PR TITLE
feat: support COUNT aggregate SQL generation for tracked entities [DHIS2-21729]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryParams.java
@@ -45,4 +45,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 @Builder(toBuilder = true)
 public class TrackedEntityQueryParams {
   private final TrackedEntityType trackedEntityType;
+
+  /** When true, the query produces an aggregate (grouped) result instead of one row per TEI. */
+  private boolean aggregate;
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity.query.context.querybuilder;
+
+import java.util.List;
+import java.util.function.Predicate;
+import lombok.Getter;
+import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.QueryContext;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryBuilder;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Service;
+
+/**
+ * Builds the SELECT and GROUP BY of a tracked entity aggregate (grouped) query. Owns the SELECT in
+ * aggregate mode: the requested dimensions become both select columns and group-by keys, plus a
+ * trailing aggregate value column.
+ */
+@Service
+@Order(0)
+public class AggregateQueryBuilder implements SqlQueryBuilder {
+
+  @Getter
+  private final List<Predicate<DimensionIdentifier<DimensionParam>>> dimensionFilters =
+      List.of(
+          dimension ->
+              OrgUnitQueryBuilder.isOu(dimension)
+                  || TrackedEntityQueryBuilder.isTrackedEntity(dimension));
+
+  @Override
+  public RenderableSqlQuery buildSqlQuery(
+      QueryContext queryContext,
+      List<DimensionIdentifier<DimensionParam>> acceptedHeaders,
+      List<DimensionIdentifier<DimensionParam>> acceptedDimensions,
+      List<AnalyticsSortingParams> acceptedSortingParams) {
+    if (!queryContext.isAggregate()) {
+      return RenderableSqlQuery.builder().build();
+    }
+
+    RenderableSqlQuery.RenderableSqlQueryBuilder builder = RenderableSqlQuery.builder();
+
+    // Each requested dimension is both a select column and a group-by key. The same
+    // alias-free field is used for both: an "as <alias>" suffix is invalid inside a GROUP BY,
+    // and the column name already identifies the dimension item.
+    acceptedDimensions.forEach(
+        dimension -> {
+          Field field = Field.ofDimensionIdentifier(dimension);
+          builder.selectField(field);
+          builder.groupByField(field);
+        });
+
+    // The aggregate value column is the last select column and is not grouped.
+    builder.selectField(Field.ofUnquoted("", () -> "count(1)", "value"));
+
+    return builder.build();
+  }
+
+  @Override
+  public boolean alwaysRun() {
+    return true;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/TrackedEntityQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/TrackedEntityQueryBuilder.java
@@ -91,6 +91,13 @@ public class TrackedEntityQueryBuilder extends SqlQueryBuilderAdaptor {
 
   @Override
   protected Stream<Field> getSelect(QueryContext queryContext) {
+    // In aggregate mode the AggregateQueryBuilder owns the SELECT; this builder's per-TEI columns
+    // (static fields, attributes, OU group-set columns, enrollments JSON) must not pollute the
+    // grouped query.
+    if (queryContext.isAggregate()) {
+      return Stream.empty();
+    }
+
     String aggregationQuery =
         SqlQueryBuilders.getJsonAggregationQuery(queryContext.getTetTableSuffix());
 
@@ -142,7 +149,7 @@ public class TrackedEntityQueryBuilder extends SqlQueryBuilderAdaptor {
    * @param dimensionIdentifier the dimension identifier
    * @return true if the given dimension identifier is either a TE dimension or a Program indicator
    */
-  private static boolean isTrackedEntity(DimensionIdentifier<DimensionParam> dimensionIdentifier) {
+  public static boolean isTrackedEntity(DimensionIdentifier<DimensionParam> dimensionIdentifier) {
     return
     // Will match all dimensionIdentifiers like {dimensionUid}.
     dimensionIdentifier.getDimensionIdentifierType() == TRACKED_ENTITY

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/QueryContext.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/QueryContext.java
@@ -59,4 +59,9 @@ public class QueryContext {
     TrackedEntityQueryParams trackedEntityQueryParams = contextParams.getTypedParsed();
     return trackedEntityQueryParams.getTrackedEntityType().getUid().toLowerCase();
   }
+
+  /** Whether the query runs in aggregate (grouped) mode. */
+  public boolean isAggregate() {
+    return contextParams.getTypedParsed().isAggregate();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.analytics.trackedentity.query.context.sql;
 
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,6 +52,7 @@ import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
 import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
+import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.AggregateQueryBuilder;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.DataElementQueryBuilder;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.EnrolledInProgramQueryBuilder;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.LimitOffsetQueryBuilder;
@@ -60,9 +62,11 @@ import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.PeriodQu
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.ProgramIndicatorQueryBuilder;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.TrackedEntityQueryBuilder;
 import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramStage;
@@ -213,6 +217,127 @@ class SqlQueryCreatorServiceTest extends TestBase {
     String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
 
     assertContains("group by t_1.\"ou\"", sql);
+  }
+
+  @Test
+  void testAggregateCountGroupedByOrgUnit() {
+    List<SqlQueryBuilder> aggregateBuilders = new ArrayList<>();
+    aggregateBuilders.add(new AggregateQueryBuilder());
+    aggregateBuilders.addAll(queryBuilders);
+    SqlQueryCreatorService service = new SqlQueryCreatorService(aggregateBuilders);
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(createTrackedEntityType('A'))
+            .aggregate(true)
+            .build();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(new CommonRequestParams())
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                    .build())
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertContains("count(1) as \"value\"", sql);
+    assertContains("group by t_1.\"ou\"", sql);
+    assertFalse(
+        sql.contains("enrollments"), "per-TEI columns must be suppressed in aggregate mode");
+  }
+
+  @Test
+  void testAggregateCountGroupedByAttribute() {
+    List<SqlQueryBuilder> aggregateBuilders = new ArrayList<>();
+    aggregateBuilders.add(new AggregateQueryBuilder());
+    aggregateBuilders.addAll(queryBuilders);
+    SqlQueryCreatorService service = new SqlQueryCreatorService(aggregateBuilders);
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(createTrackedEntityType('A'))
+            .aggregate(true)
+            .build();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(new CommonRequestParams())
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(List.of(stubAttributeDimension("attr1")))
+                    .build())
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertContains("count(1) as \"value\"", sql);
+    assertContains("group by t_1.\"attr1\"", sql);
+  }
+
+  @Test
+  void testAggregateCountGroupedByOrgUnitAndAttribute() {
+    List<SqlQueryBuilder> aggregateBuilders = new ArrayList<>();
+    aggregateBuilders.add(new AggregateQueryBuilder());
+    aggregateBuilders.addAll(queryBuilders);
+    SqlQueryCreatorService service = new SqlQueryCreatorService(aggregateBuilders);
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(createTrackedEntityType('A'))
+            .aggregate(true)
+            .build();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(new CommonRequestParams())
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(
+                        List.of(stubOuDimension("ou1"), stubAttributeDimension("attr1")))
+                    .build())
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    // every dimension becomes a group-by key; the value column is last and not grouped.
+    assertContains("select t_1.\"ou\", t_1.\"attr1\", count(1) as \"value\"", sql);
+    assertContains("group by t_1.\"ou\", t_1.\"attr1\"", sql);
+  }
+
+  private DimensionIdentifier<DimensionParam> stubAttributeDimension(String attribute) {
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new BaseDimensionalObject(attribute, DimensionType.PROGRAM_ATTRIBUTE, List.of()),
+            DimensionParamType.DIMENSIONS,
+            UID,
+            List.of());
+    return DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam)
+        .withDefaultGroupId();
+  }
+
+  private DimensionIdentifier<DimensionParam> stubOuDimension(String ou) {
+    OrganisationUnit orgUnit = new OrganisationUnit();
+    orgUnit.setUid(ou);
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new BaseDimensionalObject("ou", DimensionType.ORGANISATION_UNIT, List.of(orgUnit)),
+            DimensionParamType.DIMENSIONS,
+            UID,
+            List.of(ou));
+    return DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam)
+        .withDefaultGroupId();
   }
 
   /** Stub builder that contributes a group-by field, used to verify group-by propagation. */


### PR DESCRIPTION
## Summary

Adds the SQL-generation layer for `COUNT` aggregate queries on tracked entities (sub-task 2a of DHIS2-21690). In aggregate mode, a new `AggregateQueryBuilder` builds the `SELECT` - turning each requested dimension into a `GROUP BY` key and adding a `count(1)` value column — while `TrackedEntityQueryBuilder` "suppresses" its per-TEI columns so they don't pollute the grouped query.

This is the query-building layer only: there is no HTTP endpoint yet.

### What's now supported

Grouped `COUNT` of tracked entity instances by:
- org unit (dimension=ou)
- TE attributes (dimension=<attributeUid>)
- any combination of the above

Each requested dimension becomes both a SELECT column and a GROUP BY key; the count(1) as "value" column is always last and is not grouped.


### Example

Request dimensions `ou` + a TE attribute `attr1` in aggregate mode generates:

```sql
select t_1."ou", t_1."attr1", count(1) as "value"
from analytics_te_<tet> t_1
where <filters>
group by t_1."ou", t_1."attr1"
```
