### PR TITLE
fix: Hide ID scheme in response. Use UID instead [DHIS2-17214]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/scheme/SchemeInfo.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/scheme/SchemeInfo.java
@@ -76,26 +76,26 @@ public record SchemeInfo(Settings settings, Data data) {
 
     /** Indicates whether this query defines an identifier scheme different from UID. */
     public boolean isGeneralOutputIdSchemeSet() {
-      return outputIdScheme != null && !IdScheme.UID.equals(outputIdScheme);
+      return outputIdScheme != null;
     }
 
     /** Indicates whether this query defines an identifier scheme different from UID. */
     public boolean isDataIdSchemeSet() {
-      return dataIdScheme != null && !IdScheme.UID.equals(dataIdScheme);
+      return dataIdScheme != null;
     }
 
     public boolean isOutputDataItemIdSchemeSet() {
-      return outputDataItemIdScheme != null && !IdScheme.UID.equals(outputDataItemIdScheme);
+      return outputDataItemIdScheme != null;
     }
 
     /** Indicates whether this query defines an identifier scheme different from UID. */
     public boolean isOutputDataElementIdSchemeSet() {
-      return outputDataElementIdScheme != null && !IdScheme.UID.equals(outputDataElementIdScheme);
+      return outputDataElementIdScheme != null;
     }
 
     /** Indicates whether this query defines an identifier scheme different from UID. */
     public boolean isOutputOrgUnitIdSchemeSet() {
-      return outputOrgUnitIdScheme != null && !IdScheme.UID.equals(outputOrgUnitIdScheme);
+      return outputOrgUnitIdScheme != null;
     }
 
     /** Indicates whether a non-default identifier scheme is specified. */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.analytics.common.processing.MetadataDimensionsHandler.getDistinctPeriodUids;
+import static org.hisp.dhis.analytics.tracker.SchemeIdHandler.getValidScheme;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getCocNameMap;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getDimensionMetadataItemMap;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.handleGridForDataValueSet;
@@ -198,12 +199,12 @@ public class MetadataHandler {
         .build();
   }
 
-  private Settings schemeSettings(DataQueryParams params) {
+  Settings schemeSettings(DataQueryParams params) {
     return Settings.builder()
-        .outputDataElementIdScheme(params.getOutputDataElementIdScheme())
-        .outputDataItemIdScheme(params.getOutputDataItemIdScheme())
-        .outputIdScheme(params.getOutputIdScheme())
-        .outputOrgUnitIdScheme(params.getOutputOrgUnitIdScheme())
+        .outputDataElementIdScheme(getValidScheme(params.getOutputDataElementIdScheme()))
+        .outputDataItemIdScheme(getValidScheme(params.getOutputDataItemIdScheme()))
+        .outputIdScheme(getValidScheme(params.getOutputIdScheme()))
+        .outputOrgUnitIdScheme(getValidScheme(params.getOutputOrgUnitIdScheme()))
         .outputFormat(params.getOutputFormat())
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/SchemeIdHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/SchemeIdHandler.java
@@ -29,7 +29,9 @@
  */
 package org.hisp.dhis.analytics.tracker;
 
+import static org.hisp.dhis.common.IdScheme.ID;
 import static org.hisp.dhis.common.IdScheme.NAME;
+import static org.hisp.dhis.common.IdScheme.UID;
 
 import java.util.LinkedHashSet;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ import org.hisp.dhis.analytics.common.scheme.SchemeInfo.Settings;
 import org.hisp.dhis.analytics.data.handler.SchemeIdResponseMapper;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IdScheme;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -76,14 +79,29 @@ public class SchemeIdHandler {
         .build();
   }
 
-  private Settings schemeSettings(EventQueryParams params) {
+  Settings schemeSettings(EventQueryParams params) {
     return Settings.builder()
-        .dataIdScheme(params.getDataIdScheme())
-        .outputDataElementIdScheme(params.getOutputDataElementIdScheme())
-        .outputDataItemIdScheme(params.getOutputDataItemIdScheme())
-        .outputIdScheme(params.getOutputIdScheme())
-        .outputOrgUnitIdScheme(params.getOutputOrgUnitIdScheme())
+        .dataIdScheme(getValidScheme(params.getDataIdScheme()))
+        .outputDataElementIdScheme(getValidScheme(params.getOutputDataElementIdScheme()))
+        .outputDataItemIdScheme(getValidScheme(params.getOutputDataItemIdScheme()))
+        .outputIdScheme(getValidScheme(params.getOutputIdScheme()))
+        .outputOrgUnitIdScheme(getValidScheme(params.getOutputOrgUnitIdScheme()))
         .outputFormat(params.getOutputFormat())
         .build();
+  }
+
+  /**
+   * It returns a valid IdScheme, switching ID by UID if applicable. IDs cannot be exposed to users
+   * as they are internal PKs at database level.
+   *
+   * @param idScheme the {@link IdScheme}.
+   * @return the {@link IdScheme}.
+   */
+  public static IdScheme getValidScheme(IdScheme idScheme) {
+    if (idScheme == ID) {
+      return UID;
+    }
+
+    return idScheme;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/MetadataHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/MetadataHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.data.handler;
+
+import static org.hisp.dhis.common.IdScheme.ID;
+import static org.hisp.dhis.common.IdScheme.UID;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.common.scheme.SchemeInfo.Settings;
+import org.junit.jupiter.api.Test;
+
+class MetadataHandlerTest {
+
+  @Test
+  void schemeSettingsReturnsUIDWhenID() {
+    DataQueryParams params =
+        DataQueryParams.newBuilder()
+            .withOutputIdScheme(ID)
+            .withOutputDataElementIdScheme(ID)
+            .withOutputDataItemIdScheme(ID)
+            .withOutputOrgUnitIdScheme(ID)
+            .build();
+
+    Settings settings = new MetadataHandler(null, null, null).schemeSettings(params);
+
+    assertEquals(UID, settings.getOutputIdScheme());
+    assertEquals(UID, settings.getOutputDataElementIdScheme());
+    assertEquals(UID, settings.getOutputDataItemIdScheme());
+    assertEquals(UID, settings.getOutputOrgUnitIdScheme());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -48,7 +48,6 @@ import static org.hisp.dhis.test.TestBase.createOrganisationUnit;
 import static org.hisp.dhis.test.TestBase.createProgram;
 import static org.hisp.dhis.test.TestBase.createTrackedEntityAttribute;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -374,11 +373,10 @@ class SchemeIdResponseMapperTest {
 
     assertThat(responseMap.get(orgUnitUid), is(equalTo(organisationUnit.getUid())));
     assertThat(responseMap.get(periodIsoDate), is(equalTo(period.getUid())));
-    assertThat(responseMap.get(dataElementA.getUid()), is(emptyOrNullString()));
-    assertThat(responseMap.get(dataElementB.getUid()), is(emptyOrNullString()));
+    assertThat(responseMap.get(dataElementA.getUid()), is(dataElementA.getUid()));
+    assertThat(responseMap.get(dataElementB.getUid()), is(dataElementB.getUid()));
     assertThat(responseMap.get(dataElement.getUid()), is(dataElement.getUid()));
-    assertThat(responseMap.get(categoryOptionComboC.getUid()), is(emptyOrNullString()));
-    assertThat(responseMap.get(categoryOptionComboC.getUid()), is(emptyOrNullString()));
+    assertThat(responseMap.get(categoryOptionComboC.getUid()), is(categoryOptionComboC.getUid()));
   }
 
   @Test
@@ -721,7 +719,7 @@ class SchemeIdResponseMapperTest {
 
     // Uid is the default, so conversion is not needed. The map will not contain any conversion on
     // this case.
-    assertNull(responseMap.get(program.getUid()));
+    assertEquals(program.getUid(), responseMap.get(program.getUid()));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/SchemeIdHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/SchemeIdHandlerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.tracker;
+
+import static org.hisp.dhis.analytics.event.EventQueryParams.fromDataQueryParams;
+import static org.hisp.dhis.common.IdScheme.ID;
+import static org.hisp.dhis.common.IdScheme.UID;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.common.scheme.SchemeInfo.Settings;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.junit.jupiter.api.Test;
+
+class SchemeIdHandlerTest {
+
+  @Test
+  void schemeSettingsReturnsUIDWhenID() {
+    EventQueryParams params =
+        fromDataQueryParams(DataQueryParams.newBuilder().withOutputIdScheme(ID).build());
+
+    Settings settings = new SchemeIdHandler(null).schemeSettings(params);
+
+    assertEquals(UID, settings.getOutputIdScheme());
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv16AutoTest.java
@@ -1138,4 +1138,210 @@ public class AnalyticsQueryDv16AutoTest extends AnalyticsApiTest {
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("dx", piUid, "value", "1.0"));
   }
+
+  @Test
+  public void outputIdSchemeWithId() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("showHierarchy=false")
+            .add("includeMetadataDetails=true")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("includeNumDen=true")
+            .add("hierarchyMeta=false")
+            .add("outputIdScheme=ID")
+            .add("completedOnly=false")
+            .add(
+                "dimension=dx:cYeuwXTCPkU;Jtf34kNZhzP;hfdmMSPBgLG;fbfJHSPpUQD,ou:USER_ORGUNIT_CHILDREN")
+            .add("skipRounding=false")
+            .add("relativePeriodDate=2026-06-01");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"jUb8gELQApl\":{\"uid\":\"jUb8gELQApl\",\"code\":\"OU_204856\",\"name\":\"Kailahun\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"eIQbndfxQMb\":{\"uid\":\"eIQbndfxQMb\",\"code\":\"OU_268149\",\"name\":\"Tonkolili\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"Vth0fbpFcsO\":{\"uid\":\"Vth0fbpFcsO\",\"code\":\"OU_233310\",\"name\":\"Kono\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"O6uvpzGd5pu\":{\"uid\":\"O6uvpzGd5pu\",\"code\":\"OU_264\",\"name\":\"Bo\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"bL4ooGhyHRQ\":{\"uid\":\"bL4ooGhyHRQ\",\"code\":\"OU_260377\",\"name\":\"Pujehun\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"kJq2mPyFEHo\":{\"uid\":\"kJq2mPyFEHo\",\"code\":\"OU_222616\",\"name\":\"Kenema\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"hfdmMSPBgLG\":{\"uid\":\"hfdmMSPBgLG\",\"code\":\"DE_359599\",\"name\":\"ANC 4th or more visits\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"at6UHUQatSo\":{\"uid\":\"at6UHUQatSo\",\"code\":\"OU_278310\",\"name\":\"Western Area\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"dx\":{\"uid\":\"dx\",\"name\":\"Data\",\"dimensionType\":\"DATA_X\"},\"pq2XI5kz2BY\":{\"uid\":\"pq2XI5kz2BY\",\"code\":\"COC_167661\",\"name\":\"Fixed\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"2025\":{\"uid\":\"2025\",\"code\":\"2025\",\"name\":\"2025\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2025-01-01T00:00:00.000\",\"endDate\":\"2025-12-31T00:00:00.000\"},\"Jtf34kNZhzP\":{\"uid\":\"Jtf34kNZhzP\",\"code\":\"DE_359598\",\"name\":\"ANC 3rd visit\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"2024\":{\"uid\":\"2024\",\"code\":\"2024\",\"name\":\"2024\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2024-01-01T00:00:00.000\",\"endDate\":\"2024-12-31T00:00:00.000\"},\"PT59n8BQbqM\":{\"uid\":\"PT59n8BQbqM\",\"code\":\"COC_167660\",\"name\":\"Outreach\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"TEQlaapDQoK\":{\"uid\":\"TEQlaapDQoK\",\"code\":\"OU_254945\",\"name\":\"Port Loko\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"PMa2VCrupOd\":{\"uid\":\"PMa2VCrupOd\",\"code\":\"OU_211212\",\"name\":\"Kambia\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"2023\":{\"uid\":\"2023\",\"code\":\"2023\",\"name\":\"2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-01-01T00:00:00.000\",\"endDate\":\"2023-12-31T00:00:00.000\"},\"2022\":{\"uid\":\"2022\",\"code\":\"2022\",\"name\":\"2022\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2022-01-01T00:00:00.000\",\"endDate\":\"2022-12-31T00:00:00.000\"},\"2021\":{\"uid\":\"2021\",\"code\":\"2021\",\"name\":\"2021\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2021-01-01T00:00:00.000\",\"endDate\":\"2021-12-31T00:00:00.000\"},\"fbfJHSPpUQD\":{\"uid\":\"fbfJHSPpUQD\",\"code\":\"DE_359596\",\"name\":\"ANC 1st visit\",\"legendSet\":\"fqs276KXCXi\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"LAST_5_YEARS\":{\"name\":\"Last 5 years\"},\"USER_ORGUNIT_CHILDREN\":{\"organisationUnits\":[\"at6UHUQatSo\",\"TEQlaapDQoK\",\"PMa2VCrupOd\",\"qhqAxPSTUXp\",\"kJq2mPyFEHo\",\"jmIPBj66vD6\",\"Vth0fbpFcsO\",\"jUb8gELQApl\",\"fdc6uOvgoji\",\"eIQbndfxQMb\",\"O6uvpzGd5pu\",\"lc3eMKXaEfw\",\"bL4ooGhyHRQ\"]},\"fdc6uOvgoji\":{\"uid\":\"fdc6uOvgoji\",\"code\":\"OU_193190\",\"name\":\"Bombali\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"name\":\"Period\",\"dimensionType\":\"PERIOD\"},\"cYeuwXTCPkU\":{\"uid\":\"cYeuwXTCPkU\",\"code\":\"DE_359597\",\"name\":\"ANC 2nd visit\",\"legendSet\":\"fqs276KXCXi\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"lc3eMKXaEfw\":{\"uid\":\"lc3eMKXaEfw\",\"code\":\"OU_197385\",\"name\":\"Bonthe\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"qhqAxPSTUXp\":{\"uid\":\"qhqAxPSTUXp\",\"code\":\"OU_226213\",\"name\":\"Koinadugu\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"jmIPBj66vD6\":{\"uid\":\"jmIPBj66vD6\",\"code\":\"OU_246990\",\"name\":\"Moyamba\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"dx\":[\"cYeuwXTCPkU\",\"Jtf34kNZhzP\",\"hfdmMSPBgLG\",\"fbfJHSPpUQD\"],\"pe\":[\"2021\",\"2022\",\"2023\",\"2024\",\"2025\"],\"ou\":[\"O6uvpzGd5pu\",\"fdc6uOvgoji\",\"lc3eMKXaEfw\",\"jUb8gELQApl\",\"PMa2VCrupOd\",\"kJq2mPyFEHo\",\"qhqAxPSTUXp\",\"Vth0fbpFcsO\",\"jmIPBj66vD6\",\"TEQlaapDQoK\",\"bL4ooGhyHRQ\",\"eIQbndfxQMb\",\"at6UHUQatSo\"],\"co\":[\"pq2XI5kz2BY\",\"PT59n8BQbqM\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "numerator",
+        "Numerator",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "denominator",
+        "Denominator",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "multiplier",
+        "Multiplier",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "hfdmMSPBgLG"),
+            Map.entry("ou", "jmIPBj66vD6"),
+            Map.entry("value", "20618"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 7
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "Jtf34kNZhzP"),
+            Map.entry("ou", "eIQbndfxQMb"),
+            Map.entry("value", "21178"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 14
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "cYeuwXTCPkU"),
+            Map.entry("ou", "lc3eMKXaEfw"),
+            Map.entry("value", "12854"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 21
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "hfdmMSPBgLG"),
+            Map.entry("ou", "PMa2VCrupOd"),
+            Map.entry("value", "9012"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 28
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "Jtf34kNZhzP"),
+            Map.entry("ou", "kJq2mPyFEHo"),
+            Map.entry("value", "44756"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 35
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "hfdmMSPBgLG"),
+            Map.entry("ou", "qhqAxPSTUXp"),
+            Map.entry("value", "7620"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 42
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "hfdmMSPBgLG"),
+            Map.entry("ou", "O6uvpzGd5pu"),
+            Map.entry("value", "26410"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 49
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "fbfJHSPpUQD"),
+            Map.entry("ou", "TEQlaapDQoK"),
+            Map.entry("value", "47546"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+
+    // Validate row exists with values from original row index 51
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.ofEntries(
+            Map.entry("dx", "Jtf34kNZhzP"),
+            Map.entry("ou", "Vth0fbpFcsO"),
+            Map.entry("value", "12956"),
+            Map.entry("numerator", ""),
+            Map.entry("denominator", ""),
+            Map.entry("factor", ""),
+            Map.entry("multiplier", ""),
+            Map.entry("divisor", "")));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/aggregated.json
@@ -218,6 +218,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "outputIdSchemeWithId",
+      "query": "/api/analytics.json?dimension=dx:cYeuwXTCPkU;Jtf34kNZhzP;hfdmMSPBgLG;fbfJHSPpUQD&dimension=ou:USER_ORGUNIT_CHILDREN&showHierarchy=false&hierarchyMeta=false&includeMetadataDetails=true&includeNumDen=true&skipRounding=false&completedOnly=false&outputIdScheme=ID&filter=pe:LAST_5_YEARS&relativePeriodDate=2026-06-01",
+      "version": {
+        "min": 41
+      }
     }
   ]
 }


### PR DESCRIPTION
Using `outputIdSchema=ID` in the analytics endpoint returns the internal Postgres primary keys. These should not be exposed in the export. Additionally, `UID` and `UUID` do not work properly.

This PR aims to fix both issues: avoid exposing PKs and make `UID` and `UUID` work as expected.
