### PR TITLE
fix: Prevent NPE in Visualization [DHIS2-21726]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Verify.verify;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_ANCESTORS;
@@ -1155,14 +1155,28 @@ public class Visualization extends BaseAnalyticalObject implements MetadataObjec
 
     for (String dimension : rowDimensions) {
       String dimensionId = getDimensionIdentifierFor(dimension, getDimensionDescriptors());
-      String name = defaultIfEmpty(metaData.get(dimensionId).getName(), dimensionId);
-      String col = defaultIfEmpty(COLUMN_NAMES.get(dimensionId), dimensionId);
+      String name = extractDimensionName(metaData, dimensionId);
+      String col = defaultIfBlank(COLUMN_NAMES.get(dimensionId), dimensionId);
 
       grid.addHeader(new GridHeader(name + " ID", col + "id", TEXT, true, true));
       grid.addHeader(new GridHeader(name, col + "name", TEXT, false, true));
       grid.addHeader(new GridHeader(name + " code", col + "code", TEXT, true, true));
       grid.addHeader(new GridHeader(name + " description", col + "description", TEXT, true, true));
     }
+  }
+
+  /**
+   * It returns the name of the dimension uid present in the given map, or the dimension uid itself
+   * if the name is blank.
+   *
+   * @param metaData the map of uid-items.
+   * @param dimensionId the dimension uid.
+   * @return the name or the UID.
+   */
+  static String extractDimensionName(Map<String, MetadataItem> metaData, String dimensionId) {
+    return metaData.get(dimensionId) != null
+        ? defaultIfBlank(metaData.get(dimensionId).getName(), dimensionId)
+        : dimensionId;
   }
 
   /** Indicates whether this visualization is multidimensional. */

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/VisualizationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/VisualizationTest.java
@@ -29,10 +29,8 @@
  */
 package org.hisp.dhis.visualization;
 
-import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.hisp.dhis.common.MetadataItem;
 import org.junit.jupiter.api.Test;

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/VisualizationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/visualization/VisualizationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hisp.dhis.common.MetadataItem;
+import org.junit.jupiter.api.Test;
+
+class VisualizationTest {
+
+  @Test
+  void extractDimensionNameHappyFlow() {
+    Map<String, MetadataItem> metaData = Map.of("uid1", new MetadataItem("itemName1"));
+
+    String value = Visualization.extractDimensionName(metaData, "uid1");
+
+    assertEquals("itemName1", value);
+  }
+
+  @Test
+  void extractDimensionWhenNameIsBlank() {
+    Map<String, MetadataItem> metaData = Map.of("uid1", new MetadataItem(" "));
+
+    String value = Visualization.extractDimensionName(metaData, "uid1");
+
+    assertEquals("uid1", value);
+  }
+
+  @Test
+  void extractDimensionWhenNameIsNull() {
+    Map<String, MetadataItem> metaData = Map.of("uid1", new MetadataItem(null));
+
+    String value = Visualization.extractDimensionName(metaData, "uid1");
+
+    assertEquals("uid1", value);
+  }
+}


### PR DESCRIPTION
In some situations, there is no name or dimension UID in the metadata Map (part of the response object), so we have to return the UID itself instead of the dimension name.

The code was not considering such a situation.

In addition, we are now considering blank values as empty/null.
