### PR TITLE
test: Add regression test for externalAuth PUT round-trip [DHIS2-17597]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -933,6 +933,31 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
+  @DisplayName("externalAuth is preserved across repeated full GET/PUT round-trips (DHIS2-17597)")
+  void testPutJsonObjectPreservesExternalAuth() {
+    // given a user that authenticates externally (e.g. OIDC/LDAP)
+    User user = userService.getUser(peter.getUid());
+    user.setExternalAuth(true);
+    userService.updateUser(user);
+
+    // when the full representation is fetched and PUT back unchanged
+    JsonObject body = GET("/users/{id}", peter.getUid()).content();
+    assertTrue(
+        body.getBoolean("externalAuth").booleanValue(),
+        "precondition: fetched payload should carry externalAuth=true");
+    assertStatus(HttpStatus.OK, PUT("/users/" + peter.getUid(), body.toString()));
+    assertTrue(
+        userService.getUser(peter.getUid()).isExternalAuth(),
+        "externalAuth must remain true after the first round-trip PUT");
+
+    // and again with the identical payload: guards against the reported true<->false toggle
+    assertStatus(HttpStatus.OK, PUT("/users/" + peter.getUid(), body.toString()));
+    assertTrue(
+        userService.getUser(peter.getUid()).isExternalAuth(),
+        "externalAuth must remain true after a second identical PUT (no toggle)");
+  }
+
+  @Test
   void testPutJsonObject_AddUserGroupLastUpdatedByUpdated() throws JsonProcessingException {
     // create user
     User newUser = createUserWithAuth("test", "ALL");


### PR DESCRIPTION
## Summary

Adds a controller regression test for [DHIS2-17597](https://dhis2.atlassian.net/browse/DHIS2-17597) ("externalAuth changed to false when it should not be").

The original report (confirmed on 2.39.6 / 2.40.4 / 2.41.0) was that a full `PUT /api/users/{uid}` keeping `externalAuth` unchanged would *toggle* it (true→false→true) on each request.

I re-tested the exact scenario against current master (via `play.im.dhis2.org/dev`): create a user with `externalAuth=true` (+`openId`), then GET the full payload and PUT it back repeatedly while changing another field. **`externalAuth` is preserved correctly — no toggle.** The bug appears to have been resolved incidentally by later User-model / metadata-merge refactors; there is no commit tied to the ticket.

This PR adds a test that locks in the correct behavior so it cannot regress.

## What the test does

`UserControllerTest#testPutJsonObjectPreservesExternalAuth`:
1. Sets `externalAuth=true` on the user.
2. Fetches the full representation and PUTs it back unchanged.
3. Asserts `externalAuth` is still `true`.
4. PUTs the identical payload a second time and asserts it is *still* `true` — the second PUT is what would have exposed the reported toggle.

## Notes / verification

- Behavior verified empirically on master before writing the test.
- I was unable to compile/run the test locally in this environment (no JDK/Maven available). Please confirm CI green. To run locally:
  ```
  mvn install -pl dhis-web-api -am -DskipTests -q
  mvn test -pl dhis-test-web-api -Dtest=UserControllerTest#testPutJsonObjectPreservesExternalAuth
  ```
- Test-only change; no production code touched.

AI Assisted


[DHIS2-17597]: https://dhis2.atlassian.net/browse/DHIS2-17597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ