### PR TITLE
feat: Controller + Service for Tracked Entity aggregate logic [DHIS2-21732]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -613,6 +613,7 @@ public enum ErrorCode {
   /* TE analytics */
   E7250("Dimension is not a fully qualified: `{0}`"),
   E7251("Query does not support program indicators: `{0}`"),
+  E7252("Sorting is only supported on grouped dimensions in an aggregate query: `{0}`"),
   E7253(
       "Dimension `{0}` is not supported for program stage `{1}`. Only event-level dimensions are supported for stage-specific scope"),
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -52,16 +52,21 @@ import org.hisp.dhis.analytics.common.QueryExecutor;
 import org.hisp.dhis.analytics.common.SqlQuery;
 import org.hisp.dhis.analytics.common.SqlQueryResult;
 import org.hisp.dhis.analytics.common.params.AnalyticsPagingParams;
+import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
 import org.hisp.dhis.analytics.common.params.CommonParsedParams;
 import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
+import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.AggregateQueryBuilder;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.ExecutionPlan;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -102,6 +107,8 @@ public class TrackedEntityAggregateService {
     securityManager.applyOrganisationUnitConstraint(commonParams);
     securityManager.applyDimensionConstraints(commonParams);
 
+    validateSorting(contextParams);
+
     SqlQueryCreator queryCreator = sqlQueryCreatorService.getSqlQueryCreator(contextParams);
 
     Optional<SqlQueryResult> result =
@@ -125,6 +132,28 @@ public class TrackedEntityAggregateService {
     metadataParamsHandler.handle(grid, contextParams, currentUser, rowsCount);
     addGroupedOrgUnitMetadata(grid, contextParams);
     return grid;
+  }
+
+  /**
+   * Rejects sort parameters that reference a dimension the aggregate query does not group by.
+   * Sorting on a non-grouped column produces invalid grouped SQL (an {@code ORDER BY} on a column
+   * absent from {@code GROUP BY}). The grouped dimensions are the single source of truth in {@link
+   * AggregateQueryBuilder#getGroupedDimensionKeys}.
+   */
+  private void validateSorting(
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    List<AnalyticsSortingParams> orderParams = contextParams.getCommonParsed().getOrderParams();
+    if (orderParams.isEmpty()) {
+      return;
+    }
+
+    Set<String> groupedKeys = AggregateQueryBuilder.getGroupedDimensionKeys(contextParams);
+    for (AnalyticsSortingParams orderParam : orderParams) {
+      String key = orderParam.getOrderBy().getKey();
+      if (!groupedKeys.contains(key)) {
+        throw new IllegalQueryException(new ErrorMessage(ErrorCode.E7252, key));
+      }
+    }
   }
 
   /**
@@ -205,6 +234,8 @@ public class TrackedEntityAggregateService {
 
   public Grid getGridExplain(
       @Nonnull ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    validateSorting(contextParams);
+
     Grid grid = new ListGrid();
     String explainId = randomUUID().toString();
     SqlQueryCreator queryCreator = sqlQueryCreatorService.getSqlQueryCreator(contextParams);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity;
+
+import static java.util.Collections.singleton;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.analytics.trackedentity.query.TrackedEntityFields.getAggregateGridHeaders;
+import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
+
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
+import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.QueryExecutor;
+import org.hisp.dhis.analytics.common.SqlQuery;
+import org.hisp.dhis.analytics.common.SqlQueryResult;
+import org.hisp.dhis.analytics.common.params.AnalyticsPagingParams;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
+import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
+import org.hisp.dhis.common.ExecutionPlan;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.stereotype.Service;
+
+/** Executes tracked-entity aggregate (grouped) queries and assembles the grouped grid. */
+@Service
+@RequiredArgsConstructor
+public class TrackedEntityAggregateService {
+
+  private static final GridHeader VALUE_HEADER =
+      new GridHeader("value", "Value", ValueType.NUMBER, false, false);
+
+  private final QueryExecutor<SqlQuery, SqlQueryResult> queryExecutor;
+
+  private final SqlQueryCreatorService sqlQueryCreatorService;
+
+  private final ExecutionPlanStore executionPlanStore;
+
+  private final CommonParamsSecurityManager securityManager;
+
+  private final MetadataParamsHandler metadataParamsHandler;
+
+  private final UserService userService;
+
+  public Grid getGrid(
+      @Nonnull ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    CommonParsedParams commonParams = contextParams.getCommonParsed();
+    TrackedEntityQueryParams teParams = contextParams.getTypedParsed();
+
+    securityManager.decideAccess(commonParams, singleton(teParams.getTrackedEntityType()));
+    securityManager.applyOrganisationUnitConstraint(commonParams);
+    securityManager.applyDimensionConstraints(commonParams);
+
+    SqlQueryCreator queryCreator = sqlQueryCreatorService.getSqlQueryCreator(contextParams);
+
+    Optional<SqlQueryResult> result =
+        withExceptionHandling(() -> queryExecutor.find(queryCreator.createForSelect()));
+
+    long rowsCount = 0;
+    AnalyticsPagingParams paging = commonParams.getPagingParams();
+    if (paging.showTotalPages()) {
+      rowsCount =
+          withExceptionHandling(() -> queryExecutor.count(queryCreator.createForCount()))
+              .orElse(0L);
+    }
+
+    List<Field> selectFields = queryCreator.getRenderableSqlQuery().getSelectFields();
+    Grid grid = new ListGrid();
+    getAggregateGridHeaders(contextParams, selectFields).forEach(grid::addHeader);
+    grid.addHeader(VALUE_HEADER);
+
+    result.ifPresent(r -> addGroupedRows(grid, r.result()));
+
+    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    metadataParamsHandler.handle(grid, contextParams, currentUser, rowsCount);
+    return grid;
+  }
+
+  private void addGroupedRows(Grid grid, SqlRowSet rs) {
+    List<String> columns = grid.getHeaders().stream().map(GridHeader::getName).collect(toList());
+    while (rs.next()) {
+      grid.addRow();
+      columns.forEach(col -> grid.addValue(rs.getObject(col)));
+    }
+  }
+
+  public Grid getGridExplain(
+      @Nonnull ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    Grid grid = new ListGrid();
+    String explainId = randomUUID().toString();
+    SqlQueryCreator queryCreator = sqlQueryCreatorService.getSqlQueryCreator(contextParams);
+
+    withExceptionHandling(
+        () -> executionPlanStore.addExecutionPlan(explainId, queryCreator.createForSelect()));
+    if (contextParams.getCommonParsed().getPagingParams().showTotalPages()) {
+      withExceptionHandling(
+          () -> executionPlanStore.addExecutionPlan(explainId, queryCreator.createForCount()));
+    }
+    List<ExecutionPlan> plans = executionPlanStore.getExecutionPlans(explainId);
+    grid.addPerformanceMetrics(plans);
+    return grid;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.analytics.common.SqlQueryResult;
 import org.hisp.dhis.analytics.common.params.AnalyticsPagingParams;
 import org.hisp.dhis.analytics.common.params.CommonParsedParams;
 import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
-import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
 import org.hisp.dhis.common.ExecutionPlan;
@@ -103,9 +102,8 @@ public class TrackedEntityAggregateService {
               .orElse(0L);
     }
 
-    List<Field> selectFields = queryCreator.getRenderableSqlQuery().getSelectFields();
     Grid grid = new ListGrid();
-    getAggregateGridHeaders(contextParams, selectFields).forEach(grid::addHeader);
+    getAggregateGridHeaders(contextParams).forEach(grid::addHeader);
     grid.addHeader(VALUE_HEADER);
 
     result.ifPresent(r -> addGroupedRows(grid, r.result()));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -208,14 +208,7 @@ public class TrackedEntityAggregateService {
       return;
     }
 
-    Set<String> orgUnitUids = new LinkedHashSet<>();
-    for (List<Object> row : grid.getRows()) {
-      Object value = row.get(ouColumnIndex);
-      if (value != null) {
-        orgUnitUids.add(String.valueOf(value));
-      }
-    }
-
+    Set<String> orgUnitUids = getGroupedOrgUnitUids(grid, ouColumnIndex);
     if (orgUnitUids.isEmpty()) {
       return;
     }
@@ -223,29 +216,59 @@ public class TrackedEntityAggregateService {
     DisplayProperty displayProperty = contextParams.getCommonRaw().getDisplayProperty();
     boolean includeMetadataDetails = contextParams.getCommonRaw().isIncludeMetadataDetails();
 
+    Map<String, OrganisationUnit> orgUnitsByUid = getOrgUnitsByUid(orgUnitUids);
+    addOrgUnitItems(
+        metadata.items(), orgUnitUids, orgUnitsByUid, displayProperty, includeMetadataDetails);
+    addOrgUnitDimension(metadata.dimensions(), orgUnitUids);
+  }
+
+  private Set<String> getGroupedOrgUnitUids(Grid grid, int ouColumnIndex) {
+    Set<String> orgUnitUids = new LinkedHashSet<>();
+    for (List<Object> row : grid.getRows()) {
+      Object value = row.get(ouColumnIndex);
+      if (value != null) {
+        orgUnitUids.add(String.valueOf(value));
+      }
+    }
+    return orgUnitUids;
+  }
+
+  private Map<String, OrganisationUnit> getOrgUnitsByUid(Set<String> orgUnitUids) {
     Map<String, OrganisationUnit> orgUnitsByUid = new LinkedHashMap<>();
     organisationUnitService
         .getOrganisationUnitsByUid(orgUnitUids)
         .forEach(orgUnit -> orgUnitsByUid.put(orgUnit.getUid(), orgUnit));
+    return orgUnitsByUid;
+  }
 
-    if (metadata.items() != null) {
-      for (String uid : orgUnitUids) {
-        OrganisationUnit orgUnit = orgUnitsByUid.get(uid);
-        if (orgUnit != null) {
-          metadata
-              .items()
-              .put(
-                  uid,
-                  new MetadataItem(
-                      orgUnit.getDisplayProperty(displayProperty),
-                      includeMetadataDetails ? orgUnit : null));
-        }
+  private void addOrgUnitItems(
+      Map<String, Object> items,
+      Set<String> orgUnitUids,
+      Map<String, OrganisationUnit> orgUnitsByUid,
+      DisplayProperty displayProperty,
+      boolean includeMetadataDetails) {
+    if (items == null) {
+      return;
+    }
+
+    for (String uid : orgUnitUids) {
+      OrganisationUnit orgUnit = orgUnitsByUid.get(uid);
+      if (orgUnit != null) {
+        items.put(
+            uid,
+            new MetadataItem(
+                orgUnit.getDisplayProperty(displayProperty),
+                includeMetadataDetails ? orgUnit : null));
       }
     }
+  }
 
-    if (metadata.dimensions() != null) {
-      metadata.dimensions().put(ORGUNIT_DIM_ID, List.copyOf(orgUnitUids));
+  private void addOrgUnitDimension(Map<String, Object> dimensions, Set<String> orgUnitUids) {
+    if (dimensions == null) {
+      return;
     }
+
+    dimensions.put(ORGUNIT_DIM_ID, List.copyOf(orgUnitUids));
   }
 
   private GridMetadata getGridMetadata(Grid grid) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.analytics.trackedentity;
 import static java.util.Collections.singleton;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
 import static org.hisp.dhis.analytics.trackedentity.query.TrackedEntityFields.getAggregateGridHeaders;
@@ -138,8 +137,8 @@ public class TrackedEntityAggregateService {
 
   /**
    * Scopes the metadata inputs to the dimensions the aggregate query actually groups by. The TE
-   * mapper injects all of the tracked entity type's attributes into the parsed dimensions for
-   * row-level display; without this filter the shared {@link MetadataParamsHandler} would advertise
+   * mapper injects all the tracked entity type's attributes into the parsed dimensions for
+   * row-level display; without this filter the shared {@link MetadataParamsHandler} would contain
    * those non-grouped attributes in {@code metaData.dimensions}/{@code metaData.items} even though
    * they are absent from the aggregate headers and rows. Grouped dimensions come from the single
    * source of truth in {@link AggregateQueryBuilder#getGroupedDimensionKeys}.
@@ -155,7 +154,7 @@ public class TrackedEntityAggregateService {
             .dimensionIdentifiers(
                 commonParsed.getDimensionIdentifiers().stream()
                     .filter(dimension -> groupedKeys.contains(dimension.getKey()))
-                    .collect(toList()))
+                    .toList())
             .parsedHeaders(
                 commonParsed.getParsedHeaders().stream()
                     .filter(dimension -> groupedKeys.contains(dimension.getKey()))
@@ -199,16 +198,8 @@ public class TrackedEntityAggregateService {
   private void addGroupedOrgUnitMetadata(
       Grid grid,
       ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
-    Map<String, Object> metaData = grid.getMetaData();
-    if (metaData == null) {
-      return;
-    }
-
-    @SuppressWarnings("unchecked")
-    Map<String, Object> items = (Map<String, Object>) metaData.get(ITEMS.getKey());
-    @SuppressWarnings("unchecked")
-    Map<String, Object> dimensions = (Map<String, Object>) metaData.get(DIMENSIONS.getKey());
-    if (items == null && dimensions == null) {
+    GridMetadata metadata = getGridMetadata(grid);
+    if (metadata == null || metadata.isEmpty()) {
       return;
     }
 
@@ -237,26 +228,47 @@ public class TrackedEntityAggregateService {
         .getOrganisationUnitsByUid(orgUnitUids)
         .forEach(orgUnit -> orgUnitsByUid.put(orgUnit.getUid(), orgUnit));
 
-    if (items != null) {
+    if (metadata.items() != null) {
       for (String uid : orgUnitUids) {
         OrganisationUnit orgUnit = orgUnitsByUid.get(uid);
         if (orgUnit != null) {
-          items.put(
-              uid,
-              new MetadataItem(
-                  orgUnit.getDisplayProperty(displayProperty),
-                  includeMetadataDetails ? orgUnit : null));
+          metadata
+              .items()
+              .put(
+                  uid,
+                  new MetadataItem(
+                      orgUnit.getDisplayProperty(displayProperty),
+                      includeMetadataDetails ? orgUnit : null));
         }
       }
     }
 
-    if (dimensions != null) {
-      dimensions.put(ORGUNIT_DIM_ID, List.copyOf(orgUnitUids));
+    if (metadata.dimensions() != null) {
+      metadata.dimensions().put(ORGUNIT_DIM_ID, List.copyOf(orgUnitUids));
+    }
+  }
+
+  private GridMetadata getGridMetadata(Grid grid) {
+    Map<String, Object> metaData = grid.getMetaData();
+    if (metaData == null) {
+      return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> items = (Map<String, Object>) metaData.get(ITEMS.getKey());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> dimensions = (Map<String, Object>) metaData.get(DIMENSIONS.getKey());
+    return new GridMetadata(items, dimensions);
+  }
+
+  private record GridMetadata(Map<String, Object> items, Map<String, Object> dimensions) {
+    boolean isEmpty() {
+      return items == null && dimensions == null;
     }
   }
 
   private void addGroupedRows(Grid grid, SqlRowSet rs) {
-    List<String> columns = grid.getHeaders().stream().map(GridHeader::getName).collect(toList());
+    List<String> columns = grid.getHeaders().stream().map(GridHeader::getName).toList();
     while (rs.next()) {
       grid.addRow();
       columns.forEach(col -> grid.addValue(rs.getObject(col)));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.analytics.trackedentity;
 
 import static java.util.Collections.singleton;
 import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
@@ -129,9 +130,39 @@ public class TrackedEntityAggregateService {
     result.ifPresent(r -> addGroupedRows(grid, r.result()));
 
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-    metadataParamsHandler.handle(grid, contextParams, currentUser, rowsCount);
+    metadataParamsHandler.handle(
+        grid, withGroupedDimensionsOnly(contextParams), currentUser, rowsCount);
     addGroupedOrgUnitMetadata(grid, contextParams);
     return grid;
+  }
+
+  /**
+   * Scopes the metadata inputs to the dimensions the aggregate query actually groups by. The TE
+   * mapper injects all of the tracked entity type's attributes into the parsed dimensions for
+   * row-level display; without this filter the shared {@link MetadataParamsHandler} would advertise
+   * those non-grouped attributes in {@code metaData.dimensions}/{@code metaData.items} even though
+   * they are absent from the aggregate headers and rows. Grouped dimensions come from the single
+   * source of truth in {@link AggregateQueryBuilder#getGroupedDimensionKeys}.
+   */
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      withGroupedDimensionsOnly(
+          ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    Set<String> groupedKeys = AggregateQueryBuilder.getGroupedDimensionKeys(contextParams);
+    CommonParsedParams commonParsed = contextParams.getCommonParsed();
+
+    CommonParsedParams scoped =
+        commonParsed.toBuilder()
+            .dimensionIdentifiers(
+                commonParsed.getDimensionIdentifiers().stream()
+                    .filter(dimension -> groupedKeys.contains(dimension.getKey()))
+                    .collect(toList()))
+            .parsedHeaders(
+                commonParsed.getParsedHeaders().stream()
+                    .filter(dimension -> groupedKeys.contains(dimension.getKey()))
+                    .collect(toCollection(LinkedHashSet::new)))
+            .build();
+
+    return contextParams.toBuilder().commonParsed(scoped).build();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -32,11 +32,18 @@ package org.hisp.dhis.analytics.trackedentity;
 import static java.util.Collections.singleton;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
 import static org.hisp.dhis.analytics.trackedentity.query.TrackedEntityFields.getAggregateGridHeaders;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
+import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
 
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
@@ -49,10 +56,14 @@ import org.hisp.dhis.analytics.common.params.CommonParsedParams;
 import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
+import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.ExecutionPlan;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
@@ -79,6 +90,8 @@ public class TrackedEntityAggregateService {
   private final MetadataParamsHandler metadataParamsHandler;
 
   private final UserService userService;
+
+  private final OrganisationUnitService organisationUnitService;
 
   public Grid getGrid(
       @Nonnull ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
@@ -110,7 +123,76 @@ public class TrackedEntityAggregateService {
 
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     metadataParamsHandler.handle(grid, contextParams, currentUser, rowsCount);
+    addGroupedOrgUnitMetadata(grid, contextParams);
     return grid;
+  }
+
+  /**
+   * Resolves the org units grouped by the {@code ou} dimension into the grid metaData. A bare
+   * {@code ou} dimension is parsed as a static dimension (no {@link
+   * org.hisp.dhis.common.DimensionalObject}), so the shared {@link MetadataParamsHandler} never
+   * emits it. This adds {@code metaData.dimensions.ou} (the grouped org unit uids) and {@code
+   * metaData.items} entries mapping each uid to its display name, so clients can resolve org unit
+   * uids to names. The org unit uids are read from the {@code ou} column of the grid rows and
+   * resolved to {@link OrganisationUnit} objects.
+   */
+  private void addGroupedOrgUnitMetadata(
+      Grid grid,
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    Map<String, Object> metaData = grid.getMetaData();
+    if (metaData == null) {
+      return;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> items = (Map<String, Object>) metaData.get(ITEMS.getKey());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> dimensions = (Map<String, Object>) metaData.get(DIMENSIONS.getKey());
+    if (items == null && dimensions == null) {
+      return;
+    }
+
+    int ouColumnIndex = grid.getIndexOfHeader(ORGUNIT_DIM_ID);
+    if (ouColumnIndex < 0) {
+      return;
+    }
+
+    Set<String> orgUnitUids = new LinkedHashSet<>();
+    for (List<Object> row : grid.getRows()) {
+      Object value = row.get(ouColumnIndex);
+      if (value != null) {
+        orgUnitUids.add(String.valueOf(value));
+      }
+    }
+
+    if (orgUnitUids.isEmpty()) {
+      return;
+    }
+
+    DisplayProperty displayProperty = contextParams.getCommonRaw().getDisplayProperty();
+    boolean includeMetadataDetails = contextParams.getCommonRaw().isIncludeMetadataDetails();
+
+    Map<String, OrganisationUnit> orgUnitsByUid = new LinkedHashMap<>();
+    organisationUnitService
+        .getOrganisationUnitsByUid(orgUnitUids)
+        .forEach(orgUnit -> orgUnitsByUid.put(orgUnit.getUid(), orgUnit));
+
+    if (items != null) {
+      for (String uid : orgUnitUids) {
+        OrganisationUnit orgUnit = orgUnitsByUid.get(uid);
+        if (orgUnit != null) {
+          items.put(
+              uid,
+              new MetadataItem(
+                  orgUnit.getDisplayProperty(displayProperty),
+                  includeMetadataDetails ? orgUnit : null));
+        }
+      }
+    }
+
+    if (dimensions != null) {
+      dimensions.put(ORGUNIT_DIM_ID, List.copyOf(orgUnitUids));
+    }
   }
 
   private void addGroupedRows(Grid grid, SqlRowSet rs) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
@@ -202,6 +202,38 @@ public class TrackedEntityFields {
   }
 
   /**
+   * Returns a collection of headers for the given {@link TrackedEntityQueryParams}, covering only
+   * the GROUP BY dimensions present in the given list of {@link Field}. Unlike {@link
+   * #getGridHeaders(ContextParams, List)}, the unconditional per-TEI {@link
+   * TrackedEntityStaticField} headers are not included, since aggregate output has no per-TEI rows.
+   *
+   * @param contextParams the {@link ContextParams}.
+   * @param fields list of {@link Field}.
+   * @return a {@link Set} of {@link GridHeader}.
+   */
+  public static Set<GridHeader> getAggregateGridHeaders(
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams,
+      List<Field> fields) {
+    CommonParsedParams commonParsed = contextParams.getCommonParsed();
+
+    Map<String, GridHeader> headersMap = new HashMap<>();
+
+    // Dimension headers only — no TrackedEntityStaticField headers (those are per-TEI output).
+    fields.stream()
+        .map(
+            field ->
+                findDimensionParamForField(
+                    field,
+                    Stream.concat(
+                        commonParsed.getDimensionIdentifiers().stream(),
+                        getEligibleParsedHeaders(commonParsed))))
+        .filter(Objects::nonNull)
+        .forEach(dimIdentifier -> addHeaderToMap(dimIdentifier, contextParams, headersMap));
+
+    return reorder(headersMap, fields);
+  }
+
+  /**
    * Adds the header for the given dimension identifier to the headers map.
    *
    * @param dimIdentifier the dimension identifier

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
@@ -187,16 +187,7 @@ public class TrackedEntityFields {
                         true)));
 
     // Adding dimension headers.
-    fields.stream()
-        .map(
-            field ->
-                findDimensionParamForField(
-                    field,
-                    Stream.concat(
-                        commonParsed.getDimensionIdentifiers().stream(),
-                        getEligibleParsedHeaders(commonParsed))))
-        .filter(Objects::nonNull)
-        .forEach(dimIdentifier -> addHeaderToMap(dimIdentifier, contextParams, headersMap));
+    addDimensionHeaders(fields, commonParsed, contextParams, headersMap);
 
     return reorder(headersMap, fields);
   }
@@ -218,7 +209,26 @@ public class TrackedEntityFields {
 
     Map<String, GridHeader> headersMap = new HashMap<>();
 
-    // Dimension headers only — no TrackedEntityStaticField headers (those are per-TEI output).
+    // Dimension headers only - no TrackedEntityStaticField headers (those are per-TEI output).
+    addDimensionHeaders(fields, commonParsed, contextParams, headersMap);
+
+    return reorder(headersMap, fields);
+  }
+
+  /**
+   * Adds headers, to the given headers map, for the dimensions found in the given list of {@link
+   * Field}.
+   *
+   * @param fields list of {@link Field}.
+   * @param commonParsed the {@link CommonParsedParams}.
+   * @param contextParams the {@link ContextParams}.
+   * @param headersMap the headers map to add to.
+   */
+  private static void addDimensionHeaders(
+      List<Field> fields,
+      CommonParsedParams commonParsed,
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams,
+      Map<String, GridHeader> headersMap) {
     fields.stream()
         .map(
             field ->
@@ -229,8 +239,6 @@ public class TrackedEntityFields {
                         getEligibleParsedHeaders(commonParsed))))
         .filter(Objects::nonNull)
         .forEach(dimIdentifier -> addHeaderToMap(dimIdentifier, contextParams, headersMap));
-
-    return reorder(headersMap, fields);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFields.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
@@ -65,7 +66,10 @@ import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
 import org.hisp.dhis.analytics.trackedentity.query.context.TrackedEntityStaticField;
+import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.OrgUnitQueryBuilder;
+import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.TrackedEntityQueryBuilder;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RepeatableStageParams;
@@ -194,25 +198,42 @@ public class TrackedEntityFields {
 
   /**
    * Returns a collection of headers for the given {@link TrackedEntityQueryParams}, covering only
-   * the GROUP BY dimensions present in the given list of {@link Field}. Unlike {@link
-   * #getGridHeaders(ContextParams, List)}, the unconditional per-TEI {@link
-   * TrackedEntityStaticField} headers are not included, since aggregate output has no per-TEI rows.
+   * the GROUP BY dimensions requested for aggregation. Unlike {@link #getGridHeaders(ContextParams,
+   * List)}, the unconditional per-TEI {@link TrackedEntityStaticField} headers are not included,
+   * since aggregate output has no per-TEI rows.
    *
    * @param contextParams the {@link ContextParams}.
-   * @param fields list of {@link Field}.
    * @return a {@link Set} of {@link GridHeader}.
    */
   public static Set<GridHeader> getAggregateGridHeaders(
-      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams,
-      List<Field> fields) {
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
     CommonParsedParams commonParsed = contextParams.getCommonParsed();
 
-    Map<String, GridHeader> headersMap = new HashMap<>();
+    // Aggregate select fields are built via Field.ofDimensionIdentifier, which carries neither a
+    // field alias nor a dimension identifier key, so they cannot be matched back to a dimension by
+    // Field.getDimensionIdentifier() the way the per-TEI path does. Headers are therefore built
+    // directly from the grouped dimensions, mirroring the SELECT/GROUP BY selection in
+    // AggregateQueryBuilder: only user-requested org unit or tracked entity dimensions become
+    // columns. Each header is named by its dimension key to match the SQL result column name.
+    Set<String> requestedKeys =
+        contextParams.getCommonRaw().getDimension().stream()
+            .map(DimensionalObjectUtils::getDimensionFromParam)
+            .collect(Collectors.toSet());
 
-    // Dimension headers only - no TrackedEntityStaticField headers (those are per-TEI output).
-    addDimensionHeaders(fields, commonParsed, contextParams, headersMap);
+    Set<GridHeader> headers = new LinkedHashSet<>();
+    commonParsed.getDimensionIdentifiers().stream()
+        .filter(dimIdentifier -> requestedKeys.contains(dimIdentifier.getKey()))
+        .filter(
+            dimIdentifier ->
+                OrgUnitQueryBuilder.isOu(dimIdentifier)
+                    || TrackedEntityQueryBuilder.isTrackedEntity(dimIdentifier))
+        .forEach(
+            dimIdentifier -> {
+              GridHeader header = getHeaderForDimensionParam(dimIdentifier, contextParams);
+              headers.add(withStageOffsetIfNecessary(dimIdentifier, header));
+            });
 
-    return reorder(headersMap, fields);
+    return headers;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
@@ -29,7 +29,11 @@
  */
 package org.hisp.dhis.analytics.trackedentity.query.context.querybuilder;
 
+import static java.util.stream.Collectors.toSet;
+import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionFromParam;
+
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import lombok.Getter;
 import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
@@ -70,15 +74,25 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
 
     RenderableSqlQuery.RenderableSqlQueryBuilder builder = RenderableSqlQuery.builder();
 
-    // Each requested dimension is both a select column and a group-by key. The same
-    // alias-free field is used for both: an "as <alias>" suffix is invalid inside a GROUP BY,
-    // and the column name already identifies the dimension item.
-    acceptedDimensions.forEach(
-        dimension -> {
-          Field field = Field.ofDimensionIdentifier(dimension);
-          builder.selectField(field);
-          builder.groupByField(field);
-        });
+    Set<String> requestedKeys =
+        queryContext.getContextParams().getCommonRaw().getDimension().stream()
+            .map(param -> getDimensionFromParam(param))
+            .collect(toSet());
+
+    // Only dimensions explicitly requested by the user (present in the raw request's
+    // `dimension` param) become select columns and group-by keys. `acceptedDimensions` also
+    // carries dimensions injected upstream for row-level display purposes, which must not
+    // affect grouping. The same alias-free field is used for both select and group-by: an
+    // "as <alias>" suffix is invalid inside a GROUP BY, and the column name already identifies
+    // the dimension item.
+    acceptedDimensions.stream()
+        .filter(dimension -> requestedKeys.contains(dimension.getKey()))
+        .forEach(
+            dimension -> {
+              Field field = Field.ofDimensionIdentifier(dimension);
+              builder.selectField(field);
+              builder.groupByField(field);
+            });
 
     // The aggregate value column is the last select column and is not grouped.
     builder.selectField(Field.ofUnquoted("", () -> "count(1)", "value"));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
@@ -36,10 +36,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import lombok.Getter;
+import org.hisp.dhis.analytics.common.ContextParams;
 import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.QueryContext;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryBuilder;
@@ -74,10 +77,7 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
 
     RenderableSqlQuery.RenderableSqlQueryBuilder builder = RenderableSqlQuery.builder();
 
-    Set<String> requestedKeys =
-        queryContext.getContextParams().getCommonRaw().getDimension().stream()
-            .map(param -> getDimensionFromParam(param))
-            .collect(toSet());
+    Set<String> groupedKeys = getGroupedDimensionKeys(queryContext.getContextParams());
 
     // Only dimensions explicitly requested by the user (present in the raw request's
     // `dimension` param) become select columns and group-by keys. `acceptedDimensions` also
@@ -86,7 +86,7 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
     // "as <alias>" suffix is invalid inside a GROUP BY, and the column name already identifies
     // the dimension item.
     acceptedDimensions.stream()
-        .filter(dimension -> requestedKeys.contains(dimension.getKey()))
+        .filter(dimension -> groupedKeys.contains(dimension.getKey()))
         .forEach(
             dimension -> {
               Field field = Field.ofDimensionIdentifier(dimension);
@@ -98,6 +98,31 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
     builder.selectField(Field.ofUnquoted("", () -> "count(1)", "value"));
 
     return builder.build();
+  }
+
+  /**
+   * Returns the keys of the dimensions an aggregate query groups by: the dimensions the user
+   * explicitly requested (present in the raw {@code dimension} param) that are also groupable in
+   * aggregate mode (registration org unit or a tracked entity / program attribute). Only {@code
+   * commonRaw} distinguishes explicitly-requested dimensions from those injected upstream for
+   * row-level display; the parsed dimensions merge both. This is the single source of truth for
+   * what the aggregate query groups by, and therefore what may be sorted on.
+   */
+  public static Set<String> getGroupedDimensionKeys(
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
+    Set<String> requestedKeys =
+        contextParams.getCommonRaw().getDimension().stream()
+            .map(param -> getDimensionFromParam(param))
+            .collect(toSet());
+
+    return contextParams.getCommonParsed().getDimensionIdentifiers().stream()
+        .filter(
+            dimension ->
+                OrgUnitQueryBuilder.isOu(dimension)
+                    || TrackedEntityQueryBuilder.isTrackedEntity(dimension))
+        .map(DimensionIdentifier::getKey)
+        .filter(requestedKeys::contains)
+        .collect(toSet());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.analytics.trackedentity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -134,9 +135,76 @@ class TrackedEntityAggregateOuMetadataTest {
 
   @Test
   void metadataExposesGroupedOrgUnitsForBareOuDimension() {
-    OrganisationUnit ngelehun = new OrganisationUnit("Ngelehun CHC");
-    ngelehun.setUid("a04CZxe0PSe");
+    OrganisationUnit ngelehun = orgUnit("Ngelehun CHC", "a04CZxe0PSe", null);
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        contextParamsForOuDimension(new CommonRequestParams().withDimension(Set.of("ou")));
 
+    SqlRowSet rowSet =
+        fakeRowSet(
+            new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"a04CZxe0PSe", 42}));
+
+    stubQuery(ctx, rowSet);
+    when(organisationUnitService.getOrganisationUnitsByUid(Set.of("a04CZxe0PSe")))
+        .thenReturn(List.of(ngelehun));
+
+    Grid grid = service.getGrid(ctx);
+
+    Map<String, List<String>> dimensions = getDimensions(grid);
+    assertTrue(
+        dimensions.containsKey("ou"),
+        "metaData.dimensions must contain 'ou'; was: " + dimensions.keySet());
+    assertEquals(List.of("a04CZxe0PSe"), dimensions.get("ou"));
+
+    Map<String, MetadataItem> items = getItems(grid);
+    assertTrue(
+        items.containsKey("a04CZxe0PSe"),
+        "metaData.items must map the grouped org unit uid; was: " + items.keySet());
+    assertEquals("Ngelehun CHC", items.get("a04CZxe0PSe").getName());
+  }
+
+  @Test
+  void metadataKeepsGroupedOrgUnitOrderAndDetailsForResolvedUnitsOnly() {
+    OrganisationUnit ngelehun = orgUnit("Ngelehun CHC", "a04CZxe0PSe", "NGELEHUN");
+    OrganisationUnit mabesseneh = orgUnit("Mabesseneh CHP", "b04CZxe0PSe", "MABESS");
+    CommonRequestParams request =
+        new CommonRequestParams().withDimension(Set.of("ou")).withIncludeMetadataDetails(true);
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        contextParamsForOuDimension(request);
+
+    SqlRowSet rowSet =
+        fakeRowSet(
+            new String[] {"ou", "value"},
+            List.of(
+                new Object[] {"a04CZxe0PSe", 42},
+                new Object[] {"b04CZxe0PSe", 13},
+                new Object[] {"a04CZxe0PSe", 7},
+                new Object[] {null, 3},
+                new Object[] {"unresolved01", 1}));
+
+    stubQuery(ctx, rowSet);
+    when(organisationUnitService.getOrganisationUnitsByUid(
+            Set.of("a04CZxe0PSe", "b04CZxe0PSe", "unresolved01")))
+        .thenReturn(List.of(mabesseneh, ngelehun));
+
+    Grid grid = service.getGrid(ctx);
+
+    assertEquals(
+        List.of("a04CZxe0PSe", "b04CZxe0PSe", "unresolved01"), getDimensions(grid).get("ou"));
+
+    Map<String, MetadataItem> items = getItems(grid);
+    assertTrue(items.containsKey("a04CZxe0PSe"));
+    assertTrue(items.containsKey("b04CZxe0PSe"));
+    assertFalse(items.containsKey("unresolved01"));
+    assertEquals("Ngelehun CHC", items.get("a04CZxe0PSe").getName());
+    assertEquals("a04CZxe0PSe", items.get("a04CZxe0PSe").getUid());
+    assertEquals("NGELEHUN", items.get("a04CZxe0PSe").getCode());
+    assertEquals("Mabesseneh CHP", items.get("b04CZxe0PSe").getName());
+    assertEquals("b04CZxe0PSe", items.get("b04CZxe0PSe").getUid());
+    assertEquals("MABESS", items.get("b04CZxe0PSe").getCode());
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      contextParamsForOuDimension(CommonRequestParams request) {
     when(dimensionIdentifierConverter.fromString(anyList(), eq("ou")))
         .thenReturn(
             DimensionIdentifier.of(
@@ -144,46 +212,46 @@ class TrackedEntityAggregateOuMetadataTest {
                 ElementWithOffset.emptyElementWithOffset(),
                 StringUid.of("ou")));
 
-    CommonRequestParams request = new CommonRequestParams().withDimension(Set.of("ou"));
     CommonParsedParams commonParsed = parser.parse(request);
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(TrackedEntityQueryParams.builder().aggregate(true).build())
+        .commonRaw(request)
+        .commonParsed(commonParsed)
+        .build();
+  }
 
-    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
-        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
-            .typedParsed(TrackedEntityQueryParams.builder().aggregate(true).build())
-            .commonRaw(request)
-            .commonParsed(commonParsed)
-            .build();
-
-    SqlRowSet rowSet =
-        fakeRowSet(
-            new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"a04CZxe0PSe", 42}));
-
+  private void stubQuery(
+      ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx, SqlRowSet rowSet) {
     when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
     when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
     when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
-    when(organisationUnitService.getOrganisationUnitsByUid(Set.of("a04CZxe0PSe")))
-        .thenReturn(List.of(ngelehun));
+  }
 
-    Grid grid = service.getGrid(ctx);
+  private OrganisationUnit orgUnit(String name, String uid, String code) {
+    OrganisationUnit organisationUnit = new OrganisationUnit(name);
+    organisationUnit.setUid(uid);
+    organisationUnit.setCode(code);
+    return organisationUnit;
+  }
 
+  private Map<String, List<String>> getDimensions(Grid grid) {
     Map<String, Object> metaData = grid.getMetaData();
     assertNotNull(metaData, "metaData must be present");
 
     @SuppressWarnings("unchecked")
     Map<String, List<String>> dimensions = (Map<String, List<String>>) metaData.get("dimensions");
     assertNotNull(dimensions, "metaData.dimensions must be present");
-    assertTrue(
-        dimensions.containsKey("ou"),
-        "metaData.dimensions must contain 'ou'; was: " + dimensions.keySet());
-    assertEquals(List.of("a04CZxe0PSe"), dimensions.get("ou"));
+    return dimensions;
+  }
+
+  private Map<String, MetadataItem> getItems(Grid grid) {
+    Map<String, Object> metaData = grid.getMetaData();
+    assertNotNull(metaData, "metaData must be present");
 
     @SuppressWarnings("unchecked")
     Map<String, MetadataItem> items = (Map<String, MetadataItem>) metaData.get("items");
     assertNotNull(items, "metaData.items must be present");
-    assertTrue(
-        items.containsKey("a04CZxe0PSe"),
-        "metaData.items must map the grouped org unit uid; was: " + items.keySet());
-    assertEquals("Ngelehun CHC", items.get("a04CZxe0PSe").getName());
+    return items;
   }
 
   private SqlRowSet fakeRowSet(String[] columns, List<Object[]> rows) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.analytics.DataQueryService;
+import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
+import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.QueryExecutor;
+import org.hisp.dhis.analytics.common.SqlQuery;
+import org.hisp.dhis.analytics.common.SqlQueryResult;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.analytics.common.params.dimension.StringUid;
+import org.hisp.dhis.analytics.common.processing.CommonRequestParamsParser;
+import org.hisp.dhis.analytics.common.processing.DimensionIdentifierConverter;
+import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
+import org.hisp.dhis.analytics.event.EventDataQueryService;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.MetadataItem;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+/**
+ * Grounded test for the org unit metaData contract of the tracked entity aggregate endpoint. Drives
+ * the real {@link CommonRequestParamsParser} for a {@code dimension=ou} request and the real {@link
+ * MetadataParamsHandler} through {@link TrackedEntityAggregateService#getGrid}, verifying that the
+ * assembled grid exposes the grouped org units in {@code metaData.dimensions.ou} and {@code
+ * metaData.items}.
+ */
+class TrackedEntityAggregateOuMetadataTest {
+  private final SystemSettingsProvider settingsProvider = mock(SystemSettingsProvider.class);
+  private final SystemSettings settings = mock(SystemSettings.class);
+  private final DataQueryService dataQueryService = mock(DataQueryService.class);
+  private final EventDataQueryService eventDataQueryService = mock(EventDataQueryService.class);
+  private final ProgramService programService = mock(ProgramService.class);
+  private final DimensionIdentifierConverter dimensionIdentifierConverter =
+      mock(DimensionIdentifierConverter.class);
+
+  private final CommonRequestParamsParser parser =
+      new CommonRequestParamsParser(
+          settingsProvider,
+          dataQueryService,
+          eventDataQueryService,
+          programService,
+          dimensionIdentifierConverter);
+
+  @SuppressWarnings("unchecked")
+  private final QueryExecutor<SqlQuery, SqlQueryResult> queryExecutor = mock(QueryExecutor.class);
+
+  private final SqlQueryCreatorService sqlQueryCreatorService = mock(SqlQueryCreatorService.class);
+  private final SqlQueryCreator queryCreator = mock(SqlQueryCreator.class);
+  private final ExecutionPlanStore executionPlanStore = mock(ExecutionPlanStore.class);
+  private final CommonParamsSecurityManager securityManager =
+      mock(CommonParamsSecurityManager.class);
+  private final UserService userService = mock(UserService.class);
+  private final OrganisationUnitService organisationUnitService =
+      mock(OrganisationUnitService.class);
+
+  private final TrackedEntityAggregateService service =
+      new TrackedEntityAggregateService(
+          queryExecutor,
+          sqlQueryCreatorService,
+          executionPlanStore,
+          securityManager,
+          new MetadataParamsHandler(),
+          userService,
+          organisationUnitService);
+
+  @BeforeEach
+  void setUp() {
+    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
+    when(settings.getAnalyticsMaxLimit()).thenReturn(1000);
+    CurrentUserUtil.injectUserInSecurityContext(UserDetails.empty().username("tester").build());
+  }
+
+  @AfterEach
+  void tearDown() {
+    CurrentUserUtil.clearSecurityContext();
+  }
+
+  @Test
+  void metadataExposesGroupedOrgUnitsForBareOuDimension() {
+    OrganisationUnit ngelehun = new OrganisationUnit("Ngelehun CHC");
+    ngelehun.setUid("a04CZxe0PSe");
+
+    when(dimensionIdentifierConverter.fromString(anyList(), eq("ou")))
+        .thenReturn(
+            DimensionIdentifier.of(
+                ElementWithOffset.emptyElementWithOffset(),
+                ElementWithOffset.emptyElementWithOffset(),
+                StringUid.of("ou")));
+
+    CommonRequestParams request = new CommonRequestParams().withDimension(Set.of("ou"));
+    CommonParsedParams commonParsed = parser.parse(request);
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(TrackedEntityQueryParams.builder().aggregate(true).build())
+            .commonRaw(request)
+            .commonParsed(commonParsed)
+            .build();
+
+    SqlRowSet rowSet =
+        fakeRowSet(
+            new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"a04CZxe0PSe", 42}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+    when(organisationUnitService.getOrganisationUnitsByUid(Set.of("a04CZxe0PSe")))
+        .thenReturn(List.of(ngelehun));
+
+    Grid grid = service.getGrid(ctx);
+
+    Map<String, Object> metaData = grid.getMetaData();
+    assertNotNull(metaData, "metaData must be present");
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> dimensions = (Map<String, List<String>>) metaData.get("dimensions");
+    assertNotNull(dimensions, "metaData.dimensions must be present");
+    assertTrue(
+        dimensions.containsKey("ou"),
+        "metaData.dimensions must contain 'ou'; was: " + dimensions.keySet());
+    assertEquals(List.of("a04CZxe0PSe"), dimensions.get("ou"));
+
+    @SuppressWarnings("unchecked")
+    Map<String, MetadataItem> items = (Map<String, MetadataItem>) metaData.get("items");
+    assertNotNull(items, "metaData.items must be present");
+    assertTrue(
+        items.containsKey("a04CZxe0PSe"),
+        "metaData.items must map the grouped org unit uid; was: " + items.keySet());
+    assertEquals("Ngelehun CHC", items.get("a04CZxe0PSe").getName());
+  }
+
+  private SqlRowSet fakeRowSet(String[] columns, List<Object[]> rows) {
+    SqlRowSet rowSet = mock(SqlRowSet.class);
+    int[] currentRow = {-1};
+    when(rowSet.next())
+        .thenAnswer(
+            invocation -> {
+              currentRow[0]++;
+              return currentRow[0] < rows.size();
+            });
+    when(rowSet.getObject(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String column = invocation.getArgument(0);
+              int columnIndex = List.of(columns).indexOf(column);
+              return rows.get(currentRow[0])[columnIndex];
+            });
+    return rowSet;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -74,6 +75,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -125,7 +127,7 @@ class TrackedEntityAggregateServiceTest {
     assertEquals("OU_UID_1", grid.getRow(0).get(0));
     assertEquals(42, grid.getRow(0).get(1));
     verify(securityManager).decideAccess(any(), any());
-    verify(metadataParamsHandler).handle(eq(grid), eq(ctx), any(), eq(0L));
+    verify(metadataParamsHandler).handle(eq(grid), any(), any(), eq(0L));
   }
 
   @Test
@@ -164,7 +166,31 @@ class TrackedEntityAggregateServiceTest {
     service.getGrid(ctx);
 
     verify(queryExecutor).count(any());
-    verify(metadataParamsHandler).handle(any(), eq(ctx), any(), eq(9L));
+    verify(metadataParamsHandler).handle(any(), any(), any(), eq(9L));
+  }
+
+  @Test
+  void getGridMetadataExcludesInjectedNonGroupedDimensions() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsWithInjectedAttribute("w75KJ2mc4zz");
+    SqlRowSet rowSet =
+        fakeRowSet(new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"OU1", 3}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+
+    service.getGrid(ctx);
+
+    ArgumentCaptor<ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>> captor =
+        ArgumentCaptor.forClass(ContextParams.class);
+    verify(metadataParamsHandler).handle(any(), captor.capture(), any(), anyLong());
+
+    List<String> metadataDimensionKeys =
+        captor.getValue().getCommonParsed().getDimensionIdentifiers().stream()
+            .map(DimensionIdentifier::getKey)
+            .collect(toList());
+    assertEquals(List.of("ou"), metadataDimensionKeys);
   }
 
   @Test
@@ -189,6 +215,24 @@ class TrackedEntityAggregateServiceTest {
     when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
 
     assertDoesNotThrow(() -> service.getGrid(ctx));
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsWithInjectedAttribute(String attribute) {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    // Only `ou` is explicitly requested; the attribute is injected into the parsed dimensions
+    // upstream (as the TE mapper does for all TET attributes) and must not surface in metaData.
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(
+                    List.of(stubOuDimension("ou1"), stubAttributeDimension(attribute)))
+                .build())
+        .build();
   }
 
   private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -31,7 +31,9 @@ package org.hisp.dhis.analytics.trackedentity;
 
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.common.IdScheme.UID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,6 +50,7 @@ import org.hisp.dhis.analytics.common.QueryExecutor;
 import org.hisp.dhis.analytics.common.SqlQuery;
 import org.hisp.dhis.analytics.common.SqlQueryResult;
 import org.hisp.dhis.analytics.common.params.AnalyticsPagingParams;
+import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
 import org.hisp.dhis.analytics.common.params.CommonParsedParams;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
@@ -60,6 +63,9 @@ import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
@@ -159,6 +165,52 @@ class TrackedEntityAggregateServiceTest {
 
     verify(queryExecutor).count(any());
     verify(metadataParamsHandler).handle(any(), eq(ctx), any(), eq(9L));
+  }
+
+  @Test
+  void getGridRejectsSortOnNonGroupedDimension() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsGroupedByOuSortedBy(stubAttributeDimension("w75KJ2mc4zz"));
+
+    IllegalQueryException ex =
+        assertThrows(IllegalQueryException.class, () -> service.getGrid(ctx));
+    assertEquals(ErrorCode.E7252, ex.getErrorCode());
+  }
+
+  @Test
+  void getGridAllowsSortOnGroupedDimension() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsGroupedByOuSortedBy(stubOuDimension("ou1"));
+    SqlRowSet rowSet =
+        fakeRowSet(new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"OU1", 3}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+
+    assertDoesNotThrow(() -> service.getGrid(ctx));
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsGroupedByOuSortedBy(DimensionIdentifier<DimensionParam> orderBy) {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                .orderParams(
+                    List.of(
+                        AnalyticsSortingParams.builder()
+                            .orderBy(orderBy)
+                            .sortDirection(SortDirection.DESC)
+                            .index(0)
+                            .build()))
+                .build())
+        .build();
   }
 
   private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.analytics.trackedentity;
 
-import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -121,8 +120,7 @@ class TrackedEntityAggregateServiceTest {
     Grid grid = service.getGrid(ctx);
 
     assertEquals(
-        List.of("ou", "value"),
-        grid.getHeaders().stream().map(GridHeader::getName).collect(toList()));
+        List.of("ou", "value"), grid.getHeaders().stream().map(GridHeader::getName).toList());
     assertEquals(2, grid.getHeight());
     assertEquals("OU_UID_1", grid.getRow(0).get(0));
     assertEquals(42, grid.getRow(0).get(1));
@@ -145,7 +143,7 @@ class TrackedEntityAggregateServiceTest {
 
     Grid grid = service.getGrid(ctx);
 
-    List<String> names = grid.getHeaders().stream().map(GridHeader::getName).collect(toList());
+    List<String> names = grid.getHeaders().stream().map(GridHeader::getName).toList();
     assertEquals("value", names.get(names.size() - 1)); // value always last
     assertEquals(List.of("ou", "w75KJ2mc4zz", "value"), names);
   }
@@ -189,7 +187,7 @@ class TrackedEntityAggregateServiceTest {
     List<String> metadataDimensionKeys =
         captor.getValue().getCommonParsed().getDimensionIdentifiers().stream()
             .map(DimensionIdentifier::getKey)
-            .collect(toList());
+            .toList();
     assertEquals(List.of("ou"), metadataDimensionKeys);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
 import org.hisp.dhis.analytics.common.ContextParams;
@@ -53,9 +54,6 @@ import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
 import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
 import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
-import org.hisp.dhis.analytics.common.query.Field;
-import org.hisp.dhis.analytics.trackedentity.query.context.QueryContextConstants;
-import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
 import org.hisp.dhis.common.BaseDimensionalObject;
@@ -101,8 +99,6 @@ class TrackedEntityAggregateServiceTest {
   void getGridBuildsOuAndValueHeadersAndMapsGroupedRows() {
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
         aggregateContextParamsWithOuDimension();
-    RenderableSqlQuery renderable =
-        RenderableSqlQuery.builder().selectFields(List.of(ouField(), valueField())).build();
 
     SqlQuery selectQuery = mock(SqlQuery.class);
     SqlRowSet rowSet =
@@ -111,7 +107,6 @@ class TrackedEntityAggregateServiceTest {
             List.of(new Object[] {"OU_UID_1", 42}, new Object[] {"OU_UID_2", 7}));
 
     when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
-    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
     when(queryCreator.createForSelect()).thenReturn(selectQuery);
     when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
 
@@ -131,18 +126,12 @@ class TrackedEntityAggregateServiceTest {
   void getGridAppendsValueHeaderLastForOuPlusAttribute() {
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
         aggregateContextParamsWithOuAndAttribute("w75KJ2mc4zz");
-    RenderableSqlQuery renderable =
-        RenderableSqlQuery.builder()
-            .selectFields(
-                List.of(ouField(), attributeField("w75KJ2mc4zz"), valueField()))
-            .build();
     SqlRowSet rowSet =
         fakeRowSet(
             new String[] {"ou", "w75KJ2mc4zz", "value"},
             List.<Object[]>of(new Object[] {"OU1", "M", 5}));
 
     when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
-    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
     when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
     when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
 
@@ -157,13 +146,10 @@ class TrackedEntityAggregateServiceTest {
   void getGridCountsGroupsWhenShowTotalPages() {
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
         aggregateContextParamsWithOuDimensionShowTotalPages();
-    RenderableSqlQuery renderable =
-        RenderableSqlQuery.builder().selectFields(List.of(ouField(), valueField())).build();
     SqlRowSet rowSet =
         fakeRowSet(new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"OU1", 3}));
 
     when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
-    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
     when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
     when(queryCreator.createForCount()).thenReturn(mock(SqlQuery.class));
     when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
@@ -182,7 +168,7 @@ class TrackedEntityAggregateServiceTest {
 
     return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
         .typedParsed(trackedEntityQueryParams)
-        .commonRaw(new CommonRequestParams())
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
         .commonParsed(
             CommonParsedParams.builder()
                 .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
@@ -197,7 +183,7 @@ class TrackedEntityAggregateServiceTest {
 
     return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
         .typedParsed(trackedEntityQueryParams)
-        .commonRaw(new CommonRequestParams())
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou", attribute)))
         .commonParsed(
             CommonParsedParams.builder()
                 .dimensionIdentifiers(
@@ -213,25 +199,13 @@ class TrackedEntityAggregateServiceTest {
 
     return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
         .typedParsed(trackedEntityQueryParams)
-        .commonRaw(new CommonRequestParams())
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
         .commonParsed(
             CommonParsedParams.builder()
                 .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
                 .pagingParams(AnalyticsPagingParams.builder().totalPages(true).build())
                 .build())
         .build();
-  }
-
-  private Field ouField() {
-    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "ou", "ou");
-  }
-
-  private Field attributeField(String attribute) {
-    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> attribute, attribute);
-  }
-
-  private Field valueField() {
-    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "value", "value");
   }
 
   private DimensionIdentifier<DimensionParam> stubOuDimension(String ou) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity;
+
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.common.IdScheme.UID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
+import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.QueryExecutor;
+import org.hisp.dhis.analytics.common.SqlQuery;
+import org.hisp.dhis.analytics.common.SqlQueryResult;
+import org.hisp.dhis.analytics.common.params.AnalyticsPagingParams;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
+import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
+import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.query.context.QueryContextConstants;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+@ExtendWith(MockitoExtension.class)
+class TrackedEntityAggregateServiceTest {
+  @Mock private QueryExecutor<SqlQuery, SqlQueryResult> queryExecutor;
+  @Mock private SqlQueryCreatorService sqlQueryCreatorService;
+  @Mock private ExecutionPlanStore executionPlanStore;
+  @Mock private CommonParamsSecurityManager securityManager;
+  @Mock private MetadataParamsHandler metadataParamsHandler;
+  @Mock private UserService userService;
+  @Mock private SqlQueryCreator queryCreator;
+
+  @InjectMocks private TrackedEntityAggregateService service;
+
+  @BeforeEach
+  void setUp() {
+    CurrentUserUtil.injectUserInSecurityContext(UserDetails.empty().username("tester").build());
+  }
+
+  @AfterEach
+  void tearDown() {
+    CurrentUserUtil.clearSecurityContext();
+  }
+
+  @Test
+  void getGridBuildsOuAndValueHeadersAndMapsGroupedRows() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsWithOuDimension();
+    RenderableSqlQuery renderable =
+        RenderableSqlQuery.builder().selectFields(List.of(ouField(), valueField())).build();
+
+    SqlQuery selectQuery = mock(SqlQuery.class);
+    SqlRowSet rowSet =
+        fakeRowSet(
+            new String[] {"ou", "value"},
+            List.of(new Object[] {"OU_UID_1", 42}, new Object[] {"OU_UID_2", 7}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
+    when(queryCreator.createForSelect()).thenReturn(selectQuery);
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+
+    Grid grid = service.getGrid(ctx);
+
+    assertEquals(
+        List.of("ou", "value"),
+        grid.getHeaders().stream().map(GridHeader::getName).collect(toList()));
+    assertEquals(2, grid.getHeight());
+    assertEquals("OU_UID_1", grid.getRow(0).get(0));
+    assertEquals(42, grid.getRow(0).get(1));
+    verify(securityManager).decideAccess(any(), any());
+    verify(metadataParamsHandler).handle(eq(grid), eq(ctx), any(), eq(0L));
+  }
+
+  @Test
+  void getGridAppendsValueHeaderLastForOuPlusAttribute() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsWithOuAndAttribute("w75KJ2mc4zz");
+    RenderableSqlQuery renderable =
+        RenderableSqlQuery.builder()
+            .selectFields(
+                List.of(ouField(), attributeField("w75KJ2mc4zz"), valueField()))
+            .build();
+    SqlRowSet rowSet =
+        fakeRowSet(
+            new String[] {"ou", "w75KJ2mc4zz", "value"},
+            List.<Object[]>of(new Object[] {"OU1", "M", 5}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+
+    Grid grid = service.getGrid(ctx);
+
+    List<String> names = grid.getHeaders().stream().map(GridHeader::getName).collect(toList());
+    assertEquals("value", names.get(names.size() - 1)); // value always last
+    assertEquals(List.of("ou", "w75KJ2mc4zz", "value"), names);
+  }
+
+  @Test
+  void getGridCountsGroupsWhenShowTotalPages() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        aggregateContextParamsWithOuDimensionShowTotalPages();
+    RenderableSqlQuery renderable =
+        RenderableSqlQuery.builder().selectFields(List.of(ouField(), valueField())).build();
+    SqlRowSet rowSet =
+        fakeRowSet(new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"OU1", 3}));
+
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.getRenderableSqlQuery()).thenReturn(renderable);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryCreator.createForCount()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+    when(queryExecutor.count(any())).thenReturn(9L);
+
+    service.getGrid(ctx);
+
+    verify(queryExecutor).count(any());
+    verify(metadataParamsHandler).handle(any(), eq(ctx), any(), eq(9L));
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsWithOuDimension() {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams())
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                .build())
+        .build();
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsWithOuAndAttribute(String attribute) {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams())
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(
+                    List.of(stubOuDimension("ou1"), stubAttributeDimension(attribute)))
+                .build())
+        .build();
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsWithOuDimensionShowTotalPages() {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams())
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                .pagingParams(AnalyticsPagingParams.builder().totalPages(true).build())
+                .build())
+        .build();
+  }
+
+  private Field ouField() {
+    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "ou", "ou");
+  }
+
+  private Field attributeField(String attribute) {
+    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> attribute, attribute);
+  }
+
+  private Field valueField() {
+    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "value", "value");
+  }
+
+  private DimensionIdentifier<DimensionParam> stubOuDimension(String ou) {
+    OrganisationUnit orgUnit = new OrganisationUnit();
+    orgUnit.setUid(ou);
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new BaseDimensionalObject("ou", DimensionType.ORGANISATION_UNIT, List.of(orgUnit)),
+            DimensionParamType.DIMENSIONS,
+            UID,
+            List.of(ou));
+    return DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam)
+        .withDefaultGroupId();
+  }
+
+  private DimensionIdentifier<DimensionParam> stubAttributeDimension(String attribute) {
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new BaseDimensionalObject(attribute, DimensionType.PROGRAM_ATTRIBUTE, List.of()),
+            DimensionParamType.DIMENSIONS,
+            UID,
+            List.of());
+    return DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam)
+        .withDefaultGroupId();
+  }
+
+  private SqlRowSet fakeRowSet(String[] columns, List<Object[]> rows) {
+    SqlRowSet rowSet = mock(SqlRowSet.class);
+    int[] currentRow = {-1};
+    when(rowSet.next())
+        .thenAnswer(
+            invocation -> {
+              currentRow[0]++;
+              return currentRow[0] < rows.size();
+            });
+    when(rowSet.getObject(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String column = invocation.getArgument(0);
+              int columnIndex = List.of(columns).indexOf(column);
+              return rows.get(currentRow[0])[columnIndex];
+            });
+    return rowSet;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
@@ -189,6 +190,12 @@ class TrackedEntityAggregateServiceTest {
             .map(DimensionIdentifier::getKey)
             .toList();
     assertEquals(List.of("ou"), metadataDimensionKeys);
+
+    List<String> metadataHeaderKeys =
+        captor.getValue().getCommonParsed().getParsedHeaders().stream()
+            .map(DimensionIdentifier::getKey)
+            .toList();
+    assertEquals(List.of("ou"), metadataHeaderKeys);
   }
 
   @Test
@@ -229,6 +236,9 @@ class TrackedEntityAggregateServiceTest {
             CommonParsedParams.builder()
                 .dimensionIdentifiers(
                     List.of(stubOuDimension("ou1"), stubAttributeDimension(attribute)))
+                .parsedHeaders(
+                    new LinkedHashSet<>(
+                        List.of(stubOuDimension("ou1"), stubAttributeDimension(attribute))))
                 .build())
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFieldsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFieldsTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.analytics.trackedentity.query;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +46,10 @@ import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
 import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
-import org.hisp.dhis.analytics.trackedentity.query.context.QueryContextConstants;
+import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.AggregateQueryBuilder;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.QueryContext;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
+import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlParameterManager;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.GridHeader;
@@ -58,14 +62,50 @@ class TrackedEntityFieldsTest {
   void getAggregateGridHeadersOmitsStaticFieldsAndKeepsOuDimension() {
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
         aggregateContextParamsWithOuDimension();
-    List<Field> fields = List.of(ouField());
 
-    Set<GridHeader> headers = TrackedEntityFields.getAggregateGridHeaders(contextParams, fields);
+    Set<GridHeader> headers = TrackedEntityFields.getAggregateGridHeaders(contextParams);
 
     assertEquals(1, headers.size());
     assertEquals("ou", headers.iterator().next().getName());
     // No per-TEI static header leaked in:
     assertTrue(headers.stream().map(GridHeader::getName).noneMatch("ouname"::equals));
+  }
+
+  /**
+   * Grounded test: the aggregate {@code ou} group-by column is produced at runtime by the real
+   * {@link AggregateQueryBuilder} (via {@code Field.ofDimensionIdentifier}), which yields a select
+   * field carrying neither a field alias nor a dimension identifier key. This test reproduces that
+   * runtime representation - a select field that cannot be matched back to its dimension via {@code
+   * Field.getDimensionIdentifier()} - and asserts that {@link
+   * TrackedEntityFields#getAggregateGridHeaders} still emits an {@code ou} header. The header must
+   * be named {@code ou} to line up with the SQL result column consumed by the aggregate grid.
+   */
+  @Test
+  void getAggregateGridHeadersKeepsOuDimensionFromRealSelectFields() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        aggregateContextParamsWithOuDimension();
+
+    // Exercise the real aggregate select-field construction so the ou field matches runtime.
+    QueryContext queryContext = QueryContext.of(contextParams, new SqlParameterManager());
+    RenderableSqlQuery renderableSqlQuery =
+        new AggregateQueryBuilder()
+            .buildSqlQuery(
+                queryContext,
+                List.of(),
+                contextParams.getCommonParsed().getDimensionIdentifiers(),
+                List.of());
+    List<Field> selectFields = renderableSqlQuery.getSelectFields();
+    // Guard: the ou select field really is alias-free (this is what hid the bug).
+    assertTrue(
+        selectFields.stream().anyMatch(f -> isBlank(f.getDimensionIdentifier())),
+        "expected an alias-free aggregate select field from the real AggregateQueryBuilder");
+
+    Set<GridHeader> headers = TrackedEntityFields.getAggregateGridHeaders(contextParams);
+
+    assertTrue(
+        headers.stream().map(GridHeader::getName).anyMatch("ou"::equals),
+        "aggregate headers should include the requested ou dimension, but were: "
+            + headers.stream().map(GridHeader::getName).toList());
   }
 
   private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
@@ -75,16 +115,12 @@ class TrackedEntityFieldsTest {
 
     return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
         .typedParsed(trackedEntityQueryParams)
-        .commonRaw(new CommonRequestParams())
+        .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
         .commonParsed(
             CommonParsedParams.builder()
                 .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
                 .build())
         .build();
-  }
-
-  private Field ouField() {
-    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "ou", "ou");
   }
 
   private DimensionIdentifier<DimensionParam> stubOuDimension(String ou) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFieldsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/TrackedEntityFieldsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity.query;
+
+import static org.hisp.dhis.common.IdScheme.UID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
+import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
+import org.hisp.dhis.analytics.trackedentity.query.context.QueryContextConstants;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.junit.jupiter.api.Test;
+
+class TrackedEntityFieldsTest {
+
+  @Test
+  void getAggregateGridHeadersOmitsStaticFieldsAndKeepsOuDimension() {
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        aggregateContextParamsWithOuDimension();
+    List<Field> fields = List.of(ouField());
+
+    Set<GridHeader> headers = TrackedEntityFields.getAggregateGridHeaders(contextParams, fields);
+
+    assertEquals(1, headers.size());
+    assertEquals("ou", headers.iterator().next().getName());
+    // No per-TEI static header leaked in:
+    assertTrue(headers.stream().map(GridHeader::getName).noneMatch("ouname"::equals));
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      aggregateContextParamsWithOuDimension() {
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder().aggregate(true).build();
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(new CommonRequestParams())
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                .build())
+        .build();
+  }
+
+  private Field ouField() {
+    return Field.of(QueryContextConstants.TRACKED_ENTITY_ALIAS, () -> "ou", "ou");
+  }
+
+  private DimensionIdentifier<DimensionParam> stubOuDimension(String ou) {
+    OrganisationUnit orgUnit = new OrganisationUnit();
+    orgUnit.setUid(ou);
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new BaseDimensionalObject("ou", DimensionType.ORGANISATION_UNIT, List.of(orgUnit)),
+            DimensionParamType.DIMENSIONS,
+            UID,
+            List.of(ou));
+    return DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam)
+        .withDefaultGroupId();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
@@ -232,10 +232,13 @@ class SqlQueryCreatorServiceTest extends TestBase {
             .aggregate(true)
             .build();
 
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("ou"));
+
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
         ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
             .typedParsed(trackedEntityQueryParams)
-            .commonRaw(new CommonRequestParams())
+            .commonRaw(requestParams)
             .commonParsed(
                 CommonParsedParams.builder()
                     .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
@@ -263,10 +266,13 @@ class SqlQueryCreatorServiceTest extends TestBase {
             .aggregate(true)
             .build();
 
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("attr1"));
+
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
         ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
             .typedParsed(trackedEntityQueryParams)
-            .commonRaw(new CommonRequestParams())
+            .commonRaw(requestParams)
             .commonParsed(
                 CommonParsedParams.builder()
                     .dimensionIdentifiers(List.of(stubAttributeDimension("attr1")))
@@ -292,10 +298,13 @@ class SqlQueryCreatorServiceTest extends TestBase {
             .aggregate(true)
             .build();
 
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("ou", "attr1"));
+
     ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
         ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
             .typedParsed(trackedEntityQueryParams)
-            .commonRaw(new CommonRequestParams())
+            .commonRaw(requestParams)
             .commonParsed(
                 CommonParsedParams.builder()
                     .dimensionIdentifiers(
@@ -305,9 +314,44 @@ class SqlQueryCreatorServiceTest extends TestBase {
 
     String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
 
-    // every dimension becomes a group-by key; the value column is last and not grouped.
+    // every explicitly requested dimension becomes a group-by key; the value column is last
+    // and not grouped.
     assertContains("select t_1.\"ou\", t_1.\"attr1\", count(1) as \"value\"", sql);
     assertContains("group by t_1.\"ou\", t_1.\"attr1\"", sql);
+  }
+
+  @Test
+  void testAggregateGroupsByExplicitlyRequestedDimensionsOnly() {
+    List<SqlQueryBuilder> aggregateBuilders = new ArrayList<>();
+    aggregateBuilders.add(new AggregateQueryBuilder());
+    aggregateBuilders.addAll(queryBuilders);
+    SqlQueryCreatorService service = new SqlQueryCreatorService(aggregateBuilders);
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(createTrackedEntityType('A'))
+            .aggregate(true)
+            .build();
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("ou"));
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(requestParams)
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(
+                        List.of(stubOuDimension("ou1"), stubAttributeDimension("attr1")))
+                    .build())
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertContains("count(1) as \"value\"", sql);
+    assertContains("group by t_1.\"ou\"", sql);
+    assertFalse(sql.contains("attr1"), "auto-injected attribute must not leak into the SQL");
   }
 
   private DimensionIdentifier<DimensionParam> stubAttributeDimension(String attribute) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/trackedentity/TrackedEntityAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/trackedentity/TrackedEntityAnalyticsController.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.analytics.common.processing.CommonQueryRequestValidator;
 import org.hisp.dhis.analytics.common.processing.Parser;
 import org.hisp.dhis.analytics.common.processing.Validator;
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityAggregateService;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityAnalyticsDimensionsService;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityAnalyticsQueryService;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
@@ -108,6 +109,8 @@ class TrackedEntityAnalyticsController {
   @Nonnull private final TrackedEntityQueryRequestMapper mapper;
 
   @Nonnull private final ContextUtils contextUtils;
+
+  @Nonnull private final TrackedEntityAggregateService trackedEntityAggregateService;
 
   @GetMapping(
       value = "/query/{trackedEntityType}",
@@ -232,6 +235,129 @@ class TrackedEntityAnalyticsController {
         response.getWriter());
   }
 
+  @GetMapping(
+      value = "/aggregate/{trackedEntityType}",
+      produces = {APPLICATION_JSON_VALUE, "application/javascript"})
+  Grid aggregate(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams) {
+    return getAggregateGrid(
+        trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+        commonRequestParams,
+        trackedEntityAggregateService::getGrid);
+  }
+
+  @RequiresAuthority(anyOf = F_PERFORM_ANALYTICS_EXPLAIN)
+  @GetMapping(
+      value = "/aggregate/{trackedEntityType}/explain",
+      produces = {APPLICATION_JSON_VALUE, "application/javascript"})
+  Grid aggregateExplain(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams) {
+    return getAggregateGrid(
+        trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+        commonRequestParams,
+        trackedEntityAggregateService::getGridExplain);
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.xml")
+  public void aggregateXml(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_XML, "trackedEntities.xml");
+    toXml(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getOutputStream());
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.xls")
+  public void aggregateXls(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_EXCEL, "trackedEntities.xls");
+    toXls(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getOutputStream());
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.xlsx")
+  public void aggregateXlsx(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_EXCEL, "trackedEntities.xlsx");
+    toXlsx(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getOutputStream());
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.csv")
+  public void aggregateCsv(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_CSV, "trackedEntities.csv");
+    toCsv(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getWriter());
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.html")
+  public void aggregateHtml(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_HTML, "trackedEntities.html");
+    toHtml(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getWriter());
+  }
+
+  @GetMapping(value = "/aggregate/{trackedEntityType}.html+css")
+  public void aggregateHtmlCss(
+      @PathVariable String trackedEntityType,
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      HttpServletResponse response)
+      throws IOException {
+    prepareForDownload(response, CONTENT_TYPE_HTML, "trackedEntities.html");
+    toHtmlCss(
+        getAggregateGrid(
+            trackedEntityRequestParams.withTrackedEntityType(trackedEntityType),
+            commonRequestParams,
+            trackedEntityAggregateService::getGrid),
+        response.getWriter());
+  }
+
   private Grid getGrid(
       TrackedEntityRequestParams trackedEntityRequestParams,
       CommonRequestParams commonRequestParams,
@@ -242,6 +368,37 @@ class TrackedEntityAnalyticsController {
     // the TE and not from the request param.
     TrackedEntityQueryParams trackedEntityQueryParams =
         mapper.map(trackedEntityRequestParams.getTrackedEntityType(), commonRequestParams);
+
+    commonQueryRequestValidator.validate(commonRequestParams);
+    trackedEntityQueryRequestValidator.validate(trackedEntityRequestParams);
+
+    CommonParsedParams commonParsedParams = commonRequestParamsParser.parse(commonRequestParams);
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedRaw(trackedEntityRequestParams)
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(commonRequestParams)
+            .commonParsed(commonParsedParams)
+            .build();
+
+    return executor.apply(contextParams);
+  }
+
+  private Grid getAggregateGrid(
+      TrackedEntityRequestParams trackedEntityRequestParams,
+      CommonRequestParams commonRequestParams,
+      Function<ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>, Grid>
+          executor) {
+
+    // This happens first because of the particularity of TE, where the programs be loaded come from
+    // the TE and not from the request param.
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        mapper
+            .map(trackedEntityRequestParams.getTrackedEntityType(), commonRequestParams)
+            .toBuilder()
+            .aggregate(true)
+            .build();
 
     commonQueryRequestValidator.validate(commonRequestParams);
     trackedEntityQueryRequestValidator.validate(trackedEntityRequestParams);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/trackedentity/TrackedEntityAnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/trackedentity/TrackedEntityAnalyticsControllerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.trackedentity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.processing.CommonQueryRequestValidator;
+import org.hisp.dhis.analytics.common.processing.Parser;
+import org.hisp.dhis.analytics.common.processing.Validator;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityAggregateService;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityAnalyticsDimensionsService;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityAnalyticsQueryService;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryRequestMapper;
+import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
+import org.hisp.dhis.system.grid.ListGrid;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.webapi.dimension.DimensionFilteringAndPagingService;
+import org.hisp.dhis.webapi.dimension.DimensionMapperService;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test proving that requests routed through the {@code aggregate/{tet}} endpoints reach the
+ * {@link TrackedEntityAggregateService} with the aggregate flag set on the query params.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackedEntityAnalyticsControllerTest {
+
+  @Mock private TrackedEntityAnalyticsQueryService trackedEntityAnalyticsQueryService;
+
+  @Mock private Parser<CommonRequestParams, CommonParsedParams> commonRequestParamsParser;
+
+  @Mock private CommonQueryRequestValidator commonQueryRequestValidator;
+
+  @Mock private Validator<TrackedEntityRequestParams> trackedEntityQueryRequestValidator;
+
+  @Mock private DimensionFilteringAndPagingService dimensionFilteringAndPagingService;
+
+  @Mock private DimensionMapperService dimensionMapperService;
+
+  @Mock private TrackedEntityAnalyticsDimensionsService trackedEntityAnalyticsDimensionsService;
+
+  @Mock private TrackedEntityQueryRequestMapper mapper;
+
+  @Mock private ContextUtils contextUtils;
+
+  @Mock private TrackedEntityAggregateService trackedEntityAggregateService;
+
+  private TrackedEntityAnalyticsController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller =
+        new TrackedEntityAnalyticsController(
+            trackedEntityAnalyticsQueryService,
+            commonRequestParamsParser,
+            commonQueryRequestValidator,
+            trackedEntityQueryRequestValidator,
+            dimensionFilteringAndPagingService,
+            dimensionMapperService,
+            trackedEntityAnalyticsDimensionsService,
+            mapper,
+            contextUtils,
+            trackedEntityAggregateService);
+  }
+
+  @Test
+  void aggregateEndpointSetsAggregateFlagOnQueryParams() {
+    TrackedEntityType tet = new TrackedEntityType();
+    when(mapper.map(eq("tetUid"), any()))
+        .thenReturn(TrackedEntityQueryParams.builder().trackedEntityType(tet).build());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>> captor =
+        ArgumentCaptor.forClass(ContextParams.class);
+    when(trackedEntityAggregateService.getGrid(captor.capture())).thenReturn(new ListGrid());
+
+    controller.aggregate("tetUid", new TrackedEntityRequestParams(null), new CommonRequestParams());
+
+    assertTrue(captor.getValue().getTypedParsed().isAggregate());
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new HTTP endpoint that returns a `COUNT` (numeric aggregation types will be added [later](https://dhis2.atlassian.net/browse/DHIS2-21733)) of tracked entities grouped by the requested dimensions (registration org unit and/or tracked-entity attributes). 
It reuses the existing row-level TE analytics logic (same security manager, same query planner `SqlQueryCreatorService`, same executor) and switches behaviour with a single boolean, `aggregate`, carried on `TrackedEntityQueryParams` / `QueryContext`. 
When that flag is set to `true`, one builder takes over the `SELECT` and emits a `GROUP BY` clause; The result is assembled into a plain grid (dimension columns + a numeric value column) with metaData that resolves dimension UIDs to names.

### Request flow

#### TrackedEntityAnalyticsController

Added `aggregate(...)`, `aggregateExplain(...)` and six `aggregate/{tet}.{xml|xls|xlsx|csv|html|html+css}` endpoints. These new methods behave exactly as the non-aggregate counterparts, except for the `.aggregate(true)` [flag](https://github.com/dhis2/dhis2-core/pull/24346/changes#diff-60a8d644f7055ab45c9c1a6f7b9a7d30e4a944cba3acabd2e8645daba6980018R400).

#### Param building logic

`mapper.map()` ([link](https://github.com/dhis2/dhis2-core/pull/24346/changes#diff-60a8d644f7055ab45c9c1a6f7b9a7d30e4a944cba3acabd2e8645daba6980018R398)) and the parser build the parsed params exactly as for `query/{tet}`.
`map()` "blindly" adds the TET's attributes to the internal dimension list (so the row-level path can render an attribute column per TEI). The only aggregate-specific state is the boolean `aggregate` on `TrackedEntityQueryParams`.

#### TrackedEntityAggregateService

Similar to `TrackedEntityAnalyticsQueryService.getGrid`. Checks the same three security calls unchanged (`decideAccess`, `applyOrganisationUnitConstraint`, `applyDimensionConstraints`), then asks the planner for a query creator.

@maikelarabori this could be potentially refactored to avoid code duplication between the two services, but since it's only 10 lines of code, I decided to not refactor.

#### SQL generation (planner + builders)

The planner filters `parsedParams.getDimensionIdentifiers()` through each builder's `dimensionFilters`, then calls `buildSqlQuery(...)`. In aggregate mode two builders are relevant:

- `AggregateQueryBuilder` (new)
- `TrackedEntityQueryBuilder.getSelect()` returns `Stream.empty()` in **aggregate mode**, "suppressing" every per-TEI column (static fields, attributes, OU group-sets, the enrollments JSON). `WHERE` / `ORDER` still run unchanged.

#### SQL execution

`queryExecutor.find(createForSelect())` runs the aggregation `SELECT`; when paging asks for totals (`pagingParams.showTotalPages()`) `queryExecutor.count(createForCount()`) counts groups via the subquery wrap.

#### Grid & metaData

A normal `ListGrid` is built directly (the row-level `GridAdaptor/TrackedEntityListGrid` are not  touched):

- Headers - `getAggregateGridHeaders(contextParams)` builds **one header per grouped dimension**, each named by its dimension key = SQL column name; then `VALUE_HEADER` ("value", NUMBER) is appended last.

- Rows - `addGroupedRows()` iterates the grid headers and reads `rs.getObject(headerName)`, so each row is `[dimension uids…, count].`

- Metadta - the shared `metadataParamsHandler.handle(...)` is reused, then the new method `addGroupedOrgUnitMetadata(...)` resolves the grid's ou-column UIDs via `OrganisationUnitService.getOrganisationUnitsByUid` and writes metaData.items (uid→name) + metaData.dimensions.ou.