### PR TITLE
fix: Updating user datastore entry shouldn't update other user's entries [DHIS2-21740]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreService.java
@@ -76,7 +76,7 @@ public interface UserDatastoreService {
    * <p>The update only affects the entry owned by the given user so that entries of other users
    * sharing the same namespace and key are not modified.
    *
-   * @param user the owner of the entry to update
+   * @param userId the id of the user owning the entry to update
    * @param ns namespace to update
    * @param key key to update
    * @param value the new JSON value, null to remove the entry or clear the property at the provided
@@ -86,7 +86,7 @@ public interface UserDatastoreService {
    *     rolling (dropping the array head element when its size
    */
   void updateEntry(
-      @Nonnull User user,
+      long userId,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreService.java
@@ -73,6 +73,10 @@ public interface UserDatastoreService {
    * replaced with the value but the value is appended to the array. The head of the array is *
    * dropped if the size of the array is equal or larger than the roll size.
    *
+   * <p>The update only affects the entry owned by the given user so that entries of other users
+   * sharing the same namespace and key are not modified.
+   *
+   * @param user the owner of the entry to update
    * @param ns namespace to update
    * @param key key to update
    * @param value the new JSON value, null to remove the entry or clear the property at the provided
@@ -82,6 +86,7 @@ public interface UserDatastoreService {
    *     rolling (dropping the array head element when its size
    */
   void updateEntry(
+      @Nonnull User user,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreStore.java
@@ -96,6 +96,10 @@ public interface UserDatastoreStore extends IdentifiableObjectStore<UserDatastor
    * replaced with the value but the value is appended to the array. The head of the array is
    * dropped if the size of the array is equal or larger than the roll size.
    *
+   * <p>The update only affects the entry owned by the given user so that entries of other users
+   * sharing the same namespace and key are not modified.
+   *
+   * @param user the owner of the entry to update
    * @param ns namespace to update
    * @param key key to update
    * @param value the new JSON value, null to remove the entry or clear the property at the provided
@@ -106,6 +110,7 @@ public interface UserDatastoreStore extends IdentifiableObjectStore<UserDatastor
    * @return true, if the update affects an existing row
    */
   boolean updateEntry(
+      @Nonnull User user,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreStore.java
@@ -99,7 +99,7 @@ public interface UserDatastoreStore extends IdentifiableObjectStore<UserDatastor
    * <p>The update only affects the entry owned by the given user so that entries of other users
    * sharing the same namespace and key are not modified.
    *
-   * @param user the owner of the entry to update
+   * @param userId the id of the user owning the entry to update
    * @param ns namespace to update
    * @param key key to update
    * @param value the new JSON value, null to remove the entry or clear the property at the provided
@@ -110,7 +110,7 @@ public interface UserDatastoreStore extends IdentifiableObjectStore<UserDatastor
    * @return true, if the update affects an existing row
    */
   boolean updateEntry(
-      @Nonnull User user,
+      long userId,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/DefaultUserDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/DefaultUserDatastoreService.java
@@ -81,7 +81,7 @@ public class DefaultUserDatastoreService implements UserDatastoreService {
   @Override
   @Transactional
   public void updateEntry(
-      @Nonnull User user,
+      long userId,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,
@@ -89,7 +89,7 @@ public class DefaultUserDatastoreService implements UserDatastoreService {
       @CheckForNull Integer roll)
       throws BadRequestException {
     validateEntry(key, value);
-    store.updateEntry(user, ns, key, value, path, roll);
+    store.updateEntry(userId, ns, key, value, path, roll);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/DefaultUserDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/DefaultUserDatastoreService.java
@@ -81,6 +81,7 @@ public class DefaultUserDatastoreService implements UserDatastoreService {
   @Override
   @Transactional
   public void updateEntry(
+      @Nonnull User user,
       @Nonnull String ns,
       @Nonnull String key,
       @CheckForNull String value,
@@ -88,7 +89,7 @@ public class DefaultUserDatastoreService implements UserDatastoreService {
       @CheckForNull Integer roll)
       throws BadRequestException {
     validateEntry(key, value);
-    store.updateEntry(ns, key, value, path, roll);
+    store.updateEntry(user, ns, key, value, path, roll);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
@@ -158,21 +158,24 @@ public class HibernateUserDatastoreStore
 
   @Override
   public boolean updateEntry(
+      @Nonnull User user,
       @Nonnull String ns,
       @Nonnull String key,
       @Nullable String value,
       @Nullable String path,
       @Nullable Integer roll) {
+    long userId = user.getId();
     boolean rootIsTarget = path == null || path.isEmpty();
-    if (value == null && rootIsTarget) return updateEntryRootDelete(ns, key);
-    if (value == null) return updateEntryPathSetToNull(ns, key, path);
-    if (roll == null && rootIsTarget) return updateEntryRootSetToValue(ns, key, value);
-    if (roll == null) return updateEntryPathSetToValue(ns, key, value, path);
-    if (rootIsTarget) return updateEntryRootRollValue(ns, key, value, roll);
-    return updateEntryPathRollValue(ns, key, value, path, roll);
+    if (value == null && rootIsTarget) return updateEntryRootDelete(userId, ns, key);
+    if (value == null) return updateEntryPathSetToNull(userId, ns, key, path);
+    if (roll == null && rootIsTarget) return updateEntryRootSetToValue(userId, ns, key, value);
+    if (roll == null) return updateEntryPathSetToValue(userId, ns, key, value, path);
+    if (rootIsTarget) return updateEntryRootRollValue(userId, ns, key, value, roll);
+    return updateEntryPathRollValue(userId, ns, key, value, path, roll);
   }
 
   private boolean updateEntryPathRollValue(
+      long userId,
       @Nonnull String ns,
       @Nonnull String key,
       @Nonnull String value,
@@ -194,8 +197,9 @@ public class HibernateUserDatastoreStore
           when 'null'    then jsonb_set(jbvalue, cast(:path as text[]), to_jsonb(ARRAY[cast(:value as jsonb)])) \
           else jsonb_set(jbvalue, cast(:path as text[]), to_jsonb(ARRAY[cast(:value as jsonb)])) \
           end \
-        where namespace = :ns and userkey = :key""";
+        where userid = :userid and namespace = :ns and userkey = :key""";
     return nativeSynchronizedQuery(sql)
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -206,7 +210,11 @@ public class HibernateUserDatastoreStore
   }
 
   private boolean updateEntryRootRollValue(
-      @Nonnull String ns, @Nonnull String key, @Nonnull String value, @Nonnull Integer roll) {
+      long userId,
+      @Nonnull String ns,
+      @Nonnull String key,
+      @Nonnull String value,
+      @Nonnull Integer roll) {
     String sql =
         """
         update userkeyjsonvalue \
@@ -219,8 +227,9 @@ public class HibernateUserDatastoreStore
             end \
           else cast(:value as jsonb) \
           end \
-        where namespace = :ns and userkey = :key""";
+        where userid = :userid and namespace = :ns and userkey = :key""";
     return nativeSynchronizedQuery(sql)
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -230,9 +239,14 @@ public class HibernateUserDatastoreStore
   }
 
   private boolean updateEntryPathSetToValue(
-      @Nonnull String ns, @Nonnull String key, @Nonnull String value, @Nonnull String path) {
+      long userId,
+      @Nonnull String ns,
+      @Nonnull String key,
+      @Nonnull String value,
+      @Nonnull String path) {
     return nativeSynchronizedQuery(
-                "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb), false) where namespace = :ns and userkey = :key")
+                "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb), false) where userid = :userid and namespace = :ns and userkey = :key")
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -242,9 +256,10 @@ public class HibernateUserDatastoreStore
   }
 
   private boolean updateEntryRootSetToValue(
-      @Nonnull String ns, @Nonnull String key, @Nonnull String value) {
+      long userId, @Nonnull String ns, @Nonnull String key, @Nonnull String value) {
     return nativeSynchronizedQuery(
-                "update userkeyjsonvalue set jbvalue = cast(:value as jsonb) where namespace = :ns and userkey = :key")
+                "update userkeyjsonvalue set jbvalue = cast(:value as jsonb) where userid = :userid and namespace = :ns and userkey = :key")
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -253,9 +268,10 @@ public class HibernateUserDatastoreStore
   }
 
   private boolean updateEntryPathSetToNull(
-      @Nonnull String ns, @Nonnull String key, @Nonnull String path) {
+      long userId, @Nonnull String ns, @Nonnull String key, @Nonnull String path) {
     return nativeSynchronizedQuery(
-                "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), 'null', false) where namespace = :ns and userkey = :key")
+                "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), 'null', false) where userid = :userid and namespace = :ns and userkey = :key")
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("path", toJsonbPath(path))
@@ -263,10 +279,11 @@ public class HibernateUserDatastoreStore
         > 0;
   }
 
-  private boolean updateEntryRootDelete(@Nonnull String ns, @Nonnull String key) {
+  private boolean updateEntryRootDelete(long userId, @Nonnull String ns, @Nonnull String key) {
     // delete
     return nativeSynchronizedQuery(
-                "delete from userkeyjsonvalue where namespace = :ns and userkey = :key")
+                "delete from userkeyjsonvalue where userid = :userid and namespace = :ns and userkey = :key")
+            .setParameter("userid", userId)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .executeUpdate()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
@@ -158,13 +158,12 @@ public class HibernateUserDatastoreStore
 
   @Override
   public boolean updateEntry(
-      @Nonnull User user,
+      long userId,
       @Nonnull String ns,
       @Nonnull String key,
       @Nullable String value,
       @Nullable String path,
       @Nullable Integer roll) {
-    long userId = user.getId();
     boolean rootIsTarget = path == null || path.isEmpty();
     if (value == null && rootIsTarget) return updateEntryRootDelete(userId, ns, key);
     if (value == null) return updateEntryPathSetToNull(userId, ns, key, path);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
@@ -30,7 +30,9 @@
 package org.hisp.dhis.userdatastore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -158,5 +160,161 @@ class UserDatastoreEntryStoreTest extends PostgresIntegrationTestBase {
     assertTrue(
         updatedA.getValue().contains("999999"),
         "user A's value was overwritten by user B's update: " + updatedA.getValue());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read isolation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testGetEntryReturnsOnlyOwningUsersValue() {
+    User userB = createUserWithAuth("readuser");
+    addEntry(user, "read", "foo", "{\"a\": \"999999\"}");
+    addEntry(userB, "read", "foo", "{\"a\": \"111111\"}");
+    clearSession();
+
+    assertTrue(userDatastoreStore.getEntry(user, "read", "foo").getValue().contains("999999"));
+    assertTrue(userDatastoreStore.getEntry(userB, "read", "foo").getValue().contains("111111"));
+  }
+
+  @Test
+  void testGetEntryDoesNotReturnAnotherUsersEntry() {
+    User userB = createUserWithAuth("readuser2");
+    addEntry(user, "read2", "foo", "{}");
+    clearSession();
+
+    assertNotNull(userDatastoreStore.getEntry(user, "read2", "foo"));
+    assertNull(
+        userDatastoreStore.getEntry(userB, "read2", "foo"),
+        "user B must not be able to read user A's entry");
+  }
+
+  @Test
+  void testNamespacesKeysEntriesAndCountAreIsolatedPerUser() {
+    User userB = createUserWithAuth("listuser");
+    addEntry(user, "shared_ns", "keyA1", "{}");
+    addEntry(user, "shared_ns", "keyA2", "{}");
+    addEntry(user, "only_a_ns", "k", "{}");
+    addEntry(userB, "shared_ns", "keyB1", "{}");
+    addEntry(userB, "only_b_ns", "k", "{}");
+    clearSession();
+
+    // namespaces are scoped to the user
+    List<String> aNamespaces = userDatastoreStore.getNamespaces(user);
+    assertTrue(aNamespaces.contains("only_a_ns"));
+    assertFalse(aNamespaces.contains("only_b_ns"));
+
+    // keys within a namespace shared (by name) between users are scoped to the user
+    List<String> aKeys = userDatastoreStore.getKeysInNamespace(user, "shared_ns");
+    assertTrue(aKeys.contains("keyA1"));
+    assertTrue(aKeys.contains("keyA2"));
+    assertFalse(aKeys.contains("keyB1"));
+
+    // entries within the shared namespace are scoped to the user
+    assertEquals(2, userDatastoreStore.getEntriesInNamespace(user, "shared_ns").size());
+
+    // counts are scoped to the user
+    assertEquals(2, userDatastoreStore.countKeysInNamespace(user, "shared_ns"));
+    assertEquals(1, userDatastoreStore.countKeysInNamespace(userB, "shared_ns"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delete isolation (native root delete: null value, no path)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testDeleteEntryOnlyAffectsOwningUser() {
+    User userB = createUserWithAuth("deleteuser");
+    addEntry(user, "del", "foo", "{\"a\": \"999999\"}");
+    addEntry(userB, "del", "foo", "{\"a\": \"111111\"}");
+
+    // user B deletes their own entry (null value + no path -> native root delete)
+    boolean deleted = userDatastoreStore.updateEntry(userB.getId(), "del", "foo", null, null, null);
+    clearSession();
+
+    assertTrue(deleted);
+    assertNull(
+        userDatastoreStore.getEntry(userB, "del", "foo"), "user B's entry should be deleted");
+    UserDatastoreEntry remainingA = userDatastoreStore.getEntry(user, "del", "foo");
+    assertNotNull(remainingA, "user A's entry must not be deleted by user B's delete");
+    assertTrue(remainingA.getValue().contains("999999"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Update-variant isolation (one test per native SQL branch)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testUpdateEntryAtPathOnlyAffectsOwningUser() {
+    User userB = createUserWithAuth("pathuser");
+    addEntry(user, "path", "foo", "{\"a\": \"999999\"}");
+    addEntry(userB, "path", "foo", "{\"a\": \"111111\"}");
+
+    // user B sets property "a" on their own entry
+    userDatastoreStore.updateEntry(userB.getId(), "path", "foo", "\"0\"", "a", null);
+    clearSession();
+
+    assertTrue(userDatastoreStore.getEntry(userB, "path", "foo").getValue().contains("\"0\""));
+    assertTrue(
+        userDatastoreStore.getEntry(user, "path", "foo").getValue().contains("999999"),
+        "user A's entry must be untouched");
+  }
+
+  @Test
+  void testUpdateEntryPathToNullOnlyAffectsOwningUser() {
+    User userB = createUserWithAuth("nulluser");
+    addEntry(user, "pathnull", "foo", "{\"a\": \"999999\"}");
+    addEntry(userB, "pathnull", "foo", "{\"a\": \"111111\"}");
+
+    // user B nulls property "a" on their own entry (null value + path)
+    userDatastoreStore.updateEntry(userB.getId(), "pathnull", "foo", null, "a", null);
+    clearSession();
+
+    assertTrue(userDatastoreStore.getEntry(userB, "pathnull", "foo").getValue().contains("null"));
+    assertTrue(
+        userDatastoreStore.getEntry(user, "pathnull", "foo").getValue().contains("999999"),
+        "user A's entry must be untouched");
+  }
+
+  @Test
+  void testUpdateEntryRootRollOnlyAffectsOwningUser() {
+    User userB = createUserWithAuth("rolluser");
+    addEntry(user, "rollroot", "arr", "[1, 2]");
+    addEntry(userB, "rollroot", "arr", "[1, 2]");
+
+    // user B appends 3 to their own array (root value, roll size 5)
+    userDatastoreStore.updateEntry(userB.getId(), "rollroot", "arr", "3", null, 5);
+    clearSession();
+
+    assertTrue(userDatastoreStore.getEntry(userB, "rollroot", "arr").getValue().contains("3"));
+    assertFalse(
+        userDatastoreStore.getEntry(user, "rollroot", "arr").getValue().contains("3"),
+        "user A's array must be untouched");
+  }
+
+  @Test
+  void testUpdateEntryPathRollOnlyAffectsOwningUser() {
+    User userB = createUserWithAuth("pathrolluser");
+    addEntry(user, "rollpath", "obj", "{\"list\": [1, 2]}");
+    addEntry(userB, "rollpath", "obj", "{\"list\": [1, 2]}");
+
+    // user B appends 3 to the array at path "list" on their own entry (roll size 5)
+    userDatastoreStore.updateEntry(userB.getId(), "rollpath", "obj", "3", "list", 5);
+    clearSession();
+
+    assertTrue(userDatastoreStore.getEntry(userB, "rollpath", "obj").getValue().contains("3"));
+    assertFalse(
+        userDatastoreStore.getEntry(user, "rollpath", "obj").getValue().contains("3"),
+        "user A's nested array must be untouched");
+  }
+
+  private UserDatastoreEntry addEntry(User owner, String namespace, String key, String value) {
+    UserDatastoreEntry entry = new UserDatastoreEntry();
+    entry.setNamespace(namespace);
+    entry.setKey(key);
+    entry.setValue(value);
+    entry.setCreatedBy(owner);
+    userDatastoreStore.save(entry);
+    return entry;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
@@ -113,4 +113,50 @@ class UserDatastoreEntryStoreTest extends PostgresIntegrationTestBase {
     assertTrue(list.contains(userEntryA));
     assertTrue(list.contains(userEntryB));
   }
+
+  /**
+   * Reproduces DHIS2-21740: a user datastore entry must only be updated for its owning user. Two
+   * users can each own an entry under the same namespace + key. Updating one user's value must not
+   * change the other user's value.
+   */
+  @Test
+  void testUpdateEntryOnlyAffectsOwningUser() {
+    User userA = user;
+    User userB = createUserWithAuth("otheruser");
+
+    UserDatastoreEntry entryA = new UserDatastoreEntry();
+    entryA.setNamespace("test");
+    entryA.setKey("foo");
+    entryA.setValue("{\"a\": \"999999\"}");
+    entryA.setCreatedBy(userA);
+    userDatastoreStore.save(entryA);
+
+    UserDatastoreEntry entryB = new UserDatastoreEntry();
+    entryB.setNamespace("test");
+    entryB.setKey("foo");
+    entryB.setValue("{\"a\": \"111111\"}");
+    entryB.setCreatedBy(userB);
+    userDatastoreStore.save(entryB);
+
+    // user B updates the root value of their own "test"/"foo" entry
+    userDatastoreStore.updateEntry(userB, "test", "foo", "{\"a\": \"0\"}", null, null);
+
+    // the update runs as native SQL; clear the session so the entries are re-read from the DB
+    entityManager.flush();
+    entityManager.clear();
+
+    UserDatastoreEntry updatedB = userDatastoreStore.getEntry(userB, "test", "foo");
+    UserDatastoreEntry updatedA = userDatastoreStore.getEntry(userA, "test", "foo");
+    assertNotNull(updatedA);
+    assertNotNull(updatedB);
+
+    // user B's own value was updated as requested
+    assertTrue(
+        updatedB.getValue().contains("0"),
+        "user B's value should have been updated but was: " + updatedB.getValue());
+    // user A's value must be untouched by user B's update
+    assertTrue(
+        updatedA.getValue().contains("999999"),
+        "user A's value was overwritten by user B's update: " + updatedA.getValue());
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/userdatastore/UserDatastoreEntryStoreTest.java
@@ -139,7 +139,7 @@ class UserDatastoreEntryStoreTest extends PostgresIntegrationTestBase {
     userDatastoreStore.save(entryB);
 
     // user B updates the root value of their own "test"/"foo" entry
-    userDatastoreStore.updateEntry(userB, "test", "foo", "{\"a\": \"0\"}", null, null);
+    userDatastoreStore.updateEntry(userB.getId(), "test", "foo", "{\"a\": \"0\"}", null, null);
 
     // the update runs as native SQL; clear the session so the entries are re-read from the DB
     entityManager.flush();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
@@ -238,11 +238,12 @@ public class UserDatastoreController extends AbstractDatastoreController {
       @RequestParam(required = false) Integer roll,
       @RequestParam(defaultValue = "false") boolean encrypt)
       throws BadRequestException, ConflictException {
-    UserDatastoreEntry userEntry = service.getUserEntry(getUser(username), namespace, key);
+    User user = getUser(username);
+    UserDatastoreEntry userEntry = service.getUserEntry(user, namespace, key);
 
     if (userEntry == null) return addEntry(namespace, key, username, value, encrypt);
 
-    service.updateEntry(namespace, key, value, path, roll);
+    service.updateEntry(user, namespace, key, value, path, roll);
     return ok(String.format("Key updated: '%s'", key));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
@@ -243,7 +243,7 @@ public class UserDatastoreController extends AbstractDatastoreController {
 
     if (userEntry == null) return addEntry(namespace, key, username, value, encrypt);
 
-    service.updateEntry(user, namespace, key, value, path, roll);
+    service.updateEntry(user.getId(), namespace, key, value, path, roll);
     return ok(String.format("Key updated: '%s'", key));
   }
 


### PR DESCRIPTION
# Issue
In the user data store, when a User updates a namespace & key with a value, it updates that namespace and key value for any user using the same namespace and key.

No tests covering this scenario.

# Cause
The update is never user-scoped.
Old user data store used to update the `UserDatastoreEntry` directly but [new data store behaviour](https://github.com/dhis2/dhis2-core/pull/15899) was [ported to the user data store](https://github.com/dhis2/dhis2-core/pull/16534) which updates to the namespace & key.

# Fix
Use user ID in SQL updates

# Testing
- Automated integration test added covering the scenario
- Further integration tests added to cover other user-scoped scenarios (help prevent future regressions)
- Manually tested through the API & UI.