### PR TITLE
fix: Block update event when block flag on PS [DHIS2-21551]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -54,6 +54,7 @@ import lombok.SneakyThrows;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.tracker.TestSetup;
@@ -259,9 +260,17 @@ class EventImportValidationTest extends PostgresIntegrationTestBase {
   void shouldBlockUpdateOfCompletedEventWhenBlockEntryFormIsTrue() throws IOException {
     TrackerImportParams params = TrackerImportParams.builder().build();
     TrackerObjects trackerObjects =
-        testSetup.fromJson("tracker/validations/single_completed_event.json");
+        testSetup.fromJson("tracker/validations/single_active_event.json");
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
+
+    clearSession();
+
+    trackerObjects.getEvents().get(0).setStatus(EventStatus.COMPLETED);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    clearSession();
 
     importReport = trackerImportService.importTracker(params, trackerObjects);
     assertHasOnlyErrors(importReport, ValidationCode.E1326);

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/single_active_event.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/single_active_event.json
@@ -4,7 +4,7 @@
   "events": [
     {
       "event": "ZwwuwNp6gVd",
-      "status": "COMPLETED",
+      "status": "ACTIVE",
       "program": {
         "idScheme": "UID",
         "identifier": "rT3rvcn2vid"

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidator.java
@@ -36,6 +36,8 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.SingleEvent;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.Validator;
@@ -54,10 +56,29 @@ class BlockEntryFormAfterCompletionValidator implements Validator<Event> {
 
     ProgramStage programStage = preheat.getProgramStage(event.getProgramStage());
 
-    if (EventStatus.COMPLETED == event.getStatus()
-        && Boolean.TRUE.equals(programStage.getBlockEntryForm())) {
+    if (Boolean.TRUE.equals(programStage.getBlockEntryForm())
+        && EventStatus.COMPLETED == event.getStatus()
+        && EventStatus.COMPLETED == getSavedStatus(event, preheat)) {
       reporter.addError(event, E1326, event.getEvent());
     }
+  }
+
+  private EventStatus getSavedStatus(Event event, TrackerPreheat preheat) {
+    if (event instanceof TrackerEvent) {
+      org.hisp.dhis.tracker.model.TrackerEvent trackerEvent =
+          preheat.getTrackerEvent(event.getUID());
+      if (trackerEvent != null) {
+        return trackerEvent.getStatus();
+      }
+    }
+
+    if (event instanceof SingleEvent) {
+      org.hisp.dhis.tracker.model.SingleEvent singleEvent = preheat.getSingleEvent(event.getUID());
+      if (singleEvent != null) {
+        return singleEvent.getStatus();
+      }
+    }
+    return null;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
@@ -82,9 +82,11 @@ class BlockEntryFormAfterCompletionValidatorTest {
   }
 
   @Test
-  void shouldFailWhenTrackerEventIsCompletedAndBlockEntryFormIsEnabled() {
+  void shouldFailWhenTrackerEventIsCompletedAndSavedStatusIsCompletedAndBlockEntryFormIsEnabled() {
     stubProgramStage(true);
-    Event event = trackerEvent(EventStatus.COMPLETED);
+    UID uid = UID.generate();
+    stubSavedTrackerEvent(uid, EventStatus.COMPLETED);
+    Event event = trackerEvent(uid, EventStatus.COMPLETED);
 
     validator.validate(reporter, bundle, event);
 
@@ -92,24 +94,27 @@ class BlockEntryFormAfterCompletionValidatorTest {
   }
 
   @Test
-  void shouldFailWhenSingleEventIsCompletedAndBlockEntryFormIsEnabled() {
+  void shouldFailWhenSingleEventIsCompletedAndSavedStatusIsCompletedAndBlockEntryFormIsEnabled() {
     stubProgramStage(true);
-    Event event =
-        SingleEvent.builder()
-            .event(UID.generate())
-            .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
-            .status(EventStatus.COMPLETED)
-            .build();
+    UID uid = UID.generate();
+    stubSavedSingleEvent(uid, EventStatus.COMPLETED);
+    Event event = singleEvent(uid, EventStatus.COMPLETED);
 
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, E1326);
   }
 
-  @Test
-  void shouldPassWhenEventIsCompletedButBlockEntryFormIsDisabled() {
-    stubProgramStage(false);
-    Event event = trackerEvent(EventStatus.COMPLETED);
+  @ParameterizedTest
+  @EnumSource(
+      value = EventStatus.class,
+      mode = Mode.EXCLUDE,
+      names = {"COMPLETED"})
+  void shouldPassWhenTrackerEventIsCompletedButSavedStatusIsNotCompleted(EventStatus savedStatus) {
+    stubProgramStage(true);
+    UID uid = UID.generate();
+    stubSavedTrackerEvent(uid, savedStatus);
+    Event event = trackerEvent(uid, EventStatus.COMPLETED);
 
     validator.validate(reporter, bundle, event);
 
@@ -121,9 +126,67 @@ class BlockEntryFormAfterCompletionValidatorTest {
       value = EventStatus.class,
       mode = Mode.EXCLUDE,
       names = {"COMPLETED"})
-  void shouldPassWhenBlockEntryFormIsEnabledButEventIsNotCompleted(EventStatus status) {
+  void shouldPassWhenSingleEventIsCompletedButSavedStatusIsNotCompleted(EventStatus savedStatus) {
     stubProgramStage(true);
-    Event event = trackerEvent(status);
+    UID uid = UID.generate();
+    stubSavedSingleEvent(uid, savedStatus);
+    Event event = singleEvent(uid, EventStatus.COMPLETED);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldPassWhenTrackerEventIsCompletedAndSavedStatusIsCompletedButBlockEntryFormIsDisabled() {
+    stubProgramStage(false);
+    UID uid = UID.generate();
+    stubSavedTrackerEvent(uid, EventStatus.COMPLETED);
+    Event event = trackerEvent(uid, EventStatus.COMPLETED);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = EventStatus.class,
+      mode = Mode.EXCLUDE,
+      names = {"COMPLETED"})
+  void shouldPassWhenBlockEntryFormIsEnabledButTrackerEventIsNotCompleted(EventStatus status) {
+    stubProgramStage(true);
+    UID uid = UID.generate();
+    stubSavedTrackerEvent(uid, EventStatus.COMPLETED);
+    Event event = trackerEvent(uid, status);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldPassWhenSingleEventIsCompletedAndSavedStatusIsCompletedButBlockEntryFormIsDisabled() {
+    stubProgramStage(false);
+    UID uid = UID.generate();
+    stubSavedSingleEvent(uid, EventStatus.COMPLETED);
+    Event event = singleEvent(uid, EventStatus.COMPLETED);
+
+    validator.validate(reporter, bundle, event);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = EventStatus.class,
+      mode = Mode.EXCLUDE,
+      names = {"COMPLETED"})
+  void shouldPassWhenBlockEntryFormIsEnabledButSingleEventIsNotCompleted(EventStatus status) {
+    stubProgramStage(true);
+    UID uid = UID.generate();
+    stubSavedSingleEvent(uid, EventStatus.COMPLETED);
+    Event event = singleEvent(uid, status);
 
     validator.validate(reporter, bundle, event);
 
@@ -146,9 +209,31 @@ class BlockEntryFormAfterCompletionValidatorTest {
         .thenReturn(programStage);
   }
 
-  private Event trackerEvent(EventStatus status) {
+  private void stubSavedTrackerEvent(UID uid, EventStatus status) {
+    org.hisp.dhis.tracker.model.TrackerEvent savedEvent =
+        new org.hisp.dhis.tracker.model.TrackerEvent();
+    savedEvent.setStatus(status);
+    when(preheat.getTrackerEvent(uid)).thenReturn(savedEvent);
+  }
+
+  private void stubSavedSingleEvent(UID uid, EventStatus status) {
+    org.hisp.dhis.tracker.model.SingleEvent savedEvent =
+        new org.hisp.dhis.tracker.model.SingleEvent();
+    savedEvent.setStatus(status);
+    when(preheat.getSingleEvent(uid)).thenReturn(savedEvent);
+  }
+
+  private Event trackerEvent(UID uid, EventStatus status) {
     return TrackerEvent.builder()
-        .event(UID.generate())
+        .event(uid)
+        .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
+        .status(status)
+        .build();
+  }
+
+  private Event singleEvent(UID uid, EventStatus status) {
+    return SingleEvent.builder()
+        .event(uid)
         .programStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID))
         .status(status)
         .build();

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/BlockEntryFormAfterCompletionValidatorTest.java
@@ -141,7 +141,6 @@ class BlockEntryFormAfterCompletionValidatorTest {
   void shouldPassWhenTrackerEventIsCompletedAndSavedStatusIsCompletedButBlockEntryFormIsDisabled() {
     stubProgramStage(false);
     UID uid = UID.generate();
-    stubSavedTrackerEvent(uid, EventStatus.COMPLETED);
     Event event = trackerEvent(uid, EventStatus.COMPLETED);
 
     validator.validate(reporter, bundle, event);
@@ -157,7 +156,6 @@ class BlockEntryFormAfterCompletionValidatorTest {
   void shouldPassWhenBlockEntryFormIsEnabledButTrackerEventIsNotCompleted(EventStatus status) {
     stubProgramStage(true);
     UID uid = UID.generate();
-    stubSavedTrackerEvent(uid, EventStatus.COMPLETED);
     Event event = trackerEvent(uid, status);
 
     validator.validate(reporter, bundle, event);
@@ -169,7 +167,6 @@ class BlockEntryFormAfterCompletionValidatorTest {
   void shouldPassWhenSingleEventIsCompletedAndSavedStatusIsCompletedButBlockEntryFormIsDisabled() {
     stubProgramStage(false);
     UID uid = UID.generate();
-    stubSavedSingleEvent(uid, EventStatus.COMPLETED);
     Event event = singleEvent(uid, EventStatus.COMPLETED);
 
     validator.validate(reporter, bundle, event);
@@ -185,7 +182,6 @@ class BlockEntryFormAfterCompletionValidatorTest {
   void shouldPassWhenBlockEntryFormIsEnabledButSingleEventIsNotCompleted(EventStatus status) {
     stubProgramStage(true);
     UID uid = UID.generate();
-    stubSavedSingleEvent(uid, EventStatus.COMPLETED);
     Event event = singleEvent(uid, status);
 
     validator.validate(reporter, bundle, event);


### PR DESCRIPTION
Refines the "block entry form after completion" validation so that it only blocks updates to events that were **already completed**, rather than any update whose incoming status is `COMPLETED`. Previously, completing an active event (an `ACTIVE` → `COMPLETED` transition) was incorrectly rejected when the program stage had `blockEntryForm` enabled.