### PR TITLE
fix: Preserve PostgreSQL VARCHAR character semantics in Doris schema generation

### DIFF
--- a/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/main/java/org/hisp/dhis/db/sql/DorisSqlBuilder.java
@@ -61,6 +61,12 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
 
   private static final String QUOTE = "`";
 
+  /** Maximum length in bytes of a Doris {@code varchar} column. */
+  private static final int VARCHAR_MAX_BYTES = 65533;
+
+  /** Maximum number of bytes a single UTF-8 character can occupy. */
+  private static final int UTF8_MAX_BYTES_PER_CHAR = 4;
+
   // Database
 
   @Override
@@ -115,9 +121,15 @@ public class DorisSqlBuilder extends AbstractSqlBuilder {
     return String.format("char(%d)", length);
   }
 
+  /**
+   * PostgreSQL {@code varchar(n)} limits the number of characters, while Doris {@code varchar(n)}
+   * limits the number of bytes. Widen the length by the maximum number of bytes a UTF-8 character
+   * can occupy so that any value valid in PostgreSQL also fits the generated Doris column.
+   */
   @Override
   public String dataTypeVarchar(int length) {
-    return String.format("varchar(%d)", length);
+    int byteLength = Math.min(length * UTF8_MAX_BYTES_PER_CHAR, VARCHAR_MAX_BYTES);
+    return String.format("varchar(%d)", byteLength);
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-sql/src/test/java/org/hisp/dhis/db/sql/DorisSqlBuilderTest.java
@@ -107,6 +107,16 @@ class DorisSqlBuilderTest {
     assertEquals("json", sqlBuilder.dataTypeJson());
   }
 
+  @Test
+  void testDataTypeVarchar() {
+    // PostgreSQL varchar(n) limits characters, Doris varchar(n) limits bytes, so the length
+    // must be widened to accommodate multi-byte UTF-8 characters (e.g. Burmese, Chinese, Thai).
+    assertEquals("varchar(200)", sqlBuilder.dataTypeVarchar(50));
+    assertEquals("varchar(1020)", sqlBuilder.dataTypeVarchar(255));
+    // Capped at the Doris varchar byte limit.
+    assertEquals("varchar(65533)", sqlBuilder.dataTypeVarchar(20000));
+  }
+
   // Index types
 
   @Test
@@ -156,7 +166,7 @@ class DorisSqlBuilderTest {
     String expected =
         """
         create table `immunization` (`id` bigint not null,`data` char(11) not null,\
-        `period` varchar(50) not null,`created` datetime(3) null,`user` json null,\
+        `period` varchar(200) not null,`created` datetime(3) null,`user` json null,\
         `value` double null) \
         engine = olap \
         unique key (`id`) \
@@ -174,7 +184,7 @@ class DorisSqlBuilderTest {
     String expected =
         """
         create table `vaccination` (`id` int not null,\
-        `facility_type` varchar(255) null,`bcg_doses` double null) \
+        `facility_type` varchar(1020) null,`bcg_doses` double null) \
         engine = olap \
         duplicate key (`id`) \
         distributed by hash(`id`) \
@@ -207,7 +217,7 @@ class DorisSqlBuilderTest {
     String expected =
         """
         create table `immunization` (`id` bigint not null,`data` char(11) not null,\
-        `period` varchar(50) not null,`value` double null) \
+        `period` varchar(200) not null,`value` double null) \
         engine = olap \
         duplicate key (`id`) \
         distributed by hash(`id`) \


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-21756

## Summary
- PostgreSQL `VARCHAR(n)` limits the number of *characters*, but Doris `VARCHAR(n)` limits the number of *bytes*. Analytics/resource table schema generation was copying the numeric length directly, so valid PostgreSQL data containing multibyte UTF-8 characters (e.g. Burmese, Chinese, Japanese, Thai) could exceed the Doris column width and fail replication with `Insert has filtered data in strict mode`.
- `DorisSqlBuilder.dataTypeVarchar(int length)` now widens the generated Doris `varchar` length by the maximum number of bytes a UTF-8 character can occupy (4), capped at Doris's `varchar` byte limit (65533), so any value accepted by PostgreSQL is also accepted by the generated Doris schema.
- Only two lengths ever reach this method (`VARCHAR_50` and `VARCHAR_255`, via the shared `DataType` enum used across resource/analytics table definitions), and neither is ever used as a primary/distribution key column, so widening the byte capacity (rather than switching to Doris `STRING`, which cannot be a key column) is a safe, minimal-risk fix.

## Test plan
- [x] Updated `DorisSqlBuilderTest` expectations for the new `varchar` widths (50 → 200, 255 → 1020)
- [x] Added `testDataTypeVarchar` covering the 50/255 cases and the cap at 65533 bytes
- [x] `mvn test -pl dhis-support/dhis-support-sql -Dtest=DorisSqlBuilderTest -P unit-test` — 21/21 passing
- [x] `mvn spotless:check -pl dhis-support/dhis-support-sql` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)