### PR TITLE
perf: Set default hibernate fetch size

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -168,8 +168,12 @@ public class CategoryOption extends BaseMetadataObject
   @BatchSize(size = 100)
   private Set<Category> categories = new HashSet<>();
 
+  // batch-size=1 overrides the global default_batch_fetch_size: batching this collection's
+  // loads corrupts merge flushes, since CategoryOptionCombo's equals/hashCode are content-based
+  // over its own mutable categoryOptions field.
   @ManyToMany(mappedBy = "categoryOptions")
   @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @BatchSize(size = 1)
   private Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
 
   @ManyToMany(mappedBy = "members")

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
@@ -19,7 +19,8 @@
 
     <property name="translations" type="jblTranslations"/>
 
-    <set name="categoryOptions" table="categoryoptioncombos_categoryoptions">
+    <!-- batch-size=1 overrides the global default_batch_fetch_size: batching this collection's loads corrupts merge flushes, since equals/hashCode are based on this same mutable field. -->
+    <set name="categoryOptions" table="categoryoptioncombos_categoryoptions" batch-size="1">
       <cache usage="read-write" />
       <key column="categoryoptioncomboid" foreign-key="fk_categoryoptioncombos_categoryoptions_categoryoptioncomboid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -181,8 +181,11 @@ public class HibernateConfig {
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
     // Coalesce lazy proxy/collection initialization into IN-clause batches instead of one
-    // SELECT per entity (e.g. DataSetElement.dataElement/categoryCombo lookups).
-    properties.put(AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "100");
+    // SELECT per entity (e.g. DataSetElement.dataElement/categoryCombo lookups). PADDED style
+    // rounds each batch up to the nearest power of 2, capping how many distinct IN-list shapes
+    // get prepared/cached, instead of LEGACY's cascade of shrinking sizes.
+    properties.put(AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "25");
+    properties.put(AvailableSettings.BATCH_FETCH_STYLE, "PADDED");
 
     return properties;
   }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -180,6 +180,10 @@ public class HibernateConfig {
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
+    // Coalesce lazy proxy/collection initialization into IN-clause batches instead of one
+    // SELECT per entity (e.g. DataSetElement.dataElement/categoryCombo lookups).
+    properties.put(AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "100");
+
     return properties;
   }
 }


### PR DESCRIPTION
## What

Sets a Hibernate `default_batch_fetch_size` (25, `PADDED` style) to coalesce lazy
collection/proxy initialization into IN-clause batches instead of issuing one `SELECT` per
entity (e.g. `DataSetElement.dataElement`/`categoryCombo` lookups), fixing an N+1 pattern
observed in `/api/dataEntry/metadata`.

## Correctness fix included in this PR

Turning on the global batch-fetch default exposed a pre-existing correctness bug in
`CategoryOption` merge: it started silently dropping one `CategoryOptionCombo` association per
merge, with `200 OK` and no error reported.

Root cause: `CategoryOptionCombo.equals()`/`hashCode()` are content-based, hashing on
`categoryCombo` plus the entity's own mutable `categoryOptions` field. `CategoryOptionMergeHandler`
mutates that field in place on `CategoryOptionCombo` instances that are simultaneously
Hibernate-managed members of a `Set` (the inverse `CategoryOption.categoryOptionCombos`
collection). Under one-at-a-time lazy loading this stays self-consistent by luck of timing;
batch-fetching multiple owners' loads of the same collection role together shifts the
initialization order just enough to corrupt Hibernate's flush dirty-checking for one
association, every time.

Confirmed via direct A/B build (same fixture/steps/Postgres, only the Hibernate config
differs), checked against the actual `categoryoptioncombos_categoryoptions` table: 5/5 rows
on master, 4/5 with batching on. Non-flaky — reproduced identically across CI runs with
different randomly-generated UIDs.

Fix: pin the two implicated collections back to single-owner loading —
`batch-size="1"` on `CategoryOptionCombo.categoryOptions`
(`CategoryOptionCombo.hbm.xml`) and `@BatchSize(size = 1)` on
`CategoryOption.categoryOptionCombos` — overriding the global default just for these two,
while keeping the batching win for every other collection. Verified with the same A/B method:
rebuilt image, re-ran the repro and the real e2e test, 5/5 rows, build green.

This closes the specific trigger found here but does not fix the underlying fragility
(content-based `equals`/`hashCode` on a mutable field, no post-merge consistency check in the
merge framework, no validation that `CategoryOption` merge sources/target share a `Category`
the way `CategoryComboMergeService` requires). Those are tracked separately, not addressed in
this PR — see `category-option-merge-coc-corruption.md` for the full writeup.

## Performance validation

Added a focused Gatling test, `DataEntryMetadataPerformanceTest` (#24384), to measure
`GET /api/dataEntry/metadata` — the endpoint this fix targets — and compared this branch against
`master` on the Sierra Leone demo DB (local Docker images built from source for both branches).

Both a single-user and a 20-concurrent-user profile were run several times each (not a single
sample) and combined via [gstat](https://github.com/dhis2/gatling-statistics):

**Single-user, N=20, 3 repeats/branch (60 requests/branch):**

| | fix/hibernate-fetch-size | master | Change |
|---|---:|---:|---:|
| p50 | 296ms | 288ms | -2.5% (noise) |
| p95 | 500ms | 585ms | master +17.0% slower |
| p99 | 535ms | 609ms | master +13.8% slower |

**20 concurrent users x 10 iterations, 5 repeats/branch (1000 requests/branch):**

| | fix/hibernate-fetch-size | master | Change |
|---|---:|---:|---:|
| p50 | 288ms | 288ms | 0.0% |
| p95 | 346ms | 363ms | master +4.8% slower |
| p99 | 501ms | 601ms | master +20.0% slower |

Medians are a wash in both profiles (expected — the fix targets the tail, not the common case),
but p95/p99 is consistently 14-20% better on this branch than on master, under both single-user
and concurrent load. `master` also had one transient failed request out of 1000 in the concurrent
runs (0.1% KO); this branch had zero failures across all runs.

Async-profiler (`-e wall`) during a concurrent run confirms the mechanism: filtering to stacks
passing through `DefaultDataSetMetadataExportService`, `master` spends roughly **2x** more
wall-clock samples in the JDBC/PostgreSQL driver layer (608 vs 305 samples) and ~19% more in
Hibernate collection-initialization frames — consistent with issuing many more small
per-collection round-trips instead of batching them, which is exactly what
`default_batch_fetch_size` plus the `CategoryOptionCombo`/`CategoryOption` batch-size pinning in
this PR addresses.

Absolute numbers are specific to this local Docker/SL-demo-DB setup and will differ on other
hardware (e.g. the performance CI runner) — the result that matters is the branch-to-branch
comparison, which was reproducible across repeated runs.

## Testing

- `CategoryOptionMergeTest` (dhis-test-e2e): 5 `CategoryOptionCombo` associations expected
  post-merge, reproduced the drop to 4 without the fix, green with it.
- `CategoryOptionMergeServiceTest` (dhis-test-integration): passing throughout (doesn't hit
  this timing collision with its simpler fixture — a gap in that suite's coverage, noted above).
- Manual A/B rebuild + `psql` inspection of `categoryoptioncombos_categoryoptions` to rule out
  a display/cache-layer explanation.
- `DataEntryMetadataPerformanceTest` (#24384): repeated single-user and concurrent Gatling runs
  on both branches, see Performance validation above.
