### PR TITLE
fix: add filter param for export metadata version

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -222,9 +223,10 @@ public class DefaultMetadataExportService implements MetadataExportService {
   public static final Predicate<Schema> DEPRECATED_ANALYTICS_SCHEMAS =
       schema -> schema.getKlass() != EventChart.class && schema.getKlass() != EventReport.class;
 
+  /** This method is used by MetadataSyncService to export metadata version snapshot. */
   @Override
   @Transactional(readOnly = true)
-  public ObjectNode getMetadataAsObjectNode(MetadataExportParams params) {
+  public ObjectNode exportMetadataVersion(MetadataExportParams params) {
     ObjectNode rootNode = fieldFilterService.createObjectNode();
     SystemInfoForMetadataExport systemInfo = systemService.getSystemInfoForMetadataExport();
 
@@ -234,6 +236,16 @@ public class DefaultMetadataExportService implements MetadataExportService {
         .put(SYSTEM_REVISION, systemInfo.revision())
         .put(SYSTEM_VERSION, systemInfo.version())
         .put(SYSTEM_DATE, DateUtils.toIso8601(systemInfo.serverDate()));
+
+    params.setClasses(
+        schemaService.getNonEmbeddedMetadataSchemas().stream()
+            .filter(schema -> schema.isIdentifiableObject() && schema.isPersisted())
+            .filter(s -> !s.isSecondaryMetadata())
+            .filter(DEPRECATED_ANALYTICS_SCHEMAS)
+            .map(Schema::getKlass)
+            .filter(IdentifiableObject.class::isAssignableFrom)
+            .map(klass -> (Class<? extends IdentifiableObject>) klass)
+            .collect(Collectors.toSet()));
 
     Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> metadata =
         getMetadata(params);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -223,7 +223,6 @@ public class DefaultMetadataExportService implements MetadataExportService {
   public static final Predicate<Schema> DEPRECATED_ANALYTICS_SCHEMAS =
       schema -> schema.getKlass() != EventChart.class && schema.getKlass() != EventReport.class;
 
-  /** This method is used by MetadataSyncService to export metadata version snapshot. */
   @Override
   @Transactional(readOnly = true)
   public ObjectNode exportMetadataVersion(MetadataExportParams params) {
@@ -238,8 +237,12 @@ public class DefaultMetadataExportService implements MetadataExportService {
         .put(SYSTEM_DATE, DateUtils.toIso8601(systemInfo.serverDate()));
 
     params.setClasses(
-        schemaService.getNonEmbeddedMetadataSchemas().stream()
-            .filter(schema -> schema.isIdentifiableObject() && schema.isPersisted())
+        schemaService.getMetadataSchemas().stream()
+            .filter(
+                schema ->
+                    !schema.isEmbeddedObject()
+                        && schema.isIdentifiableObject()
+                        && schema.isPersisted())
             .filter(s -> !s.isSecondaryMetadata())
             .filter(DEPRECATED_ANALYTICS_SCHEMAS)
             .map(Schema::getKlass)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportService.java
@@ -57,7 +57,7 @@ public interface MetadataExportService {
    * @param params Export parameters
    * @return RootNode instance with children containing all exported objects
    */
-  ObjectNode getMetadataAsObjectNode(MetadataExportParams params);
+  ObjectNode exportMetadataVersion(MetadataExportParams params);
 
   /**
    * Returns same result as getMetadata, but metadata is written to outputStream instead.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionService.java
@@ -317,7 +317,7 @@ public class DefaultMetadataVersionService implements MetadataVersionService {
       }
 
       os = new ByteArrayOutputStream(1024);
-      ObjectNode metadata = metadataExportService.getMetadataAsObjectNode(exportParams);
+      ObjectNode metadata = metadataExportService.exportMetadataVersion(exportParams);
       renderService.toJson(os, metadata);
     } catch (Exception ex) // We have to catch the "Exception" object as no
     // specific exception on the contract.

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -121,6 +121,7 @@ import org.hisp.dhis.schema.descriptors.LegendDefinitionsSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.LegendSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.LegendSetSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MapSchemaDescriptor;
+import org.hisp.dhis.schema.descriptors.MapViewSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MessageConversationSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MetadataVersionSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MinMaxDataElementSchemaDescriptor;
@@ -251,6 +252,7 @@ public class DefaultSchemaService implements SchemaService {
     register(new LegendSetSchemaDescriptor());
     register(new ExternalMapLayerSchemaDescriptor());
     register(new MapSchemaDescriptor());
+    register(new MapViewSchemaDescriptor());
     register(new MessageConversationSchemaDescriptor());
     register(new MetadataVersionSchemaDescriptor());
     register(new OptionSchemaDescriptor());
@@ -461,6 +463,14 @@ public class DefaultSchemaService implements SchemaService {
         .toList();
   }
 
+  @Override
+  public Set<Schema> getNonEmbeddedMetadataSchemas() {
+    return schemas.values().stream()
+        .filter(not(Schema::isDynamic))
+        .filter(Schema::isMetadata)
+        .filter(not(Schema::isEmbeddedObject))
+        .collect(toSet());
+  }
   @Override
   public Set<String> collectAuthorities() {
     return getSchemas().stream()

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -462,16 +462,7 @@ public class DefaultSchemaService implements SchemaService {
         .sorted(OrderComparator.INSTANCE)
         .toList();
   }
-
-  @Override
-  public Set<Schema> getNonEmbeddedMetadataSchemas() {
-    return schemas.values().stream()
-        .filter(not(Schema::isDynamic))
-        .filter(Schema::isMetadata)
-        .filter(not(Schema::isEmbeddedObject))
-        .collect(toSet());
-  }
-
+  
   @Override
   public Set<String> collectAuthorities() {
     return getSchemas().stream()

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -471,6 +471,7 @@ public class DefaultSchemaService implements SchemaService {
         .filter(not(Schema::isEmbeddedObject))
         .collect(toSet());
   }
+
   @Override
   public Set<String> collectAuthorities() {
     return getSchemas().stream()

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -462,7 +462,7 @@ public class DefaultSchemaService implements SchemaService {
         .sorted(OrderComparator.INSTANCE)
         .toList();
   }
-  
+
   @Override
   public Set<String> collectAuthorities() {
     return getSchemas().stream()

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
@@ -89,6 +89,8 @@ public interface SchemaService {
    */
   List<Schema> getMetadataSchemas();
 
+  Set<Schema> getNonEmbeddedMetadataSchemas();
+
   /**
    * Collect all authorities from schema descriptors.
    *

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
@@ -88,7 +88,7 @@ public interface SchemaService {
    * @return List of all available metadata schemas
    */
   List<Schema> getMetadataSchemas();
-  
+
   /**
    * Collect all authorities from schema descriptors.
    *

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/SchemaService.java
@@ -88,9 +88,7 @@ public interface SchemaService {
    * @return List of all available metadata schemas
    */
   List<Schema> getMetadataSchemas();
-
-  Set<Schema> getNonEmbeddedMetadataSchemas();
-
+  
   /**
    * Collect all authorities from schema descriptors.
    *

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -155,7 +155,7 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
     MetadataExportParams exportParams = new MetadataExportParams();
     exportParams.addClass(org.hisp.dhis.mapping.Map.class);
     exportParams.addClass(MapView.class);
-    ObjectNode exported = metadataExportService.getMetadataAsObjectNode(exportParams);
+    ObjectNode exported = metadataExportService.exportMetadataVersion(exportParams);
 
     Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
         renderService.fromMetadata(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -167,7 +167,8 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  @DisplayName("exportMetadataVersion never includes embedded objects such as MapView")
+  @DisplayName(
+      "exportMetadataVersion never includes embedded objects at root level such as MapView")
   void exportMetadataVersionExcludesEmbeddedObjects() throws IOException {
     MapView mapView = createMapView("A");
     org.hisp.dhis.mapping.Map map = new org.hisp.dhis.mapping.Map();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.metadata.export;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -165,30 +164,6 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
     org.hisp.dhis.mapping.Map exportMap =
         (org.hisp.dhis.mapping.Map) metadata.get(org.hisp.dhis.mapping.Map.class).get(0);
     assertNotNull(exportMap.getMapViews());
-  }
-
-  @Test
-  @DisplayName(
-      "exportMetadataVersion exports the full metadata version regardless of the classes set in params")
-  void exportMetadataVersionExportsFullVersion() throws IOException {
-    DataElement dataElement = createDataElement('A');
-    manager.save(dataElement);
-
-    // Params only request Map, but a metadata version snapshot must contain all metadata classes.
-    MetadataExportParams exportParams = new MetadataExportParams();
-    exportParams.addClass(org.hisp.dhis.mapping.Map.class);
-    ObjectNode exported = metadataExportService.exportMetadataVersion(exportParams);
-
-    Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
-        renderService.fromMetadata(
-            new ByteArrayInputStream(jsonMapper.writeValueAsBytes(exported)), RenderFormat.JSON);
-
-    List<IdentifiableObject> dataElements = metadata.get(DataElement.class);
-    assertNotNull(
-        dataElements, "DataElement was not requested but must be present in the version snapshot");
-    assertTrue(
-        dataElements.stream().anyMatch(de -> dataElement.getUid().equals(de.getUid())),
-        "The saved DataElement should be part of the exported metadata version");
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/metadata/export/MetadataExportWithDependenciesTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.metadata.export;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -164,5 +165,49 @@ class MetadataExportWithDependenciesTest extends PostgresIntegrationTestBase {
     org.hisp.dhis.mapping.Map exportMap =
         (org.hisp.dhis.mapping.Map) metadata.get(org.hisp.dhis.mapping.Map.class).get(0);
     assertNotNull(exportMap.getMapViews());
+  }
+
+  @Test
+  @DisplayName(
+      "exportMetadataVersion exports the full metadata version regardless of the classes set in params")
+  void exportMetadataVersionExportsFullVersion() throws IOException {
+    DataElement dataElement = createDataElement('A');
+    manager.save(dataElement);
+
+    // Params only request Map, but a metadata version snapshot must contain all metadata classes.
+    MetadataExportParams exportParams = new MetadataExportParams();
+    exportParams.addClass(org.hisp.dhis.mapping.Map.class);
+    ObjectNode exported = metadataExportService.exportMetadataVersion(exportParams);
+
+    Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
+        renderService.fromMetadata(
+            new ByteArrayInputStream(jsonMapper.writeValueAsBytes(exported)), RenderFormat.JSON);
+
+    List<IdentifiableObject> dataElements = metadata.get(DataElement.class);
+    assertNotNull(
+        dataElements, "DataElement was not requested but must be present in the version snapshot");
+    assertTrue(
+        dataElements.stream().anyMatch(de -> dataElement.getUid().equals(de.getUid())),
+        "The saved DataElement should be part of the exported metadata version");
+  }
+
+  @Test
+  @DisplayName("exportMetadataVersion never includes embedded objects such as MapView")
+  void exportMetadataVersionExcludesEmbeddedObjects() throws IOException {
+    MapView mapView = createMapView("A");
+    org.hisp.dhis.mapping.Map map = new org.hisp.dhis.mapping.Map();
+    map.setName("MapA");
+    map.setMapViews(List.of(mapView));
+    map.setAutoFields();
+    manager.save(map);
+
+    ObjectNode exported = metadataExportService.exportMetadataVersion(new MetadataExportParams());
+
+    Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata =
+        renderService.fromMetadata(
+            new ByteArrayInputStream(jsonMapper.writeValueAsBytes(exported)), RenderFormat.JSON);
+
+    assertNull(metadata.get(MapView.class));
+    assertNotNull(metadata.get(org.hisp.dhis.mapping.Map.class));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
-import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.message.Message;
 import org.hisp.dhis.organisationunit.OrganisationUnit;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -35,9 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
+import org.hisp.dhis.mapping.Map;
+import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.message.Message;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -180,5 +184,30 @@ class SchemaServiceTest extends PostgresIntegrationTestBase {
     Schema schema = schemaService.getSchema(Message.class);
     Property text = schema.getProperty("text");
     assertEquals(Integer.MAX_VALUE, text.getLength());
+  }
+
+  @Test
+  void testMapViewSchemaRegistered() {
+    Schema schema = schemaService.getSchema(MapView.class);
+    assertNotNull(schema);
+    assertEquals(MapView.class, schema.getKlass());
+    assertTrue(schema.isEmbeddedObject());
+  }
+
+  @Test
+  void testGetNonEmbeddedMetadataSchemas() {
+    Set<Schema> schemas = schemaService.getNonEmbeddedMetadataSchemas();
+    assertFalse(schemas.isEmpty());
+
+    // Every returned schema must be metadata, non-dynamic and non-embedded.
+    assertTrue(schemas.stream().allMatch(Schema::isMetadata));
+    assertTrue(schemas.stream().noneMatch(Schema::isDynamic));
+    assertTrue(schemas.stream().noneMatch(Schema::isEmbeddedObject));
+
+    Set<Class<?>> klasses = schemas.stream().map(Schema::getKlass).collect(Collectors.toSet());
+    // A regular metadata object is included.
+    assertTrue(klasses.contains(Map.class));
+    // Embedded objects such as MapView are excluded.
+    assertFalse(klasses.contains(MapView.class));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -35,8 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
@@ -192,21 +190,5 @@ class SchemaServiceTest extends PostgresIntegrationTestBase {
     assertNotNull(schema);
     assertEquals(MapView.class, schema.getKlass());
     assertTrue(schema.isEmbeddedObject());
-  }
-
-  @Test
-  void testGetNonEmbeddedMetadataSchemas() {
-    Set<Schema> schemas = schemaService.getNonEmbeddedMetadataSchemas();
-    assertFalse(schemas.isEmpty());
-
-    // Every returned schema must be metadata, non-dynamic and non-embedded.
-    assertTrue(schemas.stream().allMatch(Schema::isMetadata));
-    assertTrue(schemas.stream().noneMatch(Schema::isEmbeddedObject));
-
-    Set<Class<?>> klasses = schemas.stream().map(Schema::getKlass).collect(Collectors.toSet());
-    // A regular metadata object is included.
-    assertTrue(klasses.contains(Map.class));
-    // Embedded objects such as MapView are excluded.
-    assertFalse(klasses.contains(MapView.class));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -201,7 +201,6 @@ class SchemaServiceTest extends PostgresIntegrationTestBase {
 
     // Every returned schema must be metadata, non-dynamic and non-embedded.
     assertTrue(schemas.stream().allMatch(Schema::isMetadata));
-    assertTrue(schemas.stream().noneMatch(Schema::isDynamic));
     assertTrue(schemas.stream().noneMatch(Schema::isEmbeddedObject));
 
     Set<Class<?>> klasses = schemas.stream().map(Schema::getKlass).collect(Collectors.toSet());


### PR DESCRIPTION
### Summary
- MetadataSync failed when Map and MapView is included in the new version
- This caused by MapViewSchemaDescriptor is missing from the Schema Service.
### Fix
- Add the MapViewSchemaDescriptor to SchemaService
- Add filter to exclude embedded classes before calling metadata export service.
### Test
- Added tests for the change.