### PR TITLE
fix: Custom label for enrollmentou in agg. [DHIS2-21750]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventAggregateService.java
@@ -51,6 +51,7 @@ import static org.hisp.dhis.analytics.event.EventAnalyticsUtils.addValues;
 import static org.hisp.dhis.analytics.event.EventAnalyticsUtils.generateEventDataPermutations;
 import static org.hisp.dhis.analytics.event.LabelMapper.getEnrollmentDateLabel;
 import static org.hisp.dhis.analytics.event.LabelMapper.getIncidentDateLabel;
+import static org.hisp.dhis.analytics.event.LabelMapper.getOrgUnitLabel;
 import static org.hisp.dhis.analytics.tracker.ResponseHelper.UNLIMITED_PAGING;
 import static org.hisp.dhis.analytics.tracker.ResponseHelper.addPaging;
 import static org.hisp.dhis.analytics.tracker.ResponseHelper.getDimensionsKeywords;
@@ -343,13 +344,10 @@ public class EventAggregateService {
     }
 
     if (params.hasEnrollmentOuDimension()) {
+      String ouLabel = getOrgUnitLabel(params.getProgram(), ColumnHeader.ENROLLMENT_OU.getName());
+
       grid.addHeader(
-          new GridHeader(
-              ColumnHeader.ENROLLMENT_OU.getItem(),
-              ColumnHeader.ENROLLMENT_OU.getName(),
-              TEXT,
-              false,
-              true));
+          new GridHeader(ColumnHeader.ENROLLMENT_OU.getItem(), ouLabel, TEXT, false, true));
     }
 
     if (params.hasEnrollmentStatuses()) {
@@ -363,9 +361,15 @@ public class EventAggregateService {
   }
 
   private String getDimensionHeaderColumn(DimensionalObject dimension, EventQueryParams params) {
+    String defaultColumn = dimension.getDisplayProperty(params.getDisplayProperty());
+
+    if (ORGUNIT_DIM_ID.equals(dimension.getDimension())) {
+      return getOrgUnitLabel(params.getProgram(), defaultColumn);
+    }
+
     return getStaticDateField(dimension)
         .map(dateField -> getDateFieldLabel(dateField, params.getProgram()))
-        .orElse(dimension.getDisplayProperty(params.getDisplayProperty()));
+        .orElse(defaultColumn);
   }
 
   private Optional<String> getStaticDateField(DimensionalObject dimension) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAggregateServiceTest.java
@@ -30,7 +30,9 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static org.hisp.dhis.analytics.DataQueryParams.VALUE_ID;
+import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
+import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.DimensionType.PERIOD;
 import static org.hisp.dhis.test.TestBase.createDataElement;
 import static org.hisp.dhis.test.TestBase.createLegend;
@@ -89,6 +91,17 @@ class EventAggregateServiceTest {
 
     assertEquals("incidentdate", header.getName());
     assertEquals("Incident date custom", header.getColumn());
+  }
+
+  @Test
+  void shouldUseCustomOrgUnitLabelForOuDimensionHeader() throws Exception {
+    Program program = new Program();
+    program.setOrgUnitLabel("Facility");
+
+    GridHeader header = invokeAddDimensionHeaders(orgUnitDimensionParams(program));
+
+    assertEquals("ou", header.getName());
+    assertEquals("Facility", header.getColumn());
   }
 
   @Test
@@ -246,6 +259,17 @@ class EventAggregateServiceTest {
 
     return new EventQueryParams.Builder()
         .addDimension(periodDimension)
+        .withProgram(program)
+        .build();
+  }
+
+  private EventQueryParams orgUnitDimensionParams(Program program) {
+    BaseDimensionalObject orgUnitDimension =
+        new BaseDimensionalObject(
+            ORGUNIT_DIM_ID, ORGANISATION_UNIT, "Organisation unit", List.of());
+
+    return new EventQueryParams.Builder()
+        .addDimension(orgUnitDimension)
         .withProgram(program)
         .build();
   }


### PR DESCRIPTION
Adds support for a custom label for OUs at the program level in Analytics Aggr. endpoints for events and enrollments.

Note that both endpoints share part of the same flow; hence, we have only a single place to change.