### PR TITLE
feat: support program-stage data element values in TE aggregate analytics [DHIS2-21763]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/common/CommonRequestParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/common/CommonRequestParams.java
@@ -204,8 +204,10 @@ public class CommonRequestParams {
   private Set<String> eventStatus = new LinkedHashSet<>();
 
   /**
-   * UID of the numeric dimension (a tracked entity attribute for tracked entity aggregate queries)
-   * to aggregate over. Resolved downstream. When omitted, an aggregate query counts instances.
+   * The numeric dimension to aggregate over in a tracked entity aggregate query: either a tracked
+   * entity attribute UID, or a program-stage data element in {@code
+   * programUid.programStageUid.dataElementUid} form. Resolved downstream. When omitted, an
+   * aggregate query counts instances.
    */
   private String value;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -619,6 +619,8 @@ public enum ErrorCode {
   E7254("Aggregation type is not supported by tracked entity aggregate queries: `{0}`"),
   E7255("Aggregation type `{0}` requires the `value` parameter"),
   E7256("Value `{0}` is not a numeric tracked entity attribute of tracked entity type `{1}`"),
+  E7257(
+      "Value `{0}` does not reference a numeric data element of a program stage; expected format `programUid.programStageUid.dataElementUid`"),
 
   /* Org unit analytics */
   E7300(Constants.AT_LEAST_ONE_ORGANISATION_UNIT_MUST_BE_SPECIFIED),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/EventValue.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/EventValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.trackedentity;
+
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.ProgramStage;
+
+/**
+ * The resolved program-stage event value an aggregate query aggregates over: a numeric data element
+ * of a program stage, collapsed to one chosen event per tracked entity. The {@code offset} selects
+ * which occurrence of the stage to read (0 = latest, negative = earlier, positive = ascending from
+ * the first), matching the row-level query offset semantics.
+ */
+public record EventValue(ProgramStage programStage, DataElement dataElement, int offset) {}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateService.java
@@ -29,7 +29,6 @@
  */
 package org.hisp.dhis.analytics.trackedentity;
 
-import static java.util.Collections.singleton;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toCollection;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
@@ -40,6 +39,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
 import static org.hisp.dhis.common.DimensionConstants.ORGUNIT_DIM_ID;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -65,6 +65,7 @@ import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.ExecutionPlan;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.ValueType;
@@ -122,7 +123,7 @@ public class TrackedEntityAggregateService {
     CommonParsedParams commonParams = contextParams.getCommonParsed();
     TrackedEntityQueryParams teParams = contextParams.getTypedParsed();
 
-    securityManager.decideAccess(commonParams, singleton(teParams.getTrackedEntityType()));
+    securityManager.decideAccess(commonParams, dataReadObjects(teParams));
     securityManager.applyOrganisationUnitConstraint(commonParams);
     securityManager.applyDimensionConstraints(commonParams);
 
@@ -153,6 +154,28 @@ public class TrackedEntityAggregateService {
         grid, withGroupedDimensionsOnly(contextParams), currentUser, rowsCount);
     addGroupedOrgUnitMetadata(grid, contextParams);
     return grid;
+  }
+
+  /**
+   * The objects whose data-read access must be checked beyond the query's dimensions: the tracked
+   * entity type, and — when aggregating over a program-stage data element value — that program
+   * stage. The event value is not a dimension identifier, so it is not covered by the
+   * dimension-based checks in {@link CommonParamsSecurityManager#decideAccess}; without adding the
+   * stage here a user with program/TET access but no data-read access to the stage could read its
+   * event values. The data element itself is intentionally not checked: event-data access is
+   * governed by the program stage, and data elements are in {@code CommonParamsSecurityManager}'s
+   * data-read skip set.
+   */
+  private static Set<IdentifiableObject> dataReadObjects(TrackedEntityQueryParams teParams) {
+    Set<IdentifiableObject> objects = new HashSet<>();
+    objects.add(teParams.getTrackedEntityType());
+
+    EventValue eventValue = teParams.getEventValue();
+    if (eventValue != null) {
+      objects.add(eventValue.programStage());
+    }
+
+    return objects;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryParams.java
@@ -53,9 +53,18 @@ public class TrackedEntityQueryParams {
 
   /**
    * The numeric tracked entity attribute the aggregation function of an aggregate query applies to.
-   * When null, an aggregate query counts tracked entity instances.
+   * When null, the aggregate query either counts tracked entity instances or aggregates over an
+   * {@link #eventValue}. At most one of {@code attributeValue} and {@code eventValue} is non-null.
    */
-  private final TrackedEntityAttribute value;
+  private final TrackedEntityAttribute attributeValue;
+
+  /**
+   * The numeric program-stage data element the aggregation function of an aggregate query applies
+   * to, collapsed to one chosen event per tracked entity. When null, the aggregate query either
+   * counts tracked entity instances or aggregates over an {@link #attributeValue}. At most one of
+   * {@code attributeValue} and {@code eventValue} is non-null.
+   */
+  private final EventValue eventValue;
 
   /** The aggregation function applied to the value column of an aggregate query. */
   private final AggregationType aggregationType;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryRequestMapper.java
@@ -38,7 +38,9 @@ import static org.hisp.dhis.feedback.ErrorCode.E7142;
 import static org.hisp.dhis.feedback.ErrorCode.E7254;
 import static org.hisp.dhis.feedback.ErrorCode.E7255;
 import static org.hisp.dhis.feedback.ErrorCode.E7256;
+import static org.hisp.dhis.feedback.ErrorCode.E7257;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -49,10 +51,14 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Strings;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifierHelper;
+import org.hisp.dhis.analytics.common.params.dimension.StringDimensionIdentifier;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
@@ -111,13 +117,36 @@ public class TrackedEntityQueryRequestMapper {
             getTrackedEntityAttributes(trackedEntityType).map(IdentifiableObject::getUid).toList());
 
     validateAggregationType(requestParams);
-    TrackedEntityAttribute value = resolveValue(requestParams, trackedEntityType);
+
+    List<Program> programs = List.copyOf(programService.getPrograms(requestParams.getProgram()));
+    TrackedEntityAttribute attributeValue = null;
+    EventValue eventValue = null;
+    String valueUid = requestParams.getValue();
+    if (valueUid != null) {
+      if (isProgramStageDataElement(valueUid)) {
+        eventValue = resolveEventValue(valueUid, programs);
+      } else {
+        attributeValue = resolveAttributeValue(valueUid, programs, trackedEntityType);
+      }
+    }
 
     return TrackedEntityQueryParams.builder()
         .trackedEntityType(trackedEntityType)
-        .value(value)
-        .aggregationType(aggregationTypeFor(requestParams.getAggregationType(), value))
+        .attributeValue(attributeValue)
+        .eventValue(eventValue)
+        .aggregationType(
+            aggregationTypeFor(
+                requestParams.getAggregationType(), attributeValue != null || eventValue != null))
         .build();
+  }
+
+  /**
+   * A {@code value} referencing a program-stage data element is qualified with a program and a
+   * program stage ({@code programUid.programStageUid.dataElementUid}); a bare UID references a
+   * tracked entity attribute.
+   */
+  private static boolean isProgramStageDataElement(String valueUid) {
+    return valueUid.indexOf(DimensionIdentifierHelper.DIMENSION_SEPARATOR) >= 0;
   }
 
   /**
@@ -144,26 +173,20 @@ public class TrackedEntityQueryRequestMapper {
   }
 
   /**
-   * Resolves the requested value UID into a numeric attribute to aggregate over. The candidates are
-   * the tracked entity type's own attributes and the attributes of the requested programs — the
-   * same set the analytics_te table flattens into columns, so both resolve to a bare {@code
-   * t_1."<uid>"} column. Data elements and program indicators are not accepted.
+   * Resolves a bare value UID into a numeric attribute to aggregate over. The candidates are the
+   * tracked entity type's own attributes and the attributes of the requested programs — the same
+   * set the analytics_te table flattens into columns, so both resolve to a bare {@code t_1."<uid>"}
+   * column. Data elements and program indicators are not accepted here.
    *
-   * @param requestParams the {@link CommonRequestParams} carrying the value UID and programs.
+   * @param valueUid the requested value UID.
+   * @param programs the requested programs.
    * @param trackedEntityType the {@link TrackedEntityType}.
-   * @return the resolved {@link TrackedEntityAttribute}, or null when no value was requested.
+   * @return the resolved {@link TrackedEntityAttribute}.
    * @throws IllegalQueryException if the UID does not refer to a numeric attribute of the tracked
    *     entity type or its programs.
    */
-  private TrackedEntityAttribute resolveValue(
-      CommonRequestParams requestParams, TrackedEntityType trackedEntityType) {
-    String valueUid = requestParams.getValue();
-    if (valueUid == null) {
-      return null;
-    }
-
-    List<Program> programs = List.copyOf(programService.getPrograms(requestParams.getProgram()));
-
+  private TrackedEntityAttribute resolveAttributeValue(
+      String valueUid, List<Program> programs, TrackedEntityType trackedEntityType) {
     return Stream.concat(
             getTrackedEntityAttributes(trackedEntityType), getProgramAttributes(programs))
         .filter(attribute -> valueUid.equals(attribute.getUid()))
@@ -173,17 +196,68 @@ public class TrackedEntityQueryRequestMapper {
   }
 
   /**
-   * Returns the aggregation function to apply: the requested one, falling back to AVERAGE when a
-   * value attribute is present — matching the event/enrollment aggregate contract. Without a value
-   * attribute the aggregate query counts TEIs, so no function is materialized.
+   * Resolves a {@code programUid.programStageUid.dataElementUid} value into the numeric
+   * program-stage data element to aggregate over. The program must be one of the requested
+   * programs, the stage must belong to that program, and the data element must belong to that stage
+   * and be numeric. The stage segment may carry an offset ({@code [n]}) selecting which occurrence
+   * to read; an offset on the program segment is not allowed.
+   *
+   * @param valueUid the fully qualified value in {@code programUid.programStageUid.dataElementUid}
+   *     form.
+   * @param programs the requested programs.
+   * @return the resolved {@link EventValue}.
+   * @throws IllegalQueryException if the value does not reference a numeric data element of a
+   *     program stage of the requested programs.
    */
-  private AggregationType aggregationTypeFor(
-      AggregationType requested, TrackedEntityAttribute value) {
+  private EventValue resolveEventValue(String valueUid, List<Program> programs) {
+    StringDimensionIdentifier parsed;
+    try {
+      parsed = DimensionIdentifierHelper.fromFullDimensionId(valueUid);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalQueryException(E7257, valueUid);
+    }
+
+    if (!parsed.getProgram().isPresent()
+        || !parsed.getProgramStage().isPresent()
+        || parsed.getProgram().hasOffset()) {
+      throw new IllegalQueryException(E7257, valueUid);
+    }
+
+    String programUid = parsed.getProgram().getElement().getUid();
+    String programStageUid = parsed.getProgramStage().getElement().getUid();
+    String dataElementUid = parsed.getDimension().getUid();
+    int offset = parsed.getProgramStage().getOffsetWithDefault();
+
+    ProgramStage programStage =
+        programs.stream()
+            .filter(program -> programUid.equals(program.getUid()))
+            .map(Program::getProgramStages)
+            .flatMap(Collection::stream)
+            .filter(stage -> programStageUid.equals(stage.getUid()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalQueryException(E7257, valueUid));
+
+    DataElement dataElement =
+        programStage.getDataElements().stream()
+            .filter(de -> dataElementUid.equals(de.getUid()))
+            .filter(de -> de.getValueType().isNumeric())
+            .findFirst()
+            .orElseThrow(() -> new IllegalQueryException(E7257, valueUid));
+
+    return new EventValue(programStage, dataElement, offset);
+  }
+
+  /**
+   * Returns the aggregation function to apply: the requested one, falling back to AVERAGE when a
+   * value is present — matching the event/enrollment aggregate contract. Without a value the
+   * aggregate query counts TEIs, so no function is materialized.
+   */
+  private AggregationType aggregationTypeFor(AggregationType requested, boolean hasValue) {
     if (requested != null) {
       return requested;
     }
 
-    return value != null ? AggregationType.AVERAGE : null;
+    return hasValue ? AggregationType.AVERAGE : null;
   }
 
   private Set<String> getProgramUidsFromTrackedEntityType(TrackedEntityType trackedEntityType) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/AggregateQueryBuilder.java
@@ -38,12 +38,15 @@ import java.util.Set;
 import java.util.function.Predicate;
 import lombok.Getter;
 import org.hisp.dhis.analytics.common.ContextParams;
+import org.hisp.dhis.analytics.common.ValueTypeMapping;
 import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.EventValue;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
+import org.hisp.dhis.analytics.trackedentity.query.RenderableDataValue;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.QueryContext;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.RenderableSqlQuery;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryBuilder;
@@ -58,6 +61,11 @@ import org.springframework.stereotype.Service;
 @Service
 @Order(0)
 public class AggregateQueryBuilder implements SqlQueryBuilder {
+
+  /**
+   * Alias of the collapsed program-stage event table joined when aggregating over an event value.
+   */
+  private static final String EVENT_VALUE_ALIAS = "ev";
 
   @Getter
   private final List<Predicate<DimensionIdentifier<DimensionParam>>> dimensionFilters =
@@ -95,6 +103,15 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
               builder.groupByField(field);
             });
 
+    // A program-stage data element value is aggregated from the collapsed event row, joined at
+    // tracked-entity grain so the GROUP BY counts tracked entities, not events.
+    EventValue eventValue = queryContext.getContextParams().getTypedParsed().getEventValue();
+    if (eventValue != null) {
+      builder.leftJoin(
+          SqlQueryHelper.buildEventValueLeftJoin(
+              eventValue, queryContext.getTetTableSuffix(), EVENT_VALUE_ALIAS));
+    }
+
     // The aggregate value column is the last select column and is not grouped.
     builder.selectField(
         Field.ofUnquoted("", () -> valueExpression(queryContext.getContextParams()), "value"));
@@ -103,16 +120,28 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
   }
 
   /**
-   * Returns the SQL expression of the aggregate value column. Without a value attribute the query
-   * counts TEIs; with one, the aggregation function is applied to the attribute column — including
-   * an explicit COUNT, which then counts non-null attribute values, matching the event/enrollment
-   * aggregate contract.
+   * Returns the SQL expression of the aggregate value column. Without a value the query counts
+   * TEIs. Over a tracked entity attribute the function is applied to the attribute column; over a
+   * program-stage data element it is applied to the value extracted from the collapsed event row.
+   * An explicit COUNT then counts non-null values, matching the event/enrollment aggregate
+   * contract.
    */
   private static String valueExpression(
       ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams) {
     TrackedEntityQueryParams params = contextParams.getTypedParsed();
 
-    if (params.getValue() == null) {
+    EventValue eventValue = params.getEventValue();
+    if (eventValue != null) {
+      String value =
+          RenderableDataValue.of(
+                  EVENT_VALUE_ALIAS,
+                  eventValue.dataElement().getUid(),
+                  ValueTypeMapping.fromValueType(eventValue.dataElement().getValueType()))
+              .render();
+      return params.getAggregationType().getValue() + "(" + value + ")";
+    }
+
+    if (params.getAttributeValue() == null) {
       return "count(1)";
     }
 
@@ -120,7 +149,7 @@ public class AggregateQueryBuilder implements SqlQueryBuilder {
         + "("
         + TRACKED_ENTITY_ALIAS
         + ".\""
-        + params.getValue().getUid()
+        + params.getAttributeValue().getUid()
         + "\")";
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/SqlQueryHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/trackedentity/query/context/querybuilder/SqlQueryHelper.java
@@ -41,7 +41,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.common.query.LeftJoin;
 import org.hisp.dhis.analytics.common.query.Renderable;
+import org.hisp.dhis.analytics.trackedentity.EventValue;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.OffsetHelper.Offset;
 
 /**
@@ -167,6 +169,52 @@ class SqlQueryHelper {
            where ev.rn = ${programStageOffset}
              and ev.enrollment = %s)"""
           .formatted(ENROLLMENT_ORDER_BY_SUBQUERY);
+
+  private static final String EVENT_VALUE_COLLAPSE_TABLE =
+      """
+          (select trackedentity, eventdatavalues
+           from (select trackedentity, eventdatavalues,
+                        row_number() over (partition by trackedentity order by occurreddate ${direction}) as rn
+                 from analytics_te_event_${trackedEntityTypeUid}
+                 where programstage = '${programStageUid}'
+                   and jsonb_exists(eventdatavalues, '${dataElementUid}')
+                   and status != 'SCHEDULE') e
+           where rn = ${offset}) ${alias}""";
+
+  /**
+   * Builds the LEFT JOIN that collapses each tracked entity's events for the given program stage to
+   * a single chosen row (per the offset), so a program-stage data element value can be aggregated
+   * at tracked-entity grain without fan-out. The derived table exposes {@code trackedentity} and
+   * {@code eventdatavalues} under the given alias, joined on the tracked entity.
+   *
+   * <p>The contract is deliberately tracked-entity-grained: the collapse partitions by {@code
+   * trackedentity} across <em>all</em> of the TE's events for the stage, regardless of enrollment.
+   * A TE with the stage under multiple enrollments therefore contributes the single event chosen by
+   * {@code occurreddate} across enrollments — not one per enrollment. Ties on {@code occurreddate}
+   * resolve nondeterministically, matching the row-level query's offset behaviour.
+   *
+   * @param eventValue the resolved program-stage data element value.
+   * @param trackedEntityTypeUid the lowercased tracked entity type table suffix.
+   * @param alias the alias of the collapsed event table.
+   * @return the {@link LeftJoin} attaching the collapsed events at tracked-entity grain.
+   */
+  static LeftJoin buildEventValueLeftJoin(
+      EventValue eventValue, String trackedEntityTypeUid, String alias) {
+    Offset offset = OffsetHelper.getOffset(eventValue.offset());
+    String table =
+        replace(
+            EVENT_VALUE_COLLAPSE_TABLE,
+            Map.of(
+                "direction", offset.direction(),
+                "trackedEntityTypeUid", trackedEntityTypeUid,
+                "programStageUid", eventValue.programStage().getUid(),
+                "dataElementUid", eventValue.dataElement().getUid(),
+                "offset", offset.offset(),
+                "alias", alias));
+
+    return LeftJoin.of(
+        () -> table, () -> alias + ".trackedentity = " + TRACKED_ENTITY_ALIAS + ".trackedentity");
+  }
 
   /**
    * Builds the order by sub-query for the given dimension identifier and field.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateServiceTest.java
@@ -32,7 +32,9 @@ package org.hisp.dhis.analytics.trackedentity;
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,9 +44,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
 import org.hisp.dhis.analytics.common.ContextParams;
@@ -65,10 +69,15 @@ import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
@@ -128,6 +137,55 @@ class TrackedEntityAggregateServiceTest {
     assertEquals(42, grid.getRow(0).get(1));
     verify(securityManager).decideAccess(any(), any());
     verify(metadataParamsHandler).handle(eq(grid), any(), any(), eq(0L));
+  }
+
+  @Test
+  void getGridChecksDataReadAccessForEventValueProgramStage() {
+    ProgramStage programStage = new ProgramStage();
+    programStage.setUid("PsUid000001");
+    DataElement dataElement = new DataElement();
+    dataElement.setUid("DeUid000001");
+    dataElement.setValueType(ValueType.NUMBER);
+    TrackedEntityType trackedEntityType = new TrackedEntityType();
+    trackedEntityType.setUid("TetUid00001");
+
+    TrackedEntityQueryParams teParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(trackedEntityType)
+            .aggregate(true)
+            .eventValue(new EventValue(programStage, dataElement, 0))
+            .aggregationType(AggregationType.AVERAGE)
+            .build();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> ctx =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(teParams)
+            .commonRaw(new CommonRequestParams().withDimension(Set.of("ou")))
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                    .build())
+            .build();
+
+    SqlRowSet rowSet =
+        fakeRowSet(new String[] {"ou", "value"}, List.<Object[]>of(new Object[] {"OU1", 5}));
+    when(sqlQueryCreatorService.getSqlQueryCreator(ctx)).thenReturn(queryCreator);
+    when(queryCreator.createForSelect()).thenReturn(mock(SqlQuery.class));
+    when(queryExecutor.find(any())).thenReturn(new SqlQueryResult(rowSet));
+
+    service.getGrid(ctx);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Collection<IdentifiableObject>> captor =
+        ArgumentCaptor.forClass(Collection.class);
+    verify(securityManager).decideAccess(any(), captor.capture());
+    Collection<IdentifiableObject> checked = captor.getValue();
+    assertTrue(checked.contains(trackedEntityType), "tracked entity type must be access-checked");
+    assertTrue(checked.contains(programStage), "event value program stage must be access-checked");
+    // The data element is intentionally not checked: event-data access is governed by the program
+    // stage, and data elements are in the security manager's data-read skip set.
+    assertFalse(
+        checked.contains(dataElement), "event value data element must not be access-checked");
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -41,9 +41,11 @@ import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -145,7 +147,7 @@ class TrackedEntityRequestParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, requestParams);
 
-    assertEquals(attribute.getUid(), params.getValue().getUid());
+    assertEquals(attribute.getUid(), params.getAttributeValue().getUid());
     assertEquals(AggregationType.AVERAGE, params.getAggregationType());
   }
 
@@ -164,7 +166,7 @@ class TrackedEntityRequestParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, requestParams);
 
-    assertEquals(attribute.getUid(), params.getValue().getUid());
+    assertEquals(attribute.getUid(), params.getAttributeValue().getUid());
     assertEquals(AggregationType.SUM, params.getAggregationType());
   }
 
@@ -185,7 +187,7 @@ class TrackedEntityRequestParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, requestParams);
 
-    assertEquals(attribute.getUid(), params.getValue().getUid());
+    assertEquals(attribute.getUid(), params.getAttributeValue().getUid());
     assertEquals(AggregationType.AVERAGE, params.getAggregationType());
   }
 
@@ -288,8 +290,202 @@ class TrackedEntityRequestParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, new CommonRequestParams());
 
-    assertNull(params.getValue());
+    assertNull(params.getAttributeValue());
+    assertNull(params.getEventValue());
     assertNull(params.getAggregationType());
+  }
+
+  @Test
+  void testValueResolvesToProgramStageDataElementAndDefaultsToAverage() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    DataElement dataElement =
+        stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.PsUidA00001.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, requestParams);
+
+    assertNull(params.getAttributeValue());
+    EventValue eventValue = params.getEventValue();
+    assertEquals("PsUidA00001", eventValue.programStage().getUid());
+    assertEquals(dataElement.getUid(), eventValue.dataElement().getUid());
+    assertEquals(0, eventValue.offset());
+    assertEquals(AggregationType.AVERAGE, params.getAggregationType());
+  }
+
+  @Test
+  void testEventValueStageOffsetIsParsed() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.PsUidA00001[-1].DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    TrackedEntityQueryParams params = mapper.map(trackedEntityTypeUid, requestParams);
+
+    assertEquals(-1, params.getEventValue().offset());
+  }
+
+  @Test
+  void testEventValueProgramOffsetIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A[1].PsUidA00001.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  @Test
+  void testTwoSegmentValueIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  @Test
+  void testEventValueUnknownProgramIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("Xprogram001.PsUidA00001.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  @Test
+  void testEventValueStageNotInProgramIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.PsUidZ99999.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  @Test
+  void testEventValueDataElementNotInStageIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.NUMBER);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.PsUidA00001.DeUidZ99999");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  @Test
+  void testEventValueNonNumericDataElementIsRejected() {
+    String trackedEntityTypeUid = "T1";
+    TrackedEntityType trackedEntityType = stubTrackedEntityType(trackedEntityTypeUid);
+    Program program = stubProgram("A", trackedEntityTypeUid);
+    stubStageDataElement(program, "PsUidA00001", "DeUid000001", ValueType.TEXT);
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setProgram(Set.of("A"));
+    requestParams.setValue("A.PsUidA00001.DeUid000001");
+
+    when(trackedEntityTypeService.getTrackedEntityType(trackedEntityTypeUid))
+        .thenReturn(trackedEntityType);
+    when(programService.getPrograms(Set.of("A"))).thenReturn(Set.of(program));
+
+    IllegalQueryException thrown =
+        assertThrows(
+            IllegalQueryException.class, () -> mapper.map(trackedEntityTypeUid, requestParams));
+
+    assertEquals(ErrorCode.E7257, thrown.getErrorCode());
+  }
+
+  private DataElement stubStageDataElement(
+      Program program, String stageUid, String dataElementUid, ValueType valueType) {
+    DataElement dataElement = new DataElement();
+    dataElement.setUid(dataElementUid);
+    dataElement.setValueType(valueType);
+
+    ProgramStage programStage = new ProgramStage();
+    programStage.setUid(stageUid);
+    programStage.setProgram(program);
+    programStage.addDataElement(dataElement, 1);
+
+    program.setProgramStages(Set.of(programStage));
+    return dataElement;
   }
 
   private TrackedEntityAttribute stubAttribute(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/query/context/sql/SqlQueryCreatorServiceTest.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
 import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
 import org.hisp.dhis.analytics.common.query.Field;
+import org.hisp.dhis.analytics.trackedentity.EventValue;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.analytics.trackedentity.TrackedEntityRequestParams;
 import org.hisp.dhis.analytics.trackedentity.query.context.querybuilder.AggregateQueryBuilder;
@@ -67,6 +68,8 @@ import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -334,7 +337,7 @@ class SqlQueryCreatorServiceTest extends TestBase {
         TrackedEntityQueryParams.builder()
             .trackedEntityType(createTrackedEntityType('A'))
             .aggregate(true)
-            .value(valueAttribute)
+            .attributeValue(valueAttribute)
             .aggregationType(AggregationType.AVERAGE)
             .build();
 
@@ -370,7 +373,7 @@ class SqlQueryCreatorServiceTest extends TestBase {
         TrackedEntityQueryParams.builder()
             .trackedEntityType(createTrackedEntityType('A'))
             .aggregate(true)
-            .value(valueAttribute)
+            .attributeValue(valueAttribute)
             .aggregationType(AggregationType.COUNT)
             .build();
 
@@ -391,6 +394,115 @@ class SqlQueryCreatorServiceTest extends TestBase {
 
     assertContains("count(t_1.\"" + valueAttribute.getUid() + "\") as \"value\"", sql);
     assertFalse(sql.contains("count(1)"), "explicit COUNT over a value counts non-null values");
+  }
+
+  @Test
+  void testAggregateAverageOverDataElementValue() {
+    SqlQueryCreatorService service = aggregateService();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        eventValueContextParams(
+            stubEventValue("PsUid000001", "DeUid000001", ValueType.NUMBER, 0),
+            AggregationType.AVERAGE);
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    // collapse-per-TE derived table joined at TE grain
+    assertContains("left join (select trackedentity, eventdatavalues", sql);
+    assertContains(
+        "row_number() over (partition by trackedentity order by occurreddate desc) as rn", sql);
+    assertContains("from analytics_te_event_tetuid00001", sql);
+    assertContains("programstage = 'PsUid000001'", sql);
+    assertContains("jsonb_exists(eventdatavalues, 'DeUid000001')", sql);
+    assertContains("status != 'SCHEDULE'", sql);
+    assertContains("where rn = 1) ev on ev.trackedentity = t_1.trackedentity", sql);
+    // value extraction from the collapsed event row
+    assertContains(
+        "avg((ev.\"eventdatavalues\" -> 'DeUid000001' ->> 'value')::DECIMAL) as \"value\"", sql);
+    assertContains("group by t_1.\"ou\"", sql);
+    assertFalse(sql.contains("count(1)"), "value aggregation must replace the count(1) column");
+  }
+
+  @Test
+  void testAggregateCountOverDataElementValueCountsNonNullValues() {
+    SqlQueryCreatorService service = aggregateService();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        eventValueContextParams(
+            stubEventValue("PsUid000001", "DeUid000001", ValueType.NUMBER, 0),
+            AggregationType.COUNT);
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertContains(
+        "count((ev.\"eventdatavalues\" -> 'DeUid000001' ->> 'value')::DECIMAL) as \"value\"", sql);
+    assertFalse(sql.contains("count(1)"), "explicit COUNT over a value counts non-null values");
+  }
+
+  @Test
+  void testAggregateDataElementValueWithStageOffset() {
+    SqlQueryCreatorService service = aggregateService();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        eventValueContextParams(
+            stubEventValue("PsUid000001", "DeUid000001", ValueType.NUMBER, -1),
+            AggregationType.AVERAGE);
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    // offset -1 selects the second-latest event: row_number() is 1-based, so rn = 2, desc
+    assertContains("order by occurreddate desc", sql);
+    assertContains("where rn = 2) ev on ev.trackedentity = t_1.trackedentity", sql);
+  }
+
+  @Test
+  void testAggregateDataElementValueCountQueryIncludesCollapseJoin() {
+    SqlQueryCreatorService service = aggregateService();
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        eventValueContextParams(
+            stubEventValue("PsUid000001", "DeUid000001", ValueType.NUMBER, 0),
+            AggregationType.AVERAGE);
+
+    String countSql = service.getSqlQueryCreator(contextParams).createForCount().getStatement();
+
+    assertContains("select count(*) from (", countSql);
+    assertContains("left join (select trackedentity, eventdatavalues", countSql);
+  }
+
+  @Test
+  void testAggregateAttributeValueAddsNoCollapseJoin() {
+    SqlQueryCreatorService service = aggregateService();
+
+    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
+    trackedEntityType.setUid("TetUid00001");
+    TrackedEntityAttribute valueAttribute = createTrackedEntityAttribute('V');
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(trackedEntityType)
+            .aggregate(true)
+            .attributeValue(valueAttribute)
+            .aggregationType(AggregationType.AVERAGE)
+            .build();
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("ou"));
+
+    ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams> contextParams =
+        ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+            .typedParsed(trackedEntityQueryParams)
+            .commonRaw(requestParams)
+            .commonParsed(
+                CommonParsedParams.builder()
+                    .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                    .build())
+            .build();
+
+    String sql = service.getSqlQueryCreator(contextParams).createForSelect().getStatement();
+
+    assertFalse(
+        sql.contains("analytics_te_event_"),
+        "aggregating over an attribute must not join the event table");
   }
 
   @Test
@@ -425,6 +537,51 @@ class SqlQueryCreatorServiceTest extends TestBase {
     assertContains("count(1) as \"value\"", sql);
     assertContains("group by t_1.\"ou\"", sql);
     assertFalse(sql.contains("attr1"), "auto-injected attribute must not leak into the SQL");
+  }
+
+  private SqlQueryCreatorService aggregateService() {
+    List<SqlQueryBuilder> aggregateBuilders = new ArrayList<>();
+    aggregateBuilders.add(new AggregateQueryBuilder());
+    aggregateBuilders.addAll(queryBuilders);
+    return new SqlQueryCreatorService(aggregateBuilders);
+  }
+
+  private EventValue stubEventValue(
+      String stageUid, String dataElementUid, ValueType valueType, int offset) {
+    DataElement dataElement = createDataElement('D');
+    dataElement.setUid(dataElementUid);
+    dataElement.setValueType(valueType);
+
+    ProgramStage programStage = createProgramStage('S', createProgram('P'));
+    programStage.setUid(stageUid);
+
+    return new EventValue(programStage, dataElement, offset);
+  }
+
+  private ContextParams<TrackedEntityRequestParams, TrackedEntityQueryParams>
+      eventValueContextParams(EventValue eventValue, AggregationType aggregationType) {
+    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
+    trackedEntityType.setUid("TetUid00001");
+
+    TrackedEntityQueryParams trackedEntityQueryParams =
+        TrackedEntityQueryParams.builder()
+            .trackedEntityType(trackedEntityType)
+            .aggregate(true)
+            .eventValue(eventValue)
+            .aggregationType(aggregationType)
+            .build();
+
+    CommonRequestParams requestParams = new CommonRequestParams();
+    requestParams.setDimension(Set.of("ou"));
+
+    return ContextParams.<TrackedEntityRequestParams, TrackedEntityQueryParams>builder()
+        .typedParsed(trackedEntityQueryParams)
+        .commonRaw(requestParams)
+        .commonParsed(
+            CommonParsedParams.builder()
+                .dimensionIdentifiers(List.of(stubOuDimension("ou1")))
+                .build())
+        .build();
   }
 
   private DimensionIdentifier<DimensionParam> stubAttributeDimension(String attribute) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/impl/TrackedEntityAggregatedGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/impl/TrackedEntityAggregatedGenerator.java
@@ -91,6 +91,6 @@ public class TrackedEntityAggregatedGenerator implements Generator {
 
   @Override
   public boolean assertRowIndex() {
-    return true;
+    return false;
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/tracked-entity-aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/tracked-entity-aggregated.json
@@ -2,91 +2,91 @@
   "scenarios": [
     {
       "name": "aggregateCountByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&asc=ou&pageSize=5&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&pageSize=5&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=AVERAGE&asc=ou&pageSize=5&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=AVERAGE&pageSize=5&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateSumValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=SUM&asc=ou&pageSize=5&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=SUM&pageSize=5&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateCountOfNonNullValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=COUNT&asc=ou&pageSize=5&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds&value=lw1SqmMlnfh&aggregationType=COUNT&pageSize=5&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageValueByOrgUnitAndGender",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6&value=lw1SqmMlnfh&aggregationType=AVERAGE&asc=ou,cejWyOfXge6&pageSize=5&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6&value=lw1SqmMlnfh&aggregationType=AVERAGE&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageOverDataElementValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=AVERAGE&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=AVERAGE&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateCountOverDataElementValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=COUNT&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=COUNT&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateSumBirthWeightByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=SUM&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=SUM&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateMinBirthWeightByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MIN&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MIN&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateMaxBirthWeightByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MAX&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MAX&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageBirthWeightByOrgUnitAndGender",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&asc=ou,cejWyOfXge6&pageSize=20&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&pageSize=20&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageBirthWeightByOrgUnitFilteredByFemale",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&filter=cejWyOfXge6:IN:Female&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&filter=cejWyOfXge6:IN:Female&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }
     },
     {
       "name": "aggregateAverageFirstEventValueByOrgUnit",
-      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT&aggregationType=AVERAGE&asc=ou&pageSize=10&totalPages=false",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT&aggregationType=AVERAGE&pageSize=10&totalPages=false",
       "version": {
         "min": 44
       }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/tracked-entity-aggregated.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/tracked-entity-aggregated.json
@@ -34,6 +34,62 @@
       "version": {
         "min": 44
       }
+    },
+    {
+      "name": "aggregateAverageOverDataElementValueByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=AVERAGE&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateCountOverDataElementValueByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT&aggregationType=COUNT&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateSumBirthWeightByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=SUM&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateMinBirthWeightByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MIN&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateMaxBirthWeightByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=MAX&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateAverageBirthWeightByOrgUnitAndGender",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&asc=ou,cejWyOfXge6&pageSize=20&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateAverageBirthWeightByOrgUnitFilteredByFemale",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m&value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE&filter=cejWyOfXge6:IN:Female&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "aggregateAverageFirstEventValueByOrgUnit",
+      "query": "/api/analytics/trackedEntities/aggregate/nEenWmSyUEp.json?dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r&value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT&aggregationType=AVERAGE&asc=ou&pageSize=10&totalPages=false",
+      "version": {
+        "min": 44
+      }
     }
   ]
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
@@ -1,51 +1,29 @@
-/*
- * Copyright (c) 2004-2026, University of Oslo
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package org.hisp.dhis.analytics.trackedentity.aggregate;
 
-import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
 import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
-import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-/** Groups e2e tests for "/trackedEntities/aggregate" endpoint. */
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import org.apache.commons.lang3.BooleanUtils;
+/**
+ * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
+ */
 public class TrackedEntityAggregate1AutoTest extends AnalyticsApiTest {
   private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
 
@@ -53,929 +31,195 @@ public class TrackedEntityAggregate1AutoTest extends AnalyticsApiTest {
   public void aggregateCountByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("totalPages=false")
-            .add("pageSize=5")
-            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("totalPages=false")
+    .add("pageSize=5")
+    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
     // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-
+    
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
 
+    
     // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 0, "value", "54");
-
-    // Validate selected values for row index 3 (collation-stable; index 2 swaps a1d/a1E under C
-    // collation)
-    validateRowValueByName(response, actualHeaders, 3, "ou", "a5glgtnXJRG");
-    validateRowValueByName(response, actualHeaders, 3, "value", "62");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "aBfyTU5Wgds");
-    validateRowValueByName(response, actualHeaders, 4, "value", "53");
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "54"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "61"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "53"));
   }
-
   @Test
   public void aggregateAverageValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=5")
-            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-            .add("value=lw1SqmMlnfh");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=5")
+    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+    .add("value=lw1SqmMlnfh")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
     // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-
+    
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
     // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 0, "value", "169.47");
-
-    // Validate selected values for row index 3 (collation-stable; index 2 swaps a1d/a1E under C
-    // collation)
-    validateRowValueByName(response, actualHeaders, 3, "ou", "a5glgtnXJRG");
-    validateRowValueByName(response, actualHeaders, 3, "value", "172.36");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "aBfyTU5Wgds");
-    validateRowValueByName(response, actualHeaders, 4, "value", "170.32");
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "169.47"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "168.9"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "170.32"));
   }
-
   @Test
   public void aggregateSumValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=SUM")
-            .add("totalPages=false")
-            .add("pageSize=5")
-            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-            .add("value=lw1SqmMlnfh");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=SUM")
+    .add("totalPages=false")
+    .add("pageSize=5")
+    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+    .add("value=lw1SqmMlnfh")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
     // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-
+    
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
 
+    
     // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 0, "value", "6101");
-
-    // Validate selected values for row index 3 (collation-stable; index 2 swaps a1d/a1E under C
-    // collation)
-    validateRowValueByName(response, actualHeaders, 3, "ou", "a5glgtnXJRG");
-    validateRowValueByName(response, actualHeaders, 3, "value", "7756");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "aBfyTU5Wgds");
-    validateRowValueByName(response, actualHeaders, 4, "value", "6302");
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "6101"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "7094"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "6302"));
   }
-
   @Test
   public void aggregateCountOfNonNullValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=COUNT")
-            .add("totalPages=false")
-            .add("pageSize=5")
-            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-            .add("value=lw1SqmMlnfh");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=COUNT")
+    .add("totalPages=false")
+    .add("pageSize=5")
+    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+    .add("value=lw1SqmMlnfh")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
     // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-
+    
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
 
+    
     // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 0, "value", "36");
-
-    // Validate selected values for row index 3 (collation-stable; index 2 swaps a1d/a1E under C
-    // collation)
-    validateRowValueByName(response, actualHeaders, 3, "ou", "a5glgtnXJRG");
-    validateRowValueByName(response, actualHeaders, 3, "value", "45");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "aBfyTU5Wgds");
-    validateRowValueByName(response, actualHeaders, 4, "value", "37");
-  }
-
-  @Test
-  public void aggregateAverageValueByOrgUnitAndGender() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou,cejWyOfXge6")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=5")
-            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6")
-            .add("value=lw1SqmMlnfh");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 0, "value", "162.52");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "a04CZxe0PSe");
-    validateRowValueByName(response, actualHeaders, 2, "value", "");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "a1dP5m3Clw4");
-    validateRowValueByName(response, actualHeaders, 4, "value", "177.53");
-  }
-
-  @Test
-  public void aggregateAverageOverDataElementValueByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
-    validateRowValueByName(response, actualHeaders, 0, "value", "14.56");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
-    validateRowValueByName(response, actualHeaders, 2, "value", "15.45");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
-    validateRowValueByName(response, actualHeaders, 4, "value", "12");
-  }
-
-  @Test
-  public void aggregateCountOverDataElementValueByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=COUNT")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
-    validateRowValueByName(response, actualHeaders, 0, "value", "9");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
-    validateRowValueByName(response, actualHeaders, 2, "value", "11");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
-    validateRowValueByName(response, actualHeaders, 4, "value", "9");
-  }
-
-  @Test
-  public void aggregateSumBirthWeightByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=SUM")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 0, "value", "140326");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
-    validateRowValueByName(response, actualHeaders, 2, "value", "98432");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
-    validateRowValueByName(response, actualHeaders, 4, "value", "96603");
-  }
-
-  @Test
-  public void aggregateMinBirthWeightByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=MIN")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 0, "value", "2313");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
-    validateRowValueByName(response, actualHeaders, 2, "value", "2519");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
-    validateRowValueByName(response, actualHeaders, 4, "value", "2576");
-  }
-
-  @Test
-  public void aggregateMaxBirthWeightByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=MAX")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 0, "value", "36282");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
-    validateRowValueByName(response, actualHeaders, 2, "value", "3960");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
-    validateRowValueByName(response, actualHeaders, 4, "value", "3959");
-  }
-
-  @Test
-  public void aggregateAverageBirthWeightByOrgUnitAndGender() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou,cejWyOfXge6")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=20")
-            .add(
-                "dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6")
-            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        16,
-        3,
-        3); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 0, "value", "5369.29");
-
-    // Validate selected values for row index 3
-    validateRowValueByName(response, actualHeaders, 3, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 3, "value", "");
-
-    // Validate selected values for row index 6
-    validateRowValueByName(response, actualHeaders, 6, "ou", "QII5GqfDfO3");
-    validateRowValueByName(response, actualHeaders, 6, "value", "");
-
-    // Validate selected values for row index 9
-    validateRowValueByName(response, actualHeaders, 9, "ou", "Qr41Mw2MSjo");
-    validateRowValueByName(response, actualHeaders, 9, "value", "");
-
-    // Validate selected values for row index 12
-    validateRowValueByName(response, actualHeaders, 12, "ou", "QZzRkqdGjlm");
-    validateRowValueByName(response, actualHeaders, 12, "value", "");
-
-    // Validate selected values for row index 15
-    validateRowValueByName(response, actualHeaders, 15, "ou", "VpYAl8dXs6m");
-    validateRowValueByName(response, actualHeaders, 15, "value", "");
-  }
-
-  @Test
-  public void aggregateAverageBirthWeightByOrgUnitFilteredByFemale() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("filter=cejWyOfXge6:IN:Female")
-            .add("asc=ou")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
-    validateRowValueByName(response, actualHeaders, 0, "value", "5369.29");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
-    validateRowValueByName(response, actualHeaders, 2, "value", "3430.79");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
-    validateRowValueByName(response, actualHeaders, 4, "value", "3225.63");
-  }
-
-  @Test
-  public void aggregateAverageFirstEventValueByOrgUnit() throws JSONException {
-    // Read the 'expect.postgis' system property at runtime to adapt assertions.
-    boolean expectPostgis = isPostgres();
-
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("asc=ou")
-            .add("aggregationType=AVERAGE")
-            .add("totalPages=false")
-            .add("pageSize=10")
-            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT");
-
-    // When
-    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
-
-    // Then
-    // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime
-    // 'expectPostgis' flag.
-    validateResponseStructure(
-        response,
-        expectPostgis,
-        5,
-        2,
-        2); // Pass runtime flag, row count, and expected header counts
-
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders =
-        response.extractList("headers", Map.class).stream()
-            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-            .collect(Collectors.toList());
-
-    // 3. Assert metaData.
-    String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-    validateHeaderPropertiesByName(
-        response,
-        actualHeaders,
-        "ou",
-        "Organisation unit",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeaderPropertiesByName(
-        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-
-    // rowContext not found or empty in the response, skipping assertions.
-
-    // 7. Assert row values by name at specific indices (sorted results).
-    // Validate selected values for row index 0
-    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
-    validateRowValueByName(response, actualHeaders, 0, "value", "14.11");
-
-    // Validate selected values for row index 2
-    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
-    validateRowValueByName(response, actualHeaders, 2, "value", "16.91");
-
-    // Validate selected values for row index 4
-    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
-    validateRowValueByName(response, actualHeaders, 4, "value", "13.78");
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "36"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "42"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "37"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
@@ -402,4 +402,580 @@ public class TrackedEntityAggregate1AutoTest extends AnalyticsApiTest {
     validateRowValueByName(response, actualHeaders, 4, "ou", "a1dP5m3Clw4");
     validateRowValueByName(response, actualHeaders, 4, "value", "177.53");
   }
+
+  @Test
+  public void aggregateAverageOverDataElementValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
+    validateRowValueByName(response, actualHeaders, 0, "value", "14.56");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
+    validateRowValueByName(response, actualHeaders, 2, "value", "15.45");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
+    validateRowValueByName(response, actualHeaders, 4, "value", "12");
+  }
+
+  @Test
+  public void aggregateCountOverDataElementValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=COUNT")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
+    validateRowValueByName(response, actualHeaders, 0, "value", "9");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
+    validateRowValueByName(response, actualHeaders, 2, "value", "11");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
+    validateRowValueByName(response, actualHeaders, 4, "value", "9");
+  }
+
+  @Test
+  public void aggregateSumBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=SUM")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 0, "value", "140326");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
+    validateRowValueByName(response, actualHeaders, 2, "value", "98432");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
+    validateRowValueByName(response, actualHeaders, 4, "value", "96603");
+  }
+
+  @Test
+  public void aggregateMinBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=MIN")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 0, "value", "2313");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
+    validateRowValueByName(response, actualHeaders, 2, "value", "2519");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
+    validateRowValueByName(response, actualHeaders, 4, "value", "2576");
+  }
+
+  @Test
+  public void aggregateMaxBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=MAX")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 0, "value", "36282");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
+    validateRowValueByName(response, actualHeaders, 2, "value", "3960");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
+    validateRowValueByName(response, actualHeaders, 4, "value", "3959");
+  }
+
+  @Test
+  public void aggregateAverageBirthWeightByOrgUnitAndGender() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou,cejWyOfXge6")
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=20")
+            .add(
+                "dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        16,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 0, "value", "5369.29");
+
+    // Validate selected values for row index 3
+    validateRowValueByName(response, actualHeaders, 3, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 3, "value", "");
+
+    // Validate selected values for row index 6
+    validateRowValueByName(response, actualHeaders, 6, "ou", "QII5GqfDfO3");
+    validateRowValueByName(response, actualHeaders, 6, "value", "");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "ou", "Qr41Mw2MSjo");
+    validateRowValueByName(response, actualHeaders, 9, "value", "");
+
+    // Validate selected values for row index 12
+    validateRowValueByName(response, actualHeaders, 12, "ou", "QZzRkqdGjlm");
+    validateRowValueByName(response, actualHeaders, 12, "value", "");
+
+    // Validate selected values for row index 15
+    validateRowValueByName(response, actualHeaders, 15, "ou", "VpYAl8dXs6m");
+    validateRowValueByName(response, actualHeaders, 15, "value", "");
+  }
+
+  @Test
+  public void aggregateAverageBirthWeightByOrgUnitFilteredByFemale() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=cejWyOfXge6:IN:Female")
+            .add("asc=ou")
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "DiszpKrYNg8");
+    validateRowValueByName(response, actualHeaders, 0, "value", "5369.29");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "Qr41Mw2MSjo");
+    validateRowValueByName(response, actualHeaders, 2, "value", "3430.79");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "VpYAl8dXs6m");
+    validateRowValueByName(response, actualHeaders, 4, "value", "3225.63");
+  }
+
+  @Test
+  public void aggregateAverageFirstEventValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=ou")
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ou", "IlMQTFvcq9r");
+    validateRowValueByName(response, actualHeaders, 0, "value", "14.11");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ou", "mVvEwzoFutG");
+    validateRowValueByName(response, actualHeaders, 2, "value", "16.91");
+
+    // Validate selected values for row index 4
+    validateRowValueByName(response, actualHeaders, 4, "ou", "uROAmk9ymNE");
+    validateRowValueByName(response, actualHeaders, 4, "value", "13.78");
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate1AutoTest.java
@@ -1,29 +1,51 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.analytics.trackedentity.aggregate;
 
-import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
-import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
-import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
-import org.apache.commons.lang3.BooleanUtils;
-/**
- * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
- */
+
+/** Groups e2e tests for "/trackedEntities/aggregate" endpoint. */
 public class TrackedEntityAggregate1AutoTest extends AnalyticsApiTest {
   private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
 
@@ -31,194 +53,260 @@ public class TrackedEntityAggregate1AutoTest extends AnalyticsApiTest {
   public void aggregateCountByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("totalPages=false")
-    .add("pageSize=5")
-    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("totalPages=false")
+            .add("pageSize=5")
+            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "54"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "61"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "53"));
   }
+
   @Test
   public void aggregateAverageValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=5")
-    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-    .add("value=lw1SqmMlnfh")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=5")
+            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+            .add("value=lw1SqmMlnfh");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
     // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-    
+
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "169.47"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "168.9"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "170.32"));
   }
+
   @Test
   public void aggregateSumValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=SUM")
-    .add("totalPages=false")
-    .add("pageSize=5")
-    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-    .add("value=lw1SqmMlnfh")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=SUM")
+            .add("totalPages=false")
+            .add("pageSize=5")
+            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+            .add("value=lw1SqmMlnfh");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "6101"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "7094"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "6302"));
   }
+
   @Test
   public void aggregateCountOfNonNullValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=COUNT")
-    .add("totalPages=false")
-    .add("pageSize=5")
-    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
-    .add("value=lw1SqmMlnfh")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=COUNT")
+            .add("totalPages=false")
+            .add("pageSize=5")
+            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4;a1E6QWBTEwX;a5glgtnXJRG;aBfyTU5Wgds")
+            .add("value=lw1SqmMlnfh");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"aBfyTU5Wgds\":{\"name\":\"Nduvuibu MCHP\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"a1E6QWBTEwX\":{\"name\":\"Sienga CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"a5glgtnXJRG\":{\"name\":\"Magbanabom MCHP\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\",\"a1E6QWBTEwX\",\"a5glgtnXJRG\",\"aBfyTU5Wgds\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "value", "36"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "a1E6QWBTEwX", "value", "42"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "aBfyTU5Wgds", "value", "37"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate2AutoTest.java
@@ -1,230 +1,327 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.analytics.trackedentity.aggregate;
 
-import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
-import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
-import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
-import org.apache.commons.lang3.BooleanUtils;
-/**
- * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
- */
+
+/** Groups e2e tests for "/trackedEntities/aggregate" endpoint. */
 public class TrackedEntityAggregate2AutoTest extends AnalyticsApiTest {
-    private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+  private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+
   @Test
   public void aggregateAverageValueByOrgUnitAndGender() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6")
-    .add("value=lw1SqmMlnfh")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6")
+            .add("value=lw1SqmMlnfh");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 6, 3, 3); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        6,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
-    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "Female", "value", "162.52"));
-    
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "Female", "value", "162.52"));
+
     // Validate row exists with values from original row index 2
-    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "", "value", ""));
-    
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "", "value", ""));
+
     // Validate row exists with values from original row index 4
-    validateRowExists(response, actualHeaders, Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "Male", "value", "177.53"));
-    
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "Male", "value", "177.53"));
+
     // Validate row exists with values from original row index 5
-    validateRowExists(response, actualHeaders, Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "", "value", ""));
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "", "value", ""));
   }
+
   @Test
   public void aggregateAverageOverDataElementValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "14.56"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "15.45"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "12"));
   }
+
   @Test
   public void aggregateCountOverDataElementValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=COUNT")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=COUNT")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "9"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "11"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "9"));
   }
+
   @Test
   public void aggregateSumBirthWeightByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=SUM")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=SUM")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "140326"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "98432"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "96603"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate2AutoTest.java
@@ -1,0 +1,231 @@
+package org.hisp.dhis.analytics.trackedentity.aggregate;
+
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.analytics.ValidationHelper;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import org.apache.commons.lang3.BooleanUtils;
+/**
+ * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
+ */
+public class TrackedEntityAggregate2AutoTest extends AnalyticsApiTest {
+    private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+  @Test
+  public void aggregateAverageValueByOrgUnitAndGender() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:a04CZxe0PSe;a1dP5m3Clw4,cejWyOfXge6")
+    .add("value=lw1SqmMlnfh")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 6, 3, 3); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"a04CZxe0PSe\":{\"name\":\"Murray Town CHC\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"a1dP5m3Clw4\":{\"name\":\"Baoma Kpenge CHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"a04CZxe0PSe\",\"a1dP5m3Clw4\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "Female", "value", "162.52"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "a04CZxe0PSe", "cejWyOfXge6", "", "value", ""));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "Male", "value", "177.53"));
+    
+    // Validate row exists with values from original row index 5
+    validateRowExists(response, actualHeaders, Map.of("ou", "a1dP5m3Clw4", "cejWyOfXge6", "", "value", ""));
+  }
+  @Test
+  public void aggregateAverageOverDataElementValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "14.56"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "15.45"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "12"));
+  }
+  @Test
+  public void aggregateCountOverDataElementValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=COUNT")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ.vANAXwtLwcT")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "9"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "11"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "9"));
+  }
+  @Test
+  public void aggregateSumBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=SUM")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "140326"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "98432"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "96603"));
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate3AutoTest.java
@@ -1,236 +1,335 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.analytics.trackedentity.aggregate;
 
-import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
-import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
-import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
-import org.apache.commons.lang3.BooleanUtils;
-/**
- * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
- */
+
+/** Groups e2e tests for "/trackedEntities/aggregate" endpoint. */
 public class TrackedEntityAggregate3AutoTest extends AnalyticsApiTest {
-    private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+  private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+
   @Test
   public void aggregateMinBirthWeightByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=MIN")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=MIN")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "2313"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "2519"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "2576"));
   }
+
   @Test
   public void aggregateMaxBirthWeightByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=MAX")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=MAX")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "36282"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "3960"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "3959"));
   }
+
   @Test
   public void aggregateAverageBirthWeightByOrgUnitAndGender() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=20")
-    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6")
-    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=20")
+            .add(
+                "dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 16, 3, 3); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        16,
+        3,
+        3); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
-    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "Female", "value", "5369.29"));
-    
+    validateRowExists(
+        response,
+        actualHeaders,
+        Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "Female", "value", "5369.29"));
+
     // Validate row exists with values from original row index 3
-    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "", "value", ""));
-    
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "", "value", ""));
+
     // Validate row exists with values from original row index 6
-    validateRowExists(response, actualHeaders, Map.of("ou", "QII5GqfDfO3", "cejWyOfXge6", "", "value", ""));
-    
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "QII5GqfDfO3", "cejWyOfXge6", "", "value", ""));
+
     // Validate row exists with values from original row index 9
-    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "cejWyOfXge6", "", "value", ""));
-    
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "cejWyOfXge6", "", "value", ""));
+
     // Validate row exists with values from original row index 12
-    validateRowExists(response, actualHeaders, Map.of("ou", "QZzRkqdGjlm", "cejWyOfXge6", "", "value", ""));
-    
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "QZzRkqdGjlm", "cejWyOfXge6", "", "value", ""));
+
     // Validate row exists with values from original row index 15
-    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "cejWyOfXge6", "", "value", ""));
+    validateRowExists(
+        response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "cejWyOfXge6", "", "value", ""));
   }
+
   @Test
   public void aggregateAverageBirthWeightByOrgUnitFilteredByFemale() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("filter=cejWyOfXge6:IN:Female")
-    .add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
-    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=cejWyOfXge6:IN:Female")
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+            .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
-    // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
-    // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-    
-    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
 
-    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "5369.29"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "3430.79"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "3225.63"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate3AutoTest.java
@@ -1,0 +1,237 @@
+package org.hisp.dhis.analytics.trackedentity.aggregate;
+
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.analytics.ValidationHelper;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import org.apache.commons.lang3.BooleanUtils;
+/**
+ * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
+ */
+public class TrackedEntityAggregate3AutoTest extends AnalyticsApiTest {
+    private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+  @Test
+  public void aggregateMinBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=MIN")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+    
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "2313"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "2519"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "2576"));
+  }
+  @Test
+  public void aggregateMaxBirthWeightByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=MAX")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "36282"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "3960"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "3959"));
+  }
+  @Test
+  public void aggregateAverageBirthWeightByOrgUnitAndGender() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=20")
+    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m,cejWyOfXge6")
+    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 16, 3, 3); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":20,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"pC3N9N77UmT\":{\"uid\":\"pC3N9N77UmT\",\"name\":\"Gender\",\"options\":[{\"uid\":\"rBvjJYbMCVx\",\"code\":\"Male\"},{\"uid\":\"Mnp3oXrpAbK\",\"code\":\"Female\"}]},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Mnp3oXrpAbK\":{\"code\":\"Female\",\"name\":\"Female\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"rBvjJYbMCVx\":{\"code\":\"Male\",\"name\":\"Male\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"cejWyOfXge6\":{\"name\":\"Gender\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"cejWyOfXge6", "Gender", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "Female", "value", "5369.29"));
+    
+    // Validate row exists with values from original row index 3
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "cejWyOfXge6", "", "value", ""));
+    
+    // Validate row exists with values from original row index 6
+    validateRowExists(response, actualHeaders, Map.of("ou", "QII5GqfDfO3", "cejWyOfXge6", "", "value", ""));
+    
+    // Validate row exists with values from original row index 9
+    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "cejWyOfXge6", "", "value", ""));
+    
+    // Validate row exists with values from original row index 12
+    validateRowExists(response, actualHeaders, Map.of("ou", "QZzRkqdGjlm", "cejWyOfXge6", "", "value", ""));
+    
+    // Validate row exists with values from original row index 15
+    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "cejWyOfXge6", "", "value", ""));
+  }
+  @Test
+  public void aggregateAverageBirthWeightByOrgUnitFilteredByFemale() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("filter=cejWyOfXge6:IN:Female")
+    .add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:QII5GqfDfO3;DiszpKrYNg8;QZzRkqdGjlm;Qr41Mw2MSjo;VpYAl8dXs6m")
+    .add("value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"QII5GqfDfO3\":{\"name\":\"Ngiehun Kongo CHP\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"VpYAl8dXs6m\":{\"name\":\"Bendoma (Malegohun) MCHP\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"Qr41Mw2MSjo\":{\"name\":\"Senthai MCHP\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"QZzRkqdGjlm\":{\"name\":\"Mindohun CHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"DiszpKrYNg8\",\"QII5GqfDfO3\",\"Qr41Mw2MSjo\",\"QZzRkqdGjlm\",\"VpYAl8dXs6m\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "DiszpKrYNg8", "value", "5369.29"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "Qr41Mw2MSjo", "value", "3430.79"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "VpYAl8dXs6m", "value", "3225.63"));
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate4AutoTest.java
@@ -1,29 +1,51 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.analytics.trackedentity.aggregate;
 
-import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
-import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
-import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
-import org.apache.commons.lang3.BooleanUtils;
-/**
- * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
- */
+
+/** Groups e2e tests for "/trackedEntities/aggregate" endpoint. */
 public class TrackedEntityAggregate4AutoTest extends AnalyticsApiTest {
   private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
 
@@ -31,48 +53,64 @@ public class TrackedEntityAggregate4AutoTest extends AnalyticsApiTest {
   public void aggregateAverageFirstEventValueByOrgUnit() throws JSONException {
     // Read the 'expect.postgis' system property at runtime to adapt assertions.
     boolean expectPostgis = isPostgres();
-    
-    // Given 
-    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
-    .add("totalPages=false")
-    .add("pageSize=10")
-    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
-    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT")
-    ;
-    
-        // When
-        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("aggregationType=AVERAGE")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+            .add("value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT");
+
+    // When
+    ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
 
     // Then
     // 1. Validate Response Structure (Counts, Headers, Height/Width)
-    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
-    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
-    
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        5,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
     // 2. Extract Headers into a List of Maps for easy access by name
-    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
-        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
-        .collect(Collectors.toList());
-    
-    
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
     // 3. Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
-    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
-    
+
     // 4. Validate Headers By Name (conditionally checking PostGIS headers).
-        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
-        
-    
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ou",
+        "Organisation unit",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response, actualHeaders, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
     // rowContext not found or empty in the response, skipping assertions.
-    
+
     // 7. Assert row existence by value (unsorted results - validates all columns).
     // Validate row exists with values from original row index 0
     validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "14.11"));
-    
+
     // Validate row exists with values from original row index 2
     validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "16.91"));
-    
+
     // Validate row exists with values from original row index 4
     validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "13.78"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/aggregate/TrackedEntityAggregate4AutoTest.java
@@ -1,0 +1,79 @@
+package org.hisp.dhis.analytics.trackedentity.aggregate;
+
+import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowExists;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.analytics.ValidationHelper;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsTrackedEntityActions;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
+import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import org.apache.commons.lang3.BooleanUtils;
+/**
+ * Groups e2e tests for "/trackedEntities/aggregate" endpoint.
+ */
+public class TrackedEntityAggregate4AutoTest extends AnalyticsApiTest {
+  private final AnalyticsTrackedEntityActions actions = new AnalyticsTrackedEntityActions();
+
+  @Test
+  public void aggregateAverageFirstEventValueByOrgUnit() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+    
+    // Given 
+    QueryParamsBuilder params = new QueryParamsBuilder().add("aggregationType=AVERAGE")
+    .add("totalPages=false")
+    .add("pageSize=10")
+    .add("dimension=ou:UAtEKSd5QTf;mVvEwzoFutG;uROAmk9ymNE;mMvt6zhCclb;IlMQTFvcq9r")
+    .add("value=WSGAb5XwJ3Y.edqlbukwRfQ[1].vANAXwtLwcT")
+    ;
+    
+        // When
+        ApiResponse response = actions.aggregate().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime 'expectPostgis' flag.
+    validateResponseStructure(response, expectPostgis, 5, 2, 2); // Pass runtime flag, row count, and expected header counts
+    
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders = response.extractList("headers", Map.class).stream()
+        .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+        .collect(Collectors.toList());
+    
+    
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":true},\"items\":{\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"fDd25txQckK\":{\"name\":\"Provider Follow-up and Support Tool\"},\"PFDfvmGpsR3\":{\"name\":\"Care at birth\"},\"lST1OZ5BDJ2\":{\"name\":\"Provider Follow-up and Support Tool\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"PUZaKR0Jh2k\":{\"name\":\"Previous deliveries\"},\"WZbXY0S00lP\":{\"name\":\"First antenatal care visit\"},\"Xgk8Wvl0jHr\":{\"name\":\"Delivery\"},\"bbKtnxRZKEP\":{\"name\":\"Postpartum care visit\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ou\":{\"name\":\"Organisation unit\"},\"uROAmk9ymNE\":{\"name\":\"Kindoyal Hospital\"},\"edqlbukwRfQ\":{\"name\":\"Second antenatal care visit\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"},\"mVvEwzoFutG\":{\"name\":\"Nyandehun MCHP\"},\"oRySG82BKE6\":{\"name\":\"PNC Visit\"},\"grIfo3oOf4Y\":{\"name\":\"ANC Visit (2-4+)\"},\"eaDHS084uMp\":{\"name\":\"ANC 1st visit\"},\"UAtEKSd5QTf\":{\"name\":\"Konta (Gorama M) CHP\"},\"uy2gU8kT1jF\":{\"name\":\"MNCH \\/ PNC (Adult Woman)\"},\"IlMQTFvcq9r\":{\"name\":\"Lowoma CHC\"},\"WSGAb5XwJ3Y\":{\"name\":\"WHO RMNCH Tracker\"},\"mMvt6zhCclb\":{\"name\":\"Manjama MCHP\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"IlMQTFvcq9r\",\"mMvt6zhCclb\",\"mVvEwzoFutG\",\"UAtEKSd5QTf\",\"uROAmk9ymNE\"]}}";
+    String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+    
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+        validateHeaderPropertiesByName(response, actualHeaders,"ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+        validateHeaderPropertiesByName(response, actualHeaders,"value", "Value", "NUMBER", "java.lang.Double", false, false);
+        
+    
+    // rowContext not found or empty in the response, skipping assertions.
+    
+    // 7. Assert row existence by value (unsorted results - validates all columns).
+    // Validate row exists with values from original row index 0
+    validateRowExists(response, actualHeaders, Map.of("ou", "IlMQTFvcq9r", "value", "14.11"));
+    
+    // Validate row exists with values from original row index 2
+    validateRowExists(response, actualHeaders, Map.of("ou", "mVvEwzoFutG", "value", "16.91"));
+    
+    // Validate row exists with values from original row index 4
+    validateRowExists(response, actualHeaders, Map.of("ou", "uROAmk9ymNE", "value", "13.78"));
+  }
+}


### PR DESCRIPTION
## Summary

Extends the tracked-entity aggregate endpoint `/api/analytics/trackedEntities/aggregate/{trackedEntityType}` so the `value` parameter can be a **program-stage data element** (an event value), not just a tracked-entity attribute.

Previously `value` resolved only to a numeric tracked-entity attribute — a single column on the flat one-row-per-tracked-entity table `analytics_te_<tet>`. Event data element values live in a separate table (`analytics_te_event_<tet>`) with **many rows per tracked entity** (one per event), so they could not be aggregated. This PR reduces each tracked entity's events for the stage to one chosen event, joins it back, and aggregates it — giving correct per-tracked-entity results.

`value` now accepts `programUid.programStageUid.dataElementUid` (with an optional stage offset), in addition to the existing bare attribute UID.

## What this enables

- **Average birth weight per org unit** — from the Birth stage of the Child Programme.
- **Sum / min / max / count of any numeric event data element**, grouped by org unit and/or tracked-entity attributes (e.g. total doses administered per org unit; min/max measurement per district).
- **Average birth weight per org unit and gender** — the event value combined with an attribute group-by key.
- **Count of tracked entities that have a recorded measurement** per org unit — `aggregationType=COUNT` over the data element counts non-null values (one per tracked entity), not events.
- **Value from a chosen visit** — the stage offset picks which occurrence to read: `[0]` latest (default), `[-1]` the visit before, `[1]` the first.

## Example queries

```
# Average latest birth weight (Child Programme, Birth stage) per org unit
GET /api/analytics/trackedEntities/aggregate/nEenWmSyUEp
    ?dimension=ou:QII5GqfDfO3;DiszpKrYNg8
    &value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU
    &aggregationType=AVERAGE

# Sum / min / max of the same value per org unit — swap aggregationType=SUM|MIN|MAX

# Average birth weight per org unit AND gender (attribute group-by key)
GET .../aggregate/nEenWmSyUEp
    ?dimension=ou:QII5GqfDfO3;DiszpKrYNg8,cejWyOfXge6
    &value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE

# Average birth weight per org unit, filtered to Female (WHERE, not a group-by column)
GET .../aggregate/nEenWmSyUEp
    ?dimension=ou:QII5GqfDfO3;DiszpKrYNg8
    &value=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU&aggregationType=AVERAGE
    &filter=cejWyOfXge6:IN:Female

# COUNT of tracked entities with a non-null value per org unit
GET .../aggregate/nEenWmSyUEp?dimension=ou:...&value=<prg.stage.de>&aggregationType=COUNT

# The first recorded value instead of the latest (stage offset)
GET .../aggregate/nEenWmSyUEp?dimension=ou:...&value=<prg>.<stage>[1].<de>&aggregationType=AVERAGE
```

The response is the same grid shape as the existing aggregate endpoint: one column per grouped dimension (carrying the dimension-item UID) plus a trailing numeric `value` column; grouped org-unit UIDs resolve to names via `metaData.items`.

## Generated SQL

Aggregating a data element requires reducing each tracked entity's events for the stage to a single chosen event before joining, otherwise the join would match every event and the aggregation would count events instead of tracked entities.

```sql
select t_1."ou",
       avg((ev."eventdatavalues" -> 'UXz7xuGCEhU' ->> 'value')::DECIMAL) as "value"
from analytics_te_nEenWmSyUEp t_1
left join (select trackedentity, eventdatavalues
           from (select trackedentity, eventdatavalues,
                        row_number() over (partition by trackedentity
                                           order by occurreddate desc) as rn
                 from analytics_te_event_nEenWmSyUEp
                 where programstage = 'A03MvHHogjR'
                   and jsonb_exists(eventdatavalues, 'UXz7xuGCEhU')
                   and status != 'SCHEDULE') e
           where rn = 1) ev on ev.trackedentity = t_1.trackedentity
group by t_1."ou"
```

- The inner `row_number() over (partition by trackedentity order by occurreddate <dir>)` + `rn = <offset>` selects one event per tracked entity (default: the latest event that carries the data element).
- `jsonb_exists(eventdatavalues, '<de>')` restricts to events that actually have the value (used instead of the `?` operator, which `NamedParameterJdbcTemplate` would misparse as a bind placeholder).
- `status != 'SCHEDULE'` excludes scheduled events (which have no `occurreddate`), matching the row-level query.
- The value is aggregated with the per-data-element PostgreSQL cast; `COUNT` counts non-null values.