### PR TITLE
test: assert optionSet on stage-scoped data element headers [DHIS2-21344]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate5AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate5AutoTest.java
@@ -91,7 +91,8 @@ public class EventsAggregate5AutoTest extends AnalyticsApiTest {
         "TEXT",
         "java.lang.String",
         false,
-        true);
+        true,
+        "iDFPKpFTiVw");
     validateHeader(response, 1, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -263,7 +264,8 @@ public class EventsAggregate5AutoTest extends AnalyticsApiTest {
         "TEXT",
         "java.lang.String",
         false,
-        true);
+        true,
+        "iDFPKpFTiVw");
     validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
 


### PR DESCRIPTION
## Summary
- `EventsAggregate5AutoTest` already exercised an optionSet-backed, stage-scoped data element (`Zj7UnCAulEk.fWIAEtYVEGk`, Mode of Discharge) in two tests, but both asserted the header via the `ValidationHelper.validateHeader` overload that skips `optionSet`, using the existing 8-arg overload instead of the 9-arg one that already asserts it.
- This gap meant neither test would have caught `DataElement.optionSet` going missing from `/api/analytics/events/aggregate` headers — which is exactly what happened on the `2.43` maintenance line (see dhis2/dhis2-core#24394) after `12ebdf2d78` ("chore: annotation mapping for DataElement", #23092) fixed a latent Hibernate mapping bug on master but was never backported.
- Master itself is unaffected (already has `12ebdf2d78`), so this PR is test-coverage only — no production code change.

## Test plan
- [x] `mvn compile` passes on `dhis-test-e2e`.
- [ ] CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)