### PR TITLE
perf: avoid loading org unit group members for OUG{} indicator counts (2.42.5.1)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.organisationunit;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
@@ -43,4 +44,14 @@ public interface OrganisationUnitGroupStore
 
   OrganisationUnitGroup getOrgUnitGroupInGroupSet(
       Set<OrganisationUnitGroup> groups, OrganisationUnitGroupSet groupSet);
+
+  /**
+   * Returns the number of members (organisation units) for each of the given organisation unit
+   * groups, keyed by group UID. The count is computed with a {@code size}/{@code count} query and
+   * does not initialise the (potentially very large) members collection.
+   *
+   * @param uids the UIDs of the organisation unit groups to count members for.
+   * @return a map of organisation unit group UID to member count. Non-existent groups are omitted.
+   */
+  Map<String, Integer> getOrganisationUnitGroupMemberCounts(Set<String> uids);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -134,6 +134,7 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupStore;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
@@ -183,6 +184,8 @@ public class DefaultExpressionService implements ExpressionService {
   private final I18nManager i18nManager;
 
   private final SqlBuilder sqlBuilder;
+
+  private final OrganisationUnitGroupStore organisationUnitGroupStore;
 
   // -------------------------------------------------------------------------
   // Static data
@@ -285,7 +288,9 @@ public class DefaultExpressionService implements ExpressionService {
       IdentifiableObjectManager idObjectManager,
       I18nManager i18nManager,
       CacheProvider cacheProvider,
-      SqlBuilder sqlBuilder) {
+      SqlBuilder sqlBuilder,
+      @Qualifier("org.hisp.dhis.organisationunit.OrganisationUnitGroupStore")
+          OrganisationUnitGroupStore organisationUnitGroupStore) {
     checkNotNull(expressionStore);
     checkNotNull(constantService);
     checkNotNull(dimensionService);
@@ -293,6 +298,7 @@ public class DefaultExpressionService implements ExpressionService {
     checkNotNull(i18nManager);
     checkNotNull(cacheProvider);
     checkNotNull(sqlBuilder);
+    checkNotNull(organisationUnitGroupStore);
 
     this.expressionStore = expressionStore;
     this.constantService = constantService;
@@ -301,6 +307,7 @@ public class DefaultExpressionService implements ExpressionService {
     this.i18nManager = i18nManager;
     this.constantMapCache = cacheProvider.createAllConstantsCache();
     this.sqlBuilder = sqlBuilder;
+    this.organisationUnitGroupStore = organisationUnitGroupStore;
   }
 
   // -------------------------------------------------------------------------
@@ -433,7 +440,7 @@ public class DefaultExpressionService implements ExpressionService {
   }
 
   @Override
-  @Transactional
+  @Transactional(readOnly = true)
   public void substituteIndicatorExpressions(Collection<Indicator> indicators) {
     if (indicators == null || indicators.isEmpty()) {
       return;
@@ -443,18 +450,44 @@ public class DefaultExpressionService implements ExpressionService {
         new CachingMap<String, Constant>()
             .load(idObjectManager.getAllNoAcl(Constant.class), IdentifiableObject::getUid);
 
-    Map<String, OrganisationUnitGroup> orgUnitGroups =
-        new CachingMap<String, OrganisationUnitGroup>()
-            .load(
-                idObjectManager.getAllNoAcl(OrganisationUnitGroup.class),
-                IdentifiableObject::getUid);
+    // Resolve org unit group member counts with a single count query. Reading the size of the lazy
+    // members collection directly would initialise it, hydrating every member of a group that may
+    // contain tens of thousands of org units into the session.
+    Set<String> orgUnitGroupUids =
+        indicators.stream()
+            .flatMap(indicator -> Stream.of(indicator.getNumerator(), indicator.getDenominator()))
+            .flatMap(expression -> getReferencedOrgUnitGroupUids(expression).stream())
+            .collect(Collectors.toSet());
+
+    Map<String, Integer> orgUnitGroupCounts =
+        organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(orgUnitGroupUids);
 
     for (Indicator indicator : indicators) {
       indicator.setExplodedNumerator(
-          regenerateIndicatorExpression(indicator.getNumerator(), constants, orgUnitGroups));
+          regenerateIndicatorExpression(indicator.getNumerator(), constants, orgUnitGroupCounts));
       indicator.setExplodedDenominator(
-          regenerateIndicatorExpression(indicator.getDenominator(), constants, orgUnitGroups));
+          regenerateIndicatorExpression(indicator.getDenominator(), constants, orgUnitGroupCounts));
     }
+  }
+
+  /**
+   * Returns the UIDs of the organisation unit groups referenced by {@code OUG{...}} in the given
+   * expression.
+   */
+  private Set<String> getReferencedOrgUnitGroupUids(String expression) {
+    Set<String> uids = new HashSet<>();
+
+    if (expression == null || expression.isEmpty()) {
+      return uids;
+    }
+
+    Matcher matcher = OU_GROUP_PATTERN.matcher(expression);
+
+    while (matcher.find()) {
+      uids.add(matcher.group(GROUP_ID));
+    }
+
+    return uids;
   }
 
   // -------------------------------------------------------------------------
@@ -772,9 +805,7 @@ public class DefaultExpressionService implements ExpressionService {
    * orgUnitCounts.
    */
   private String regenerateIndicatorExpression(
-      String expression,
-      Map<String, Constant> constants,
-      Map<String, OrganisationUnitGroup> orgUnitGroups) {
+      String expression, Map<String, Constant> constants, Map<String, Integer> orgUnitGroupCounts) {
     if (expression == null || expression.isEmpty()) {
       return null;
     }
@@ -809,10 +840,9 @@ public class DefaultExpressionService implements ExpressionService {
     while (matcher.find()) {
       String oug = matcher.group(GROUP_ID);
 
-      OrganisationUnitGroup group = orgUnitGroups.get(oug);
+      Integer memberCount = orgUnitGroupCounts.get(oug);
 
-      String replacement =
-          group != null ? String.valueOf(group.getMembers().size()) : NULL_REPLACEMENT;
+      String replacement = memberCount != null ? String.valueOf(memberCount) : NULL_REPLACEMENT;
 
       matcher.appendReplacement(sb, replacement);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
@@ -30,7 +30,9 @@
 package org.hisp.dhis.organisationunit.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -75,5 +77,29 @@ public class HibernateOrganisationUnitGroupStore
         .setParameter("groups", groups)
         .setMaxResults(1)
         .uniqueResult();
+  }
+
+  @Override
+  public Map<String, Integer> getOrganisationUnitGroupMemberCounts(Set<String> uids) {
+    Map<String, Integer> counts = new HashMap<>();
+
+    if (uids == null || uids.isEmpty()) {
+      return counts;
+    }
+
+    // size(g.members) translates to a count subquery; the members collection is never initialised.
+    List<Object[]> rows =
+        getSession()
+            .createQuery(
+                "select g.uid, size(g.members) from OrganisationUnitGroup g where g.uid in :uids",
+                Object[].class)
+            .setParameter("uids", uids)
+            .list();
+
+    for (Object[] row : rows) {
+      counts.put((String) row[0], ((Number) row[1]).intValue());
+    }
+
+    return counts;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -101,6 +102,7 @@ import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupStore;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
@@ -133,6 +135,8 @@ class ExpressionServiceTest extends TestBase {
   @Mock private CacheProvider cacheProvider;
 
   @Spy private PostgreSqlBuilder sqlBuilder;
+
+  @Mock private OrganisationUnitGroupStore organisationUnitGroupStore;
 
   private DefaultExpressionService target;
 
@@ -255,7 +259,8 @@ class ExpressionServiceTest extends TestBase {
             idObjectManager,
             i18nManager,
             cacheProvider,
-            sqlBuilder);
+            sqlBuilder,
+            organisationUnitGroupStore);
 
     categoryOptionA = new CategoryOption("Under 5");
     categoryOptionB = new CategoryOption("Over 5");
@@ -1045,11 +1050,9 @@ class ExpressionServiceTest extends TestBase {
     List<Constant> constants =
         ImmutableList.<Constant>builder().add(constantA).add(constantB).build();
 
-    List<OrganisationUnitGroup> orgUnitGroups =
-        ImmutableList.<OrganisationUnitGroup>builder().add(groupA).build();
-
     when(idObjectManager.getAllNoAcl(Constant.class)).thenReturn(constants);
-    when(idObjectManager.getAllNoAcl(OrganisationUnitGroup.class)).thenReturn(orgUnitGroups);
+    when(organisationUnitGroupStore.getOrganisationUnitGroupMemberCounts(Set.of(groupA.getUid())))
+        .thenReturn(Map.of(groupA.getUid(), groupA.getMembers().size()));
 
     target.substituteIndicatorExpressions(indicators);
 
@@ -1057,6 +1060,9 @@ class ExpressionServiceTest extends TestBase {
     assertEquals("#{deabcdefghA." + coc.getUid() + "}*2.0", indicatorA.getExplodedDenominator());
     assertEquals("#{deabcdefghA." + coc.getUid() + "}*3", indicatorB.getExplodedNumerator());
     assertEquals(expressionZ, indicatorB.getExplodedDenominator());
+
+    // The members collection must never be loaded; counts come from the store count query.
+    verify(idObjectManager, never()).getAllNoAcl(OrganisationUnitGroup.class);
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1650,4 +1650,25 @@ class ExpressionServiceTest extends PostgresIntegrationTestBase {
         validity("greatest(#{dataElemenA.catOptCombB},C{xxxxxxxxx05})", PREDICTOR_EXPRESSION));
     assertEquals(EXPRESSION_IS_NOT_WELL_FORMED, validity("1*", PREDICTOR_EXPRESSION));
   }
+
+  @Test
+  void testSubstituteIndicatorExpressionsResolvesOrgUnitGroupCounts() {
+    // Equivalence guard for the OUG{} count fix: substituteIndicatorExpressions must produce the
+    // same exploded expression as the previous group.getMembers().size() implementation, while
+    // resolving the count with a count query instead of initialising the members collection.
+    Indicator indicator = createIndicator('Z', indicatorTypeB);
+    indicator.setNumerator("OUG{" + orgUnitGroupA.getUid() + "}");
+    indicator.setDenominator("OUG{" + orgUnitGroupB.getUid() + "}");
+
+    expressionService.substituteIndicatorExpressions(List.of(indicator));
+
+    // The substituted count must equal what group.getMembers().size() returned before the change.
+    assertEquals(
+        String.valueOf(orgUnitGroupA.getMembers().size()), indicator.getExplodedNumerator());
+    assertEquals(
+        String.valueOf(orgUnitGroupB.getMembers().size()), indicator.getExplodedDenominator());
+    // orgUnitGroupA has 5 members, orgUnitGroupB has 3 (see setUp).
+    assertEquals("5", indicator.getExplodedNumerator());
+    assertEquals("3", indicator.getExplodedDenominator());
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
@@ -31,9 +31,11 @@ package org.hisp.dhis.organisationunit;
 
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -71,5 +73,34 @@ class OrganisationUnitGroupStoreTest extends OrganisationUnitBaseSpringTest {
     Set<OrganisationUnitGroup> groups = Sets.newHashSet(groupA, groupB);
     OrganisationUnitGroupSet groupSet = addOrganisationUnitGroupSet('A', groupA, groupC);
     assertEquals(groupA, groupStore.getOrgUnitGroupInGroupSet(groups, groupSet));
+  }
+
+  @Test
+  void testGetOrganisationUnitGroupMemberCounts() {
+    OrganisationUnit unitA = addOrganisationUnit('A');
+    OrganisationUnit unitB = addOrganisationUnit('B');
+    OrganisationUnit unitC = addOrganisationUnit('C');
+    OrganisationUnitGroup groupA = addOrganisationUnitGroup('A', unitA, unitB, unitC);
+    OrganisationUnitGroup groupB = addOrganisationUnitGroup('B', unitB);
+    OrganisationUnitGroup groupEmpty = addOrganisationUnitGroup('E');
+
+    Map<String, Integer> counts =
+        groupStore.getOrganisationUnitGroupMemberCounts(
+            Set.of(groupA.getUid(), groupB.getUid(), groupEmpty.getUid()));
+
+    assertEquals(3, counts.get(groupA.getUid()));
+    assertEquals(1, counts.get(groupB.getUid()));
+    assertEquals(0, counts.get(groupEmpty.getUid()));
+  }
+
+  @Test
+  void testGetOrganisationUnitGroupMemberCountsEmptyAndUnknown() {
+    OrganisationUnit unitA = addOrganisationUnit('A');
+    addOrganisationUnitGroup('A', unitA);
+
+    assertTrue(groupStore.getOrganisationUnitGroupMemberCounts(Set.of()).isEmpty());
+    assertTrue(
+        groupStore.getOrganisationUnitGroupMemberCounts(Set.of("nonExistnt0")).isEmpty(),
+        "unknown group UIDs must be omitted, not present with a zero count");
   }
 }


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/24260