### PR TITLE
chore: Use safe PropertyPath instead of String

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/CodeGenerator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/CodeGenerator.java
@@ -229,7 +229,7 @@ public class CodeGenerator {
    * @param code the code to validate.
    * @return true if the code is valid.
    */
-  public static boolean isValidUid(String code) {
+  public static boolean isValidUid(CharSequence code) {
     return code != null && UID_PATTERN.matcher(code).matches();
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -47,7 +47,8 @@ import org.hisp.dhis.jsontree.Text;
  * @param parent the parent path (or null for root)
  * @param segment last segment in the path (without the dots)
  */
-public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segment) {
+public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segment)
+    implements Comparable<PropertyPath> {
 
   public PropertyPath {
     // enforce path pattern by construction
@@ -76,6 +77,33 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
       start = i;
     }
     return res;
+  }
+
+  /** For lexicographical sort order */
+  @Override
+  public int compareTo(@Nonnull PropertyPath b) {
+    PropertyPath a = this;
+    PropertyPath aParent = a.parent;
+    PropertyPath bParent = b.parent;
+    if (aParent == null && bParent == null) return a.segment.compareTo(b.segment);
+    if (aParent == null) return -1;
+    if (bParent == null) return 1;
+    int aLen = a.length();
+    int bLen = b.length();
+    if (aLen == bLen) {
+      int res = aParent.compareTo(bParent);
+      return res != 0 ? res : a.segment.compareTo(b.segment);
+    }
+    if (aLen < bLen) {
+      for (int i = 0; i < bLen - aLen; i++) b = bParent;
+      int res = aParent.compareTo(bParent);
+      if (res == 0) res = a.segment.compareTo(b.segment);
+      return res != 0 ? res : -1;
+    }
+    for (int i = 0; i < aLen - bLen; i++) a = aParent;
+    int res = aParent.compareTo(bParent);
+    if (res == 0) res = a.segment.compareTo(b.segment);
+    return res != 0 ? res : 1;
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.common;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
@@ -203,8 +203,8 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   @Nonnull
-  public List<Text> segments() {
-    if (parent == null) return List.of(segment);
+  public Stream<Text> segments() {
+    if (parent == null) return Stream.of(segment);
     int n = length();
     PropertyPath path = this;
     Text[] res = new Text[n];
@@ -213,7 +213,7 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
       res[i--] = path.segment;
       path = path.parent;
     }
-    return Stream.of(res).toList();
+    return Stream.of(res);
   }
 
   @Nonnull
@@ -226,7 +226,8 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   public PropertyPath concat(@Nonnull PropertyPath subPath) {
     if (subPath.parent == null) return concat(subPath.segment);
     PropertyPath res = this;
-    for (Text segment : subPath.segments()) res = new PropertyPath(res, segment);
+    Iterator<Text> iter = subPath.segments().iterator();
+    while (iter.hasNext()) res = new PropertyPath(res, iter.next());
     return res;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -66,7 +66,8 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     requireNonNull(segment);
     requireNonEmpty(segment);
     requirePathChars(segment);
-    requireBarePathModifier(parent, segment);
+    requireExcludeIsExclusive(parent, segment);
+    requirePresetIsTail(parent);
   }
 
   @Nonnull
@@ -161,12 +162,12 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   public boolean isPreset() {
-    return parent == null && segment.charAt(0) == ':';
+    return isPresetModifier(segment.charAt(0));
   }
 
   public boolean isAll() {
     // note that * would have been changed to all during parsing
-    return parent == null && segment.contentEquals(":all");
+    return segment.contentEquals(":all");
   }
 
   /**
@@ -212,6 +213,7 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
 
   @Nonnull
   public PropertyPath concat(@Nonnull Text segment) {
+    if (segment.contentEquals("*")) return concat(Text.of(":all"));
     return new PropertyPath(this, segment);
   }
 
@@ -249,25 +251,31 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   private static boolean isPathModifier(char c) {
-    // presets and excludes need this so we allow it
-    return c == ':' || isExcludeModifier(c);
+    return isPresetModifier(c) || isExcludeModifier(c);
+  }
+
+  private static boolean isPresetModifier(char c) {
+    return c == ':';
   }
 
   private static boolean isExcludeModifier(char c) {
     return c == '-' || c == '!';
   }
 
-  /** Only the head segment may have a modifier */
-  private static void requireBarePathModifier(PropertyPath parent, Text segment) {
-    int c = isPathModifier(segment.charAt(0)) ? 1 : 0;
-    PropertyPath p = parent;
-    while (p != null) {
-      if (isPathModifier(p.segment.charAt(0))) c++;
-      p = p.parent;
-    }
-    if (c > 1)
+  private static void requireExcludeIsExclusive(PropertyPath parent, Text segment) {
+    if (parent == null) return;
+    if (!isExcludeModifier(segment.charAt(0))) return;
+    if (parent.isExclude())
       throw new IllegalArgumentException(
           "A property path can only have one exclude or preset modifier");
+  }
+
+  /** A preset modifier must always be at the tail segment of a path */
+  private static void requirePresetIsTail(PropertyPath parent) {
+    if (parent == null) return;
+    if (parent.isPreset())
+      throw new IllegalArgumentException(
+          "A property path with preset must always feature the preset at the tail");
   }
 
   @Nonnull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.jsontree.Text;
+
+/**
+ * A property path as used in the schema model or generally when reflecting on a Java object model.
+ *
+ * <p>The main benefit of using {@link PropertyPath} over {@link String} is that it enforces only
+ * valid paths are possible to construct which indirectly validates user supplied path values so
+ * such inputs cannot be abused for e.g. SQL injection.
+ *
+ * @param parent the parent path (or null for root)
+ * @param segment last segment in the path (without the dots)
+ */
+public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segment) {
+
+  public PropertyPath {
+    // enforce path pattern by construction
+    requireNonNull(segment);
+    requireNonEmpty(segment);
+    requirePathChars(segment);
+  }
+
+  @Nonnull
+  public static PropertyPath of(@CheckForNull String path) {
+    if (path == null || path.isEmpty())
+      throw new IllegalArgumentException("A property path cannot be null or empty");
+    if ("*".equals(path)) return of(":all");
+    Text p = Text.of(path);
+    int start = 0;
+    int end = path.length();
+    int i = start;
+    PropertyPath res = null;
+    while (i < end) {
+      while (i < end && isPathChar(p.charAt(i))) i++;
+      Text seg = p.subSequence(start, i);
+      if (seg.isEmpty()) throw illegalEmptySegment();
+      res = new PropertyPath(res, seg);
+      if (i < end && p.charAt(i) != '.') throw illegalCharacter(p.charAt(i));
+      i++;
+      start = i;
+    }
+    return res;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PropertyPath other)) return false;
+    return Objects.equals(parent, other.parent) && segment.equals(other.segment);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = parent == null ? 1 : parent.hashCode();
+    return hash * 31 + segment.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    if (parent == null) return segment.toString();
+    return parent + "." + segment;
+  }
+
+  public boolean isNested() {
+    return parent != null;
+  }
+
+  public boolean isExclude() {
+    char c0 = segment.charAt(0);
+    return c0 == '-' || c0 == '!';
+  }
+
+  public boolean isPreset() {
+    return parent == null && segment.charAt(0) == ':';
+  }
+
+  public boolean isAll() {
+    // note that * would have been changed to all during parsing
+    return parent == null && segment.contentEquals(":all");
+  }
+
+  /**
+   * @return true if the last segment of the path is a valid UID as used for attribute properties
+   */
+  public boolean isUID() {
+    return segment.length() == 11 && CodeGenerator.isValidUid(segment);
+  }
+
+  /**
+   * @return the number of segments in this path, zero for the root (self)
+   */
+  public int length() {
+    return parent == null ? 1 : parent.length() + 1;
+  }
+
+  public Text head() {
+    return parent == null ? segment : parent.head();
+  }
+
+  @Nonnull
+  public List<Text> segments() {
+    if (parent == null) return List.of(segment);
+    int n = length();
+    PropertyPath p = this;
+    Text[] res = new Text[n];
+    for (int i = n - 1; i >= 0; i--) {
+      res[i] = p.segment;
+      p = p.parent;
+    }
+    return List.of(res);
+  }
+
+  @Nonnull
+  public PropertyPath concat(@Nonnull Text segment) {
+    return new PropertyPath(this, segment);
+  }
+
+  @Nonnull
+  public PropertyPath concat(@Nonnull PropertyPath subPath) {
+    if (subPath.parent == null) return concat(subPath.segment);
+    PropertyPath res = this;
+    for (Text segment : subPath.segments()) res = new PropertyPath(res, segment);
+    return res;
+  }
+
+  public PropertyPath withTail(@Nonnull String segment) {
+    return new PropertyPath(parent, Text.of(segment));
+  }
+
+  public PropertyPath withTail(@Nonnull Text segment) {
+    return new PropertyPath(parent, segment);
+  }
+
+  private static void requireNonEmpty(Text segment) {
+    if (segment.isEmpty()) throw illegalEmptySegment();
+  }
+
+  private static void requirePathChars(Text segment) {
+    for (int i = 0; i < segment.length(); i++)
+      if (!isPathChar(segment.charAt(i))) throw illegalCharacter(segment.charAt(i));
+  }
+
+  private static boolean isPathChar(char c) {
+    return c == '_'
+        || c == '-'
+        || c >= 'a' && c <= 'z'
+        || c >= 'A' && c <= 'Z'
+        || c >= '0' && c <= '9'
+        // presets and excludes need this so we allow it
+        || c == ':'
+        || c == '!';
+  }
+
+  @Nonnull
+  private static IllegalArgumentException illegalEmptySegment() {
+    return new IllegalArgumentException("A property path segment cannot be empty");
+  }
+
+  @Nonnull
+  private static IllegalArgumentException illegalCharacter(char c) {
+    return new IllegalArgumentException("A property path contained an illegal character: " + c);
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -101,6 +101,11 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     return res;
   }
 
+  @Nonnull
+  public static PropertyPath concat(@CheckForNull PropertyPath parent, @Nonnull Text property) {
+    return parent == null ? of(property) : parent.concat(property);
+  }
+
   /**
    * Value was chosen to give some protection against attacks abusing very long paths but long
    * enough to allow for even seriously nested paths with long segment names.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -155,10 +155,9 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     return parent != null;
   }
 
+  /** An exclude is marked with {@code !} or {@code -} (dash) either at head or tail segment. */
   public boolean isExclude() {
-    if (parent != null) return parent.isExclude();
-    char c0 = segment.charAt(0);
-    return c0 == '-' || c0 == '!';
+    return isExcludeModifier(segment.charAt(0)) || parent != null && parent.isExclude();
   }
 
   public boolean isPreset() {
@@ -188,7 +187,7 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
    * @return the property name the path ends with
    */
   public String property() {
-    return parent == null && isExclude()
+    return isExcludeModifier(segment.charAt(0))
         ? segment.subSequence(1, segment.length()).toString()
         : segment.toString();
   }
@@ -251,7 +250,11 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
 
   private static boolean isPathModifier(char c) {
     // presets and excludes need this so we allow it
-    return c == '-' || c == ':' || c == '!';
+    return c == ':' || isExcludeModifier(c);
+  }
+
+  private static boolean isExcludeModifier(char c) {
+    return c == '-' || c == '!';
   }
 
   /** Only the head segment may have a modifier */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.jsontree.Text;
@@ -44,6 +45,16 @@ import org.hisp.dhis.jsontree.Text;
  * valid paths are possible to construct which indirectly validates user supplied path values so
  * such inputs cannot be abused for e.g. SQL injection.
  *
+ * <p>A {@linkplain PropertyPath} is a sequence of path {@link #segment}s. Each segment is an
+ * alphanumerical {@link Text} (underscore is allowed to). One segment in the sequence may have a
+ * {@link #isPathModifier(char)} to make the segment an {@link #isExclude()} or {@link #isPreset()}.
+ *
+ * <p>The {@code *} alias for {@code :all} is specially handled by {@link #of(CharSequence)} by
+ * replacing it with {@code :all} so on the character level {@code * is not a valid character for a
+ * path}. This means {@code new PropertyPath(null, Text.of("*"))} will result in an error.
+ *
+ * @author Jan Bernitt
+ * @since 2.44
  * @param parent the parent path (or null for root)
  * @param segment last segment in the path (without the dots)
  */
@@ -55,19 +66,21 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     requireNonNull(segment);
     requireNonEmpty(segment);
     requirePathChars(segment);
+    requireBarePathModifier(parent, segment);
   }
 
   @Nonnull
-  public static PropertyPath of(@CheckForNull String path) {
-    if (path == null || path.isEmpty())
-      throw new IllegalArgumentException("A property path cannot be null or empty");
-    if ("*".equals(path)) return of(":all");
+  public static PropertyPath of(@CheckForNull CharSequence path) {
+    if (path == null || path.isEmpty()) throw illegalEmpty();
     Text p = Text.of(path);
+    if (p.contentEquals("*")) return of(":all");
     int start = 0;
     int end = path.length();
+    if (end > MAX_LENGTH) throw illegalTooLong();
     int i = start;
     PropertyPath res = null;
     while (i < end) {
+      if (isPathModifier(p.charAt(i))) i++;
       while (i < end && isPathChar(p.charAt(i))) i++;
       Text seg = p.subSequence(start, i);
       if (seg.isEmpty()) throw illegalEmptySegment();
@@ -76,8 +89,22 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
       i++;
       start = i;
     }
+    if (res == null) throw illegalEmpty();
     return res;
   }
+
+  public static PropertyPath of(CharSequence... segments) {
+    if (segments == null || segments.length == 0) throw illegalEmpty();
+    PropertyPath res = PropertyPath.of(segments[0]);
+    for (int i = 1; i < segments.length; i++) res = res.concat(Text.of(segments[i]));
+    return res;
+  }
+
+  /**
+   * Value was chosen to give some protection against attacks abusing very long paths but long
+   * enough to allow for even seriously nested paths with long segment names.
+   */
+  private static final int MAX_LENGTH = 1024;
 
   /** For lexicographical sort order */
   @Override
@@ -129,6 +156,7 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   public boolean isExclude() {
+    if (parent != null) return parent.isExclude();
     char c0 = segment.charAt(0);
     return c0 == '-' || c0 == '!';
   }
@@ -156,6 +184,15 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     return parent == null ? 1 : parent.length() + 1;
   }
 
+  /**
+   * @return the property name the path ends with
+   */
+  public String property() {
+    return parent == null && isExclude()
+        ? segment.subSequence(1, segment.length()).toString()
+        : segment.toString();
+  }
+
   public Text head() {
     return parent == null ? segment : parent.head();
   }
@@ -164,13 +201,14 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   public List<Text> segments() {
     if (parent == null) return List.of(segment);
     int n = length();
-    PropertyPath p = this;
+    PropertyPath path = this;
     Text[] res = new Text[n];
-    for (int i = n - 1; i >= 0; i--) {
-      res[i] = p.segment;
-      p = p.parent;
+    int i = n - 1;
+    while (path != null) {
+      res[i--] = path.segment;
+      path = path.parent;
     }
-    return List.of(res);
+    return Stream.of(res).toList();
   }
 
   @Nonnull
@@ -199,19 +237,45 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   private static void requirePathChars(Text segment) {
-    for (int i = 0; i < segment.length(); i++)
+    char c0 = segment.charAt(0);
+    if (!isPathChar(c0) && !isPathModifier(c0)) throw illegalCharacter(c0);
+    int len = segment.length();
+    if (len == 1 && !isPathChar(c0)) throw illegalEmptySegment();
+    for (int i = 1; i < len; i++)
       if (!isPathChar(segment.charAt(i))) throw illegalCharacter(segment.charAt(i));
   }
 
   private static boolean isPathChar(char c) {
-    return c == '_'
-        || c == '-'
-        || c >= 'a' && c <= 'z'
-        || c >= 'A' && c <= 'Z'
-        || c >= '0' && c <= '9'
-        // presets and excludes need this so we allow it
-        || c == ':'
-        || c == '!';
+    return c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9';
+  }
+
+  private static boolean isPathModifier(char c) {
+    // presets and excludes need this so we allow it
+    return c == '-' || c == ':' || c == '!';
+  }
+
+  /** Only the head segment may have a modifier */
+  private static void requireBarePathModifier(PropertyPath parent, Text segment) {
+    int c = isPathModifier(segment.charAt(0)) ? 1 : 0;
+    PropertyPath p = parent;
+    while (p != null) {
+      if (isPathModifier(p.segment.charAt(0))) c++;
+      p = p.parent;
+    }
+    if (c > 1)
+      throw new IllegalArgumentException(
+          "A property path can only have one exclude or preset modifier");
+  }
+
+  @Nonnull
+  private static IllegalArgumentException illegalEmpty() {
+    return new IllegalArgumentException("A property path cannot be null or empty");
+  }
+
+  @Nonnull
+  private static IllegalArgumentException illegalTooLong() {
+    return new IllegalArgumentException(
+        "A property path cannot be longer than %d characters".formatted(MAX_LENGTH));
   }
 
   @Nonnull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
@@ -268,15 +268,14 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       Text name = this.name;
       if (name.length() >= 2 && isExcludeMarker(name.charAt(0)) && isPresetMarker(name.charAt(1)))
         name = name.subSequence(1, name.length()); // drop negation of preset
-      if (name.contentEquals("*")) name = Text.of(":all"); // unify * to :all
-      Field f = new Field(chain(parentPath, name));
+      Field f = new Field(PropertyPath.concat(parentPath, name));
       Text renamedName = null;
       for (TransformExp t : transforms)
         if (t.type.contentEquals("rename")) renamedName = t.args.get(0);
       if (renamedName != null || parentRenamedPath != null)
         f =
             f.withRenamedPath(
-                chain(
+                PropertyPath.concat(
                     parentRenamedPath == null ? parentPath : parentRenamedPath,
                     renamedName == null ? name : renamedName));
       if (transforms.isEmpty() && children.isEmpty()) return Stream.of(f);
@@ -295,10 +294,6 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       Stream<Field> childrenRes =
           children.stream().flatMap(e -> e.toFields(parent.propertyPath(), parent.renamedPath()));
       return noTransform ? childrenRes : Stream.concat(transformRes, childrenRes);
-    }
-
-    static PropertyPath chain(PropertyPath parent, Text property) {
-      return parent == null ? PropertyPath.of(property) : parent.concat(property);
     }
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
@@ -34,7 +34,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPathTransformer;
 import org.hisp.dhis.jsontree.Text;
@@ -66,7 +68,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     if (fields == null || fields.isEmpty()) return DEFAULT;
     List<FieldExp> res = new ArrayList<>();
     parseFields(Text.of(fields), 0, res);
-    return new Fields(res.stream().flatMap(e -> e.toFields("", "")).toList());
+    return new Fields(res.stream().flatMap(e -> e.toFields(null, null)).toList());
   }
 
   /**
@@ -83,7 +85,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
   }
 
   public List<String> names() {
-    return fields.stream().map(Fields.Field::path).toList();
+    return fields.stream().map(Fields.Field::path).map(PropertyPath::toString).toList();
   }
 
   public Fields add(Field f) {
@@ -112,8 +114,8 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
    * @param args transformation arguments
    */
   public record Field(
-      @Nonnull String propertyPath,
-      @Nonnull String renamedPath,
+      @Nonnull PropertyPath propertyPath,
+      @CheckForNull PropertyPath renamedPath,
       @Nonnull Transform transformation,
       @Nonnull List<String> args) {
 
@@ -121,9 +123,13 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       return Fields.of(field).fields.get(0);
     }
 
-    public static final String REFS_PATH = "__refs__";
-    public static final String ALL_PATH = "*";
-    public static final Field ALL = new Field(ALL_PATH, Transform.NONE);
+    public static final Field REFS =
+        new Field(
+            PropertyPath.of("__refs__"),
+            PropertyPath.of("apiEndpoints"),
+            Transform.NONE,
+            List.of());
+    public static final Field ALL = new Field(":all", Transform.NONE);
 
     public Field(String propertyPath) {
       this(propertyPath, Transform.AUTO);
@@ -134,14 +140,14 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public Field(String propertyPath, Transform transformation, List<String> args) {
-      this(propertyPath, "", transformation, args);
+      this(PropertyPath.of(propertyPath), null, transformation, args);
     }
 
     /**
      * @return the effective path to render in the output
      */
     @Nonnull
-    public String path() {
+    public PropertyPath path() {
       return isRenamed() ? renamedPath : propertyPath;
     }
 
@@ -154,10 +160,18 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public Field withPropertyPath(String path) {
+      return withPropertyPath(PropertyPath.of(path));
+    }
+
+    public Field withPropertyPath(PropertyPath path) {
       return new Field(path, renamedPath, transformation, args);
     }
 
     public Field withRenamedPath(String path) {
+      return withRenamedPath(PropertyPath.of(path));
+    }
+
+    public Field withRenamedPath(PropertyPath path) {
       return new Field(propertyPath, path, transformation, args);
     }
 
@@ -178,7 +192,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public boolean isRefs() {
-      return REFS_PATH.equals(propertyPath);
+      return propertyPath.equals(REFS.propertyPath);
     }
 
     public boolean isMultiPluck() {
@@ -186,15 +200,15 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public boolean isExclude() {
-      return isExcludeMarker(propertyPath.charAt(propertyPath.lastIndexOf('.') + 1));
+      return propertyPath.isExclude();
     }
 
     public boolean isPreset() {
-      return isPresetMarker(propertyPath.charAt(propertyPath.lastIndexOf('.') + 1));
+      return propertyPath.isPreset();
     }
 
     public boolean isRenamed() {
-      return !renamedPath.isEmpty();
+      return renamedPath != null;
     }
 
     public boolean isTransformed() {
@@ -202,7 +216,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public boolean isNested() {
-      return propertyPath.indexOf('.') >= 0;
+      return propertyPath.length() > 1;
     }
   }
 
@@ -246,7 +260,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       return Stream.concat(Stream.of(f), children.stream().flatMap(c -> c.toFieldPaths(path)));
     }
 
-    Stream<Field> toFields(String parentPath, String parentRenamedPath) {
+    Stream<Field> toFields(PropertyPath parentPath, PropertyPath parentRenamedPath) {
       String name = this.name.toString();
       if (name.length() >= 2 && isExcludeMarker(name.charAt(0)) && isPresetMarker(name.charAt(1)))
         name = name.substring(1); // drop negation of preset
@@ -255,11 +269,11 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       String renamedName = "";
       for (TransformExp t : transforms)
         if (t.type.contentEquals("rename")) renamedName = t.args.get(0).toString();
-      if (!renamedName.isEmpty() || !parentRenamedPath.isEmpty())
+      if (!renamedName.isEmpty() || parentRenamedPath != null)
         f =
             f.withRenamedPath(
                 chain(
-                    parentRenamedPath.isEmpty() ? parentPath : parentRenamedPath,
+                    parentRenamedPath == null ? parentPath : parentRenamedPath,
                     renamedName.isEmpty() ? name : renamedName));
       if (transforms.isEmpty() && children.isEmpty()) return Stream.of(f);
       Field base = f;
@@ -279,8 +293,8 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       return noTransform ? childrenRes : Stream.concat(transformRes, childrenRes);
     }
 
-    static String chain(String parent, String child) {
-      return parent.isEmpty() ? child : parent + "." + child;
+    static String chain(PropertyPath parent, String child) {
+      return parent == null ? child : parent.concat(Text.of(child)).toString();
     }
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
@@ -216,7 +216,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     public boolean isNested() {
-      return propertyPath.length() > 1;
+      return propertyPath.isNested();
     }
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
@@ -131,8 +131,12 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
             List.of());
     public static final Field ALL = new Field(":all", Transform.NONE);
 
-    public Field(String propertyPath) {
+    public Field(@Nonnull String propertyPath) {
       this(propertyPath, Transform.AUTO);
+    }
+
+    public Field(@Nonnull PropertyPath propertyPath) {
+      this(propertyPath, null, Transform.AUTO, List.of());
     }
 
     public Field(String propertyPath, Transform transformation) {
@@ -261,20 +265,20 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     }
 
     Stream<Field> toFields(PropertyPath parentPath, PropertyPath parentRenamedPath) {
-      String name = this.name.toString();
+      Text name = this.name;
       if (name.length() >= 2 && isExcludeMarker(name.charAt(0)) && isPresetMarker(name.charAt(1)))
-        name = name.substring(1); // drop negation of preset
-      if ("*".equals(name)) name = ":all"; // unify * to :all
+        name = name.subSequence(1, name.length()); // drop negation of preset
+      if (name.contentEquals("*")) name = Text.of(":all"); // unify * to :all
       Field f = new Field(chain(parentPath, name));
-      String renamedName = "";
+      Text renamedName = null;
       for (TransformExp t : transforms)
-        if (t.type.contentEquals("rename")) renamedName = t.args.get(0).toString();
-      if (!renamedName.isEmpty() || parentRenamedPath != null)
+        if (t.type.contentEquals("rename")) renamedName = t.args.get(0);
+      if (renamedName != null || parentRenamedPath != null)
         f =
             f.withRenamedPath(
                 chain(
                     parentRenamedPath == null ? parentPath : parentRenamedPath,
-                    renamedName.isEmpty() ? name : renamedName));
+                    renamedName == null ? name : renamedName));
       if (transforms.isEmpty() && children.isEmpty()) return Stream.of(f);
       Field base = f;
       boolean noTransform = transforms.isEmpty() || base.isRenamed() && transforms.size() == 1;
@@ -293,8 +297,8 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       return noTransform ? childrenRes : Stream.concat(transformRes, childrenRes);
     }
 
-    static String chain(PropertyPath parent, String child) {
-      return parent == null ? child : parent.concat(Text.of(child)).toString();
+    static PropertyPath chain(PropertyPath parent, Text property) {
+      return parent == null ? PropertyPath.of(property) : parent.concat(property);
     }
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
@@ -49,12 +49,14 @@ import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.jackson.config.geometry.GeometrySerializer;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonBuilder.JsonObjectBuilder.AddMember;
 import org.hisp.dhis.jsontree.JsonNode;
 import org.hisp.dhis.jsontree.JsonValue;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.object.ObjectOutput;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
@@ -432,8 +434,7 @@ public final class JsonStreamOutput {
   }
 
   public static AddMember<Object> getAdder(ObjectOutput.Property property) {
-    if (!property.arrayAggregate() || !property.path().contains("."))
-      return getAdder(property.type());
+    if (!property.arrayAggregate() || !property.path().isNested()) return getAdder(property.type());
     return getAdder(property.type().componentType());
   }
 
@@ -442,16 +443,17 @@ public final class JsonStreamOutput {
   }
 
   private static String getPath(ObjectOutput.Property property) {
-    if (!property.arrayAggregate()) return property.path();
-    String path = property.path();
-    if (!path.contains(".")) return path;
-    String[] parts = path.split("\\.");
-    if (parts.length == 2) return "[" + parts[0] + "]." + parts[1];
+    if (!property.arrayAggregate()) return property.path().toString();
+    PropertyPath path = property.path();
+    if (!path.isNested()) return path.toString();
+    List<Text> parts = path.segments();
+    int len = parts.size();
+    if (len == 2) return "[" + parts.get(0) + "]." + parts.get(1);
     return "%s.[%s].%s"
         .formatted(
-            Stream.of(parts).limit(parts.length - 2).collect(joining(".")),
-            parts[parts.length - 1],
-            parts[parts.length - 1]);
+            Stream.of(parts).limit(len - 2).map(Object::toString).collect(joining(".")),
+            parts.get(len - 1),
+            parts.get(len - 1));
   }
 
   public static AddMember<Object> getAdder(ObjectOutput.Type valueType) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
@@ -446,7 +446,7 @@ public final class JsonStreamOutput {
     if (!property.arrayAggregate()) return property.path().toString();
     PropertyPath path = property.path();
     if (!path.isNested()) return path.toString();
-    List<Text> parts = path.segments();
+    List<Text> parts = path.segments().toList();
     int len = parts.size();
     if (len == 2) return "[" + parts.get(0) + "]." + parts.get(1);
     return "%s.[%s].%s"

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/json/JsonStreamOutput.java
@@ -452,7 +452,7 @@ public final class JsonStreamOutput {
     return "%s.[%s].%s"
         .formatted(
             Stream.of(parts).limit(len - 2).map(Object::toString).collect(joining(".")),
-            parts.get(len - 1),
+            parts.get(len - 2),
             parts.get(len - 1));
   }
 
@@ -494,7 +494,9 @@ public final class JsonStreamOutput {
     return getGuardedAdder(
         Map.class,
         (obj, name, val) ->
-            obj.addObject(name, map -> ((Map<String, String>) val).forEach(map::addString)));
+            obj.addObject(
+                name,
+                map -> ((Map<?, String>) val).forEach((k, v) -> map.addString(k.toString(), v))));
   }
 
   @CheckForNull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
@@ -36,6 +36,8 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.PropertyPath;
+import org.hisp.dhis.jsontree.Text;
 
 /**
  * Utility for generic output handling. In this context this means converting form domain objects to
@@ -91,7 +93,7 @@ public final class ObjectOutput {
    * @param arrayAggregate true for array properties that originally are simple properties array
    *     aggregated for the parent property which itself was the original collection property
    */
-  public record Property(String path, Type type, boolean arrayAggregate) {
+  public record Property(PropertyPath path, Type type, boolean arrayAggregate) {
 
     public Property {
       requireNonNull(path);
@@ -105,7 +107,7 @@ public final class ObjectOutput {
      *     part)
      */
     public String name() {
-      return name(path);
+      return path.segment().toString();
     }
 
     /**
@@ -113,7 +115,9 @@ public final class ObjectOutput {
      *     this property
      */
     public List<String> parentPath() {
-      return parentPath(path);
+      if (!path.isNested()) return List.of();
+      List<Text> segments = path.segments();
+      return segments.stream().limit(segments.size() - 1).map(Text::toString).toList();
     }
 
     @Nonnull

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
@@ -37,7 +37,6 @@ import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.PropertyPath;
-import org.hisp.dhis.jsontree.Text;
 
 /**
  * Utility for generic output handling. In this context this means converting form domain objects to
@@ -107,17 +106,7 @@ public final class ObjectOutput {
      *     part)
      */
     public String name() {
-      return path.segment().toString();
-    }
-
-    /**
-     * @return the segments of the {@link #path()} that make drill down into the parent (owner) of
-     *     this property
-     */
-    public List<String> parentPath() {
-      if (!path.isNested()) return List.of();
-      List<Text> segments = path.segments();
-      return segments.stream().limit(segments.size() - 1).map(Text::toString).toList();
+      return path.property();
     }
 
     @Nonnull

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -80,6 +80,7 @@ class PropertyPathTest {
     assertIllegalPath("-foo.-bar");
     assertIllegalPath(":foo.:bar");
     assertIllegalPath("!foo.!bar");
+    assertIllegalPath("foo.:bar.baz");
   }
 
   @Test
@@ -219,6 +220,7 @@ class PropertyPathTest {
   @Test
   void testConcat() {
     assertEquals(PropertyPath.of("foo.bar"), PropertyPath.of("foo").concat(Text.of("bar")));
+    assertEquals(PropertyPath.of("foo.:all"), PropertyPath.of("foo").concat(Text.of("*")));
     assertEquals(
         PropertyPath.of("foo.bar.baz"), PropertyPath.of("foo").concat(PropertyPath.of("bar.baz")));
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PropertyPathTest {
+
+  @Test
+  void testOf() {
+    assertPropertyPath("foo");
+    assertPropertyPath("foo.bar");
+    assertPropertyPath("foo.bar.baz");
+  }
+
+  private static void assertPropertyPath(String path) {
+    PropertyPath actual = PropertyPath.of(path);
+    assertEquals(path, actual.toString(), "toString() of a path should be the same as the input");
+    String[] segments = path.split("\\.");
+    assertEquals(
+        segments.length,
+        actual.length(),
+        "number of segments should be the same as a regex split on dot");
+    for (int i = 0; i < segments.length; i++)
+      assertEquals(segments[i], actual.segments().get(i).toString());
+  }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -131,6 +131,7 @@ class PropertyPathTest {
 
     assertTrue(PropertyPath.of("-a.b").isExclude());
     assertTrue(PropertyPath.of("-foo").isExclude());
+    assertTrue(PropertyPath.of("foo.-bar").isExclude());
 
     assertFalse(PropertyPath.of(":foo").isExclude());
   }
@@ -204,6 +205,7 @@ class PropertyPathTest {
     assertEquals("foo", PropertyPath.of("!foo").property());
     assertEquals("bar", PropertyPath.of("!foo.bar").property());
     assertEquals("baz", PropertyPath.of("!foo.bar.baz").property());
+    assertEquals("baz", PropertyPath.of("foo.bar.!baz").property());
     assertEquals("foo", PropertyPath.of("-foo").property());
   }
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -221,8 +221,6 @@ class PropertyPathTest {
         PropertyPath.of("foo.bar.baz"), PropertyPath.of("foo").concat(PropertyPath.of("bar.baz")));
 
     assertEquals(PropertyPath.of("!foo.bar"), PropertyPath.of("!foo").concat(Text.of("bar")));
-    assertThrowsExactly(
-        IllegalArgumentException.class, () -> PropertyPath.of("foo").concat(Text.of("!bar")));
   }
 
   @Test

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -243,8 +243,10 @@ class PropertyPathTest {
         segments.length,
         actual.length(),
         "number of segments should be the same as a regex split on dot");
-    for (int i = 0; i < segments.length; i++)
-      assertEquals(segments[i], actual.segments().get(i).toString());
+    List<Text> actualSegments = actual.segments().toList();
+    for (int i = 0; i < segments.length; i++) {
+      assertEquals(segments[i], actualSegments.get(i).toString());
+    }
   }
 
   private static void assertIllegalPath(String path) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -30,9 +30,20 @@
 package org.hisp.dhis.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.stream.Stream;
+import org.hisp.dhis.jsontree.Text;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests the {@link PropertyPath} value class.
+ *
+ * @author Jan Bernitt
+ */
 class PropertyPathTest {
 
   @Test
@@ -40,6 +51,186 @@ class PropertyPathTest {
     assertPropertyPath("foo");
     assertPropertyPath("foo.bar");
     assertPropertyPath("foo.bar.baz");
+    // more uncommon cases with special 1st character
+    assertPropertyPath(":all");
+    assertPropertyPath("-foo");
+    assertPropertyPath("!foo");
+    assertPropertyPath("-foo.bar");
+    assertPropertyPath("!foo.bar");
+  }
+
+  @Test
+  void testOf_Star() {
+    assertEquals(":all", PropertyPath.of("*").toString(), "* should become :all");
+  }
+
+  @Test
+  void testOf_Varagrs() {
+    assertEquals(PropertyPath.of("foo.bar"), PropertyPath.of("foo", "bar"));
+    assertEquals(PropertyPath.of("foo.bar.baz"), PropertyPath.of("foo", "bar", "baz"));
+  }
+
+  @Test
+  void testOf_Illegal() {
+    assertIllegalPath("");
+    assertIllegalPath("**");
+    assertIllegalPath("!!foo");
+    assertIllegalPath("::all");
+    assertIllegalPath("foo..bar");
+    assertIllegalPath("-foo.-bar");
+    assertIllegalPath(":foo.:bar");
+    assertIllegalPath("!foo.!bar");
+  }
+
+  @Test
+  void testOf_IllegalEmpty() {
+    assertThrowsExactly(IllegalArgumentException.class, PropertyPath::of);
+  }
+
+  @Test
+  void testCompareTo() {
+    assertEquals(
+        List.of(
+            PropertyPath.of("a"),
+            PropertyPath.of("abc"),
+            PropertyPath.of("b"),
+            PropertyPath.of("a.a"),
+            PropertyPath.of("a.b"),
+            PropertyPath.of("a.a.c"),
+            PropertyPath.of("a.b.b")),
+        Stream.of(
+                PropertyPath.of("b"),
+                PropertyPath.of("a.a.c"),
+                PropertyPath.of("abc"),
+                PropertyPath.of("a.b"),
+                PropertyPath.of("a.a"),
+                PropertyPath.of("a.b.b"),
+                PropertyPath.of("a"))
+            .sorted()
+            .toList());
+  }
+
+  @Test
+  void testIsNested() {
+    assertTrue(PropertyPath.of("a.b").isNested());
+    assertTrue(PropertyPath.of("!a.b").isNested());
+
+    assertFalse(PropertyPath.of("foo").isNested());
+    assertFalse(PropertyPath.of("!foo").isNested());
+
+    assertFalse(PropertyPath.of(":foo").isNested());
+  }
+
+  @Test
+  void testIsExclude() {
+    assertFalse(PropertyPath.of("a.b").isExclude());
+    assertFalse(PropertyPath.of("foo").isExclude());
+
+    assertTrue(PropertyPath.of("!a.b").isExclude());
+    assertTrue(PropertyPath.of("!foo").isExclude());
+
+    assertTrue(PropertyPath.of("-a.b").isExclude());
+    assertTrue(PropertyPath.of("-foo").isExclude());
+
+    assertFalse(PropertyPath.of(":foo").isExclude());
+  }
+
+  @Test
+  void testIsPreset() {
+    assertFalse(PropertyPath.of("a.b").isPreset());
+    assertFalse(PropertyPath.of("foo").isPreset());
+
+    assertFalse(PropertyPath.of("!a.b").isPreset());
+    assertFalse(PropertyPath.of("!foo").isPreset());
+
+    assertFalse(PropertyPath.of("-a.b").isPreset());
+    assertFalse(PropertyPath.of("-foo").isPreset());
+
+    assertTrue(PropertyPath.of(":foo").isPreset());
+  }
+
+  @Test
+  void testIsAll() {
+    assertFalse(PropertyPath.of("a.b").isAll());
+    assertFalse(PropertyPath.of("foo").isAll());
+
+    assertFalse(PropertyPath.of("!a.b").isAll());
+    assertFalse(PropertyPath.of("!foo").isAll());
+
+    assertFalse(PropertyPath.of("-a.b").isAll());
+    assertFalse(PropertyPath.of("-foo").isAll());
+
+    assertFalse(PropertyPath.of(":foo").isAll());
+
+    assertTrue(PropertyPath.of(":all").isAll());
+    assertTrue(PropertyPath.of("*").isAll());
+  }
+
+  @Test
+  void testIsUID() {
+    assertFalse(PropertyPath.of("a.b").isUID());
+    assertFalse(PropertyPath.of("foo").isUID());
+
+    assertFalse(PropertyPath.of("!a.b").isUID());
+    assertFalse(PropertyPath.of("!foo").isUID());
+
+    assertFalse(PropertyPath.of("-a.b").isUID());
+    assertFalse(PropertyPath.of("-foo").isUID());
+
+    assertFalse(PropertyPath.of(":foo").isUID());
+    assertFalse(PropertyPath.of(":all").isUID());
+    assertFalse(PropertyPath.of("*").isUID());
+
+    assertTrue(PropertyPath.of("ou123456789").isUID());
+  }
+
+  @Test
+  void testLength() {
+    assertEquals(1, PropertyPath.of("foo").length());
+    assertEquals(2, PropertyPath.of("foo.bar").length());
+    assertEquals(3, PropertyPath.of("foo.bar.baz").length());
+
+    assertEquals(2, PropertyPath.of("!a.b").length());
+    assertEquals(1, PropertyPath.of("!foo").length());
+    assertEquals(2, PropertyPath.of("-a.b").length());
+    assertEquals(1, PropertyPath.of("-foo").length());
+  }
+
+  @Test
+  void testProperty() {
+    assertEquals("foo", PropertyPath.of("foo").property());
+    assertEquals("bar", PropertyPath.of("foo.bar").property());
+    assertEquals("baz", PropertyPath.of("foo.bar.baz").property());
+    assertEquals("foo", PropertyPath.of("!foo").property());
+    assertEquals("bar", PropertyPath.of("!foo.bar").property());
+    assertEquals("baz", PropertyPath.of("!foo.bar.baz").property());
+    assertEquals("foo", PropertyPath.of("-foo").property());
+  }
+
+  @Test
+  void testHead() {
+    assertEquals(Text.of("foo"), PropertyPath.of("foo").head());
+    assertEquals(Text.of("foo"), PropertyPath.of("foo.bar").head());
+    assertEquals(Text.of("foo"), PropertyPath.of("foo.bar.baz").head());
+  }
+
+  @Test
+  void testConcat() {
+    assertEquals(PropertyPath.of("foo.bar"), PropertyPath.of("foo").concat(Text.of("bar")));
+    assertEquals(
+        PropertyPath.of("foo.bar.baz"), PropertyPath.of("foo").concat(PropertyPath.of("bar.baz")));
+
+    assertEquals(PropertyPath.of("!foo.bar"), PropertyPath.of("!foo").concat(Text.of("bar")));
+    assertThrowsExactly(
+        IllegalArgumentException.class, () -> PropertyPath.of("foo").concat(Text.of("!bar")));
+  }
+
+  @Test
+  void testWithTail() {
+    assertEquals(PropertyPath.of("y"), PropertyPath.of("foo").withTail("y"));
+    assertEquals(PropertyPath.of("foo.y"), PropertyPath.of("foo.bar").withTail("y"));
+    assertEquals(
+        PropertyPath.of("foo.bar.y"), PropertyPath.of("foo.bar.baz").withTail(Text.of("y")));
   }
 
   private static void assertPropertyPath(String path) {
@@ -52,5 +243,18 @@ class PropertyPathTest {
         "number of segments should be the same as a regex split on dot");
     for (int i = 0; i < segments.length; i++)
       assertEquals(segments[i], actual.segments().get(i).toString());
+  }
+
+  private static void assertIllegalPath(String path) {
+    assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> PropertyPath.of(path),
+        "of %s should not be a valid path".formatted(path));
+    assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> new PropertyPath(null, Text.of(path)),
+        "new with %s should not be a valid path".formatted(path));
+    String[] segments = path.split("\\.");
+    assertThrowsExactly(IllegalArgumentException.class, () -> PropertyPath.of(segments));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -48,6 +48,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonNode;
@@ -121,7 +122,7 @@ public class DefaultGistService implements GistService {
     RelativePropertyContext context = createPropertyContext(query);
     List<ObjectOutput.Property> res = new ArrayList<>(query.getFields().size());
     for (Fields.Field f : query.getFields()) {
-      String path = f.path();
+      PropertyPath path = f.path();
       if (f.isAttribute()) {
         ObjectOutput.Type type =
             f.isAttributeAsJson()
@@ -131,7 +132,9 @@ public class DefaultGistService implements GistService {
       } else if (f.isRefs()) {
         res.add(
             new ObjectOutput.Property(
-                "apiEndpoints", new ObjectOutput.Type(Map.class, String.class), false));
+                PropertyPath.of("apiEndpoints"),
+                new ObjectOutput.Type(Map.class, String.class),
+                false));
       } else {
         Property p = context.resolveMandatory(f.propertyPath());
         ObjectOutput.Type type =

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBridge.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBridge.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.schema.Property;
@@ -152,7 +153,8 @@ public class GistBridge {
     return true;
   }
 
-  private static List<Property> getPropertyPath(String path, RelativePropertyContext context) {
+  private static List<Property> getPropertyPath(
+      PropertyPath path, RelativePropertyContext context) {
     Property leaf = context.resolve(path);
     if (leaf == null) return List.of(); // unknown property, give up
     return context.resolvePath(path);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -37,7 +37,6 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.common.collection.CollectionUtils.merge;
 import static org.hisp.dhis.commons.util.TextUtils.replace;
-import static org.hisp.dhis.gist.GistLogic.attributePath;
 import static org.hisp.dhis.gist.GistLogic.getBaseType;
 import static org.hisp.dhis.gist.GistLogic.isAccessProperty;
 import static org.hisp.dhis.gist.GistLogic.isAttributeFlagProperty;
@@ -45,12 +44,9 @@ import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPat
 import static org.hisp.dhis.gist.GistLogic.isCollectionSizeFilter;
 import static org.hisp.dhis.gist.GistLogic.isHrefProperty;
 import static org.hisp.dhis.gist.GistLogic.isJsonCollectionFilter;
-import static org.hisp.dhis.gist.GistLogic.isNestedPath;
 import static org.hisp.dhis.gist.GistLogic.isPersistentCollectionField;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
 import static org.hisp.dhis.gist.GistLogic.isStringLengthFilter;
-import static org.hisp.dhis.gist.GistLogic.parentPath;
-import static org.hisp.dhis.gist.GistLogic.pathOnSameParent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.lang.reflect.Method;
@@ -76,6 +72,7 @@ import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.Locale;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.common.input.Fields.Field;
 import org.hisp.dhis.gist.GistQuery.Comparison;
@@ -83,6 +80,7 @@ import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.gist.GistQuery.Owner;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonNode;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.query.JpaQueryUtils;
@@ -134,8 +132,6 @@ final class GistBuilder {
    */
   private static final String HQL_NULL = "cast(null as char)";
 
-  private static final String TRANSLATIONS_PROPERTY = "translations";
-
   private static final String ID_PROPERTY = "id";
 
   private static final String SHARING_PROPERTY = "sharing";
@@ -170,7 +166,7 @@ final class GistBuilder {
 
   private final List<Consumer<Object[]>> fieldResultTransformers = new ArrayList<>();
 
-  private final Map<String, Integer> fieldIndexByPath = new HashMap<>();
+  private final Map<PropertyPath, Integer> fieldIndexByPath = new HashMap<>();
 
   /**
    * Depending on what fields should be listed other fields are needed to fully compute the
@@ -197,19 +193,19 @@ final class GistBuilder {
     // ID column not present but ID column required?
     if ((isPersistentCollectionField(p) || isHrefProperty(p))
         && !existsSameParentField(query, f, ID_PROPERTY)) {
-      return query.addField(pathOnSameParent(f.propertyPath(), ID_PROPERTY));
+      return query.addField(f.propertyPath().withTail(ID_PROPERTY));
     }
 
     // Access based on Sharing
     if (isAccessProperty(p) && !existsSameParentField(query, f, SHARING_PROPERTY)) {
-      return query.addField(pathOnSameParent(f.propertyPath(), SHARING_PROPERTY));
+      return query.addField(f.propertyPath().withTail(SHARING_PROPERTY));
     }
 
     // flags on Attribute map to/from objectTypes set
     if (query.getElementType() == Attribute.class
         && isAttributeFlagProperty(p)
         && !existsSameParentField(query, f, OBJECT_TYPES)) {
-      return query.addField(pathOnSameParent(f.propertyPath(), OBJECT_TYPES));
+      return query.addField(f.propertyPath().withTail(OBJECT_TYPES));
     }
 
     return addFromTransformationSupportFields(query, f);
@@ -219,7 +215,7 @@ final class GistBuilder {
     if (f.transformation() == Transform.FROM) {
       for (String propertyName : f.args()) {
         if (!existsSameParentField(query, f, propertyName)) {
-          query = query.addField(pathOnSameParent(f.propertyPath(), propertyName));
+          query = query.addField(f.propertyPath().withTail(propertyName));
         }
       }
     }
@@ -227,12 +223,13 @@ final class GistBuilder {
   }
 
   private static boolean existsSameParentField(GistQuery query, Field field, String property) {
-    String parentPath = parentPath(field.propertyPath());
-    String requiredPath = parentPath.isEmpty() ? property : parentPath + "." + property;
+    PropertyPath parentPath = field.propertyPath().parent();
+    PropertyPath requiredPath =
+        parentPath == null ? PropertyPath.of(property) : parentPath.concat(Text.of(property));
     return query.getFields().fields().stream().anyMatch(f -> f.propertyPath().equals(requiredPath));
   }
 
-  private String getMemberPath(String property) {
+  private String getMemberPath(PropertyPath property) {
     List<Property> path = context.resolvePath(property);
     return path.size() == 1
         ? path.get(0).getFieldName()
@@ -269,13 +266,13 @@ final class GistBuilder {
   }
 
   private void addRefsTransformer(Field field) {
-    String path = field.propertyPath();
+    PropertyPath path = field.propertyPath();
     if (!query.isReferences()) return;
     Property property = context.resolveMandatory(path);
     String endpointRoot = getSameParentEndpointRoot(path);
     if (endpointRoot == null) return;
     Integer idFieldIndex = getSameParentFieldIndex(path, ID_PROPERTY);
-    Integer refIndex = fieldIndexByPath.get(Fields.Field.REFS_PATH);
+    Integer refIndex = fieldIndexByPath.get(Fields.Field.REFS.propertyPath());
     if (idFieldIndex != null && refIndex != null)
       addTransformer(
           row ->
@@ -384,7 +381,7 @@ final class GistBuilder {
 
   private String createFieldHQL(int index, Field field) {
     if (field.isRefs()) return HQL_NULL;
-    String path = field.propertyPath();
+    PropertyPath path = field.propertyPath();
     if (field.isAttribute()) {
       if (field.isAttributeAsJson()) {
         addTransformer(row -> row[index] = JsonNode.of((String) row[index]));
@@ -419,7 +416,7 @@ final class GistBuilder {
       @SuppressWarnings("unchecked")
       Class<? extends IdentifiableObject> objType =
           (Class<? extends IdentifiableObject>)
-              (!isNestedPath(path) ? query.getElementType() : property.getKlass());
+              (!path.isNested() ? query.getElementType() : property.getKlass());
       addTransformer(
           row -> row[index] = access.asAccess(objType, (Sharing) row[sharingFieldIndex]));
       return HQL_NULL;
@@ -466,7 +463,7 @@ final class GistBuilder {
   }
 
   private void createFromTransformedFieldHQL(
-      int index, Field field, String path, Property property) {
+      int index, Field field, PropertyPath path, Property property) {
     Object bean = newQueryElementInstance();
     if (bean == null) {
       return;
@@ -493,7 +490,7 @@ final class GistBuilder {
   }
 
   private String createReferenceFieldHQL(int index, Field field) {
-    String path = field.propertyPath();
+    PropertyPath path = field.propertyPath();
     Property property = context.resolveMandatory(path);
     Class<?> table = property.getKlass();
     RelativePropertyContext fieldContext = context.switchedTo(table);
@@ -700,7 +697,7 @@ final class GistBuilder {
             entry("alias", alias),
             entry("table", table.getSimpleName()),
             entry("path", getMemberPath(field.propertyPath())),
-            entry("property", field.propertyPath()),
+            entry("property", field.propertyPath().toString()),
             entry("compare", compare));
     return replace(
         "(select count(*) ${compare} from ${table} ${alias} where ${alias} in elements(e.${path}) and ${alias}.uid = :p_${property} and ${access})",
@@ -715,7 +712,7 @@ final class GistBuilder {
     if (row[refIndex] == null) {
       row[refIndex] = new TreeMap<>();
     }
-    ((Map<String, String>) row[refIndex]).put(field.path(), url);
+    ((Map<PropertyPath, String>) row[refIndex]).put(field.path(), url);
   }
 
   private String toEndpointURL(String endpointRoot, Object id) {
@@ -746,11 +743,11 @@ final class GistBuilder {
         || obj instanceof Number && ((Number) obj).intValue() == 0;
   }
 
-  private Integer getSameParentFieldIndex(String path, String property) {
-    return fieldIndexByPath.get(pathOnSameParent(path, property));
+  private Integer getSameParentFieldIndex(PropertyPath path, String property) {
+    return fieldIndexByPath.get(path.withTail(property));
   }
 
-  private String getSameParentEndpointRoot(String path) {
+  private String getSameParentEndpointRoot(PropertyPath path) {
     return getEndpointRoot(context.switchedTo(path).getHome());
   }
 
@@ -787,14 +784,14 @@ final class GistBuilder {
   }
 
   private String createFilterHQL(int index, Filter filter) {
-    String propertyPath = filter.getPropertyPath();
+    PropertyPath propertyPath = filter.getPropertyPath();
     if (isAttributeValuesAttributePropertyPath(propertyPath)) {
-      filter = filter.withPropertyPath(attributePath(propertyPath));
+      filter = filter.withPropertyPath(propertyPath.segment().toString());
       return replace(
           "jsonb_exists_any(e.attributeValues, (select array_agg(uid) from Attribute a where ${filter})) = true",
           Map.of("filter", createFilterHQL(index, filter, "a." + filter.getPropertyPath())));
     }
-    if (isNestedPath(propertyPath)) {
+    if (propertyPath.isNested()) {
       List<Property> path = context.resolvePath(propertyPath);
       if (filter.isSubSelect()) {
         return createSubSelectFilterHQL(index, filter, path);
@@ -906,7 +903,7 @@ final class GistBuilder {
   }
 
   private String createAccessFilterHQL(int index, Filter filter, String property) {
-    String path = filter.getPropertyPath();
+    PropertyPath path = filter.getPropertyPath();
     Property p = context.resolveMandatory(path);
     Class<?> table = p.getItemKlass();
     String alias = alias(table, index);
@@ -926,7 +923,7 @@ final class GistBuilder {
       return replace(
           "${property} in (select ${alias} from ${table} ${alias} where ${filter})", variables);
     }
-    if (isNestedPath(path)) {
+    if (path.isNested()) {
       throw new UnsupportedOperationException("Access filter not supported for property: " + path);
     }
     // trivial case: the filter property is a non nested non-identifiable
@@ -981,10 +978,11 @@ final class GistBuilder {
   }
 
   private String createOrderByHQL(Integer index, GistQuery.Order order) {
-    String propertyPath = order.getPropertyPath();
+    PropertyPath propertyPath = order.getPropertyPath();
     String dir = order.getDirection().name().toLowerCase();
     Property property =
-        context.resolve(Property.resolveTranslationBasePropertyName(order.getPropertyPath()));
+        context.resolve(
+            Property.resolveTranslationBasePropertyName(order.getPropertyPath().toString()));
     if (property != null && property.canBeTranslated()) {
       return "coalesce(jsonb_get_translated_value(e.translations, '%s', '%s'), e.%s) %s"
           .formatted(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -786,7 +786,7 @@ final class GistBuilder {
   private String createFilterHQL(int index, Filter filter) {
     PropertyPath propertyPath = filter.getPropertyPath();
     if (isAttributeValuesAttributePropertyPath(propertyPath)) {
-      filter = filter.withPropertyPath(propertyPath.segment().toString());
+      filter = filter.withPropertyPath(propertyPath.property());
       return replace(
           "jsonb_exists_any(e.attributeValues, (select array_agg(uid) from Attribute a where ${filter})) = true",
           Map.of("filter", createFilterHQL(index, filter, "a." + filter.getPropertyPath())));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.gist;
 
 import org.hisp.dhis.attribute.AttributeValues;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.schema.Property;
@@ -85,8 +86,10 @@ final class GistLogic {
     return path.length() == 11 && CodeGenerator.isValidUid(path);
   }
 
-  static boolean isAttributeValuesAttributePropertyPath(String path) {
-    return path.startsWith("attributeValues.attribute.");
+  static boolean isAttributeValuesAttributePropertyPath(PropertyPath path) {
+    return path.length() == 3
+        && path.head().contentEquals("attributeValues")
+        && path.parent().segment().contentEquals("attribute");
   }
 
   static String attributePath(String path) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistObject.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistObject.java
@@ -35,6 +35,7 @@ import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.object.ObjectOutput.Property;
 
@@ -87,7 +88,7 @@ public record GistObject(@Nonnull List<Property> properties, @CheckForNull Objec
     }
 
     public List<String> paths() {
-      return properties.stream().map(Property::path).toList();
+      return properties.stream().map(Property::path).map(PropertyPath::toString).toList();
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistObjectList.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistObjectList.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.object.ObjectOutput.Property;
 
 /**
@@ -98,7 +99,7 @@ public record GistObjectList(
     }
 
     public List<String> paths() {
-      return properties.stream().map(Property::path).toList();
+      return properties.stream().map(Property::path).map(PropertyPath::toString).toList();
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistOutput.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistOutput.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.csv.CsvBuilder;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -81,7 +82,7 @@ public final class GistOutput {
       Stream<IntFunction<Object>> values = Stream.of(i -> obj.values()[i]);
       JsonNode array =
           JsonBuilder.createArray(FORMAT, arr -> addArrayElements(arr, properties, values));
-      JsonValue value = JsonMixed.of(array).getObject(0).get(properties.get(0).path());
+      JsonValue value = JsonMixed.of(array).getObject(0).get(properties.get(0).path().toString());
       try (PrintWriter json = new PrintWriter(out)) {
         json.append(value.toJson());
       }
@@ -127,10 +128,10 @@ public final class GistOutput {
         // list each only as the property itself
         // to do that, first list objects but to written to a string
         // then iterate the values from the array
-        String path = properties.get(0).path();
+        PropertyPath path = properties.get(0).path();
         JsonNode array =
             JsonBuilder.createArray(temp -> addArrayElements(temp, properties, values));
-        array.elements().forEach(e -> arr.addElement(e.get(path)));
+        array.elements().forEach(e -> arr.addElement(e.get(path.toString())));
       } else {
         // list each as an object with the given properties
         addArrayElements(arr, properties, values);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPipeline.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPipeline.java
@@ -47,6 +47,7 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -282,7 +283,8 @@ public class GistPipeline {
         elementType, key -> schemaService.getSchema(key).getCollectionName());
   }
 
-  private static final Property MATCH = new Property("match", new Type(Boolean.class), false);
+  private static final Property MATCH =
+      new Property(PropertyPath.of("match"), new Type(Boolean.class), false);
 
   /**
    * @implNote When listing OU with their ancestors the main query just matches using filters as

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -254,7 +254,8 @@ final class GistPlanner {
                   }
                 });
       } else if (path.isExclude()) {
-        PropertyPath excluded = path.withTail(path.segment().subSequence(1, path.length()));
+        PropertyPath excluded =
+            path.withTail(path.segment().subSequence(1, path.segment().length()));
         expanded.removeIf(field -> field.propertyPath().equals(excluded));
       } else {
         expanded.add(f);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -34,15 +34,11 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.gist.GistLogic.effectiveTransform;
-import static org.hisp.dhis.gist.GistLogic.isAttributePath;
 import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPath;
 import static org.hisp.dhis.gist.GistLogic.isCollectionSizeFilter;
 import static org.hisp.dhis.gist.GistLogic.isIncludedField;
-import static org.hisp.dhis.gist.GistLogic.isNestedPath;
 import static org.hisp.dhis.gist.GistLogic.isPersistentCollectionField;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
-import static org.hisp.dhis.gist.GistLogic.parentPath;
-import static org.hisp.dhis.gist.GistLogic.pathOnSameParent;
 import static org.hisp.dhis.schema.PropertyType.COLLECTION;
 
 import java.util.ArrayList;
@@ -56,12 +52,14 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.NameableObject;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.common.input.Fields.Field;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.RelativePropertyContext;
@@ -119,8 +117,8 @@ final class GistPlanner {
   }
 
   private boolean isUnboundSubSelect(@Nonnull Filter f) {
-    String path = f.getPropertyPath();
-    if (!path.contains(".")) return false;
+    PropertyPath path = f.getPropertyPath();
+    if (!path.isNested()) return false;
     if (context.resolve(path) == null) return false;
     List<Property> segments = context.resolvePath(path);
     if (segments.size() != 2) return false;
@@ -130,7 +128,10 @@ final class GistPlanner {
   private List<Filter> withAttributeIdAsPropertyFilters(List<Filter> filters) {
     return map1to1(
         filters,
-        f -> isAttributePath(f.getPropertyPath()) && context.resolve(f.getPropertyPath()) == null,
+        f ->
+            !f.getPropertyPath().isNested()
+                && f.getPropertyPath().isUID()
+                && context.resolve(f.getPropertyPath()) == null,
         Filter::asAttribute);
   }
 
@@ -142,7 +143,8 @@ final class GistPlanner {
     return map1to1(
         filters,
         f ->
-            f.getPropertyPath().equals("attributeValues.attribute.id")
+            isAttributeValuesAttributePropertyPath(f.getPropertyPath())
+                && f.getPropertyPath().segment().contentEquals("id")
                 && f.getOperator() == Comparison.EQ,
         f -> new Filter(f.getValue()[0], Comparison.NOT_NULL).asAttribute());
   }
@@ -226,11 +228,15 @@ final class GistPlanner {
    * account.
    */
   private List<Field> withPresetFields(List<Field> fields) {
-    Set<String> explicit = fields.stream().map(Fields.Field::propertyPath).collect(toSet());
+    Set<String> explicit =
+        fields.stream()
+            .map(Fields.Field::propertyPath)
+            .map(PropertyPath::toString)
+            .collect(toSet());
     List<Field> expanded = new ArrayList<>();
     for (Field f : fields) {
-      String path = f.propertyPath();
-      if (isPresetField(path)) {
+      PropertyPath path = f.propertyPath();
+      if (path.isPreset()) {
         Schema schema = context.getHome();
         Predicate<Property> canRead = getAccessFilter(schema);
         schema.getProperties().stream()
@@ -247,8 +253,9 @@ final class GistPlanner {
                     addReferenceFields(expanded, path, schema, p);
                   }
                 });
-      } else if (isExcludeField(path)) {
-        expanded.removeIf(field -> field.propertyPath().equals(path.substring(1)));
+      } else if (path.isExclude()) {
+        PropertyPath excluded = path.withTail(path.segment().subSequence(1, path.length()));
+        expanded.removeIf(field -> field.propertyPath().equals(excluded));
       } else {
         expanded.add(f);
       }
@@ -256,7 +263,8 @@ final class GistPlanner {
     return expanded;
   }
 
-  private void addReferenceFields(List<Field> expanded, String path, Schema schema, Property p) {
+  private void addReferenceFields(
+      List<Field> expanded, PropertyPath path, Schema schema, Property p) {
     Schema propertySchema = context.switchedTo(p.getKlass()).getHome();
     if (isPersistentReferenceField(p) && propertySchema.getRelativeApiEndpoint() == null) {
       // reference to an object with no endpoint API
@@ -290,7 +298,8 @@ final class GistPlanner {
         fields,
         f ->
             f.isAuto()
-                && isAttributePath(f.propertyPath())
+                && !f.propertyPath().isNested()
+                && f.propertyPath().isUID()
                 && context.resolve(f.propertyPath()) == null,
         Fields.Field::asAttribute);
   }
@@ -300,11 +309,11 @@ final class GistPlanner {
         fields,
         Field::isAuto,
         f -> {
-          String path = f.propertyPath();
+          PropertyPath path = f.propertyPath();
           Property p = context.resolve(path);
           if (p == null) return f;
           String name = Property.resolveTranslationBasePropertyName(p.getName());
-          String basePath = pathOnSameParent(path, name);
+          PropertyPath basePath = path.withTail(name);
           Property b = context.resolve(basePath);
           if (b == null || !b.isTranslatable()) return f;
           if (name.equals(p.getName())) return f;
@@ -317,12 +326,12 @@ final class GistPlanner {
   private List<Field> withCollectionItemPropertyAsTransformation(List<Field> fields) {
     List<Field> mapped = new ArrayList<>();
     for (Field f : fields) {
-      String path = f.propertyPath();
-      String parentPath = parentPath(path);
-      if (isNestedPath(path) && context.resolveMandatory(parentPath).isCollection()) {
-        String propertyName = path.substring(path.lastIndexOf('.') + 1);
+      PropertyPath path = f.propertyPath();
+      PropertyPath parentPath = path.parent();
+      if (parentPath != null && context.resolveMandatory(parentPath).isCollection()) {
+        Text propertyName = path.segment();
         Property collection = context.resolveMandatory(parentPath);
-        if ("id".equals(propertyName)
+        if (propertyName.contentEquals("id")
             && PrimaryKeyObject.class.isAssignableFrom(collection.getItemKlass())) {
           mapped.add(
               f.withPropertyPath(parentPath)
@@ -332,7 +341,7 @@ final class GistPlanner {
           mapped.add(
               f.withPropertyPath(parentPath)
                   .withRenamedPath(f.path())
-                  .withTransformation(Transform.PLUCK, List.of(propertyName)));
+                  .withTransformation(Transform.PLUCK, List.of(propertyName.toString())));
         }
       } else {
         mapped.add(f);
@@ -358,26 +367,19 @@ final class GistPlanner {
       return fields;
     }
     ArrayList<Field> extended = new ArrayList<>(fields);
-    extended.add(new Field(Fields.Field.REFS_PATH, Transform.NONE).withRenamedPath("apiEndpoints"));
+    extended.add(Field.REFS);
     return extended;
   }
 
-  private Predicate<Property> getPresetFilter(String path) {
-    if (isAllField(path)) {
+  private Predicate<Property> getPresetFilter(PropertyPath path) {
+    if (path.isAll()) {
       return p -> isIncludedField(p, query.getAutoType());
     }
-    if (":identifiable".equals(path)) {
-      return getPresetFilter(IdentifiableObject.class);
-    }
-    if (":nameable".equals(path)) {
-      return getPresetFilter(NameableObject.class);
-    }
-    if (":persisted".equals(path)) {
-      return Property::isPersisted;
-    }
-    if (":owner".equals(path)) {
-      return p -> p.isPersisted() && p.isOwner();
-    }
+    Text preset = path.segment();
+    if (preset.contentEquals(":identifiable")) return getPresetFilter(IdentifiableObject.class);
+    if (preset.contentEquals(":nameable")) return getPresetFilter(NameableObject.class);
+    if (preset.contentEquals(":persisted")) return Property::isPersisted;
+    if (preset.contentEquals(":owner")) return p -> p.isPersisted() && p.isOwner();
     throw new IllegalQueryException(new ErrorMessage(ErrorCode.E2038, path));
   }
 
@@ -389,18 +391,6 @@ final class GistPlanner {
                     m.getName().equals(p.getGetterMethod().getName())
                         && m.getParameterCount() == 0
                         && p.isPersisted());
-  }
-
-  private static boolean isPresetField(String path) {
-    return path.startsWith(":") || Fields.Field.ALL_PATH.equals(path);
-  }
-
-  private static boolean isExcludeField(String path) {
-    return path.startsWith("-") || path.startsWith("!");
-  }
-
-  private static boolean isAllField(String path) {
-    return Fields.Field.ALL_PATH.equals(path) || ":*".equals(path) || ":all".equals(path);
   }
 
   private static <T> List<T> map1to1(List<T> from, Predicate<T> when, UnaryOperator<T> then) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -254,8 +254,8 @@ final class GistPlanner {
                   }
                 });
       } else if (path.isExclude()) {
-        PropertyPath excluded =
-            path.withTail(path.segment().subSequence(1, path.segment().length()));
+        // note that property() always returns just the name without exclude
+        PropertyPath excluded = path.withTail(path.property());
         expanded.removeIf(field -> field.propertyPath().equals(excluded));
       } else {
         expanded.add(f);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -46,6 +46,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.schema.annotation.Gist.Transform;
 
@@ -172,8 +173,10 @@ public final class GistQuery {
     return asList(value.split(splitRegex));
   }
 
-  public GistQuery addField(String path) {
-    return toBuilder().fields(fields.add(Fields.Field.of(path))).build();
+  public GistQuery addField(PropertyPath path) {
+    return toBuilder()
+        .fields(fields.add(new Fields.Field(path, null, Transform.AUTO, List.of())))
+        .build();
   }
 
   public GistQuery withFields(List<Fields.Field> fields) {
@@ -297,17 +300,17 @@ public final class GistQuery {
   @Builder
   @AllArgsConstructor
   public static final class Order {
-    @JsonProperty private final String propertyPath;
+    @JsonProperty private final PropertyPath propertyPath;
 
     @JsonProperty @Builder.Default private final Direction direction = Direction.ASC;
 
     public static Order parse(String order) {
       String[] parts = order.split("(?:::|:|~|@)");
       if (parts.length == 1) {
-        return new Order(order, Direction.ASC);
+        return new Order(PropertyPath.of(order), Direction.ASC);
       }
       if (parts.length == 2) {
-        return new Order(parts[0], Direction.valueOf(parts[1].toUpperCase()));
+        return new Order(PropertyPath.of(parts[0]), Direction.valueOf(parts[1].toUpperCase()));
       }
       throw new IllegalArgumentException("Not a valid order expression: " + order);
     }
@@ -331,14 +334,14 @@ public final class GistQuery {
         ",(?![^\\[\\]]*\\]|[^\\(\\)]*\\)|([a-zA-Z0-9]+,?)+\\))";
 
     @JsonProperty private final int group;
-    @JsonProperty private final String propertyPath;
+    @JsonProperty private final PropertyPath propertyPath;
     @JsonProperty private final Comparison operator;
     @JsonProperty private final String[] value;
     @JsonProperty private final boolean attribute;
     @JsonProperty private final boolean subSelect;
 
     public Filter(String propertyPath, Comparison operator, String... value) {
-      this(0, propertyPath, operator, value, false, false);
+      this(0, PropertyPath.of(propertyPath), operator, value, false, false);
     }
 
     @Nonnull
@@ -347,11 +350,11 @@ public final class GistQuery {
     }
 
     public Filter withPropertyPath(String path) {
-      return new Filter(path, operator, value);
+      return new Filter(group, PropertyPath.of(path), operator, value, false, false);
     }
 
     public Filter withValue(String... value) {
-      return new Filter(propertyPath, operator, value);
+      return new Filter(group, propertyPath, operator, value, false, false);
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -198,8 +198,7 @@ final class GistValidator {
   private void validateFilterPath(Filter f, RelativePropertyContext context) {
     PropertyPath propertyPath = f.getPropertyPath();
     if (isAttributeValuesAttributePropertyPath(propertyPath)) {
-      Property p =
-          context.switchedTo(Attribute.class).resolveMandatory(propertyPath.segment().toString());
+      Property p = context.switchedTo(Attribute.class).resolveMandatory(propertyPath.property());
       if (!p.isPersisted())
         throw createIllegalProperty(
             p, "Property `%s` cannot be used as an attribute filter property");

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -30,15 +30,14 @@
 package org.hisp.dhis.gist;
 
 import static java.util.Arrays.stream;
-import static org.hisp.dhis.gist.GistLogic.attributePath;
 import static org.hisp.dhis.gist.GistLogic.getBaseType;
 import static org.hisp.dhis.gist.GistLogic.isAttributeValuesAttributePropertyPath;
-import static org.hisp.dhis.gist.GistLogic.isNestedPath;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.input.Fields.Field;
 import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
@@ -99,9 +98,9 @@ final class GistValidator {
 
   private void validateField(Field f, RelativePropertyContext context) {
     if (f.isRefs() || f.isAttribute()) return;
-    String path = f.propertyPath();
+    PropertyPath path = f.propertyPath();
     Property field = context.resolveMandatory(path);
-    if (isNestedPath(path)) {
+    if (path.isNested()) {
       List<Property> pathElements = context.resolvePath(path);
       Property head = pathElements.get(0);
       if (head.isCollection() && head.isPersisted()) {
@@ -171,12 +170,12 @@ final class GistValidator {
    * type but there are fields that are generally visible.
    */
   private void validateFieldAccess(Field f, RelativePropertyContext context) {
-    String path = f.propertyPath();
+    PropertyPath path = f.propertyPath();
     Property field = context.resolveMandatory(path);
-    if (!access.canRead(query.getElementType(), path)) {
+    if (!access.canRead(query.getElementType(), path.toString())) {
       throw createNoReadAccess(f, query.getElementType());
     }
-    if (isNestedPath(path)) {
+    if (path.isNested()) {
       Schema fieldOwner = context.switchedTo(path).getHome();
       @SuppressWarnings("unchecked")
       Class<? extends PrimaryKeyObject> ownerType =
@@ -197,10 +196,10 @@ final class GistValidator {
   }
 
   private void validateFilterPath(Filter f, RelativePropertyContext context) {
-    String propertyPath = f.getPropertyPath();
+    PropertyPath propertyPath = f.getPropertyPath();
     if (isAttributeValuesAttributePropertyPath(propertyPath)) {
       Property p =
-          context.switchedTo(Attribute.class).resolveMandatory(attributePath(propertyPath));
+          context.switchedTo(Attribute.class).resolveMandatory(propertyPath.segment().toString());
       if (!p.isPersisted())
         throw createIllegalProperty(
             p, "Property `%s` cannot be used as an attribute filter property");

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/input/FieldsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/input/FieldsTest.java
@@ -27,13 +27,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.gist;
+package org.hisp.dhis.common.input;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.schema.annotation.Gist;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
@@ -96,7 +96,7 @@ class GistQueryTest {
   private void assertFilterEquals(
       Filter actual, int group, String name, Comparison op, String... value) {
     assertEquals(group, actual.getGroup());
-    assertEquals(name, actual.getPropertyPath());
+    assertEquals(name, actual.getPropertyPath().toString());
     assertEquals(op, actual.getOperator());
     assertArrayEquals(value, actual.getValue());
   }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.common.PropertyPath;
 
 /**
  * A utility to resolve the {@link Property} for a given path.
@@ -92,12 +93,21 @@ public final class RelativePropertyContext {
             homeType, home -> new RelativePropertyContext(home, schemaLookup, byHomeType));
   }
 
+  public RelativePropertyContext switchedTo(PropertyPath path) {
+    return switchedTo(path.toString());
+  }
+
   public RelativePropertyContext switchedTo(String path) {
     if (path.indexOf('.') < 0) {
       return this;
     }
     List<Property> segments = resolvePath(path);
     return switchedTo(segments.get(segments.size() - 2).getKlass());
+  }
+
+  @Nonnull
+  public Property resolveMandatory(@Nonnull PropertyPath path) {
+    return resolveMandatory(path.toString());
   }
 
   @Nonnull
@@ -110,6 +120,11 @@ public final class RelativePropertyContext {
   }
 
   @CheckForNull
+  public Property resolve(@Nonnull PropertyPath path) {
+    return resolve(path.toString());
+  }
+
+  @CheckForNull
   public Property resolve(String path) {
     if (path.indexOf('.') < 0) {
       // just for performance do simple and common case first
@@ -117,6 +132,11 @@ public final class RelativePropertyContext {
       return homeSchema.getProperty(path);
     }
     return cache.computeIfAbsent(path, key -> resolvePath(key, null));
+  }
+
+  @Nonnull
+  public List<Property> resolvePath(@Nonnull PropertyPath path) {
+    return resolvePath(path.toString());
   }
 
   @Nonnull

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -378,7 +378,7 @@ public abstract class AbstractFullReadOnlyController<
       Property property = getSchema().getProperty(path.toString());
       if (property == null) {
         if (path.isUID()) {
-          String fieldName = path.segment().toString();
+          String fieldName = path.property();
           schemaBuilder.addColumn(fieldName);
           obj2valueByProperty.put(fieldName, obj -> getAttributeValue(obj, fieldName));
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.attribute.AttributeService;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Maturity;
@@ -63,6 +62,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.PropertyNames;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.input.Fields;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -373,11 +373,12 @@ public abstract class AbstractFullReadOnlyController<
   private void setupSchemaAndProperties(
       Builder schemaBuilder, String fields, Map<String, Function<T, Object>> obj2valueByProperty) {
     for (Fields.Field field : Fields.of(fields)) {
-      String fieldName = field.propertyPath();
-      Property property = getSchema().getProperty(fieldName);
-
+      PropertyPath path = field.propertyPath();
+      if (path.isNested()) continue;
+      Property property = getSchema().getProperty(path.toString());
       if (property == null) {
-        if (CodeGenerator.isValidUid(fieldName)) {
+        if (path.isUID()) {
+          String fieldName = path.segment().toString();
           schemaBuilder.addColumn(fieldName);
           obj2valueByProperty.put(fieldName, obj -> getAttributeValue(obj, fieldName));
         }


### PR DESCRIPTION
Continuation of #24011 

### Summary
The core idea is that by using a new type `PropertyPath` instead of `String` we can make sure that all values of paths are formally valid property paths. 

This makes it trivial to see that user inputs that become property paths, like paths of `fields`, `filter` and `order` URL parameters, cannot be abused to perform SQL injection attacks.

In addition having a dedicated type for a `PropertyPath` makes reuse of utility functions around paths easier as they no longer have to be static helper methods in some utility class but can be methods on the type.

### Automatic Testing
Added comprehensive suite of unit tests for the new `PropertyPath` type.

Obviously it is also tested a lot indirectly as the type has a central role for the `fields` parameter. 