### PR TITLE
test: Special handling for COC in API contract test

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/contract/ApiContractTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/contract/ApiContractTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.api.TestCategoryMetadata;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonGenerator;
 import org.hisp.dhis.test.webapi.json.domain.JsonSchema;
@@ -74,6 +75,7 @@ import org.springframework.transaction.annotation.Transactional;
 class ApiContractTest extends H2ControllerIntegrationTestBase {
 
   private static final ObjectMapper mapper = new ObjectMapper();
+  private static final Set<String> typeRequiresSpecialHandling = Set.of("categoryOptionCombo");
 
   @TestFactory
   @DisplayName("Test API contracts")
@@ -119,13 +121,17 @@ class ApiContractTest extends H2ControllerIntegrationTestBase {
   }
 
   /**
-   * Create type to be tested using existing JsonSchema code
+   * Create type to be tested using existing JsonSchema code. Some types require special handling
+   * and bypass the normal generator flow.
    *
    * @param contract contract which contains type
    * @return UID of created type
    */
   private String createType(ApiContract contract, JsonGenerator generator) {
     String type = contract.name();
+
+    // handle types that require special handling - skipping normal flow
+    if (typeRequiresSpecialHandling.contains(type)) return typeWithSpecialHandling(type);
 
     JsonSchema schema = GET("/schemas/" + type).content().as(JsonSchema.class);
     Map<String, String> objects = generator.generateObjects(schema);
@@ -168,5 +174,22 @@ class ApiContractTest extends H2ControllerIntegrationTestBase {
       return Set.of();
     }
     return contracts;
+  }
+
+  /**
+   * Special handling for qualifying types. This list will likely grow over time so left as a switch
+   * statement.
+   *
+   * @param type the contract that requires special handling
+   * @return the uid from the type required for the contract test
+   */
+  private String typeWithSpecialHandling(String type) {
+    return switch (type) {
+      case "categoryOptionCombo" -> {
+        TestCategoryMetadata categoryMetadata = setupCategoryMetadata("apiContractTest");
+        yield categoryMetadata.coc1().getUid();
+      }
+      default -> throw new IllegalArgumentException("Type needs special handling: " + type);
+    };
   }
 }


### PR DESCRIPTION
- CategoryOptionCombos (COC) cannot be created individually and therefore require special handling in the automated generation of test objects for API contracts
- This change uses an existing helper method to create a full category model with easy access to a valid COC