### PR TITLE
fix: add handleAnalyticalDimensions for mapView

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
@@ -90,21 +90,7 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
 
   /**
    * Reconstructs the persisted dimension state of an analytical object from its transient {@code
-   * columns}/{@code rows}/{@code filters} when the payload uses the analytics-app ("favorite")
-   * format.
-   *
-   * <p>The analytics apps serialize the analytical dimensions as the transient {@code
-   * columns}/{@code rows}/{@code filters} arrays and omit the persisted identifiers (e.g. {@code
-   * columnDimensions}/{@code filterDimensions}, organisation unit levels). Unlike the {@code
-   * MapController}, which decomposes those transient arrays before saving, the metadata import path
-   * historically did not - so importing such a payload silently dropped the {@code
-   * columns}/{@code rows}/{@code filters} on read-back. This mirrors {@code
-   * MapController.mergeMapView} so a Map imported through metadata import round-trips like one saved
-   * through the API.
-   *
-   * <p>Only applied to {@link MapView} for now, and only when the transient arrays are populated -
-   * the raw metadata format populates the persisted collections and identifiers directly and must
-   * be left untouched (guarding here also preserves that behaviour for the existing import tests).
+   * columns}/{@code rows}/{@code filters}
    */
   private void handleAnalyticalDimensions(BaseAnalyticalObject analyticalObject) {
     if (!(analyticalObject instanceof MapView mapView) || !hasAnalyticalDimensions(mapView)) {
@@ -117,8 +103,12 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
     mapView.getColumnDimensions().clear();
     mapView.getFilterDimensions().clear();
 
-    mapView.getColumnDimensions().addAll(DimensionalObjectUtils.getDimensions(mapView.getColumns()));
-    mapView.getFilterDimensions().addAll(DimensionalObjectUtils.getDimensions(mapView.getFilters()));
+    mapView
+        .getColumnDimensions()
+        .addAll(DimensionalObjectUtils.getDimensions(mapView.getColumns()));
+    mapView
+        .getFilterDimensions()
+        .addAll(DimensionalObjectUtils.getDimensions(mapView.getFilters()));
   }
 
   private boolean hasAnalyticalDimensions(BaseAnalyticalObject analyticalObject) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
@@ -39,12 +39,15 @@ import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.DataDimensionItem;
+import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.legend.LegendSet;
+import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension;
@@ -66,12 +69,15 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
 
   private final IdentifiableObjectManager objectManager;
 
+  private final DimensionService dimensionService;
+
   @Override
   public void handleAnalyticalObject(
       EntityManager entityManager,
       Schema schema,
       BaseAnalyticalObject analyticalObject,
       ObjectBundle bundle) {
+    handleAnalyticalDimensions(analyticalObject);
     handleDataDimensionItems(entityManager, schema, analyticalObject, bundle);
     handleCategoryDimensions(entityManager, schema, analyticalObject, bundle);
     handleDataElementDimensions(entityManager, schema, analyticalObject, bundle);
@@ -80,6 +86,45 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
     handleAnalyticalLegendSet(schema, analyticalObject, bundle);
     handleRelativePeriods(schema, analyticalObject);
     handleOrgUnitGroupSetDimensions(entityManager, schema, analyticalObject, bundle);
+  }
+
+  /**
+   * Reconstructs the persisted dimension state of an analytical object from its transient {@code
+   * columns}/{@code rows}/{@code filters} when the payload uses the analytics-app ("favorite")
+   * format.
+   *
+   * <p>The analytics apps serialize the analytical dimensions as the transient {@code
+   * columns}/{@code rows}/{@code filters} arrays and omit the persisted identifiers (e.g. {@code
+   * columnDimensions}/{@code filterDimensions}, organisation unit levels). Unlike the {@code
+   * MapController}, which decomposes those transient arrays before saving, the metadata import path
+   * historically did not - so importing such a payload silently dropped the {@code
+   * columns}/{@code rows}/{@code filters} on read-back. This mirrors {@code
+   * MapController.mergeMapView} so a Map imported through metadata import round-trips like one saved
+   * through the API.
+   *
+   * <p>Only applied to {@link MapView} for now, and only when the transient arrays are populated -
+   * the raw metadata format populates the persisted collections and identifiers directly and must
+   * be left untouched (guarding here also preserves that behaviour for the existing import tests).
+   */
+  private void handleAnalyticalDimensions(BaseAnalyticalObject analyticalObject) {
+    if (!(analyticalObject instanceof MapView mapView) || !hasAnalyticalDimensions(mapView)) {
+      return;
+    }
+
+    dimensionService.mergeAnalyticalObject(mapView);
+    dimensionService.mergeEventAnalyticalObject(mapView);
+
+    mapView.getColumnDimensions().clear();
+    mapView.getFilterDimensions().clear();
+
+    mapView.getColumnDimensions().addAll(DimensionalObjectUtils.getDimensions(mapView.getColumns()));
+    mapView.getFilterDimensions().addAll(DimensionalObjectUtils.getDimensions(mapView.getFilters()));
+  }
+
+  private boolean hasAnalyticalDimensions(BaseAnalyticalObject analyticalObject) {
+    return !analyticalObject.getColumns().isEmpty()
+        || !analyticalObject.getRows().isEmpty()
+        || !analyticalObject.getFilters().isEmpty();
   }
 
   /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -906,6 +906,11 @@ class MetadataImportServiceTest extends PostgresIntegrationTestBase {
     assertEquals("#ddeeff", mapView.getNoDataColor());
     assertEquals("#aabbcc", mapView.getOrganisationUnitColor());
     assertEquals(ThematicMapType.CHOROPLETH, mapView.getThematicMapType());
+    // The favorite format carries the analytical dimensions in the transient columns/rows/filters
+    // only; the import must decompose them into the persisted dimension identifiers so the MapView
+    // round-trips (regression test for [DHIS2-21608]).
+    assertEquals(List.of("dx"), mapView.getColumnDimensions());
+    assertEquals(List.of("pe"), mapView.getFilterDimensions());
     metadata =
         renderService.fromMetadata(
             new ClassPathResource("dxf2/map_update.json").getInputStream(), RenderFormat.JSON);
@@ -922,6 +927,8 @@ class MetadataImportServiceTest extends PostgresIntegrationTestBase {
     assertEquals("#ddeeff", mapView.getNoDataColor());
     assertEquals("#aabbcc", mapView.getOrganisationUnitColor());
     assertEquals(ThematicMapType.CHOROPLETH, mapView.getThematicMapType());
+    assertEquals(List.of("dx"), mapView.getColumnDimensions());
+    assertEquals(List.of("pe"), mapView.getFilterDimensions());
   }
 
   /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -906,9 +906,6 @@ class MetadataImportServiceTest extends PostgresIntegrationTestBase {
     assertEquals("#ddeeff", mapView.getNoDataColor());
     assertEquals("#aabbcc", mapView.getOrganisationUnitColor());
     assertEquals(ThematicMapType.CHOROPLETH, mapView.getThematicMapType());
-    // The favorite format carries the analytical dimensions in the transient columns/rows/filters
-    // only; the import must decompose them into the persisted dimension identifiers so the MapView
-    // round-trips (regression test for [DHIS2-21608]).
     assertEquals(List.of("dx"), mapView.getColumnDimensions());
     assertEquals(List.of("pe"), mapView.getFilterDimensions());
     metadata =


### PR DESCRIPTION
### Issue

  - Importing a Map through the metadata import endpoint (/api/metadata, importService.importMetadata) silently dropped a MapView's columns, rows, and filters. 
  - Root cause:  The REST controller path (MapController.mergeMapView) decomposes those transient arrays into
  persisted state before saving, but the metadata import path (DefaultAnalyticalObjectImportHandler) never did. 
  So on read-back `MapView.populateAnalyticalProperties()` rebuilt empty columns/rows/filters.

  ### Fix

  - Added `handleAnalyticalDimensions(...)` to `DefaultAnalyticalObjectImportHandler`. It mirrors `MapController.mergeMapView`
  - Only applies to `MapView` to reduce the scope of this PR. Will investigate and apply for other analytic objects in future PR.

  ### Test
  - Updated `MetadataImportServiceTest.testImportMapCreateAndUpdate`

