### PR TITLE
CI: skip Sonar analysis gracefully when Sonar token is missing

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -52,10 +52,13 @@ jobs:
           cache: maven
 
       - name: Check Sonar token
+        id: sonar_token
         run: |
           if [ -z "${{ secrets.DHIS2_BOT_SONARCLOUD_TOKEN }}" ]; then
-            echo "SONAR_TOKEN is not set"
-            exit 1
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "SONAR_TOKEN is not set; skipping Sonar analysis"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Analyse PR
@@ -63,13 +66,13 @@ jobs:
           BASE_BRANCH: ${{ github.base_ref }}
           BRANCH: ${{ github.ref }}
           PR: ${{ github.event.number }}
-        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event_name == 'pull_request'
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event_name == 'pull_request' && steps.sonar_token.outputs.available == 'true'
         run: |
           mvn -f dhis-2/pom.xml clean install --threads 2C --batch-mode --update-snapshots --no-transfer-progress -DskipTests
           mvn -f dhis-2/pom.xml sonar:sonar -Dsonar.internal.analysis.dbd=false --batch-mode --no-transfer-progress -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }} -Dsonar.projectKey=dhis2_dhis2-core
 
       - name: Analyse long-living branch
-        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event_name != 'pull_request'
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event_name != 'pull_request' && steps.sonar_token.outputs.available == 'true'
         run: |
           mvn -f dhis-2/pom.xml clean install --threads 2C --batch-mode --update-snapshots --no-transfer-progress -DskipTests
           mvn -f dhis-2/pom.xml sonar:sonar -Dsonar.internal.analysis.dbd=false --batch-mode --no-transfer-progress -Dsonar.branch.name=${GITHUB_REF#refs/heads/} -Dsonar.projectKey=dhis2_dhis2-core


### PR DESCRIPTION
## Summary

This change prevents SonarQube analysis from failing when `DHIS2_BOT_SONARCLOUD_TOKEN` is unavailable in the workflow context.

- Replaces hard exit in token check with a step output (`available=true`/`false`)
- Sonar analysis steps now run only when the token is available
- Result: CI remains green for contexts without secret access, while still running Sonar where properly configured

This unblocks PRs where the Sonar secret is unavailable (forks, missing secret, etc.).

## After merge

Rebase/re-run PR #24407 so it picks up this workflow fix.

## Test plan

- [ ] Confirm workflow YAML is valid
- [ ] On a PR without Sonar token access: job should skip analysis and succeed
- [ ] On a PR/push with Sonar token: analysis should still run as before