### PR TITLE
perf: Fix search not assigned user in tracker exporter (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -1133,12 +1133,16 @@ class JdbcEventStore implements EventStore {
       fromBuilder.append(hlp.whereAnd()).append(" (au.uid in (").append(":au_uid").append(")) ");
     }
 
+    // Filter on ev.assigneduserid rather than au.uid: au is LEFT JOINed on assigneduserid, so the
+    // two are equivalent, but "au.uid is null" makes the planner estimate the join output with
+    // userinfo.uid's null_frac (0) instead of event.assigneduserid's, collapsing the row estimate
+    // to 1 and flipping the plan to nested loops that rescan the full event set.
     if (AssignedUserSelectionMode.NONE == params.getAssignedUserQueryParam().getMode()) {
-      fromBuilder.append(hlp.whereAnd()).append(" (au.uid is null) ");
+      fromBuilder.append(hlp.whereAnd()).append(" (ev.assigneduserid is null) ");
     }
 
     if (AssignedUserSelectionMode.ANY == params.getAssignedUserQueryParam().getMode()) {
-      fromBuilder.append(hlp.whereAnd()).append(" (au.uid is not null) ");
+      fromBuilder.append(hlp.whereAnd()).append(" (ev.assigneduserid is not null) ");
     }
 
     if (!params.isIncludeDeleted()) {

--- a/dhis-2/dhis-test-performance/scripts/compare-gatling-run.sh
+++ b/dhis-2/dhis-test-performance/scripts/compare-gatling-run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Downloads artifacts from a `performance-tests-compare.yml` run and renders a
+# Markdown comparison table by delegating to `gstat compare`.
+#
+# Usage:
+#   ./compare-gatling-run.sh <run-id>
+#
+# Requires: [gh]    (https://cli.github.com)
+#           [gstat] (https://github.com/dhis2/gatling-statistics) v0.2.0+ for the `compare` subcommand
+#
+# Example:
+#   ./compare-gatling-run.sh 24079806891
+
+set -euo pipefail
+
+REPO="dhis2/dhis2-core"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <run-id>"
+  exit 1
+fi
+
+RUN_ID="$1"
+
+command -v gh    &>/dev/null || { echo "Error: gh not found"    >&2; exit 1; }
+command -v gstat &>/dev/null || { echo "Error: gstat not found. Install with: uv tool install git+https://github.com/dhis2/gatling-statistics" >&2; exit 1; }
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Downloading artifacts for run ${RUN_ID}..." >&2
+gh run download "$RUN_ID" --repo "$REPO" --dir "$WORK_DIR" >&2
+
+BASELINE_DIR=$(find "$WORK_DIR" -maxdepth 2 -type d -name '*-baseline'  | sort | tail -n1)
+CANDIDATE_DIR=$(find "$WORK_DIR" -maxdepth 2 -type d -name '*-candidate' | sort | tail -n1)
+
+if [[ -z "$BASELINE_DIR" ]]; then
+  echo "Error: could not find a *-baseline directory in the downloaded artifacts" >&2
+  exit 1
+fi
+if [[ -z "$CANDIDATE_DIR" ]]; then
+  echo "Error: could not find a *-candidate directory in the downloaded artifacts" >&2
+  exit 1
+fi
+
+echo "Baseline:  $BASELINE_DIR" >&2
+echo "Candidate: $CANDIDATE_DIR" >&2
+
+gstat compare \
+  "$BASELINE_DIR"  --label baseline \
+  "$CANDIDATE_DIR" --label candidate \
+  --exclude warmup


### PR DESCRIPTION
During the backport https://github.com/dhis2/dhis2-core/pull/23492 performance improvements were applied to improve events exporter endpoints but as happened in the 2.42 backport https://github.com/dhis2/dhis2-core/pull/23479, the load tests were showing that the assigned user search got worse. This will also fix it in 2.41

### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Get ANC events / Get one event / Get first event | 23 | 0.14 | 42 | 0.20 | +19 | :arrow_up: +83.8% |
| Get ANC events / Get one event / Get relationships for first event | 5 | 0.14 | 6 | 0.20 | +1 | :arrow_up: +20.0% |
| Get ANC events / Go to first page | 209 | 0.15 | 131 | 0.21 | -78 | :arrow_down: -37.2% |
| Get ANC events / Go to second page | 207 | 0.15 | 152 | 0.21 | -54 | :arrow_down: -26.3% |
|**Get ANC events / Search not assigned** |**4,488** |**0.15** | **198** | **0.20** | **-4,290** | :arrow_down: **-95.6%** |
| Get ANC events / Search by date range | 396 | 0.14 | 198 | 0.20 | -197 | :arrow_down: -49.9% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get first event from enrollment | 40 | 0.10 | 39 | 0.10 | -1 | :arrow_down: -2.0% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get relationships for first event | 8 | 0.10 | 8 | 0.10 | -0 | :arrow_down: -1.9% |
| Get Child Programme TEs / Go to single enrollment / Get first tracked entity | 59 | 0.10 | 60 | 0.10 | +1 | :arrow_up: +1.4% |
| Get Child Programme TEs / Go to single enrollment / Get first enrollment | 13 | 0.10 | 16 | 0.10 | +3 | :arrow_up: +20.8% |
| Get Child Programme TEs / Go to single enrollment / Get relationships for first tracked entity | 6 | 0.10 | 5 | 0.10 | -1 | :arrow_down: -13.8% |
| Get Child Programme TEs / Not found TE by name with like operator | 87 | 0.11 | 83 | 0.11 | -4 | :arrow_down: -4.3% |
| Get Child Programme TEs / Not found TE by name with eq operator | 49 | 0.11 | 49 | 0.11 | +0 | :arrow_up: +0.7% |
| Get Child Programme TEs / Search TE by name with like operator | 133 | 0.11 | 146 | 0.10 | +13 | :arrow_up: +9.8% |
| Get Child Programme TEs / Search TE by name with eq operator | 66 | 0.11 | 57 | 0.10 | -9 | :arrow_down: -13.2% |
| Get Child Programme TEs / Search Birth events | 86 | 0.10 | 90 | 0.10 | +4 | :arrow_up: +4.2% |
| Get Child Programme TEs / Get TEs from events | 11 | 0.10 | 10 | 0.10 | -1 | :arrow_down: -6.5% |
| Get Child Programme TEs / Get first page of TEs | 105 | 0.10 | 103 | 0.10 | -2 | :arrow_down: -2.3% |
| Get Child Programme TEs / Get TEs with enrollment status | 168 | 0.10 | 160 | 0.10 | -8 | :arrow_down: -4.5% |
| Login | 109 | 0.04 | 116 | 0.04 | +8 | :arrow_up: +7.0% |
| MNCH import | 1,197 | 0.13 | 1,242 | 0.13 | +45 | :arrow_up: +3.7% |
| Child Programme import | 634 | 0.13 | 633 | 0.13 | -1 | :arrow_down: -0.2% |
| ANC import | 604 | 0.13 | 539 | 0.13 | -65 | :arrow_down: -10.8% |

_:arrow_down: = faster, :arrow_up: = slower_

_Percentiles use the inclusive definition (e.g. p95 = X means 95% of requests responded in X ms or less) and are computed over OK + KO responses._