### PR TITLE
test: e2e test cleanup and improvements

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/TestRunStorage.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/TestRunStorage.java
@@ -29,8 +29,6 @@
  */
 package org.hisp.dhis.test.e2e;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -67,7 +65,7 @@ public class TestRunStorage {
     return getCreatedEntities().entrySet().stream()
         .filter(entrySet -> resource.equals(entrySet.getValue()))
         .map(Entry::getKey)
-        .collect(toList());
+        .toList();
   }
 
   public static void removeEntity(final String resource, final String id) {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/TestRunStorage.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/TestRunStorage.java
@@ -29,6 +29,8 @@
  */
 package org.hisp.dhis.test.e2e;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -65,7 +67,7 @@ public class TestRunStorage {
     return getCreatedEntities().entrySet().stream()
         .filter(entrySet -> resource.equals(entrySet.getValue()))
         .map(Entry::getKey)
-        .toList();
+        .collect(toList());
   }
 
   public static void removeEntity(final String resource, final String id) {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/actions/IdGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/actions/IdGenerator.java
@@ -29,21 +29,36 @@
  */
 package org.hisp.dhis.test.e2e.actions;
 
-import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
+import java.security.SecureRandom;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class IdGenerator extends RestApiActions {
+  private static final String LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  private static final String ALLOWED_CHARS = "0123456789" + LETTERS;
+
+  private static final int CODE_SIZE = 11;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
   public IdGenerator() {
     super("/system");
   }
 
+  /**
+   * Generates a DHIS2 UID client-side, matching the server's {@code CodeGenerator} format: 11
+   * characters, the first a letter and the remaining alphanumeric. This avoids a server round-trip
+   * (previously {@code GET /api/system/id}) per generated id.
+   */
   public String generateUniqueId() {
-    return get("id.json", new QueryParamsBuilder().add("limit=1"))
-        .validate()
-        .statusCode(200)
-        .extract()
-        .path("codes[0]");
+    char[] uid = new char[CODE_SIZE];
+    // First char is a letter so the uid is a valid XML/HTML identifier, as required by DHIS2.
+    uid[0] = LETTERS.charAt(RANDOM.nextInt(LETTERS.length()));
+    for (int i = 1; i < CODE_SIZE; i++) {
+      uid[i] = ALLOWED_CHARS.charAt(RANDOM.nextInt(ALLOWED_CHARS.length()));
+    }
+    return new String(uid);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/actions/IdGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/actions/IdGenerator.java
@@ -36,11 +36,8 @@ import java.security.SecureRandom;
  */
 public class IdGenerator extends RestApiActions {
   private static final String LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
   private static final String ALLOWED_CHARS = "0123456789" + LETTERS;
-
   private static final int CODE_SIZE = 11;
-
   private static final SecureRandom RANDOM = new SecureRandom();
 
   public IdGenerator() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/TestCleanUp.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/TestCleanUp.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hisp.dhis.test.e2e.TestRunStorage;
@@ -52,6 +53,21 @@ public class TestCleanUp {
   private int deleteCount = 0;
 
   /**
+   * Resources whose deletion is a soft delete and can leave rows behind that block deletion of
+   * referencing objects. Deleting any of these requires a follow-up {@code /maintenance} sweep to
+   * physically purge the soft-deleted rows. Everything else (plain metadata) is a hard delete and
+   * needs no sweep.
+   */
+  private static final Set<String> SOFT_DELETABLE_RESOURCES =
+      Set.of(
+          "trackedEntities",
+          "events",
+          "enrollments",
+          "relationships",
+          "dataValues",
+          "dataValueSets");
+
+  /**
    * Deletes entities created during test run. Entities deleted one by one starting from last
    * created one.
    */
@@ -60,13 +76,23 @@ public class TestCleanUp {
     List<String> reverseOrderedKeys = new ArrayList<>(createdEntities.keySet());
     Collections.reverse(reverseOrderedKeys);
 
-    for (String key : reverseOrderedKeys) {
-      boolean deleted = deleteEntity(createdEntities.get(key), key);
-      if (deleted) {
-        TestRunStorage.removeEntity(createdEntities.get(key), key);
-        createdEntities.remove(createdEntities.get(key), key);
-      }
+    boolean deletedSoftDeletableData = false;
 
+    for (String key : reverseOrderedKeys) {
+      String resource = createdEntities.get(key);
+      boolean deleted = deleteEntity(resource, key);
+      if (deleted) {
+        TestRunStorage.removeEntity(resource, key);
+        createdEntities.remove(key);
+        deletedSoftDeletableData |= requiresSoftDeleteMaintenance(resource);
+      }
+    }
+
+    // Purge soft-deleted rows once per pass, and only if this pass actually deleted
+    // tracker/data-value data. This previously ran after every single entity deletion, adding a
+    // full DB-wide maintenance sweep per entity - even for pure-metadata cleanups that never
+    // produce soft-deleted rows.
+    if (deletedSoftDeletableData) {
       new MaintenanceActions().removeSoftDeletedData();
     }
 
@@ -76,6 +102,14 @@ public class TestCleanUp {
     }
 
     TestRunStorage.removeAllEntities();
+  }
+
+  private static boolean requiresSoftDeleteMaintenance(String resource) {
+    if (resource == null) {
+      return false;
+    }
+    String normalized = resource.startsWith("/") ? resource.substring(1) : resource;
+    return SOFT_DELETABLE_RESOURCES.contains(normalized);
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -49,15 +49,15 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Luciano Fiandesio
  */
-public class MetadataPaginationTest extends ApiTest {
+class MetadataPaginationTest extends ApiTest {
   private MetadataPaginationActions paginationActions;
 
-  private int startPage = 1;
+  private final int startPage = 1;
 
-  private int pageSize = 5;
+  private final int pageSize = 5;
 
   @BeforeAll
-  public void setUp() {
+  void setUp() {
     new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/optionSets");
 
@@ -82,7 +82,7 @@ public class MetadataPaginationTest extends ApiTest {
   }
 
   @Test
-  public void checkPaginationResultsForcingInMemoryPagination() {
+  void checkPaginationResultsForcingInMemoryPagination() {
     // this test forces the metadata query engine to execute an "in memory"
     // sorting and pagination
     // since the sort ("order") value is set to 'displayName' that is a
@@ -101,7 +101,7 @@ public class MetadataPaginationTest extends ApiTest {
   }
 
   @Test
-  public void checkPaginationResultsForcingDatabaseOnlyPagination() {
+  void checkPaginationResultsForcingDatabaseOnlyPagination() {
     // this test forces the metadata query engine to execute the query
     // (including pagination) on the database only.
     // The sort ("order") value is set to 'id' that is mapped to a DB

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -32,15 +32,18 @@ package org.hisp.dhis.metadata;
 import static org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FIELDS;
 import static org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FILTER;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.test.e2e.actions.LoginActions;
+import org.hisp.dhis.test.e2e.actions.metadata.MetadataActions;
 import org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions;
-import org.hisp.dhis.test.e2e.actions.metadata.OptionActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
-import org.junit.jupiter.api.BeforeEach;
+import org.hisp.dhis.test.e2e.helpers.JsonObjectBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -53,18 +56,29 @@ public class MetadataPaginationTest extends ApiTest {
 
   private int pageSize = 5;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
-    LoginActions loginActions = new LoginActions();
-    OptionActions optionActions = new OptionActions();
+    new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/optionSets");
-    loginActions.loginAsSuperUser();
 
-    // Creates 100 Option Sets
+    // The pagination assertions only require that at least 100 option sets exist (the pager's
+    // total/pageCount are checked with greaterThanOrEqualTo), so the fixture is created once for
+    // the
+    // whole class rather than per test method, and in a single bulk metadata import instead of 100
+    // sequential POSTs per @BeforeEach run.
+    JsonArray optionSets = new JsonArray();
     for (int i = 0; i < 100; i++) {
-      optionActions.createOptionSet(
-          RandomStringUtils.randomAlphabetic(10), "INTEGER", (String[]) null);
+      optionSets.add(
+          new JsonObjectBuilder()
+              .addProperty("name", RandomStringUtils.randomAlphabetic(10) + i)
+              .addProperty("valueType", "INTEGER")
+              .build());
     }
+
+    JsonObject metadata = new JsonObject();
+    metadata.add("optionSets", optionSets);
+
+    new MetadataActions().importAndValidateMetadata(metadata);
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/MetadataPaginationTest.java
@@ -61,11 +61,7 @@ class MetadataPaginationTest extends ApiTest {
     new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/optionSets");
 
-    // The pagination assertions only require that at least 100 option sets exist (the pager's
-    // total/pageCount are checked with greaterThanOrEqualTo), so the fixture is created once for
-    // the
-    // whole class rather than per test method, and in a single bulk metadata import instead of 100
-    // sequential POSTs per @BeforeEach run.
+    // Create all optionsets once for the whole class in one bulk import.
     JsonArray optionSets = new JsonArray();
     for (int i = 0; i < 100; i++) {
       optionSets.add(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
@@ -65,14 +65,8 @@ class UserPaginationTest extends ApiTest {
     new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/users");
 
-    // The pagination assertions only require that at least `total` users exist (the pager's
-    // total/pageCount are checked with greaterThanOrEqualTo), so the fixture is created once for
-    // the
-    // whole class rather than per test method. All users share a single role and are created in one
-    // bulk metadata import, replacing what used to be ~300 sequential POSTs (a role + a user per
-    // iteration, times three @BeforeEach runs).
+    // Create all users once for the whole class, sharing a single role, in one bulk import.
     String roleUid = new UserRoleActions().createWithAuthorities();
-
     JsonArray users = new JsonArray();
     for (int i = 0; i < total; i++) {
       users.add(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
@@ -32,16 +32,20 @@ package org.hisp.dhis.metadata.users;
 import static org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FIELDS;
 import static org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions.DEFAULT_METADATA_FILTER;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.util.Arrays;
 import java.util.Collections;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.helpers.PasswordGenerator;
 import org.hisp.dhis.test.e2e.actions.LoginActions;
-import org.hisp.dhis.test.e2e.actions.UserActions;
+import org.hisp.dhis.test.e2e.actions.UserRoleActions;
+import org.hisp.dhis.test.e2e.actions.metadata.MetadataActions;
 import org.hisp.dhis.test.e2e.actions.metadata.MetadataPaginationActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.hisp.dhis.test.e2e.helpers.JsonObjectBuilder;
 import org.hisp.dhis.test.e2e.utils.DataGenerator;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,30 +54,41 @@ import org.junit.jupiter.api.Test;
 public class UserPaginationTest extends ApiTest {
   private MetadataPaginationActions paginationActions;
 
-  private UserActions userActions;
-
   private int startPage = 2;
 
   private int pageSize = 5;
 
   private int total = 50;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
-    LoginActions loginActions = new LoginActions();
-    userActions = new UserActions();
-
+    new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/users");
-    loginActions.loginAsSuperUser();
 
-    // Creates Users
+    // The pagination assertions only require that at least `total` users exist (the pager's
+    // total/pageCount are checked with greaterThanOrEqualTo), so the fixture is created once for
+    // the
+    // whole class rather than per test method. All users share a single role and are created in one
+    // bulk metadata import, replacing what used to be ~300 sequential POSTs (a role + a user per
+    // iteration, times three @BeforeEach runs).
+    String roleUid = new UserRoleActions().createWithAuthorities();
+
+    JsonArray users = new JsonArray();
     for (int i = 0; i < total; i++) {
-      userActions.addUserFull(
-          DataGenerator.randomString() + i,
-          DataGenerator.randomString() + i,
-          (DataGenerator.randomString() + i).toLowerCase(),
-          new String(PasswordGenerator.generateValidPassword(12)));
+      users.add(
+          new JsonObjectBuilder()
+              .addProperty("firstName", DataGenerator.randomString() + i)
+              .addProperty("surname", DataGenerator.randomString() + i)
+              .addProperty("username", (DataGenerator.randomString() + i).toLowerCase())
+              .addProperty("password", new String(PasswordGenerator.generateValidPassword(12)))
+              .addArray("userRoles", new JsonObjectBuilder().addProperty("id", roleUid).build())
+              .build());
     }
+
+    JsonObject metadata = new JsonObject();
+    metadata.add("users", users);
+
+    new MetadataActions().importAndValidateMetadata(metadata);
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserPaginationTest.java
@@ -51,17 +51,17 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-public class UserPaginationTest extends ApiTest {
+class UserPaginationTest extends ApiTest {
   private MetadataPaginationActions paginationActions;
 
-  private int startPage = 2;
+  private final int startPage = 2;
 
-  private int pageSize = 5;
+  private final int pageSize = 5;
 
-  private int total = 50;
+  private final int total = 50;
 
   @BeforeAll
-  public void setUp() {
+  void setUp() {
     new LoginActions().loginAsSuperUser();
     paginationActions = new MetadataPaginationActions("/users");
 
@@ -92,7 +92,7 @@ public class UserPaginationTest extends ApiTest {
   }
 
   @Test
-  public void checkPaginationResultsForcingInMemoryPagination() {
+  void checkPaginationResultsForcingInMemoryPagination() {
     // this test forces the metadata query engine to execute an "in memory"
     // sorting and pagination
     // since the sort ("order") value is set to 'displayName' that is a
@@ -111,7 +111,7 @@ public class UserPaginationTest extends ApiTest {
   }
 
   @Test
-  public void checkPaginationResultsWithBothDatabaseAndInMemory() {
+  void checkPaginationResultsWithBothDatabaseAndInMemory() {
     ApiResponse response =
         paginationActions.getPaginatedWithFiltersOnly(
             Arrays.asList(DEFAULT_METADATA_FILTER.split(",")), startPage, pageSize);
@@ -123,7 +123,7 @@ public class UserPaginationTest extends ApiTest {
   }
 
   @Test
-  public void checkPaginationResultsForcingDatabaseOnlyPagination() {
+  void checkPaginationResultsForcingDatabaseOnlyPagination() {
     // this test forces the metadata query engine to execute the query
     // (including pagination) on the database only.
     // The sort ("order") value is set to 'id' that is mapped to a DB


### PR DESCRIPTION
## E2E Test improvements

- Should reduce full test run by `~2.5 mins`
  - 4 runs measured against last 30 successful runs
- Total requests (`POST`, `DELETE`, `GET`) from `~6.8k` -> `~4.4k` (⬇️ `-35%`)

## Details
###  API requests
Thousands of needless API requests are made during tests
1. `TestCleanup` makes `POST` calls to `/maintenance` after every entity delete in order to purge soft-deleted data regardless whether the entity has relationships with soft-deleted data

✅ Changes
- remove from per entity delete loop
- Only make those delete calls for entities that have soft-deletable data
- call diff `POST` `/maintenance` `1,542` -> `245`

2. A map used for tracking which entities were created was not being cleaned up correctly thereby causing more delete retries

✅ Changes
Remove entries from map correctly
- eliminates delete retry mechanism (retry if map not empty)

### ID Generator
Calls were being made to the server to get system IDs (UIDs) to use within test payloads

✅ Change
Generate simple `UID` locally, matching server expectation
- call diff `GET` `/system/id` `303` -> `0`

### Existing Tests
2 existing tests were making lots of repeated calls during each test setup -  creating 1 entity at a time in a loop, repeated per test
- `UserPaginationTest`
- `MetadataPaginationTest`

✅ Changes
1. `UserPaginationTest`-  one time `beforeAll` setup used by all 3 `GET` tests
    - call diff `POST` `300` -> `3`
2. `MetadataPaginationTest` -  one time `beforeAll` setup used by all 2 `GET` tests
    - call diff `POST` `200` -> `2`

🤖 AI assisted