### PR TITLE
fix: Correctly populate Program attributes into rule-engine context [DHIS2-21785](2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -449,7 +449,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
 
     if (trackedEntity != null) {
       List<String> payloadAttributeValuesIds =
-          payloadAttributeValues.stream().map(av -> av.getAttribute().getUid()).toList();
+          attributeValues.stream().map(av -> av.getAttribute().getUid()).toList();
 
       attributeValues.addAll(
           trackedEntity.getTrackedEntityAttributeValues().stream()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -58,7 +58,10 @@ import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -85,6 +88,8 @@ class ProgramRuleAssignActionTest extends TrackerTest {
   @Autowired private ProgramRuleVariableService programRuleVariableService;
 
   @Autowired private SystemSettingManager systemSettingManager;
+
+  @Autowired private TrackedEntityAttributeValueService attributeValueService;
 
   private Program program;
 
@@ -143,6 +148,34 @@ class ProgramRuleAssignActionTest extends TrackerTest {
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
 
     assertHasOnlyWarnings(importReport, E1310);
+  }
+
+  @Test
+  void shouldImportWhenAttributeUsedToCalculateAssignedValueIsUpdatedInEnrollment()
+      throws IOException {
+    TrackedEntity trackedEntity = manager.get(TrackedEntity.class, "IOR1AXXl24H");
+    TrackedEntityAttribute attribute2 = manager.get(TrackedEntityAttribute.class, "fRGt4l6yIRb");
+    attributeValueService.addTrackedEntityAttributeValue(
+        new TrackedEntityAttributeValue(attribute1, trackedEntity, "Tom"));
+    attributeValueService.addTrackedEntityAttributeValue(
+        new TrackedEntityAttributeValue(attribute2, trackedEntity, "Tom"));
+    assignProgramRule();
+    dbmsManager.clearSession();
+
+    TrackerImportParams params = new TrackerImportParams();
+    params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
+    TrackerObjects trackerObjects =
+        fromJson("tracker/programrule/te_enrollment_update_attribute_different_value.json");
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyWarnings(importReport, E1310);
+    List<String> attributeValues =
+        manager.get(TrackedEntity.class, "IOR1AXXl24H").getTrackedEntityAttributeValues().stream()
+            .filter(av -> av.getAttribute().getUid().equals("dIVt4l5vIOa"))
+            .map(TrackedEntityAttributeValue::getValue)
+            .toList();
+    assertContainsOnly(List.of("John"), attributeValues);
   }
 
   @ParameterizedTest

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/te_enrollment_update_attribute_different_value.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/te_enrollment_update_attribute_different_value.json
@@ -1,0 +1,97 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE_AND_UPDATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [
+        {
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "dIVt4l5vIOa"
+          },
+          "storedBy": "admin",
+          "value": "John"
+        },
+        {
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "fRGt4l6yIRb"
+          },
+          "storedBy": "admin",
+          "value": "John"
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  Fixes [DHIS2-21785]: on 2.41, updating a tracked entity attribute that a program rule uses to calculate another attribute (ASSIGN action) fails with `E1309 — The provided value must be empty or match the calculated value` when the attributes are sent in the **enrollment** section of the payload (the standard location for program attributes, used by the Capture app and Android). The rule engine was evaluating the rule against the stale server-side value instead of the payload value, so the recalculated result never matched. Master and 2.42+ are not affected — the same logic was fixed there incidentally by the rule-engine model refactor (DHIS2-18093).

  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  - `tracker/imports/programrule/DefaultProgramRuleService.java`: when merging payload and saved attribute values for rule-engine evaluation, saved DB values are now filtered against attributes present in **either** payload section (enrollment + trackedEntity) instead of the trackedEntity section only. Previously, a program attribute sent in the enrollment section ended up duplicated in the rule-engine input (payload value + stale DB value); since the rule engine resolves duplicates last-wins (`RuleVariableValueMapBuilder` uses Kotlin `associateBy`), the stale DB value won and any rule variable reading that attribute evaluated against outdated data. This affected not just ASSIGN validation but any rule condition/expression referencing an attribute updated via the enrollment section.           

[DHIS2-21785]: https://dhis2.atlassian.net/browse/DHIS2-21785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ