### PR TITLE
fix: add handleCategoryOptionGroupSetDimensions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
@@ -37,6 +37,9 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionGroup;
+import org.hisp.dhis.category.CategoryOptionGroupSet;
+import org.hisp.dhis.category.CategoryOptionGroupSetDimension;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
@@ -86,6 +89,7 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
     handleAnalyticalLegendSet(schema, analyticalObject, bundle);
     handleRelativePeriods(schema, analyticalObject);
     handleOrgUnitGroupSetDimensions(entityManager, schema, analyticalObject, bundle);
+    handleCategoryOptionGroupSetDimensions(entityManager, schema, analyticalObject, bundle);
   }
 
   /**
@@ -205,6 +209,86 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
           organisationUnitGroupSetDimension, bundle.getPreheat(), bundle.getPreheatIdentifier());
 
       entityManager.persist(organisationUnitGroupSetDimension);
+    }
+  }
+
+  /**
+   * This method implements required custom handling for {@link CategoryOptionGroupSetDimension}s.
+   * Without it, when importing, these objects throw TransientObjectException because the dimension
+   * ({@link CategoryOptionGroupSet}) and its items ({@link CategoryOptionGroup}) are cascade
+   * persisted from the analytical object while still referencing transient, deserialized instances.
+   *
+   * <p>This mirrors {@link #handleOrgUnitGroupSetDimensions}: for both the dimension and each item,
+   * use the instance from the bundle preheat if available, otherwise fall back to the persisted
+   * instance (adding it to the preheat for {@code connectReferences}).
+   *
+   * @param entityManager entityManager to save object
+   * @param schema schema to check object property
+   * @param analyticalObject object that needs custom handling
+   * @param bundle bundle with preheat objects
+   */
+  private void handleCategoryOptionGroupSetDimensions(
+      EntityManager entityManager,
+      Schema schema,
+      BaseAnalyticalObject analyticalObject,
+      ObjectBundle bundle) {
+    if (!schema.hasPersistedProperty("categoryOptionGroupSetDimensions")) return;
+
+    for (CategoryOptionGroupSetDimension categoryOptionGroupSetDimension :
+        analyticalObject.getCategoryOptionGroupSetDimensions()) {
+
+      // handle dimension
+      CategoryOptionGroupSet catOptionGroupSetBundle =
+          bundle
+              .getPreheat()
+              .get(bundle.getPreheatIdentifier(), categoryOptionGroupSetDimension.getDimension());
+
+      // use from bundle if available
+      if (catOptionGroupSetBundle != null) {
+        categoryOptionGroupSetDimension.setDimension(catOptionGroupSetBundle);
+      } else {
+        // use from persisted if available
+        CategoryOptionGroupSet catOptionGroupSetPersisted =
+            objectManager.get(
+                CategoryOptionGroupSet.class,
+                categoryOptionGroupSetDimension.getDimension().getUid());
+
+        if (catOptionGroupSetPersisted != null) {
+          categoryOptionGroupSetDimension.setDimension(catOptionGroupSetPersisted);
+
+          bundle
+              .getPreheat()
+              .put(bundle.getPreheatIdentifier(), categoryOptionGroupSetDimension.getDimension());
+        }
+      }
+
+      // handle items
+      List<CategoryOptionGroup> categoryOptionGroups =
+          new ArrayList<>(categoryOptionGroupSetDimension.getItems());
+      categoryOptionGroupSetDimension.getItems().clear();
+
+      categoryOptionGroups.forEach(
+          cog -> {
+            // use from bundle if available
+            CategoryOptionGroup catOptionGroupBundle =
+                bundle.getPreheat().get(bundle.getPreheatIdentifier(), cog);
+            if (catOptionGroupBundle != null) {
+              categoryOptionGroupSetDimension.getItems().add(catOptionGroupBundle);
+            } else {
+              // use from persisted if available
+              CategoryOptionGroup catOptionGroupPersisted =
+                  objectManager.get(CategoryOptionGroup.class, cog.getUid());
+              if (catOptionGroupPersisted != null) {
+                categoryOptionGroupSetDimension.getItems().add(catOptionGroupPersisted);
+                bundle.getPreheat().put(bundle.getPreheatIdentifier(), catOptionGroupPersisted);
+              }
+            }
+          });
+
+      preheatService.connectReferences(
+          categoryOptionGroupSetDimension, bundle.getPreheat(), bundle.getPreheatIdentifier());
+
+      entityManager.persist(categoryOptionGroupSetDimension);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultAnalyticalObjectImportHandler.java
@@ -218,10 +218,6 @@ public class DefaultAnalyticalObjectImportHandler implements AnalyticalObjectImp
    * ({@link CategoryOptionGroupSet}) and its items ({@link CategoryOptionGroup}) are cascade
    * persisted from the analytical object while still referencing transient, deserialized instances.
    *
-   * <p>This mirrors {@link #handleOrgUnitGroupSetDimensions}: for both the dimension and each item,
-   * use the instance from the bundle preheat if available, otherwise fall back to the persisted
-   * instance (adding it to the preheat for {@code connectReferences}).
-   *
    * @param entityManager entityManager to save object
    * @param schema schema to check object property
    * @param analyticalObject object that needs custom handling

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -820,6 +820,50 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
   }
 
   @Test
+  @DisplayName(
+      "Importing Map with MapView with CategoryOptionGroupSetDimensions in same import succeeds")
+  void importingMapWithMapViewAndCategoryOptionGroupSetDimensionsPayloadTest() {
+    // When importing a Map with MapView that references CategoryOptionGroupSet data in the same
+    // import (as produced by a metadata dependency export)
+    JsonImportSummary report =
+        POST(
+                "/metadata",
+                Path.of("metadata/metadata_map_mapview_with_cat_option_group_set_dimension.json"))
+            .content()
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    // Then the import is successful and the CategoryOptionGroupSetDimension is present when
+    // retrieved
+    assertEquals("OK", report.getStatus());
+
+    JsonMixed content = GET("/maps/C7x2WOLhCA8").content(HttpStatus.OK);
+
+    assertEquals(
+        "C5jldMd8OHv",
+        content
+            .getArray("mapViews")
+            .getObject(0)
+            .getArray("categoryOptionGroupSetDimensions")
+            .getObject(0)
+            .getObject("categoryOptionGroupSet")
+            .getString("id")
+            .string());
+
+    assertEquals(
+        "CYxK4wmcPqA",
+        content
+            .getArray("mapViews")
+            .getObject(0)
+            .getArray("categoryOptionGroupSetDimensions")
+            .getObject(0)
+            .getArray("categoryOptionGroups")
+            .getObject(0)
+            .getString("id")
+            .string());
+  }
+
+  @Test
   @DisplayName("Partial import (update) with expected CategoryOptionCombos should succeed")
   void partialImportExpectedCocsTest() {
     // Given category metadata exists

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/metadata_map_mapview_with_cat_option_group_set_dimension.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/metadata_map_mapview_with_cat_option_group_set_dimension.json
@@ -1,0 +1,55 @@
+{
+  "maps": [
+    {
+      "name": "Donor thematic map",
+      "mapViews": [
+        {
+          "name": "DANIDA funded",
+          "categoryOptionGroupSetDimensions": [
+            {
+              "categoryOptionGroupSet": {
+                "id": "C5jldMd8OHv"
+              },
+              "categoryOptionGroups": [
+                {
+                  "id": "CYxK4wmcPqA"
+                }
+              ]
+            }
+          ],
+          "layer": "thematic",
+          "id": "CAy9rtc7qV4"
+        }
+      ],
+      "id": "C7x2WOLhCA8"
+    }
+  ],
+  "categoryOptionGroups": [
+    {
+      "name": "DANIDA",
+      "id": "CYxK4wmcPqA",
+      "shortName": "DANIDA",
+      "dataDimensionType": "DISAGGREGATION",
+      "groupSets": [
+        {
+          "id": "C5jldMd8OHv"
+        }
+      ]
+    }
+  ],
+  "categoryOptionGroupSets": [
+    {
+      "name": "Donor",
+      "id": "C5jldMd8OHv",
+      "shortName": "Donor",
+      "description": "Donor",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": true,
+      "categoryOptionGroups": [
+        {
+          "id": "CYxK4wmcPqA"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-21212

### Summary
- Importing `Map` which contains `CategoryOptionGroupSetDimension` failed with error 
```
 ERROR 2026-07-14T02:26:22,140 Process failed: org.hibernate.TransientPropertyValueException: object references an unsaved transient instance - save the transient instance    
  before flushing : org.hisp.dhis.category.CategoryOptionGroupSetDimension.dimension -> org.hisp.dhis.category.CategoryOptionGroupSet (DefaultNotifier [pool-5-thread-1])       
 ERROR 2026-07-14T02:26:22,141 [METADATA_IMPORT fpHKrWbkqrF] Process failed after 1m15.627s: org.hibernate.TransientPropertyValueException: object references an unsaved     
  transient instance - save the transient instance before flushing : org.hisp.dhis.category.CategoryOptionGroupSetDimension.dimension ->                                        
  org.hisp.dhis.category.CategoryOptionGroupSet (RecordingJobProgress [pool-6-thread-7]) UID:fpHKrWbkqrF                                
```

### Fix
- In `DefaultAnalyticalObjectImportHandler` we have a special handling method `handleOrgUnitGroupSetDimensions` but no method for handling `CategoryOptionGroupSetDimension`.
- Adding similar handling method help solve the issue.

### Test
- Added test to verify