### PR TITLE
fix: Pass valid date for setting value during CDSR sync [DHIS2-21781]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
@@ -102,16 +102,14 @@ public class CompleteDataSetRegistrationSynchronization
             this::createContext);
 
     if (context.getObjectsToSynchronize() == 0) {
-      settingsService.put(
-          "keyLastCompleteDataSetRegistrationSyncSuccess", context.getStartTime().toString());
+      settingsService.put("keyLastCompleteDataSetRegistrationSyncSuccess", context.getStartTime());
       String msg = "Skipping completeness synchronization, no new or updated data";
       progress.completedProcess(msg);
       return SynchronizationResult.success(msg);
     }
 
     if (runSync(context, progress)) {
-      settingsService.put(
-          "keyLastCompleteDataSetRegistrationSyncSuccess", context.getStartTime().toString());
+      settingsService.put("keyLastCompleteDataSetRegistrationSyncSuccess", context.getStartTime());
       String msg = "Complete data set registration synchronization is done.";
       progress.completedProcess(msg);
       return SynchronizationResult.success(msg);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronizationTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronizationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.sync;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
+import org.hisp.dhis.dxf2.dataset.CompleteDataSetRegistrationExchangeService;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.setting.Settings;
+import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Tests {@link CompleteDataSetRegistrationSynchronization}.
+ *
+ * <p>Regression test for {@code BadRequestException: Not a valid value for setting
+ * keyLastCompleteDataSetRegistrationSyncSuccess} thrown during sync process. The value handed to
+ * {@link SystemSettingsService#put} must be a persistable setting value, i.e. round-trip through
+ * {@link Settings#valueOf} into a value the settings validation accepts.
+ */
+@ExtendWith(MockitoExtension.class)
+class CompleteDataSetRegistrationSynchronizationTest {
+
+  private static final String SYNC_SUCCESS_KEY = "keyLastCompleteDataSetRegistrationSyncSuccess";
+
+  @Mock private SystemSettingsService settingsService;
+  @Mock private RestTemplate restTemplate;
+  @Mock private CompleteDataSetRegistrationService completeDataSetRegistrationService;
+
+  @Mock
+  private CompleteDataSetRegistrationExchangeService completeDataSetRegistrationExchangeService;
+
+  @Captor private ArgumentCaptor<Serializable> settingValueCaptor;
+
+  @Test
+  void storesAPersistableTimestampWhenNothingToSynchronize() {
+    // remote server configured and available, and no complete data sets to synchronize
+    SystemSettings settings =
+        SystemSettings.of(
+            Map.of(
+                "keyRemoteInstanceUrl", "http://remote.example.org",
+                "keyRemoteInstanceUsername", "admin",
+                "keyRemoteInstancePassword", "district"));
+    when(settingsService.getCurrentSettings()).thenReturn(settings);
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(String.class)))
+        .thenReturn(new ResponseEntity<>("pong", HttpStatus.OK));
+    when(completeDataSetRegistrationService.getCompleteDataSetCountLastUpdatedAfter(any()))
+        .thenReturn(0);
+
+    CompleteDataSetRegistrationSynchronization sync =
+        new CompleteDataSetRegistrationSynchronization(
+            settingsService,
+            restTemplate,
+            completeDataSetRegistrationService,
+            completeDataSetRegistrationExchangeService);
+
+    JobProgress progress = JobProgress.noop();
+    sync.synchronizeData(progress);
+
+    // the "last success" timestamp must be recorded ...
+    verify(settingsService).put(eq(SYNC_SUCCESS_KEY), settingValueCaptor.capture());
+    // ... as a value the settings layer can actually persist (this is what put() does internally).
+    // Passing Date.toString() produces an unparseable value and would fail validation here.
+    Serializable stored = settingValueCaptor.getValue();
+    assertTrue(
+        SystemSettings.of(Map.of()).isValid(SYNC_SUCCESS_KEY, Settings.valueOf(stored)),
+        "value handed to the settings service must be a persistable setting value, but was: "
+            + stored);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -256,6 +256,11 @@ class SystemSettingsTest {
     assertTrue(settings.isValid("keyLastMonitoringRun", date));
     assertFalse(settings.isValid("keyLastMonitoringRun", "hello"));
     assertFalse(settings.isValid("keyLastMonitoringRun", "true"));
+    // the correctly serialized form of a Date is accepted ...
+    assertTrue(settings.isValid("keyLastMonitoringRun", Settings.valueOf(new Date())));
+    // ... but Date.toString() output is NOT
+    assertFalse(settings.isValid("keyLastMonitoringRun", new Date().toString()));
+    assertFalse(settings.isValid("keyLastMonitoringRun", "Mon Jun 08 07:50:29 IST 2026"));
   }
 
   @Test


### PR DESCRIPTION
## Issue
CompleteDataSetRegistrationSync date settings throws exception when passing date string

## Cause
`.toString()` was added on the date values when passing them as a system setting in #18649 (other sync settings were left without `.toString()`)

## Fix 
Remove`.toString()` - system setting accepts the date object as a valid value

## Testing
Test added to catch invalid dates as sync setting values