### PR TITLE
fix: scope batch-size to cut /dataEntry/metadata N+1 [DHIS2-21757] (42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryCombo.hbm.xml
@@ -6,7 +6,11 @@
   >
 
 <hibernate-mapping>
-  <class name="org.hisp.dhis.category.CategoryCombo" table="categorycombo">
+  <!-- batch-size: coalesce one-at-a-time lazy proxy inits into IN(...) batches. Targets the
+       CategoryCombo proxy N+1 on GET /api/dataEntry/metadata (DHIS2-21757), reached via
+       DataSetElement.categoryCombo and DataElement.categoryCombo. Scoped to this entity
+       (not global, cf. closed PR #24380); does not touch CategoryOption(Combo) collections. -->
+  <class name="org.hisp.dhis.category.CategoryCombo" table="categorycombo" batch-size="100">
 
     <cache usage="read-write" />
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
@@ -5,7 +5,10 @@
   [<!ENTITY identifiableProperties SYSTEM "classpath://org/hisp/dhis/common/identifiableProperties.hbm">]
   >
 <hibernate-mapping>
-  <class name="org.hisp.dhis.dataelement.DataElement" table="dataelement">
+  <!-- batch-size: coalesce one-at-a-time lazy proxy inits into IN(...) batches. Targets the
+       DataElement proxy N+1 on GET /api/dataEntry/metadata (DHIS2-21757). Scoped to this entity
+       (not global, cf. closed PR #24380); does not touch CategoryOption(Combo) collections. -->
+  <class name="org.hisp.dhis.dataelement.DataElement" table="dataelement" batch-size="100">
 
     <cache usage="read-write" />
 


### PR DESCRIPTION
GET /api/42/dataEntry/metadata suffers a Hibernate N+1 explosion: on the Uganda instance one call fired ~10,202 single-row lazy loads, ran ~245s and returned HTTP 500. ~30% of those queries are DataElement proxies loaded one primary key at a time (DataSetElement.dataElement), plus the CategoryCombo proxies reached via DataSetElement.categoryCombo and DataElement.categoryCombo.

Add batch-size="100" to the DataElement and CategoryCombo class mappings so Hibernate coalesces sibling proxy initialisations into IN(...) batches. This is deliberately scoped to these two entity classes rather than the global default_batch_fetch_size that PR #24380 set (closed unmerged after it exposed a silent CategoryOption-merge corruption). The corruption class requires an entity whose equals/hashCode is content-based over a mutable collection mutated in place during merge (CategoryOptionCombo.categoryOptions); DataElement and CategoryCombo key equals/hashCode on uid+code+name (stable identity), and no merge handler mutates those fields while the entity is a managed Set member, so the batched entities are outside that hazard. The CategoryOption/CategoryOptionCombo collections are intentionally untouched.

Short-term mitigation only: it batches the to-one proxy N+1 but not the collection loads (DataElement.dataSetElements, COC option links), so query count is reduced, not made size-independent. 

Response body is unchanged (byte-identical); no API change.