### PR TITLE
fix: Send single event notifications for ORGANISATION_UNIT_CONTACT recipient [DHIS2-21800]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
@@ -689,6 +689,9 @@ public class DefaultProgramNotificationService extends HibernateGenericStore<Tra
       } else if (template.getDeliveryChannels().contains(DeliveryChannel.EMAIL)) {
         recipients.getEmailAddresses().addAll(recipientList);
       }
+    } else if (template.getNotificationRecipient()
+        == ProgramNotificationRecipient.ORGANISATION_UNIT_CONTACT) {
+      recipients.setOrganisationUnit(event.getOrganisationUnit());
     }
     return recipients;
   }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
@@ -432,6 +432,29 @@ class ProgramNotificationServiceTest extends TrackerTestBase {
   }
 
   @Test
+  void shouldSendMessageToEventOrgUnitWhenSingleEventRecipientIsOrgUnitContact() {
+    when(programMessageService.sendMessages(anyList()))
+        .thenAnswer(
+            invocation -> {
+              sentProgramMessages.addAll((List<ProgramMessage>) invocation.getArguments()[0]);
+              return new BatchResponseStatus(Collections.emptyList());
+            });
+
+    when(singleEventNotificationRenderer.render(
+            any(SingleEvent.class), any(NotificationTemplate.class)))
+        .thenReturn(notificationMessage);
+
+    programNotificationTemplate.setNotificationRecipient(
+        ProgramNotificationRecipient.ORGANISATION_UNIT_CONTACT);
+
+    programNotificationService.sendNotification(programNotificationTemplate, singleEvent, Map.of());
+
+    assertEquals(1, sentProgramMessages.size());
+    ProgramMessage programMessage = sentProgramMessages.iterator().next();
+    assertEquals(lvlTwoLeftLeft, programMessage.getRecipients().getOrganisationUnit());
+  }
+
+  @Test
   void testUserGroupRecipientForTrackerEvent() {
     when(messageService.sendMessage(any()))
         .thenAnswer(

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
@@ -171,7 +171,7 @@ class ProgramNotificationServiceTest extends TrackerTestBase {
   private ProgramNotificationInstance programNotificationInstaceForToday;
 
   @BeforeEach
-  public void initTest() {
+  void initTest() {
     programNotificationService =
         new DefaultProgramNotificationService(
             this.programMessageService,


### PR DESCRIPTION
## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  Fixes [DHIS2-21800]: program notifications for single (event-program) events configured with the `ORGANISATION_UNIT_CONTACT` recipient were never delivered. Since the tracker/single-event split ([DHIS2-19888], first released in 2.43.0), `resolveSingleEventNotificationRecipients` only handled the `DATA_ELEMENT` recipient type and returned empty recipients for every other type, so the delivery-channel strategy threw `IllegalQueryException("No destination found")` inside the async `NotificationTask` — the error only surfaced in the server log, and no message was sent or persisted. In 2.42 and earlier this recipient type worked, as event-program events were resolved through `resolveRecipients(...)`.                                                                                                                                        
                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  - `DefaultProgramNotificationService.resolveSingleEventNotificationRecipients`: sets the event's organisation unit as the message recipient when the template's recipient type is `ORGANISATION_UNIT_CONTACT`, mirroring what `resolveRecipients(...)` does for enrollments and tracker events. The other recipient types handled there (`TRACKED_ENTITY_INSTANCE`, `PROGRAM_ATTRIBUTE`) are not applicable to single events, which have no tracked entity or enrollment.                                                                                                                                                                                 
  - `ProgramNotificationServiceTest`: adds `shouldSendMessageToEventOrgUnitWhenSingleEventRecipientIsOrgUnitContact`, covering the previously untested single-event + `ORGANISATION_UNIT_CONTACT` path — existing coverage for this recipient type only exercised enrollments. 

[DHIS2-21800]: https://dhis2.atlassian.net/browse/DHIS2-21800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-19888]: https://dhis2.atlassian.net/browse/DHIS2-19888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ