### PR TITLE
refactor: use PropertPath for Metadata API field filtering

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -184,6 +184,10 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     return segment.length() == 11 && CodeGenerator.isValidUid(segment);
   }
 
+  public boolean isExcluded(CharSequence path) {
+    return isExcluded(PropertyPath.of(path));
+  }
+
   /**
    * @param other the path to test for exclusion by this path
    * @return when this path {@link #isExclude()} and the given path is referring to the same
@@ -191,27 +195,35 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
    */
   public boolean isExcluded(PropertyPath other) {
     if (!isExclude()) return false;
-    // if the exclude targets something more nested it cannot apply to the given path
-    int lenExclude = length();
-    int lenOther = other.length();
-    if (lenExclude > lenOther) return false;
+    return other.isParent(this);
+  }
+
+  public boolean isParent(PropertyPath other) {
+    int len = length();
+    int len2 = other.length();
+    if (len2 > len) return false; // cannot be a parent
     // drop parents until equal length
-    PropertyPath test = other;
-    int drop = lenOther - lenExclude;
-    while (test != null && drop > 0) {
-      test = test.parent;
+    PropertyPath a = this;
+    int drop = len - len2;
+    while (a != null && drop > 0) {
+      a = a.parent;
       drop--;
     }
     // the properties of exclude and test now must be the same for a match
-    PropertyPath exclude = this;
-    while (test != null && exclude != null) {
-      if (!test.property().equals(exclude.property())) return false;
-      test = test.parent;
-      exclude = exclude.parent;
+    PropertyPath b = other;
+    while (a != null && b != null) {
+      if (!a.property().equals(b.property())) return false;
+      a = a.parent;
+      b = b.parent;
     }
     return true;
   }
 
+  /**
+   * @param segment a segment to look for
+   * @return true, if one {@link #segment} in this path matches the given segment exactly (markers
+   *     included)
+   */
   public boolean contains(CharSequence segment) {
     return this.segment.contentEquals(segment) || parent != null && parent.contains(segment);
   }
@@ -285,15 +297,18 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   /**
-   * Drops parents up and including the given parent segment.
+   * Drops parents from start up to and including the given parent segment. If this path does not
+   * have the given parent the result is equal to this path. If the given parent path matches the
+   * tail null is returned
    *
-   * @param segment a segment found at some level of parent for this path
+   * @param parent a segment found at some level of parent for this path
    * @return
    */
-  @Nonnull
-  public PropertyPath relativeTo(@Nonnull Text segment) {
-    // TODO
-    return this;
+  @CheckForNull
+  public PropertyPath relativeTo(@Nonnull CharSequence parent) {
+    if (segment.contentEquals(parent)) return null;
+    if (this.parent == null) return this;
+    return new PropertyPath(this.parent.relativeTo(parent), segment);
   }
 
   private static void requireNonEmpty(Text segment) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PropertyPath.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -97,12 +98,13 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   public static PropertyPath of(CharSequence... segments) {
     if (segments == null || segments.length == 0) throw illegalEmpty();
     PropertyPath res = PropertyPath.of(segments[0]);
-    for (int i = 1; i < segments.length; i++) res = res.concat(Text.of(segments[i]));
+    for (int i = 1; i < segments.length; i++) res = res.concat(segments[i]);
     return res;
   }
 
   @Nonnull
-  public static PropertyPath concat(@CheckForNull PropertyPath parent, @Nonnull Text property) {
+  public static PropertyPath concat(
+      @CheckForNull PropertyPath parent, @Nonnull CharSequence property) {
     return parent == null ? of(property) : parent.concat(property);
   }
 
@@ -183,43 +185,84 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
   }
 
   /**
+   * @param other the path to test for exclusion by this path
+   * @return when this path {@link #isExclude()} and the given path is referring to the same
+   *     property or a property nested within the excluded property
+   */
+  public boolean isExcluded(PropertyPath other) {
+    if (!isExclude()) return false;
+    // if the exclude targets something more nested it cannot apply to the given path
+    int lenExclude = length();
+    int lenOther = other.length();
+    if (lenExclude > lenOther) return false;
+    // drop parents until equal length
+    PropertyPath test = other;
+    int drop = lenOther - lenExclude;
+    while (test != null && drop > 0) {
+      test = test.parent;
+      drop--;
+    }
+    // the properties of exclude and test now must be the same for a match
+    PropertyPath exclude = this;
+    while (test != null && exclude != null) {
+      if (!test.property().equals(exclude.property())) return false;
+      test = test.parent;
+      exclude = exclude.parent;
+    }
+    return true;
+  }
+
+  public boolean contains(CharSequence segment) {
+    return this.segment.contentEquals(segment) || parent != null && parent.contains(segment);
+  }
+
+  /**
    * @return the number of segments in this path, zero for the root (self)
    */
   public int length() {
     return parent == null ? 1 : parent.length() + 1;
   }
 
-  /**
-   * @return the property name the path ends with
-   */
-  public String property() {
-    return isExcludeModifier(segment.charAt(0))
-        ? segment.subSequence(1, segment.length()).toString()
-        : segment.toString();
-  }
-
   public Text head() {
     return parent == null ? segment : parent.head();
   }
 
+  /**
+   * @return the property name the path ends with
+   */
+  public Text property() {
+    return isExcludeModifier(segment.charAt(0))
+        ? segment.subSequence(1, segment.length())
+        : segment;
+  }
+
+  public Stream<Text> properties() {
+    return segments(PropertyPath::property);
+  }
+
   @Nonnull
   public Stream<Text> segments() {
-    if (parent == null) return Stream.of(segment);
+    return segments(PropertyPath::segment);
+  }
+
+  private Stream<Text> segments(Function<PropertyPath, Text> f) {
+    if (parent == null) return Stream.of(f.apply(this));
     int n = length();
     PropertyPath path = this;
     Text[] res = new Text[n];
     int i = n - 1;
     while (path != null) {
-      res[i--] = path.segment;
+      res[i--] = f.apply(path);
       path = path.parent;
     }
     return Stream.of(res);
   }
 
   @Nonnull
-  public PropertyPath concat(@Nonnull Text segment) {
-    if (segment.contentEquals("*")) return concat(Text.of(":all"));
-    return new PropertyPath(this, segment);
+  public PropertyPath concat(@Nonnull CharSequence segment) {
+    Text s = Text.of(segment);
+    if (s.contentEquals("*")) return concat(":all");
+    return new PropertyPath(this, s);
   }
 
   @Nonnull
@@ -231,12 +274,26 @@ public record PropertyPath(@CheckForNull PropertyPath parent, @Nonnull Text segm
     return res;
   }
 
-  public PropertyPath withTail(@Nonnull String segment) {
+  public PropertyPath withTail(@Nonnull CharSequence segment) {
     return new PropertyPath(parent, Text.of(segment));
   }
 
-  public PropertyPath withTail(@Nonnull Text segment) {
-    return new PropertyPath(parent, segment);
+  @CheckForNull
+  public PropertyPath dropHead() {
+    if (parent == null) return null;
+    return new PropertyPath(parent.dropHead(), segment);
+  }
+
+  /**
+   * Drops parents up and including the given parent segment.
+   *
+   * @param segment a segment found at some level of parent for this path
+   * @return
+   */
+  @Nonnull
+  public PropertyPath relativeTo(@Nonnull Text segment) {
+    // TODO
+    return this;
   }
 
   private static void requireNonEmpty(Text segment) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/input/Fields.java
@@ -81,7 +81,7 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
     if (fields == null || fields.isEmpty()) return List.of();
     List<FieldExp> res = new ArrayList<>();
     parseFields(Text.of(fields), 0, res);
-    return res.stream().flatMap(e -> e.toFieldPaths(List.of())).distinct().toList();
+    return res.stream().flatMap(e -> e.toFieldPaths(null)).distinct().toList();
   }
 
   public List<String> names() {
@@ -242,15 +242,8 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
    */
   private record FieldExp(Text name, List<TransformExp> transforms, List<FieldExp> children) {
 
-    Stream<FieldPath> toFieldPaths(List<String> parentPath) {
-      String name = this.name.toString();
-      boolean exclude = isExcludeMarker(name.charAt(0));
-      if (exclude) name = name.substring(1);
-      if (name.isEmpty()) return Stream.empty(); // ignore empty name or bare exclude
-      if ("*".equals(name)) name = ":all";
-      boolean preset = isPresetMarker(name.charAt(0));
-      if (preset) name = name.substring(1);
-      if (preset && exclude) exclude = false;
+    Stream<FieldPath> toFieldPaths(@CheckForNull PropertyPath parentPath) {
+      Text name = unifiedName();
       List<FieldPathTransformer> transformers =
           this.transforms.stream()
               .map(
@@ -258,16 +251,15 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
                       new FieldPathTransformer(
                           t.type.toString(), t.args.stream().map(Text::toString).toList()))
               .toList();
-      FieldPath f = new FieldPath(name, parentPath, exclude, preset, transformers);
+      PropertyPath path = PropertyPath.concat(parentPath, name);
+      FieldPath f = FieldPath.of(path).withTransformers(transformers);
       if (children.isEmpty()) return Stream.of(f);
-      List<String> path = Stream.concat(parentPath.stream(), Stream.of(name)).toList();
       return Stream.concat(Stream.of(f), children.stream().flatMap(c -> c.toFieldPaths(path)));
     }
 
-    Stream<Field> toFields(PropertyPath parentPath, PropertyPath parentRenamedPath) {
-      Text name = this.name;
-      if (name.length() >= 2 && isExcludeMarker(name.charAt(0)) && isPresetMarker(name.charAt(1)))
-        name = name.subSequence(1, name.length()); // drop negation of preset
+    Stream<Field> toFields(
+        @CheckForNull PropertyPath parentPath, @CheckForNull PropertyPath parentRenamedPath) {
+      Text name = unifiedName();
       Field f = new Field(PropertyPath.concat(parentPath, name));
       Text renamedName = null;
       for (TransformExp t : transforms)
@@ -294,6 +286,14 @@ public record Fields(List<Field> fields) implements Iterable<Fields.Field> {
       Stream<Field> childrenRes =
           children.stream().flatMap(e -> e.toFields(parent.propertyPath(), parent.renamedPath()));
       return noTransform ? childrenRes : Stream.concat(transformRes, childrenRes);
+    }
+
+    @Nonnull
+    private Text unifiedName() {
+      Text name = this.name;
+      if (name.length() >= 2 && isExcludeMarker(name.charAt(0)) && isPresetMarker(name.charAt(1)))
+        name = name.subSequence(1, name.length()); // drop negation of preset
+      return name;
     }
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
@@ -30,13 +30,13 @@
 package org.hisp.dhis.fieldfiltering;
 
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.hisp.dhis.common.PropertyPath;
-import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.schema.Property;
 
 /**
@@ -56,13 +56,13 @@ public final class FieldPath {
 
   public static final String FIELD_PATH_SEPARATOR = ".";
 
-  private final PropertyPath path;
+  @Nonnull private final PropertyPath path;
 
   /** Transformers to apply to field, can be empty. */
-  private final List<FieldPathTransformer> transformers;
+  @Nonnull private final List<FieldPathTransformer> transformers;
 
   /** Schema Property if present (added by {@link FieldPathHelper}). */
-  @Setter private Property property;
+  @CheckForNull @Setter private Property property;
 
   public FieldPath withTransformers(FieldPathTransformer... transformers) {
     return withTransformers(List.of(transformers));
@@ -73,15 +73,17 @@ public final class FieldPath {
   }
 
   public FieldPath relativeTo(@Nonnull CharSequence parentSegment) {
-    return new FieldPath(path.relativeTo(Text.of(parentSegment)), transformers, property);
+    PropertyPath relativePath = path.relativeTo(parentSegment);
+    if (relativePath == null)
+      throw new IllegalArgumentException("Relative path leads to empty path");
+    return new FieldPath(relativePath, transformers, property);
   }
 
-  public String getName() {
+  /**
+   * @return the name of the property the path points to (tail or leaf of the path)
+   */
+  public String getPropertyName() {
     return path.property().toString();
-  }
-
-  public List<String> properties() {
-    return path.properties().map(Text::toString).toList();
   }
 
   public boolean isPreset() {
@@ -96,7 +98,7 @@ public final class FieldPath {
    * @return true if we have at least one field path transformer
    */
   public boolean isTransformer() {
-    return transformers != null && !transformers.isEmpty();
+    return !transformers.isEmpty();
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
@@ -80,11 +80,6 @@ public final class FieldPath {
     return path.property().toString();
   }
 
-  public String getFullPath() {
-    // FIXME this would include markers but the caller might expect a clean property name path
-    return toString();
-  }
-
   public List<String> properties() {
     return path.properties().map(Text::toString).toList();
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fieldfiltering/FieldPath.java
@@ -29,100 +29,72 @@
  */
 package org.hisp.dhis.fieldfiltering;
 
-import java.util.ArrayList;
 import java.util.List;
-import lombok.EqualsAndHashCode;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
+import org.hisp.dhis.common.PropertyPath;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.schema.Property;
 
 /**
  * @author Morten Olav Hansen
  */
-@ToString
-@EqualsAndHashCode
 @Getter
-public class FieldPath {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FieldPath {
 
-  public static FieldPath ofPath(String path) {
-    int lastDot = path.lastIndexOf('.');
-    if (lastDot < 0) return new FieldPath(path);
-    String name = path.substring(lastDot + 1);
-    return new FieldPath(name, List.of(path.substring(0, lastDot).split("\\.")));
+  public static FieldPath of(CharSequence path) {
+    return of(PropertyPath.of(path));
+  }
+
+  public static FieldPath of(PropertyPath path) {
+    return new FieldPath(path, List.of(), null);
   }
 
   public static final String FIELD_PATH_SEPARATOR = ".";
 
-  /** Name of field (excluding path). */
-  private final String name;
-
-  /** Path to reach field name, can be empty for root level fields. */
-  private final List<String> path;
-
-  /**
-   * True if field path should be excluded (removed) from the set of paths to include. In the API
-   * this is exposed as "?fields=id,name,!do_not_include" where "!" marks the path as not to be
-   * included.
-   */
-  private final boolean exclude;
-
-  /**
-   * True if the field path should be handled as a preset path, which means we have to expand before
-   * going into the filtering process. For example ":owner" would be expanded to include all
-   * properties where "property.owner=true".
-   */
-  private final boolean preset;
+  private final PropertyPath path;
 
   /** Transformers to apply to field, can be empty. */
   private final List<FieldPathTransformer> transformers;
 
   /** Schema Property if present (added by {@link FieldPathHelper}). */
-  @Setter @ToString.Exclude @EqualsAndHashCode.Exclude private Property property;
+  @Setter private Property property;
 
-  /** Fully calculated dot separated path for FieldPath. */
-  @EqualsAndHashCode.Exclude private final String fullPath;
-
-  public FieldPath(String name) {
-    this(name, List.of());
+  public FieldPath withTransformers(FieldPathTransformer... transformers) {
+    return withTransformers(List.of(transformers));
   }
 
-  public FieldPath(String name, List<String> path) {
-    this(name, path, false, false);
+  public FieldPath withTransformers(@Nonnull List<FieldPathTransformer> transformers) {
+    return new FieldPath(path, transformers, property);
   }
 
-  public FieldPath(String name, List<String> path, boolean exclude, boolean preset) {
-    this(name, path, exclude, preset, new ArrayList<>());
+  public FieldPath relativeTo(@Nonnull CharSequence parentSegment) {
+    return new FieldPath(path.relativeTo(Text.of(parentSegment)), transformers, property);
   }
 
-  public FieldPath(String name, List<String> path, List<FieldPathTransformer> transformers) {
-    this(name, path, false, false, transformers);
+  public String getName() {
+    return path.property().toString();
   }
 
-  public FieldPath(
-      String name,
-      List<String> path,
-      boolean exclude,
-      boolean preset,
-      List<FieldPathTransformer> transformers) {
-    this.name = name;
-    this.path = path;
-    this.fullPath =
-        path.isEmpty()
-            ? name
-            : String.join(FIELD_PATH_SEPARATOR, path) + FIELD_PATH_SEPARATOR + name;
-    this.exclude = exclude;
-    this.preset = preset;
-    this.transformers = transformers;
+  public String getFullPath() {
+    // FIXME this would include markers but the caller might expect a clean property name path
+    return toString();
   }
 
-  public FieldPath relativeTo(String parentSegment) {
-    return new FieldPath(
-        name,
-        path.subList(path.indexOf(parentSegment) + 1, path.size()),
-        exclude,
-        preset,
-        transformers);
+  public List<String> properties() {
+    return path.properties().map(Text::toString).toList();
+  }
+
+  public boolean isPreset() {
+    return path.isPreset();
+  }
+
+  public boolean isExclude() {
+    return path.isExclude();
   }
 
   /**
@@ -132,10 +104,18 @@ public class FieldPath {
     return transformers != null && !transformers.isEmpty();
   }
 
-  /**
-   * @return true if name is the root of the path
-   */
-  public boolean isRoot() {
-    return path.isEmpty();
+  @Override
+  public String toString() {
+    return path.toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof FieldPath p && path.equals(p.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return path.hashCode();
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/object/ObjectOutput.java
@@ -106,7 +106,7 @@ public final class ObjectOutput {
      *     part)
      */
     public String name() {
-      return path.property();
+      return path.property().toString();
     }
 
     @Nonnull

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -211,6 +212,22 @@ class PropertyPathTest {
   }
 
   @Test
+  void testProperties() {
+    assertEquals(List.of("foo"), PropertyPath.of("foo").properties().map(Text::toString).toList());
+    assertEquals(
+        List.of("foo", "bar"),
+        PropertyPath.of("foo.bar").properties().map(Text::toString).toList());
+    assertEquals(
+        List.of("foo", "bar"),
+        PropertyPath.of("!foo.bar").properties().map(Text::toString).toList());
+    assertEquals(
+        List.of("foo", "bar"),
+        PropertyPath.of("foo.!bar").properties().map(Text::toString).toList());
+    assertEquals(
+        List.of(":foo"), PropertyPath.of(":foo").properties().map(Text::toString).toList());
+  }
+
+  @Test
   void testHead() {
     assertEquals(Text.of("foo"), PropertyPath.of("foo").head());
     assertEquals(Text.of("foo"), PropertyPath.of("foo.bar").head());
@@ -232,6 +249,47 @@ class PropertyPathTest {
     assertEquals(PropertyPath.of("y"), PropertyPath.of("foo").withTail("y"));
     assertEquals(PropertyPath.of("foo.y"), PropertyPath.of("foo.bar").withTail("y"));
     assertEquals(PropertyPath.of("foo.bar.y"), PropertyPath.of("foo.bar.baz").withTail("y"));
+  }
+
+  @Test
+  void testRelativeTo() {
+    assertNull(PropertyPath.of("foo").relativeTo("foo"));
+    assertEquals(PropertyPath.of("bar"), PropertyPath.of("foo.bar").relativeTo("foo"));
+    assertEquals(
+        PropertyPath.of("a1234567890"),
+        PropertyPath.of("attributeValues.attribute.a1234567890").relativeTo("attribute"));
+  }
+
+  @Test
+  void testContains() {
+    assertTrue(PropertyPath.of("foo.bar").contains("bar"));
+    assertTrue(PropertyPath.of("foo.bar").contains("foo"));
+    assertFalse(PropertyPath.of("foo.bar").contains("!bar"));
+    assertFalse(PropertyPath.of("foo.bar").contains("!foo"));
+    assertFalse(PropertyPath.of("foo.bar").contains("baz"));
+    assertFalse(PropertyPath.of("foo.bar").contains("foo.bar"));
+  }
+
+  @Test
+  void testIsExcluded() {
+    assertTrue(PropertyPath.of("!code").isExcluded("code"));
+    assertTrue(PropertyPath.of("!x").isExcluded("x.bar"));
+    assertTrue(PropertyPath.of("x.!y").isExcluded("x.y"));
+    assertTrue(PropertyPath.of("x.!y").isExcluded("x.y.z"));
+
+    assertFalse(PropertyPath.of("code").isExcluded("code"));
+    assertFalse(PropertyPath.of("!code").isExcluded("name"));
+    assertFalse(PropertyPath.of("!foo.code").isExcluded("code"));
+    assertFalse(PropertyPath.of("foo.!code").isExcluded("code"));
+  }
+
+  @Test
+  void testDropHead() {
+    assertNull(PropertyPath.of("foo").dropHead());
+    assertEquals(PropertyPath.of("bar"), PropertyPath.of("foo.bar").dropHead());
+    assertEquals(PropertyPath.of("bar"), PropertyPath.of("!foo.bar").dropHead());
+    assertEquals(PropertyPath.of("!bar"), PropertyPath.of("foo.!bar").dropHead());
+    assertEquals(PropertyPath.of("bar.baz"), PropertyPath.of("foo.bar.baz").dropHead());
   }
 
   private static void assertPropertyPath(String path) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/PropertyPathTest.java
@@ -200,14 +200,14 @@ class PropertyPathTest {
 
   @Test
   void testProperty() {
-    assertEquals("foo", PropertyPath.of("foo").property());
-    assertEquals("bar", PropertyPath.of("foo.bar").property());
-    assertEquals("baz", PropertyPath.of("foo.bar.baz").property());
-    assertEquals("foo", PropertyPath.of("!foo").property());
-    assertEquals("bar", PropertyPath.of("!foo.bar").property());
-    assertEquals("baz", PropertyPath.of("!foo.bar.baz").property());
-    assertEquals("baz", PropertyPath.of("foo.bar.!baz").property());
-    assertEquals("foo", PropertyPath.of("-foo").property());
+    assertEquals("foo", PropertyPath.of("foo").property().toString());
+    assertEquals("bar", PropertyPath.of("foo.bar").property().toString());
+    assertEquals("baz", PropertyPath.of("foo.bar.baz").property().toString());
+    assertEquals("foo", PropertyPath.of("!foo").property().toString());
+    assertEquals("bar", PropertyPath.of("!foo.bar").property().toString());
+    assertEquals("baz", PropertyPath.of("!foo.bar.baz").property().toString());
+    assertEquals("baz", PropertyPath.of("foo.bar.!baz").property().toString());
+    assertEquals("foo", PropertyPath.of("-foo").property().toString());
   }
 
   @Test
@@ -219,20 +219,19 @@ class PropertyPathTest {
 
   @Test
   void testConcat() {
-    assertEquals(PropertyPath.of("foo.bar"), PropertyPath.of("foo").concat(Text.of("bar")));
-    assertEquals(PropertyPath.of("foo.:all"), PropertyPath.of("foo").concat(Text.of("*")));
+    assertEquals(PropertyPath.of("foo.bar"), PropertyPath.of("foo").concat("bar"));
+    assertEquals(PropertyPath.of("foo.:all"), PropertyPath.of("foo").concat("*"));
     assertEquals(
         PropertyPath.of("foo.bar.baz"), PropertyPath.of("foo").concat(PropertyPath.of("bar.baz")));
 
-    assertEquals(PropertyPath.of("!foo.bar"), PropertyPath.of("!foo").concat(Text.of("bar")));
+    assertEquals(PropertyPath.of("!foo.bar"), PropertyPath.of("!foo").concat("bar"));
   }
 
   @Test
   void testWithTail() {
     assertEquals(PropertyPath.of("y"), PropertyPath.of("foo").withTail("y"));
     assertEquals(PropertyPath.of("foo.y"), PropertyPath.of("foo.bar").withTail("y"));
-    assertEquals(
-        PropertyPath.of("foo.bar.y"), PropertyPath.of("foo.bar.baz").withTail(Text.of("y")));
+    assertEquals(PropertyPath.of("foo.bar.y"), PropertyPath.of("foo.bar.baz").withTail("y"));
   }
 
   private static void assertPropertyPath(String path) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -80,7 +80,6 @@ import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.gist.GistQuery.Owner;
 import org.hisp.dhis.jsontree.JsonBuilder;
 import org.hisp.dhis.jsontree.JsonNode;
-import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.query.JpaQueryUtils;
@@ -225,7 +224,7 @@ final class GistBuilder {
   private static boolean existsSameParentField(GistQuery query, Field field, String property) {
     PropertyPath parentPath = field.propertyPath().parent();
     PropertyPath requiredPath =
-        parentPath == null ? PropertyPath.of(property) : parentPath.concat(Text.of(property));
+        parentPath == null ? PropertyPath.of(property) : parentPath.concat(property);
     return query.getFields().fields().stream().anyMatch(f -> f.propertyPath().equals(requiredPath));
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -349,7 +349,7 @@ public final class GistQuery {
       return getStrings(filter, FILTERS_SPLIT).stream().map(Filter::parse).toList();
     }
 
-    public Filter withPropertyPath(String path) {
+    public Filter withPropertyPath(CharSequence path) {
       return new Filter(group, PropertyPath.of(path), operator, value, false, false);
     }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -18,10 +18,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
@@ -78,6 +74,10 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>json-tree</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>
@@ -93,11 +93,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -29,6 +29,9 @@
  */
 package org.hisp.dhis.fieldfiltering;
 
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
@@ -49,9 +52,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.CodeGenerator;
@@ -123,30 +126,6 @@ public class FieldFilterService {
     objectMapper.setAnnotationIntrospector(new IgnoreJsonSerializerRefinementAnnotationInspector());
 
     return objectMapper;
-  }
-
-  /**
-   * Determines whether given path is included in the resulting ObjectNodes after applying {@link
-   * #toObjectNode(Object, List)}. This obviously requires that the actual data contains such path
-   * when filtered.
-   *
-   * <p>For example given a structure like
-   *
-   * <p><code>{"event": "relationships": [] }</code> and a
-   *
-   * <p><code>filter="*,first[second[!third]]"</code>
-   *
-   * <p>both paths<code>first</code> and <code>first.second</code> will result in true as they will
-   * be included in the filtered result. While <code>first.second.third</code> will result in false.
-   *
-   * @param rootClass class the filter will be applied on
-   * @param filter field paths to be applied on the class
-   * @param path path to check for inclusion in the filter
-   * @return true if path is included in filter
-   */
-  public boolean filterIncludes(Class<?> rootClass, List<FieldPath> filter, String path) {
-    return fieldPathHelper.apply(filter, rootClass).stream()
-        .anyMatch(f -> f.getFullPath().equals(path));
   }
 
   public static class IgnoreJsonSerializerRefinementAnnotationInspector
@@ -258,7 +237,7 @@ public class FieldFilterService {
     // other object mappers (running across other threads)
     ObjectMapper objectMapper = jsonMapper.copy().setFilterProvider(filterProvider);
 
-    Map<String, List<FieldTransformer>> fieldTransformers = getTransformers(paths);
+    Map<PropertyPath, List<FieldTransformer>> fieldTransformers = getTransformers(paths);
     List<FieldPath> absoluteAttributePaths = getAttributePropertyPathsInAttributeValues(paths);
     List<FieldPath> relativeAttributePaths =
         absoluteAttributePaths.stream().map(e -> e.relativeTo("attribute")).toList();
@@ -273,7 +252,7 @@ public class FieldFilterService {
       addAttributeFieldsInAttributeValues(
           object, objectNode, relativeAttributePaths, attributeProperties);
       applyAttributeAsPropertyFields(object, objectNode, paths);
-      applyTransformers(objectNode, null, "", fieldTransformers);
+      applyTransformers(objectNode, fieldTransformers);
 
       if (excludeDefaults) removeEmptyObjects(objectNode);
 
@@ -314,8 +293,8 @@ public class FieldFilterService {
     }
   }
 
-  private static final Pattern ATTRIBUTE_VALUES_PATH =
-      Pattern.compile("attributeValues\\.attribute\\.(?!id).*");
+  private static final PropertyPath ATTRIBUTE_VALUES_PATH =
+      PropertyPath.of("attributeValues.attribute");
 
   /**
    * @param paths all paths requested
@@ -324,7 +303,14 @@ public class FieldFilterService {
    */
   private static List<FieldPath> getAttributePropertyPathsInAttributeValues(List<FieldPath> paths) {
     return paths.stream()
-        .filter(path -> ATTRIBUTE_VALUES_PATH.matcher(path.getFullPath()).matches())
+        .filter(
+            path -> {
+              PropertyPath p = path.getPath();
+              if (p.length() != 4) return false;
+              if (!p.isParent(ATTRIBUTE_VALUES_PATH)) return false;
+              PropertyPath parent = p.parent();
+              return parent != null && !parent.segment().contentEquals("id");
+            })
         .toList();
   }
 
@@ -416,7 +402,7 @@ public class FieldFilterService {
 
   private void applyAttributeAsPropertyField(
       IdentifiableObject object, ObjectNode node, FieldPath path) {
-    String attributeId = path.getFullPath();
+    String attributeId = path.getPath().property().toString();
     if (path.getProperty() != null || !CodeGenerator.isValidUid(attributeId)) {
       return;
     }
@@ -462,57 +448,63 @@ public class FieldFilterService {
     return jsonMapper.createArrayNode();
   }
 
+  private void applyTransformers(
+      JsonNode root, Map<PropertyPath, List<FieldTransformer>> fieldTransformers) {
+    if (fieldTransformers.isEmpty()) return;
+    fieldTransformers.forEach((path, transformers) -> applyTransformers(root, path, transformers));
+  }
+
   /** Recursively applies FieldTransformers to a Json node. */
   private void applyTransformers(
-      JsonNode node,
-      JsonNode parent,
-      String path,
-      Map<String, List<FieldTransformer>> fieldTransformers) {
-    if (parent != null && !parent.isArray() && !path.isEmpty()) {
-      List<FieldTransformer> transformers = fieldTransformers.get(path.substring(1));
-
-      if (transformers != null) {
-        transformers.forEach(tf -> tf.apply(path.substring(1), node, parent));
+      JsonNode parent, PropertyPath path, List<FieldTransformer> transformers) {
+    if (path == null) return; // just to make null checker happy
+    if (path.parent() != null) {
+      // need to drill down
+      String name = path.head().toString();
+      JsonNode node = parent.get(name);
+      if (node == null || node.isNull()) return; // done here
+      if (node.isObject()) {
+        applyTransformers(node, path.dropHead(), transformers);
+      } else if (node.isArray()) {
+        PropertyPath subPath = path.dropHead();
+        Iterator<JsonNode> iter = node.elements();
+        while (iter.hasNext()) applyTransformers(iter.next(), subPath, transformers);
       }
-    }
-
-    if (node.isObject()) {
-      ObjectNode objectNode = (ObjectNode) node;
-
-      List<String> fieldNames = new ArrayList<>();
-      objectNode.fieldNames().forEachRemaining(fieldNames::add);
-
-      for (String fieldName : fieldNames) {
-        applyTransformers(
-            objectNode.get(fieldName), objectNode, path + "." + fieldName, fieldTransformers);
-      }
-    } else if (node.isArray()) {
-      ArrayNode arrayNode = (ArrayNode) node;
-
-      for (JsonNode item : arrayNode) {
-        applyTransformers(item, arrayNode, path, fieldTransformers);
-      }
+    } else {
+      // need to apply the transformers
+      if (!parent.isObject()) return; // must be an object, otherwise ignore
+      String name = path.property().toString();
+      JsonNode target = parent.get(name);
+      if (target == null || target.isNull()) return; // nothing to do here
+      transformers.forEach(t -> t.apply(path, target, parent));
     }
   }
 
   private SimpleFilterProvider getSimpleFilterProvider(
       List<FieldPath> fieldPaths, boolean skipSharing, boolean excludeDefaults) {
     SimpleFilterProvider filterProvider = new SimpleFilterProvider();
+    Set<String> includePaths =
+        fieldPaths.stream()
+            .map(p -> p.getPath().properties().collect(joining(".")))
+            .collect(toUnmodifiableSet());
+    Set<String> skipPaths =
+        skipSharing
+            ? Set.of("user", "publicAccess", "userGroupAccesses", "userAccesses", "sharing")
+            : Set.of();
     filterProvider.addFilter(
         "field-filter",
-        new FieldFilterSimpleBeanPropertyFilter(fieldPaths, skipSharing, excludeDefaults));
+        new FieldFilterSimpleBeanPropertyFilter(includePaths, skipPaths, excludeDefaults));
 
     return filterProvider;
   }
 
-  private Map<String, List<FieldTransformer>> getTransformers(List<FieldPath> fieldPaths) {
-    Map<String, List<FieldTransformer>> transformerMap = new HashMap<>();
+  private Map<PropertyPath, List<FieldTransformer>> getTransformers(List<FieldPath> fieldPaths) {
+    Map<PropertyPath, List<FieldTransformer>> transformerMap = new HashMap<>();
 
     for (FieldPath fieldPath : fieldPaths) {
       List<FieldTransformer> fieldTransformers = new ArrayList<>();
-      String fullPath = fieldPath.getFullPath();
 
-      transformerMap.put(fullPath, fieldTransformers);
+      transformerMap.put(fieldPath.getPath(), fieldTransformers);
 
       for (FieldPathTransformer fieldPathTransformer : fieldPath.getTransformers()) {
         switch (fieldPathTransformer.name()) {

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -306,10 +306,9 @@ public class FieldFilterService {
         .filter(
             path -> {
               PropertyPath p = path.getPath();
-              if (p.length() != 4) return false;
+              if (p.length() != 3) return false;
               if (!p.isParent(ATTRIBUTE_VALUES_PATH)) return false;
-              PropertyPath parent = p.parent();
-              return parent != null && !parent.segment().contentEquals("id");
+              return !p.segment().contentEquals("id");
             })
         .toList();
   }
@@ -402,7 +401,7 @@ public class FieldFilterService {
 
   private void applyAttributeAsPropertyField(
       IdentifiableObject object, ObjectNode node, FieldPath path) {
-    String attributeId = path.getPath().property().toString();
+    String attributeId = path.getPropertyName();
     if (path.getProperty() != null || !CodeGenerator.isValidUid(attributeId)) {
       return;
     }
@@ -507,13 +506,13 @@ public class FieldFilterService {
       transformerMap.put(fieldPath.getPath(), fieldTransformers);
 
       for (FieldPathTransformer fieldPathTransformer : fieldPath.getTransformers()) {
-        switch (fieldPathTransformer.name()) {
+        switch (fieldPathTransformer.name().toLowerCase()) {
           case "rename" -> fieldTransformers.add(new RenameFieldTransformer(fieldPathTransformer));
           case "size" -> fieldTransformers.add(SizeFieldTransformer.INSTANCE);
-          case "isEmpty" -> fieldTransformers.add(IsEmptyFieldTransformer.INSTANCE);
-          case "isNotEmpty" -> fieldTransformers.add(IsNotEmptyFieldTransformer.INSTANCE);
+          case "isempty" -> fieldTransformers.add(IsEmptyFieldTransformer.INSTANCE);
+          case "isnotempty" -> fieldTransformers.add(IsNotEmptyFieldTransformer.INSTANCE);
           case "pluck" -> fieldTransformers.add(new PluckFieldTransformer(fieldPathTransformer));
-          case "keyBy" -> fieldTransformers.add(new KeyByFieldTransformer(fieldPathTransformer));
+          case "keyby" -> fieldTransformers.add(new KeyByFieldTransformer(fieldPathTransformer));
           default -> {
             // invalid transformer
           }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -49,13 +49,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.transformers.IsEmptyFieldTransformer;
 import org.hisp.dhis.fieldfiltering.transformers.IsNotEmptyFieldTransformer;
 import org.hisp.dhis.fieldfiltering.transformers.KeyByFieldTransformer;
@@ -439,12 +440,8 @@ public class FieldFilterService {
   }
 
   private void applyFieldPathVisitor(
-      Object object,
-      List<FieldPath> fieldPaths,
-      boolean isSkipSharing,
-      Predicate<String> filter,
-      Consumer<Object> consumer) {
-    if (object == null || isSkipSharing) {
+      Object object, List<FieldPath> fieldPaths, BiConsumer<Object, PropertyPath> visitor) {
+    if (object == null) {
       return;
     }
 
@@ -454,12 +451,7 @@ public class FieldFilterService {
       return;
     }
 
-    fieldPaths.forEach(
-        fp -> {
-          if (filter.test(fp.getFullPath())) {
-            fieldPathHelper.visitFieldPaths(object, List.of(fp), consumer);
-          }
-        });
+    fieldPathHelper.visitFieldPaths(object, fieldPaths, visitor);
   }
 
   public ObjectNode createObjectNode() {
@@ -544,31 +536,21 @@ public class FieldFilterService {
 
   private void applySharingDisplayNames(
       Object root, List<FieldPath> fieldPaths, boolean isSkipSharing) {
+    if (isSkipSharing) return;
     applyFieldPathVisitor(
         root,
         fieldPaths,
-        isSkipSharing,
-        s -> s.contains("sharing"),
-        o -> {
-          if (root instanceof IdentifiableObject rootObject && rootObject.hasSharing()) {
-            rootObject
+        (obj, path) -> {
+          if (obj instanceof IdentifiableObject object
+              && object.hasSharing()
+              && path.segment().contentEquals("sharing")) {
+            object
                 .getSharing()
                 .getUserGroups()
                 .values()
                 .forEach(uga -> uga.setDisplayName(userGroupService.getDisplayName(uga.getId())));
-            rootObject
+            object
                 .getSharing()
-                .getUsers()
-                .values()
-                .forEach(ua -> ua.setDisplayName(userService.getDisplayName(ua.getId())));
-          }
-
-          if (o instanceof IdentifiableObject obj && obj.hasSharing()) {
-            obj.getSharing()
-                .getUserGroups()
-                .values()
-                .forEach(uga -> uga.setDisplayName(userGroupService.getDisplayName(uga.getId())));
-            obj.getSharing()
                 .getUsers()
                 .values()
                 .forEach(ua -> ua.setDisplayName(userService.getDisplayName(ua.getId())));
@@ -577,15 +559,14 @@ public class FieldFilterService {
   }
 
   private void applyAccess(
-      Object object, List<FieldPath> fieldPaths, boolean isSkipSharing, UserDetails userDetails) {
+      Object root, List<FieldPath> fieldPaths, boolean isSkipSharing, UserDetails userDetails) {
+    if (isSkipSharing) return;
     applyFieldPathVisitor(
-        object,
+        root,
         fieldPaths,
-        isSkipSharing,
-        s -> s.equals("access") || s.endsWith(".access"),
-        o -> {
-          if (o instanceof IdentifiableObject identifiableObject) {
-            identifiableObject.setAccess(aclService.getAccess(identifiableObject, userDetails));
+        (obj, path) -> {
+          if (obj instanceof IdentifiableObject object && path.segment().contentEquals("access")) {
+            object.setAccess(aclService.getAccess(object, userDetails));
           }
         });
   }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
@@ -36,13 +36,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Strings;
 import org.hisp.dhis.common.SystemDefaultMetadataObject;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.system.util.AnnotationUtils;
@@ -58,8 +56,8 @@ import org.hisp.dhis.system.util.AnnotationUtils;
 @Slf4j
 @RequiredArgsConstructor
 public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilter {
-  private final List<FieldPath> fieldPaths;
-  private final boolean skipSharing;
+  private final Set<String> includePaths;
+  private final Set<String> skipPaths;
   private final boolean excludeDefaults;
 
   /** Cache that contains true/false for classes that should always be expanded. */
@@ -78,40 +76,23 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
   protected boolean include(final PropertyWriter writer, final JsonGenerator jgen, Object object) {
     PathContext ctx = getPath(writer, jgen);
 
-    if (ctx.getCurrentValue() == null) {
+    if (ctx.currentValue() == null) {
       return false;
     }
 
     if (log.isDebugEnabled()) {
-      log.debug(ctx.getCurrentValue().getClass().getSimpleName() + ": " + ctx.getFullPath());
+      log.debug(ctx.currentValue().getClass().getSimpleName() + ": " + ctx.fullPath());
     }
 
     if (excludeDefaults && object instanceof SystemDefaultMetadataObject sdmo && sdmo.isDefault()) {
       return false;
     }
 
-    if (skipSharing
-        && Strings.CS.equalsAny(
-            ctx.getFullPath(),
-            "user",
-            "publicAccess",
-            "userGroupAccesses",
-            "userAccesses",
-            "sharing")) {
-      return false;
-    }
+    if (skipPaths.contains(ctx.fullPath())) return false;
 
-    if (ctx.isAlwaysExpand()) {
-      return true;
-    }
+    if (ctx.alwaysExpand()) return true;
 
-    for (FieldPath fieldPath : fieldPaths) {
-      if (fieldPath.getFullPath().equals(ctx.getFullPath())) {
-        return true;
-      }
-    }
-
-    return false;
+    return includePaths.contains(ctx.fullPath());
   }
 
   private PathContext getPath(PropertyWriter writer, JsonGenerator jgen) {
@@ -172,14 +153,9 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
   }
 }
 
-/** Simple container class used by getPath to handle Maps. */
-@Data
-@RequiredArgsConstructor
-class PathContext {
-  private final String fullPath;
-
-  private final Object currentValue;
-
-  /** true if special type we do not support field filtering on. */
-  private final boolean alwaysExpand;
-}
+/**
+ * Simple container class used by getPath to handle Maps.
+ *
+ * @param alwaysExpand true if special type we do not support field filtering on.
+ */
+record PathContext(String fullPath, Object currentValue, boolean alwaysExpand) {}

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -174,7 +174,7 @@ public class FieldPathHelper {
               Schema schema = getSchemaByPath(fp.getPath().parent(), rootKlass);
 
               if (schema != null) {
-                fp.setProperty(schema.getProperty(fp.getName()));
+                fp.setProperty(schema.getProperty(fp.getPropertyName()));
               }
             });
   }
@@ -253,10 +253,9 @@ public class FieldPathHelper {
 
     if (property.isCollection()) {
       Collection<?> c = safeInvoke(object, property.getGetterMethod());
+      if (c == null || c.isEmpty()) return;
       PropertyPath cPath = path.dropHead();
-      for (Object e : c) {
-        visitFieldPath(e, cPath, visitor);
-      }
+      for (Object e : c) visitFieldPath(e, cPath, visitor);
     } else {
       Object currentObject = safeInvoke(object, property.getGetterMethod());
       visitFieldPath(currentObject, path.dropHead(), visitor);

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -36,18 +36,17 @@ import static org.hisp.dhis.schema.DefaultSchemaService.safeInvoke;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
+import org.hisp.dhis.jsontree.Text;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.Schema;
@@ -71,10 +70,10 @@ public class FieldPathHelper {
       return List.of();
     }
 
-    Map<String, FieldPath> fieldPathMap =
+    Map<PropertyPath, FieldPath> fieldPathMap =
         fieldPaths.stream()
             .filter(not(FieldPath::isPreset).and(not(FieldPath::isExclude)))
-            .collect(Collectors.toMap(FieldPath::getFullPath, Function.identity()));
+            .collect(Collectors.toMap(FieldPath::getPath, Function.identity()));
 
     applyProperties(fieldPathMap.values(), rootKlass);
 
@@ -83,12 +82,11 @@ public class FieldPathHelper {
 
     calculatePathCount(fieldPathMap.values())
         .forEach(
-            (k, v) -> {
-              if (v > 1L) {
+            (path, count) -> {
+              if (count > 1) {
                 return;
               }
-
-              applyDefaults(fieldPathMap.get(k), rootKlass, fieldPathMap);
+              applyDefaults(fieldPathMap.get(path), rootKlass, fieldPathMap);
             });
 
     List<FieldPath> exclusions = fieldPaths.stream().filter(FieldPath::isExclude).toList();
@@ -103,11 +101,8 @@ public class FieldPathHelper {
    * that we expose the reference identifier.
    */
   private void applyDefaults(
-      FieldPath fieldPath, Class<?> klass, Map<String, FieldPath> fieldPathMap) {
-    List<String> paths = new ArrayList<>(fieldPath.getPath());
-    paths.add(fieldPath.getName());
-
-    Schema schema = getSchemaByPath(paths, klass);
+      FieldPath fieldPath, Class<?> klass, Map<PropertyPath, FieldPath> fieldPathMap) {
+    Schema schema = getSchemaByPath(fieldPath.getPath(), klass);
 
     if (schema == null) {
       return;
@@ -116,18 +111,15 @@ public class FieldPathHelper {
     Property property = fieldPath.getProperty();
 
     if (isComplex(property)) {
-      expandComplex(fieldPathMap, paths, schema);
+      expandComplex(fieldPathMap, fieldPath.getPath(), schema);
     } else if (isReference(property)) {
-      expandReference(fieldPathMap, paths, schema);
+      expandReference(fieldPathMap, fieldPath.getPath(), schema);
     }
   }
 
-  private void applyDefault(FieldPath fieldPath, Map<String, FieldPath> fieldPathMap) {
-    List<String> paths = new ArrayList<>(fieldPath.getPath());
-    paths.add(fieldPath.getName());
-
+  private void applyDefault(FieldPath fieldPath, Map<PropertyPath, FieldPath> fieldPathMap) {
     Property property = fieldPath.getProperty();
-    fieldPathMap.put(fieldPath.getFullPath(), fieldPath);
+    fieldPathMap.put(fieldPath.getPath(), fieldPath);
 
     if (property.isSimple()) {
       return;
@@ -142,33 +134,31 @@ public class FieldPathHelper {
     }
 
     if (isComplex(property)) {
-      expandComplex(fieldPathMap, paths, schema);
+      expandComplex(fieldPathMap, fieldPath.getPath(), schema);
     } else if (isReference(property)) {
-      expandReference(fieldPathMap, paths, schema);
+      expandReference(fieldPathMap, fieldPath.getPath(), schema);
     }
   }
 
   private void expandReference(
-      Map<String, FieldPath> fieldPathMap, List<String> paths, Schema schema) {
+      Map<PropertyPath, FieldPath> fieldPathMap, PropertyPath parent, Schema schema) {
     Property idProperty = schema.getProperty("id");
 
-    FieldPath fp =
-        new FieldPath(
-            idProperty.isCollection() ? idProperty.getCollectionName() : idProperty.getName(),
-            paths);
-    fp.setProperty(idProperty);
+    String name = idProperty.isCollection() ? idProperty.getCollectionName() : idProperty.getName();
+    FieldPath id = FieldPath.of(parent.concat(name));
+    id.setProperty(idProperty);
 
-    fieldPathMap.put(fp.getFullPath(), fp);
+    fieldPathMap.put(id.getPath(), id);
   }
 
   private void expandComplex(
-      Map<String, FieldPath> fieldPathMap, List<String> paths, Schema schema) {
+      Map<PropertyPath, FieldPath> fieldPathMap, PropertyPath parent, Schema schema) {
     schema
         .getProperties()
         .forEach(
             p -> {
-              FieldPath fp =
-                  new FieldPath(p.isCollection() ? p.getCollectionName() : p.getName(), paths);
+              String name = p.isCollection() ? p.getCollectionName() : p.getName();
+              FieldPath fp = FieldPath.of(parent.concat(name));
               fp.setProperty(p);
 
               // check if anything else needs to be expanded
@@ -177,14 +167,16 @@ public class FieldPathHelper {
   }
 
   private void applyProperties(Collection<FieldPath> fieldPaths, Class<?> rootKlass) {
-    fieldPaths.forEach(
-        fp -> {
-          Schema schema = getSchemaByPath(fp.getPath(), rootKlass);
+    fieldPaths.stream()
+        .filter(fp -> fp.getProperty() == null)
+        .forEach(
+            fp -> {
+              Schema schema = getSchemaByPath(fp.getPath().parent(), rootKlass);
 
-          if (schema != null) {
-            fp.setProperty(schema.getProperty(fp.getName()));
-          }
-        });
+              if (schema != null) {
+                fp.setProperty(schema.getProperty(fp.getName()));
+              }
+            });
   }
 
   /**
@@ -195,102 +187,88 @@ public class FieldPathHelper {
    * @param rootKlass the root class type of the entity.
    */
   public void applyPresets(
-      List<FieldPath> presets, Map<String, FieldPath> fieldPathMap, Class<?> rootKlass) {
+      List<FieldPath> presets, Map<PropertyPath, FieldPath> fieldPathMap, Class<?> rootKlass) {
     List<FieldPath> fieldPaths = new ArrayList<>();
 
     for (FieldPath preset : presets) {
-      Schema schema = getSchemaByPath(preset.getPath(), rootKlass);
+      PropertyPath parent = preset.getPath().parent();
+      Schema schema = getSchemaByPath(parent, rootKlass);
 
       if (schema == null) {
         continue;
       }
-      if (FieldPreset.ALL.getName().equals(preset.getName())) {
-        schema.getProperties().forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
-      } else if (FieldPreset.OWNER.getName().equals(preset.getName())) {
+      Text presetName = preset.getPath().segment();
+      if (presetName.contentEquals(":all")) {
+        schema.getProperties().forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
+      } else if (presetName.contentEquals(":owner")) {
         schema.getProperties().stream()
             .filter(Property::isOwner)
-            .forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
-      } else if (FieldPreset.PERSISTED.getName().equals(preset.getName())) {
+            .forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
+      } else if (presetName.contentEquals(":persisted")) {
         schema.getProperties().stream()
             .filter(Property::isPersisted)
-            .forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
-      } else if (FieldPreset.IDENTIFIABLE.getName().equals(preset.getName())) {
+            .forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
+      } else if (presetName.contentEquals(":identifiable")) {
         schema.getProperties().stream()
             .filter(p -> FieldPreset.IDENTIFIABLE.getFields().contains(p.getName()))
-            .forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
-      } else if (FieldPreset.SIMPLE.getName().equals(preset.getName())) {
+            .forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
+      } else if (presetName.contentEquals(":simple")) {
         schema.getProperties().stream()
             .filter(p -> p.getPropertyType().isSimple())
-            .forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
-      } else if (FieldPreset.NAMEABLE.getName().equals(preset.getName())) {
+            .forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
+      } else if (presetName.contentEquals(":nameable")) {
         schema.getProperties().stream()
             .filter(p -> FieldPreset.NAMEABLE.getFields().contains(p.getName()))
-            .forEach(p -> fieldPaths.add(toFieldPath(preset.getPath(), p)));
+            .forEach(p -> fieldPaths.add(toFieldPath(parent, p)));
       }
     }
 
-    fieldPaths.forEach(fp -> fieldPathMap.putIfAbsent(fp.getFullPath(), fp));
+    fieldPaths.forEach(fp -> fieldPathMap.putIfAbsent(fp.getPath(), fp));
   }
 
   public void visitFieldPaths(
-      Object object, List<FieldPath> fieldPaths, Consumer<Object> objectConsumer) {
-    if (object == null || fieldPaths.isEmpty()) {
-      return;
-    }
+      Object root, List<FieldPath> fieldPaths, BiConsumer<Object, PropertyPath> visitor) {
+    if (root == null || fieldPaths.isEmpty()) return;
 
-    Schema schema = schemaService.getSchema(HibernateProxyUtils.getRealClass(object));
+    Schema schema = schemaService.getSchema(HibernateProxyUtils.getRealClass(root));
 
-    if (!schema.isIdentifiableObject()) {
-      return;
-    }
+    if (!schema.isIdentifiableObject()) return;
 
-    fieldPaths.forEach(fp -> visitFieldPath(object, new ArrayList<>(fp.getPath()), objectConsumer));
+    fieldPaths.forEach(fp -> visitFieldPath(root, fp.getPath(), visitor));
   }
 
-  private void visitFieldPath(Object object, List<String> paths, Consumer<Object> objectConsumer) {
-    if (object == null) {
-      return;
-    }
+  private void visitFieldPath(
+      Object object, PropertyPath path, BiConsumer<Object, PropertyPath> visitor) {
+    if (object == null) return;
 
-    if (paths.isEmpty()) {
-      objectConsumer.accept(object);
+    if (path.parent() == null) {
+      visitor.accept(object, path);
       return;
     }
 
     Schema schema = schemaService.getSchema(HibernateProxyUtils.getRealClass(object));
-    String currentPath = paths.remove(0);
+    Property property = schema.getProperty(path.head().toString());
 
-    Property property = schema.getProperty(currentPath);
-
-    if (property == null) {
-      return;
-    }
+    if (property == null) return;
 
     if (property.isCollection()) {
-      Collection<?> currentObjects = safeInvoke(object, property.getGetterMethod());
-
-      for (Object o : currentObjects) {
-        visitFieldPath(o, new ArrayList<>(paths), objectConsumer);
+      Collection<?> c = safeInvoke(object, property.getGetterMethod());
+      PropertyPath cPath = path.dropHead();
+      for (Object e : c) {
+        visitFieldPath(e, cPath, visitor);
       }
     } else {
       Object currentObject = safeInvoke(object, property.getGetterMethod());
-      visitFieldPath(currentObject, new ArrayList<>(paths), objectConsumer);
+      visitFieldPath(currentObject, path.dropHead(), visitor);
     }
   }
 
   /** Modifies the passed in fieldPathMap by removing any matching exclusions. */
-  private void applyExclusions(List<FieldPath> exclusions, Map<String, FieldPath> fieldPathMap) {
-    Set<String> excludedPaths = new HashSet<>();
+  private void applyExclusions(
+      List<FieldPath> exclusions, Map<PropertyPath, FieldPath> fieldPathMap) {
     for (FieldPath exclusion : exclusions) {
-      excludedPaths.add(exclusion.getFullPath());
-
-      for (String fieldPath : fieldPathMap.keySet()) {
-        if (fieldShouldBeExcluded(fieldPath, exclusion.getFullPath())) {
-          excludedPaths.add(fieldPath);
-        }
-      }
+      fieldPathMap.keySet().removeIf(path -> fieldShouldBeExcluded(path, exclusion.getPath()));
     }
-    fieldPathMap.keySet().removeAll(excludedPaths);
   }
 
   // ----------------------------------------------------------------------------------------------------------------
@@ -333,32 +311,11 @@ public class FieldPathHelper {
    *
    * @return true if the field should be excluded <br>
    */
-  public static boolean fieldShouldBeExcluded(String fullFieldPath, String fullExclusionPath) {
-    if (ObjectUtils.anyNull(fullFieldPath, fullExclusionPath)) return false;
-
-    return fullFieldPath.equals(fullExclusionPath)
-        || exclusionIsPathOfFieldPath.test(fullFieldPath, fullExclusionPath);
+  public static boolean fieldShouldBeExcluded(
+      PropertyPath fullFieldPath, PropertyPath fullExclusionPath) {
+    if (fullFieldPath == null || fullExclusionPath == null) return false;
+    return fullExclusionPath.isExcluded(fullFieldPath);
   }
-
-  /** If the exclusion path is a subpath (or the same) then return true. */
-  private static final BiPredicate<String, String> exclusionIsPathOfFieldPath =
-      (fullFieldPath, fullExclusionPath) -> {
-        String[] fields = fullFieldPath.split("\\.");
-        String[] exclFields = fullExclusionPath.split("\\.");
-
-        // when the exclusion path is deeper (more '.') then the field won't be excluded
-        if (exclFields.length > fields.length) {
-          return false;
-        }
-
-        // when an exclusion path does not match a field path then it won't be excluded
-        for (int i = 0; i < exclFields.length; ++i) {
-          if (!exclFields[i].equals(fields[i])) {
-            return false;
-          }
-        }
-        return true;
-      };
 
   private boolean isReference(Property property) {
     return property.is(PropertyType.REFERENCE) || property.itemIs(PropertyType.REFERENCE);
@@ -375,8 +332,8 @@ public class FieldPathHelper {
   }
 
   /** Calculates a weighted map of paths to find candidates for default expansion. */
-  private Map<String, Long> calculatePathCount(Collection<FieldPath> fieldPaths) {
-    Map<String, Long> pathCount = new HashMap<>();
+  private Map<PropertyPath, Integer> calculatePathCount(Collection<FieldPath> fieldPaths) {
+    Map<PropertyPath, Integer> pathCount = new HashMap<>();
 
     for (FieldPath fieldPath : fieldPaths) {
       Property property = fieldPath.getProperty();
@@ -385,42 +342,40 @@ public class FieldPathHelper {
         continue;
       }
 
-      List<String> paths = new ArrayList<>();
-
-      for (String path : fieldPath.getPath()) {
-        paths.add(path);
-        pathCount.compute(
-            StringUtils.join(paths, FieldPath.FIELD_PATH_SEPARATOR),
-            (key, count) -> count == null ? 1L : count + 1L);
+      PropertyPath path = fieldPath.getPath().parent();
+      while (path != null) {
+        pathCount.compute(path, (key, count) -> count == null ? 1 : count + 1);
+        path = path.parent();
       }
 
       if (isReference(property) || isComplex(property)) {
-        pathCount.compute(fieldPath.getFullPath(), (key, count) -> count == null ? 1L : count + 1L);
+        pathCount.compute(fieldPath.getPath(), (key, count) -> count == null ? 1 : count + 1);
       }
     }
 
     return pathCount;
   }
 
-  private FieldPath toFieldPath(List<String> path, Property property) {
+  private FieldPath toFieldPath(@CheckForNull PropertyPath parent, Property property) {
     String name = property.isCollection() ? property.getCollectionName() : property.getName();
-
-    FieldPath fieldPath = new FieldPath(name, path);
-    fieldPath.setProperty(property);
-
-    return fieldPath;
+    FieldPath res = FieldPath.of(PropertyPath.concat(parent, name));
+    res.setProperty(property);
+    return res;
   }
 
-  private Schema getSchemaByPath(List<String> paths, Class<?> klass) {
-    requireNonNull(paths);
+  private Schema getSchemaByPath(@CheckForNull PropertyPath path, Class<?> klass) {
     requireNonNull(klass);
 
     // get root schema
     Schema schema = schemaService.getSchema(klass);
+
+    if (path == null) return schema;
+
     Property currentProperty;
 
-    for (String path : paths) {
-      currentProperty = schema.getProperty(path);
+    Iterator<String> iter = path.properties().map(Text::toString).iterator();
+    while (iter.hasNext()) {
+      currentProperty = schema.getProperty(iter.next());
 
       if (currentProperty == null) {
         return null; // invalid path

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldTransformer.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.fieldfiltering;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.springframework.core.Ordered;
 
 /**
@@ -40,18 +41,7 @@ import org.springframework.core.Ordered;
  */
 @FunctionalInterface
 public interface FieldTransformer extends Ordered {
-  JsonNode apply(String path, JsonNode value, JsonNode parent);
-
-  default String getFieldName(String path) {
-    int idx = path.lastIndexOf('.');
-    String key = path;
-
-    if (idx > -1) {
-      key = path.substring(idx + 1);
-    }
-
-    return key;
-  }
+  JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent);
 
   default int getOrder() {
     return Ordered.HIGHEST_PRECEDENCE;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldTransformer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 
 /**
@@ -44,18 +45,11 @@ public class IsEmptyFieldTransformer implements FieldTransformer {
   public static final IsEmptyFieldTransformer INSTANCE = new IsEmptyFieldTransformer();
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
-    if (!parent.isObject()) {
-      return value;
-    }
-
-    String fieldName = getFieldName(path);
-
-    if (value.isArray()) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
+    if (parent.isObject() && value.isArray()) {
       // overwrite array node with true/false depending on empty status
-      ((ObjectNode) parent).put(fieldName, value.isEmpty());
+      ((ObjectNode) parent).put(path.property().toString(), value.isEmpty());
     }
-
     return value;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldTransformer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 
 /**
@@ -44,18 +45,11 @@ public class IsNotEmptyFieldTransformer implements FieldTransformer {
   public static final IsNotEmptyFieldTransformer INSTANCE = new IsNotEmptyFieldTransformer();
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
-    if (!parent.isObject()) {
-      return value;
-    }
-
-    String fieldName = getFieldName(path);
-
-    if (value.isArray()) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
+    if (parent.isObject() && value.isArray()) {
       // overwrite array node with true/false depending on empty status
-      ((ObjectNode) parent).put(fieldName, !value.isEmpty());
+      ((ObjectNode) parent).put(path.property().toString(), !value.isEmpty());
     }
-
     return value;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/KeyByFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/KeyByFieldTransformer.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldPathTransformer;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 import org.springframework.util.StringUtils;
@@ -52,7 +53,7 @@ public class KeyByFieldTransformer implements FieldTransformer {
   }
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
     if (!parent.isObject()) {
       return value;
     }
@@ -62,8 +63,6 @@ public class KeyByFieldTransformer implements FieldTransformer {
     if (!fieldPathTransformer.parameters().isEmpty()) {
       keyByFieldName = fieldPathTransformer.parameters().get(0);
     }
-
-    String fieldName = getFieldName(path);
 
     if (value.isArray()) {
       ObjectNode objectNode = ((ArrayNode) value).arrayNode().objectNode();
@@ -90,7 +89,7 @@ public class KeyByFieldTransformer implements FieldTransformer {
         }
       }
 
-      ((ObjectNode) parent).replace(fieldName, objectNode);
+      ((ObjectNode) parent).replace(path.property().toString(), objectNode);
     }
 
     return value;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/PluckFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/PluckFieldTransformer.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldPathTransformer;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 
@@ -50,7 +51,7 @@ public class PluckFieldTransformer implements FieldTransformer {
   }
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
     if (!parent.isObject()) {
       return value;
     }
@@ -60,8 +61,6 @@ public class PluckFieldTransformer implements FieldTransformer {
     if (!fieldPathTransformer.parameters().isEmpty()) {
       pluckFieldName = fieldPathTransformer.parameters().get(0);
     }
-
-    String fieldName = getFieldName(path);
 
     if (value.isArray()) {
       ArrayNode arrayNode = ((ArrayNode) value).arrayNode();
@@ -74,7 +73,7 @@ public class PluckFieldTransformer implements FieldTransformer {
         }
       }
 
-      ((ObjectNode) parent).replace(fieldName, arrayNode);
+      ((ObjectNode) parent).replace(path.property().toString(), arrayNode);
     }
 
     return value;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldTransformer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldPathTransformer;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 
@@ -49,14 +50,12 @@ public class RenameFieldTransformer implements FieldTransformer {
   }
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
     if (fieldPathTransformer.parameters().isEmpty() && !parent.isObject()) {
       return value;
     }
 
-    String fieldName = getFieldName(path);
-
-    value = ((ObjectNode) parent).remove(fieldName);
+    value = ((ObjectNode) parent).remove(path.property().toString());
     ((ObjectNode) parent).set(fieldPathTransformer.parameters().get(0), value);
 
     return value;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldTransformer.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.fieldfiltering.transformers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldTransformer;
 
 /**
@@ -44,12 +45,12 @@ public class SizeFieldTransformer implements FieldTransformer {
   public static final SizeFieldTransformer INSTANCE = new SizeFieldTransformer();
 
   @Override
-  public JsonNode apply(String path, JsonNode value, JsonNode parent) {
+  public JsonNode apply(PropertyPath path, JsonNode value, JsonNode parent) {
     if (!parent.isObject()) {
       return value;
     }
 
-    String fieldName = getFieldName(path);
+    String fieldName = path.property().toString();
 
     if (value.isArray()) {
       ((ObjectNode) parent).put(fieldName, value.size());

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldFilterParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldFilterParserTest.java
@@ -261,6 +261,6 @@ class FieldFilterParserTest {
   }
 
   private static String list(List<FieldPath> fields) {
-    return fields.stream().map(FieldPath::getFullPath).collect(joining(","));
+    return fields.stream().map(FieldPath::toString).collect(joining(","));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldFilterParserTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldFilterParserTest.java
@@ -43,19 +43,18 @@ class FieldFilterParserTest {
   @Test
   void testDepth0Filters() {
     assertFieldsEquals(
-        List.of(new FieldPath("id"), new FieldPath("name"), new FieldPath("abc")),
-        "id, name,    abc");
+        List.of(FieldPath.of("id"), FieldPath.of("name"), FieldPath.of("abc")), "id, name,    abc");
   }
 
   @Test
   void testDepth1Filters() {
     assertFieldsEquals(
         List.of(
-            FieldPath.ofPath("id"),
-            FieldPath.ofPath("name"),
-            FieldPath.ofPath("group"),
-            FieldPath.ofPath("group.id"),
-            FieldPath.ofPath("group.name")),
+            FieldPath.of("id"),
+            FieldPath.of("name"),
+            FieldPath.of("group"),
+            FieldPath.of("group.id"),
+            FieldPath.of("group.name")),
         "id,name,group[id,name]");
   }
 
@@ -63,37 +62,31 @@ class FieldFilterParserTest {
   void testDepthXFilters() {
     assertFieldsEquals(
         List.of(
-            FieldPath.ofPath("id"),
-            FieldPath.ofPath("name"),
-            FieldPath.ofPath("group"),
-            FieldPath.ofPath("group.id"),
-            FieldPath.ofPath("group.name"),
-            FieldPath.ofPath("group.group"),
-            FieldPath.ofPath("group.group.id"),
-            FieldPath.ofPath("group.group.name"),
-            FieldPath.ofPath("group.group.group"),
-            FieldPath.ofPath("group.group.group.id"),
-            FieldPath.ofPath("group.group.group.name")),
+            FieldPath.of("id"),
+            FieldPath.of("name"),
+            FieldPath.of("group"),
+            FieldPath.of("group.id"),
+            FieldPath.of("group.name"),
+            FieldPath.of("group.group"),
+            FieldPath.of("group.group.id"),
+            FieldPath.of("group.group.name"),
+            FieldPath.of("group.group.group"),
+            FieldPath.of("group.group.group.id"),
+            FieldPath.of("group.group.group.name")),
         "id,name,group[id,name],group[id,name,group[id,name,group[id,name]]]");
   }
 
   @Test
   void testOnlyBlockFilters() {
     assertFieldsEquals(
-        List.of(
-            FieldPath.ofPath("group"),
-            FieldPath.ofPath("group.id"),
-            FieldPath.ofPath("group.name")),
+        List.of(FieldPath.of("group"), FieldPath.of("group.id"), FieldPath.of("group.name")),
         "group[id,name]");
   }
 
   @Test
   void testOnlySpringBlockFilters() {
     assertFieldsEquals(
-        List.of(
-            FieldPath.ofPath("group"),
-            FieldPath.ofPath("group.id"),
-            FieldPath.ofPath("group.name")),
+        List.of(FieldPath.of("group"), FieldPath.of("group.id"), FieldPath.of("group.name")),
         "group[id,name]");
   }
 
@@ -101,11 +94,10 @@ class FieldFilterParserTest {
   void testParseWithTransformer1() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name", List.of(), List.of(new FieldPathTransformer("x", List.of("a", "b")))),
-            new FieldPath(
-                "id", List.of(), List.of(new FieldPathTransformer("y", List.of("a", "b", "c")))),
-            new FieldPath("code", List.of(), List.of(new FieldPathTransformer("z", List.of("t"))))),
+            FieldPath.of("name").withTransformers(new FieldPathTransformer("x", List.of("a", "b"))),
+            FieldPath.of("id")
+                .withTransformers(new FieldPathTransformer("y", List.of("a", "b", "c"))),
+            FieldPath.of("code").withTransformers(new FieldPathTransformer("z", List.of("t")))),
         "name::x(a;b),id~y(a;b;c),code|z(t)");
   }
 
@@ -113,11 +105,9 @@ class FieldFilterParserTest {
   void testParseWithTransformer2() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("groups"),
-            new FieldPath(
-                "name",
-                List.of("groups"),
-                List.of(new FieldPathTransformer("x", List.of("a", "b"))))),
+            FieldPath.of("groups"),
+            FieldPath.of("groups.name")
+                .withTransformers(new FieldPathTransformer("x", List.of("a", "b")))),
         "groups[name::x(a;b)]");
   }
 
@@ -125,13 +115,11 @@ class FieldFilterParserTest {
   void testParseWithTransformer3() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("groups"),
-            new FieldPath(
-                "name",
-                List.of("groups"),
-                List.of(new FieldPathTransformer("x", List.of("a", "b")))),
-            new FieldPath(
-                "code", List.of("groups"), List.of(new FieldPathTransformer("y", List.of("a"))))),
+            FieldPath.of("groups"),
+            FieldPath.of("groups.name")
+                .withTransformers(new FieldPathTransformer("x", List.of("a", "b"))),
+            FieldPath.of("groups.code")
+                .withTransformers(new FieldPathTransformer("y", List.of("a")))),
         "groups[name::x(a;b), code~y(a)]");
   }
 
@@ -139,10 +127,9 @@ class FieldFilterParserTest {
   void testParseWithTransformer4() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name", List.of(), List.of(new FieldPathTransformer("rename", List.of("n")))),
-            new FieldPath("groups"),
-            new FieldPath("name", List.of("groups"))),
+            FieldPath.of("name").withTransformers(new FieldPathTransformer("rename", List.of("n"))),
+            FieldPath.of("groups"),
+            FieldPath.of("groups.name")),
         "name::rename(n),groups[name]");
   }
 
@@ -150,14 +137,11 @@ class FieldFilterParserTest {
   void testParseWithTransformer5() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name", List.of(), List.of(new FieldPathTransformer("rename", List.of("n")))),
-            new FieldPath(
-                "groups", List.of(), List.of(new FieldPathTransformer("rename", List.of("g")))),
-            new FieldPath(
-                "name",
-                List.of("groups"),
-                List.of(new FieldPathTransformer("rename", List.of("n"))))),
+            FieldPath.of("name").withTransformers(new FieldPathTransformer("rename", List.of("n"))),
+            FieldPath.of("groups")
+                .withTransformers(new FieldPathTransformer("rename", List.of("g"))),
+            FieldPath.of("groups.name")
+                .withTransformers(new FieldPathTransformer("rename", List.of("n")))),
         "name::rename(n),groups::rename(g)[name::rename(n)]");
   }
 
@@ -165,11 +149,10 @@ class FieldFilterParserTest {
   void testParseWithTransformer6() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name", List.of(), List.of(new FieldPathTransformer("rename", List.of("n")))),
-            new FieldPath(
-                "groups", List.of(), List.of(new FieldPathTransformer("rename", List.of("g")))),
-            new FieldPath("name", List.of("groups"))),
+            FieldPath.of("name").withTransformers(new FieldPathTransformer("rename", List.of("n"))),
+            FieldPath.of("groups")
+                .withTransformers(new FieldPathTransformer("rename", List.of("g"))),
+            FieldPath.of("groups.name")),
         "name::rename(n),groups::rename(g)[name]");
   }
 
@@ -177,8 +160,8 @@ class FieldFilterParserTest {
   void testParseWithTransformer7() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("name", List.of(), List.of(new FieldPathTransformer("size"))),
-            new FieldPath("group", List.of(), List.of(new FieldPathTransformer("isEmpty")))),
+            FieldPath.of("name").withTransformers(new FieldPathTransformer("size")),
+            FieldPath.of("group").withTransformers(new FieldPathTransformer("isEmpty"))),
         "name::size,group::isEmpty");
   }
 
@@ -186,8 +169,8 @@ class FieldFilterParserTest {
   void testParseWithTransformer8() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name", List.of(), List.of(new FieldPathTransformer("rename", List.of("n"))))),
+            FieldPath.of("name")
+                .withTransformers(new FieldPathTransformer("rename", List.of("n")))),
         "name::rename(n)");
   }
 
@@ -195,12 +178,10 @@ class FieldFilterParserTest {
   void testParseWithMultipleTransformers() {
     assertFieldsEquals(
         List.of(
-            new FieldPath(
-                "name",
-                List.of(),
-                List.of(
+            FieldPath.of("name")
+                .withTransformers(
                     new FieldPathTransformer("size"),
-                    new FieldPathTransformer("rename", List.of("n"))))),
+                    new FieldPathTransformer("rename", List.of("n")))),
         "name::size::rename(n)");
   }
 
@@ -208,10 +189,10 @@ class FieldFilterParserTest {
   void testParseWithPresetAndExclude1() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("id"),
-            new FieldPath("name"),
-            new FieldPath("code", List.of(), true, false),
-            new FieldPath("owner", List.of(), false, true)),
+            FieldPath.of("id"),
+            FieldPath.of("name"),
+            FieldPath.of("!code"),
+            FieldPath.of(":owner")),
         "id,name,!code,:owner");
   }
 
@@ -219,35 +200,31 @@ class FieldFilterParserTest {
   void testParseWithPresetAndExclude() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("id"),
-            new FieldPath("name"),
-            new FieldPath("code", List.of(), true, false),
-            new FieldPath("owner", List.of(), false, true),
-            new FieldPath("group"),
-            new FieldPath("owner", List.of("group"), false, true),
-            new FieldPath("all", List.of("group"), false, true),
-            new FieldPath("code", List.of("group"), true, false),
-            new FieldPath("hello", List.of("group"))),
+            FieldPath.of("id"),
+            FieldPath.of("name"),
+            FieldPath.of("!code"),
+            FieldPath.of(":owner"),
+            FieldPath.of("group"),
+            FieldPath.of("group.:owner"),
+            FieldPath.of("group.:all"),
+            FieldPath.of("group.!code"),
+            FieldPath.of("group.hello")),
         "id,name,!code,:owner,group[:owner,:all,!code,hello]");
   }
 
   @Test
   void testParseWithAsterisk1() {
-    assertFieldsEquals(
-        List.of(
-            new FieldPath("all", List.of(), false, true),
-            new FieldPath("code", List.of(), true, false)),
-        "*,!code");
+    assertFieldsEquals(List.of(FieldPath.of(":all"), FieldPath.of("!code")), "*,!code");
   }
 
   @Test
   void testParseWithAsterisk2() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("all", List.of(), false, true),
-            new FieldPath("code", List.of(), true, false),
-            new FieldPath("group"),
-            new FieldPath("all", List.of("group"), false, true)),
+            FieldPath.of(":all"),
+            FieldPath.of("!code"),
+            FieldPath.of("group"),
+            FieldPath.of("group.:all")),
         "*,!code,group[*]");
   }
 
@@ -255,12 +232,12 @@ class FieldFilterParserTest {
   void testMixedBlockSingleFields() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("id"),
-            new FieldPath("name"),
-            new FieldPath("group"),
-            new FieldPath("id", List.of("group")),
-            new FieldPath("name", List.of("group")),
-            new FieldPath("code")),
+            FieldPath.of("id"),
+            FieldPath.of("name"),
+            FieldPath.of("group"),
+            FieldPath.of("group.id"),
+            FieldPath.of("group.name"),
+            FieldPath.of("code")),
         "id,name,group[id,name],code");
   }
 
@@ -268,13 +245,11 @@ class FieldFilterParserTest {
   void testMixedBlockWithTransformation() {
     assertFieldsEquals(
         List.of(
-            new FieldPath("id"),
-            new FieldPath("categoryCombo"),
-            new FieldPath(
-                "categoryOptionCombos",
-                List.of("categoryCombo"),
-                List.of(new FieldPathTransformer("size"))),
-            new FieldPath("displayName")),
+            FieldPath.of("id"),
+            FieldPath.of("categoryCombo"),
+            FieldPath.of("categoryCombo.categoryOptionCombos")
+                .withTransformers(new FieldPathTransformer("size")),
+            FieldPath.of("displayName")),
         "id,categoryCombo[categoryOptionCombos~size],displayName");
   }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
+import org.hisp.dhis.common.PropertyPath;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -48,14 +49,20 @@ class FieldPathHelperTest {
   @MethodSource("fieldShouldNotBeExcluded")
   @DisplayName("Field should not be excluded")
   void fieldShouldNotBeExcludedTest(String fullFieldPath, String fullExclusionPath) {
-    assertFalse(FieldPathHelper.fieldShouldBeExcluded(fullFieldPath, fullExclusionPath));
+    assertFalse(
+        FieldPathHelper.fieldShouldBeExcluded(
+            PropertyPath.of(fullFieldPath), PropertyPath.of("!" + fullExclusionPath)),
+        () -> "%s should not exclude %s".formatted(fullExclusionPath, fullFieldPath));
   }
 
   @ParameterizedTest
   @MethodSource("fieldShouldBeExcluded")
   @DisplayName("Field should be excluded")
   void fieldShouldBeExcludedTest(String fullFieldPath, String fullExclusionPath) {
-    assertTrue(FieldPathHelper.fieldShouldBeExcluded(fullFieldPath, fullExclusionPath));
+    assertTrue(
+        FieldPathHelper.fieldShouldBeExcluded(
+            PropertyPath.of(fullFieldPath), PropertyPath.of("!" + fullExclusionPath)),
+        () -> "%s should exclude %s".formatted(fullExclusionPath, fullFieldPath));
   }
 
   private static Stream<Arguments> fieldShouldNotBeExcluded() {
@@ -63,9 +70,6 @@ class FieldPathHelperTest {
         arguments("username", "user"),
         arguments("task", "user"),
         arguments("userRoles", "user"),
-        arguments("", "user"),
-        arguments(null, "user"),
-        arguments("", null),
         arguments("test", "user"),
         arguments("user.name.last", "user.names"),
         arguments("organisationUnits", "organisationUnits.translations"),

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathTest.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.fieldfiltering;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,10 +41,10 @@ class FieldPathTest {
 
   @Test
   void testFieldPathToFullPath() {
-    FieldPath fieldPath = new FieldPath("field", Lists.newArrayList("a", "b"));
+    FieldPath fieldPath = FieldPath.of("a.b.field");
     assertEquals("field", fieldPath.getName());
     assertTrue(fieldPath.getPath().contains("a"));
     assertTrue(fieldPath.getPath().contains("b"));
-    assertEquals("a.b.field", fieldPath.getFullPath());
+    assertEquals("a.b.field", fieldPath.toString());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathTest.java
@@ -42,7 +42,7 @@ class FieldPathTest {
   @Test
   void testFieldPathToFullPath() {
     FieldPath fieldPath = FieldPath.of("a.b.field");
-    assertEquals("field", fieldPath.getName());
+    assertEquals("field", fieldPath.getPropertyName());
     assertTrue(fieldPath.getPath().contains("a"));
     assertTrue(fieldPath.getPath().contains("b"));
     assertEquals("a.b.field", fieldPath.toString());

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldFilterTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ class IsEmptyFieldFilterTest {
     ObjectNode objectNode = jsonMapper.createObjectNode();
     objectNode.set("a", jsonMapper.createArrayNode());
     IsEmptyFieldTransformer transformer = new IsEmptyFieldTransformer();
-    transformer.apply("a", objectNode.get("a"), objectNode);
+    transformer.apply(PropertyPath.of("a"), objectNode.get("a"), objectNode);
     assertTrue(objectNode.has("a"));
     assertTrue(objectNode.get("a").isBoolean());
     assertTrue(objectNode.get("a").asBoolean());

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldFilterTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ class IsNotEmptyFieldFilterTest {
     ObjectNode objectNode = jsonMapper.createObjectNode();
     objectNode.set("a", jsonMapper.createArrayNode());
     IsNotEmptyFieldTransformer transformer = new IsNotEmptyFieldTransformer();
-    transformer.apply("a", objectNode.get("a"), objectNode);
+    transformer.apply(PropertyPath.of("a"), objectNode.get("a"), objectNode);
     assertTrue(objectNode.has("a"));
     assertTrue(objectNode.get("a").isBoolean());
     assertFalse(objectNode.get("a").asBoolean());

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldFilterTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.fieldfiltering.FieldPathTransformer;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ class RenameFieldFilterTest {
     FieldPathTransformer fieldPathTransformer =
         new FieldPathTransformer("rename", Collections.singletonList("aaa"));
     RenameFieldTransformer transformer = new RenameFieldTransformer(fieldPathTransformer);
-    transformer.apply("a", objectNode.get("a"), objectNode);
+    transformer.apply(PropertyPath.of("a"), objectNode.get("a"), objectNode);
     assertNull(objectNode.get("a"));
     assertNotNull(objectNode.get("aaa"));
   }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldFilterTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.junit.jupiter.api.Test;
 
@@ -49,8 +50,8 @@ class SizeFieldFilterTest {
     objectNode.set("a", jsonMapper.createArrayNode());
     objectNode.put("b", "hello");
     SizeFieldTransformer transformer = new SizeFieldTransformer();
-    transformer.apply("a", objectNode.get("a"), objectNode);
-    transformer.apply("b", objectNode.get("b"), objectNode);
+    transformer.apply(PropertyPath.of("a"), objectNode.get("a"), objectNode);
+    transformer.apply(PropertyPath.of("b"), objectNode.get("b"), objectNode);
     assertTrue(objectNode.has("a"));
     assertTrue(objectNode.get("a").isInt());
     assertEquals(0, objectNode.get("a").asInt());

--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -93,6 +93,10 @@
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
 
     <!-- Test -->
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/RelativePropertyContext.java
@@ -29,9 +29,7 @@
  */
 package org.hisp.dhis.schema;
 
-import static java.util.Collections.singletonList;
-
-import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,6 +37,7 @@ import java.util.function.Function;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.PropertyPath;
+import org.hisp.dhis.jsontree.Text;
 
 /**
  * A utility to resolve the {@link Property} for a given path.
@@ -59,7 +58,7 @@ public final class RelativePropertyContext {
 
   private final Function<Class<?>, Schema> schemaLookup;
 
-  private final Map<String, Property> cache = new ConcurrentHashMap<>();
+  private final Map<PropertyPath, Property> cache = new ConcurrentHashMap<>();
 
   private final Map<Class<?>, RelativePropertyContext> byHomeType;
 
@@ -93,12 +92,12 @@ public final class RelativePropertyContext {
             homeType, home -> new RelativePropertyContext(home, schemaLookup, byHomeType));
   }
 
-  public RelativePropertyContext switchedTo(PropertyPath path) {
-    return switchedTo(path.toString());
+  public RelativePropertyContext switchedTo(CharSequence path) {
+    return switchedTo(PropertyPath.of(path));
   }
 
-  public RelativePropertyContext switchedTo(String path) {
-    if (path.indexOf('.') < 0) {
+  public RelativePropertyContext switchedTo(PropertyPath path) {
+    if (path.parent() == null) {
       return this;
     }
     List<Property> segments = resolvePath(path);
@@ -106,12 +105,12 @@ public final class RelativePropertyContext {
   }
 
   @Nonnull
-  public Property resolveMandatory(@Nonnull PropertyPath path) {
-    return resolveMandatory(path.toString());
+  public Property resolveMandatory(@Nonnull CharSequence path) {
+    return resolveMandatory(PropertyPath.of(path));
   }
 
   @Nonnull
-  public Property resolveMandatory(String path) {
+  public Property resolveMandatory(@Nonnull PropertyPath path) {
     Property property = resolve(path);
     if (property == null) {
       throw createNoSuchPath(path);
@@ -120,65 +119,65 @@ public final class RelativePropertyContext {
   }
 
   @CheckForNull
-  public Property resolve(@Nonnull PropertyPath path) {
-    return resolve(path.toString());
+  public Property resolve(@Nonnull CharSequence path) {
+    return resolve(PropertyPath.of(path));
   }
 
   @CheckForNull
-  public Property resolve(String path) {
-    if (path.indexOf('.') < 0) {
+  public Property resolve(@Nonnull PropertyPath path) {
+    if (path.parent() == null) {
       // just for performance do simple and common case first
       // also these are not cached
-      return homeSchema.getProperty(path);
+      return homeSchema.getProperty(path.property().toString());
     }
     return cache.computeIfAbsent(path, key -> resolvePath(key, null));
   }
 
   @Nonnull
-  public List<Property> resolvePath(@Nonnull PropertyPath path) {
-    return resolvePath(path.toString());
+  public List<Property> resolvePath(@Nonnull CharSequence path) {
+    return resolvePath(PropertyPath.of(path));
   }
 
   @Nonnull
-  public List<Property> resolvePath(String path) {
-    if (path.indexOf('.') < 0) {
+  public List<Property> resolvePath(@Nonnull PropertyPath path) {
+    if (path.parent() == null) {
       // just for performance do simple and common case first
-      return singletonList(resolveMandatory(path));
+      return List.of(resolveMandatory(path));
     }
-    ArrayList<Property> pathElements = new ArrayList<>();
-    Property tail = resolvePath(path, pathElements);
+    Property[] properties = new Property[path.length()];
+    Property tail = resolvePath(path, properties);
     if (tail == null) {
       throw createNoSuchPath(path);
     }
-    return pathElements;
+    return List.of(properties);
   }
 
-  private Property resolvePath(String path, List<Property> pathElements) {
-    String[] segments = path.split("\\.");
+  private Property resolvePath(PropertyPath path, @CheckForNull Property[] properties) {
+    int i = 0;
     Schema curSchema = homeSchema;
     Property curProp = null;
-    for (int i = 0; i < segments.length - 1; i++) {
-      curProp = curSchema.getProperty(segments[i]);
+    Iterator<String> iter = path.properties().map(Text::toString).iterator();
+    while (iter.hasNext()) {
+      curProp = curSchema.getProperty(iter.next());
       if (curProp == null) {
         return null; // does not exist
       }
-      if (pathElements != null) {
-        pathElements.add(curProp);
+      if (properties != null) {
+        properties[i++] = curProp;
       }
-      curSchema =
-          schemaLookup.apply(curProp.isCollection() ? curProp.getItemKlass() : curProp.getKlass());
-      if (curSchema == null) {
-        return null; // does not exist
+      if (iter.hasNext()) {
+        curSchema =
+            schemaLookup.apply(
+                curProp.isCollection() ? curProp.getItemKlass() : curProp.getKlass());
+        if (curSchema == null) {
+          return null; // does not exist
+        }
       }
     }
-    Property tail = curSchema.getProperty(segments[segments.length - 1]);
-    if (pathElements != null) {
-      pathElements.add(tail);
-    }
-    return tail;
+    return curProp;
   }
 
-  private SchemaPathException createNoSuchPath(String path) {
+  private SchemaPathException createNoSuchPath(PropertyPath path) {
     return new SchemaPathException(
         String.format("Property `%s` does not exist in %s", path, homeSchema.getSingular()));
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
@@ -123,7 +123,7 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
     assertEquals(58, result.size()); // all user properties
     assertTrue(
         result.stream()
-            .map(FieldPath::getName)
+            .map(FieldPath::getPropertyName)
             .toList()
             .containsAll(List.of("username", "userRoles")));
   }
@@ -143,7 +143,7 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
     assertTrue(
         FieldPreset.NAMEABLE
             .getFields()
-            .containsAll(fieldPathMap.values().stream().map(FieldPath::getName).toList()));
+            .containsAll(fieldPathMap.values().stream().map(FieldPath::getPropertyName).toList()));
   }
 
   @Test
@@ -164,6 +164,6 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
       String propertyName, Map<PropertyPath, FieldPath> fieldMapPath) {
     PropertyPath path = PropertyPath.of(propertyName);
     assertNotNull(fieldMapPath.get(path));
-    assertEquals(propertyName, fieldMapPath.get(path).getName());
+    assertEquals(propertyName, fieldMapPath.get(path).getPropertyName());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.user.User;
@@ -58,9 +59,9 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
 
   @Test
   void testApplySimplePreset() {
-    Map<String, FieldPath> fieldMapPath = new HashMap<>();
+    Map<PropertyPath, FieldPath> fieldMapPath = new HashMap<>();
 
-    FieldPath owner = new FieldPath(FieldPreset.SIMPLE.getName(), List.of(), false, true);
+    FieldPath owner = FieldPath.of(":simple");
 
     helper.applyPresets(List.of(owner), fieldMapPath, DataElement.class);
 
@@ -72,18 +73,18 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
     assertPropertyExists("aggregationType", fieldMapPath);
     assertPropertyExists("domainType", fieldMapPath);
 
-    assertNull(fieldMapPath.get("access"));
-    assertNull(fieldMapPath.get("dataSetElements"));
-    assertNull(fieldMapPath.get("optionSet"));
-    assertNull(fieldMapPath.get("categoryCombo"));
-    assertNull(fieldMapPath.get("translations"));
+    assertNull(fieldMapPath.get(PropertyPath.of("access")));
+    assertNull(fieldMapPath.get(PropertyPath.of("dataSetElements")));
+    assertNull(fieldMapPath.get(PropertyPath.of("optionSet")));
+    assertNull(fieldMapPath.get(PropertyPath.of("categoryCombo")));
+    assertNull(fieldMapPath.get(PropertyPath.of("translations")));
   }
 
   @Test
   void testApplyIdentifiablePreset() {
-    Map<String, FieldPath> fieldMapPath = new HashMap<>();
+    Map<PropertyPath, FieldPath> fieldMapPath = new HashMap<>();
 
-    FieldPath owner = new FieldPath(FieldPreset.IDENTIFIABLE.getName(), List.of(), false, true);
+    FieldPath owner = FieldPath.of(":identifiable");
 
     helper.applyPresets(List.of(owner), fieldMapPath, DataElement.class);
 
@@ -94,22 +95,22 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
     assertPropertyExists("lastUpdated", fieldMapPath);
     assertPropertyExists("lastUpdatedBy", fieldMapPath);
 
-    assertNull(fieldMapPath.get("shortName"));
-    assertNull(fieldMapPath.get("description"));
+    assertNull(fieldMapPath.get(PropertyPath.of("shortName")));
+    assertNull(fieldMapPath.get(PropertyPath.of("description")));
   }
 
   @Test
   @DisplayName("Excluding skip sharing fields on the User class does not remove incorrect fields")
   void skipSharingFieldsExcludeCorrectFieldsTest() {
     // given skipSharing exclusions
-    FieldPath user = new FieldPath("user", List.of(), true, false);
-    FieldPath publicAccess = new FieldPath("publicAccess", List.of(), true, false);
-    FieldPath userGroupAccesses = new FieldPath("userGroupAccesses", List.of(), true, false);
-    FieldPath userAccesses = new FieldPath("userAccesses", List.of(), true, false);
-    FieldPath sharing = new FieldPath("sharing", List.of(), true, false);
+    FieldPath user = FieldPath.of("!user");
+    FieldPath publicAccess = FieldPath.of("!publicAccess");
+    FieldPath userGroupAccesses = FieldPath.of("!userGroupAccesses");
+    FieldPath userAccesses = FieldPath.of("!userAccesses");
+    FieldPath sharing = FieldPath.of("!sharing");
 
     // and default preset owner
-    FieldPath owner = new FieldPath("owner", List.of(), false, true);
+    FieldPath owner = FieldPath.of(":owner");
 
     // when applying skipSharing exclusions for the User class
     List<FieldPath> result =
@@ -131,8 +132,8 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
   @DisplayName("nameable field filter for DataElement returns expected fields")
   void nameableFieldFilterTest() {
     // given
-    FieldPath fieldPath = new FieldPath(FieldPreset.NAMEABLE.getName(), List.of());
-    Map<String, FieldPath> fieldPathMap = new HashMap<>();
+    FieldPath fieldPath = FieldPath.of(":nameable");
+    Map<PropertyPath, FieldPath> fieldPathMap = new HashMap<>();
 
     // when
     helper.applyPresets(List.of(fieldPath), fieldPathMap, DataElement.class);
@@ -149,8 +150,8 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
   @DisplayName("persisted field filter for DataElement returns fields")
   void persistedFieldFilterTest() {
     // given
-    FieldPath fieldPath = new FieldPath(FieldPreset.PERSISTED.getName(), List.of());
-    Map<String, FieldPath> fieldPathMap = new HashMap<>();
+    FieldPath fieldPath = FieldPath.of(":persisted");
+    Map<PropertyPath, FieldPath> fieldPathMap = new HashMap<>();
 
     // when
     helper.applyPresets(List.of(fieldPath), fieldPathMap, DataElement.class);
@@ -159,8 +160,10 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
     assertFalse(fieldPathMap.isEmpty());
   }
 
-  private void assertPropertyExists(String propertyName, Map<String, FieldPath> fieldMapPath) {
-    assertNotNull(fieldMapPath.get(propertyName));
-    assertEquals(propertyName, fieldMapPath.get(propertyName).getName());
+  private void assertPropertyExists(
+      String propertyName, Map<PropertyPath, FieldPath> fieldMapPath) {
+    PropertyPath path = PropertyPath.of(propertyName);
+    assertNotNull(fieldMapPath.get(path));
+    assertEquals(propertyName, fieldMapPath.get(path).getName());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/FieldPathConverterTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/FieldPathConverterTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -56,10 +55,10 @@ class FieldPathConverterTest {
   void setUp() {
     List<FieldPath> expected =
         List.of(
-            new FieldPath("attributes", Collections.emptyList()),
-            new FieldPath("attribute", List.of("attributes")),
-            new FieldPath("value", List.of("attributes")),
-            new FieldPath("deleted", Collections.emptyList()));
+            FieldPath.of("attributes"),
+            FieldPath.of("attributes.attribute"),
+            FieldPath.of("attributes.value"),
+            FieldPath.of("deleted"));
 
     DefaultFormattingConversionService formattingConversionService =
         new DefaultFormattingConversionService();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import lombok.Data;
+import org.hisp.dhis.common.PropertyPath;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -62,11 +63,9 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
         "filterIncludes should match what's included in the filtered JSON",
         () ->
             assertJSONIncludes(fieldFilterService.toObjectNode(root, filter), "first.second.third"),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first")),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first.second")),
-        () ->
-            assertTrue(
-                fieldFilterService.filterIncludes(Root.class, filter, "first.second.third")));
+        () -> assertTrue(filterIncludes(filter, "first")),
+        () -> assertTrue(filterIncludes(filter, "first.second")),
+        () -> assertTrue(filterIncludes(filter, "first.second.third")));
   }
 
   @Test
@@ -78,11 +77,9 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
         "filterIncludes should match what's included in the filtered JSON",
         () ->
             assertJSONIncludes(fieldFilterService.toObjectNode(root, filter), "first.second.third"),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first")),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first.second")),
-        () ->
-            assertTrue(
-                fieldFilterService.filterIncludes(Root.class, filter, "first.second.third")));
+        () -> assertTrue(filterIncludes(filter, "first")),
+        () -> assertTrue(filterIncludes(filter, "first.second")),
+        () -> assertTrue(filterIncludes(filter, "first.second.third")));
   }
 
   @Test
@@ -93,11 +90,9 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
     assertAll(
         "filterIncludes should match what's included in the filtered JSON",
         () -> assertJSONExcludes(fieldFilterService.toObjectNode(root, filter), "first"),
-        () -> assertFalse(fieldFilterService.filterIncludes(Root.class, filter, "first")),
-        () -> assertFalse(fieldFilterService.filterIncludes(Root.class, filter, "first.second")),
-        () ->
-            assertFalse(
-                fieldFilterService.filterIncludes(Root.class, filter, "first.second.third")));
+        () -> assertFalse(filterIncludes(filter, "first")),
+        () -> assertFalse(filterIncludes(filter, "first.second")),
+        () -> assertFalse(filterIncludes(filter, "first.second.third")));
   }
 
   @Test
@@ -108,13 +103,11 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
     assertAll(
         "filterIncludes should match what's included in the filtered JSON",
         () -> assertJSONIncludes(fieldFilterService.toObjectNode(root, filter), "first.second"),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first")),
-        () -> assertTrue(fieldFilterService.filterIncludes(Root.class, filter, "first.second")),
+        () -> assertTrue(filterIncludes(filter, "first")),
+        () -> assertTrue(filterIncludes(filter, "first.second")),
         () ->
             assertJSONExcludes(fieldFilterService.toObjectNode(root, filter), "first.second.third"),
-        () ->
-            assertFalse(
-                fieldFilterService.filterIncludes(Root.class, filter, "first.second.third")));
+        () -> assertFalse(filterIncludes(filter, "first.second.third")));
   }
 
   @Test
@@ -126,11 +119,9 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
     assertAll(
         "filterIncludes should match what's included in the filtered JSON",
         () -> assertJSONExcludes(fieldFilterService.toObjectNode(root, filter), "first"),
-        () -> assertFalse(fieldFilterService.filterIncludes(Root.class, filter, "first")),
-        () -> assertFalse(fieldFilterService.filterIncludes(Root.class, filter, "first.second")),
-        () ->
-            assertFalse(
-                fieldFilterService.filterIncludes(Root.class, filter, "first.second.third")));
+        () -> assertFalse(filterIncludes(filter, "first")),
+        () -> assertFalse(filterIncludes(filter, "first.second")),
+        () -> assertFalse(filterIncludes(filter, "first.second.third")));
   }
 
   void assertJSONIncludes(ObjectNode json, String path) {
@@ -172,5 +163,28 @@ class FieldFilterServiceTest extends H2ControllerIntegrationTestBase {
   @Data
   private static class Third {
     @JsonProperty private final String value = "3";
+  }
+
+  /**
+   * Determines whether given path is included in the resulting ObjectNodes after applying {@link
+   * #toObjectNode(Object, List)}. This obviously requires that the actual data contains such path
+   * when filtered.
+   *
+   * <p>For example given a structure like
+   *
+   * <p><code>{"event": "relationships": [] }</code> and a
+   *
+   * <p><code>filter="*,first[second[!third]]"</code>
+   *
+   * <p>both paths<code>first</code> and <code>first.second</code> will result in true as they will
+   * be included in the filtered result. While <code>first.second.third</code> will result in false.
+   *
+   * @param filter field paths to be applied on the class
+   * @param path path to check for inclusion in the filter
+   * @return true if path is included in filter
+   */
+  private boolean filterIncludes(List<FieldPath> filter, String path) {
+    return fieldPathHelper.apply(filter, Root.class).stream()
+        .anyMatch(f -> f.getPath().equals(PropertyPath.of(path)));
   }
 }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParserTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/fieldfiltering/FieldsParserTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.export.fieldfiltering;
 
+import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.test.utils.Assertions.assertContains;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.test.utils.Assertions.assertNotEmpty;
@@ -687,11 +688,13 @@ class FieldsParserTest {
   private static void assertField(ExpectField expected, List<FieldPath> fieldPaths) {
     String what = expected.included ? "include" : "exclude";
     List<FieldPath> actual =
-        fieldPaths.stream().filter(fp -> expected.dotPath.equals(fp.getFullPath())).toList();
+        fieldPaths.stream()
+            .filter(fp -> expected.dotPath.equals(fp.getPath().properties().collect(joining("."))))
+            .toList();
     assertNotEmpty(
         actual,
         () ->
-            fieldPaths.stream().map(FieldPath::getFullPath).collect(Collectors.toSet())
+            fieldPaths.stream().map(FieldPath::toString).collect(Collectors.toSet())
                 + " should contain "
                 + expected.dotPath
                 + " and "
@@ -705,7 +708,7 @@ class FieldsParserTest {
       assertFalse(
           actual.stream().anyMatch(FieldPath::isExclude),
           () ->
-              fieldPaths.stream().map(FieldPath::getFullPath).collect(Collectors.toSet())
+              fieldPaths.stream().map(FieldPath::toString).collect(Collectors.toSet())
                   + " should includes "
                   + expected.dotPath
                   + " but it contains the path with an exclusion");
@@ -717,7 +720,7 @@ class FieldsParserTest {
     assertTrue(
         path.isPresent(),
         () ->
-            fieldPaths.stream().map(FieldPath::getFullPath).collect(Collectors.toSet())
+            fieldPaths.stream().map(FieldPath::toString).collect(Collectors.toSet())
                 + " should contain "
                 + expected.dotPath
                 + " and "

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -378,7 +378,7 @@ public abstract class AbstractFullReadOnlyController<
       Property property = getSchema().getProperty(path.toString());
       if (property == null) {
         if (path.isUID()) {
-          String fieldName = path.property();
+          String fieldName = path.property().toString();
           schemaBuilder.addColumn(fieldName);
           obj2valueByProperty.put(fieldName, obj -> getAttributeValue(obj, fieldName));
         }


### PR DESCRIPTION
Continuation of #24403 

### Summary
The starting point was to make `FieldPath` be based on a `PropertyPath` path (instead of `String`) and always construct `FieldPath` using `of(CharSequence)` as a starting point.

Changes were escalated from there. This required more then just substituting types and the equivalent methods. Touching the workings of the field filtering to use `PropertyPath` made clear that the processing itself has issues and at the very least was very doing some parts very inefficiently. This matches the findings Ivo made a while back. I have made the processing more straight forward and less wasteful. 

### Automatic Testing
Property path related utilities were moved into methods on `PropertyPath` which got covered with new unit test cases.
Existing tests got adjusted.

### Manual Testing
The basic test is to use the metadata API with variation of `fields` parameters, for example: `/api/dataElements?fields=id,name,attributeValues`. Naturally there are countless variation of fields and transformers. Many combinations will have indirect coverage from automatic testing. 