### PR TITLE
chore: replace Spring Framework APIs removed in Spring 7

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultAsyncTaskExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultAsyncTaskExecutor.java
@@ -32,19 +32,19 @@ package org.hisp.dhis.common;
 import java.util.concurrent.Future;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 
 /**
- * A mere DHIS2 front for springs {@link AsyncListenableTaskExecutor}.
+ * A mere DHIS2 front for Spring's {@link AsyncTaskExecutor}.
  *
  * @author Jan Bernitt
  */
 @RequiredArgsConstructor
 @Service
-public class DefaultAsyncTaskExecutor implements AsyncTaskExecutor {
+public class DefaultAsyncTaskExecutor implements org.hisp.dhis.common.AsyncTaskExecutor {
   @Qualifier("taskScheduler")
-  private final AsyncListenableTaskExecutor jobExecutor;
+  private final AsyncTaskExecutor jobExecutor;
 
   @Override
   public void executeTask(Runnable job) {
@@ -53,6 +53,6 @@ public class DefaultAsyncTaskExecutor implements AsyncTaskExecutor {
 
   @Override
   public Future<?> executeTaskWithCancelation(Runnable task) {
-    return jobExecutor.submitListenable(task);
+    return jobExecutor.submitCompletable(task);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/MessageSendingCallback.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/MessageSendingCallback.java
@@ -29,11 +29,11 @@
  */
 package org.hisp.dhis.sms.config;
 
+import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponseSummary;
 import org.springframework.stereotype.Component;
-import org.springframework.util.concurrent.ListenableFutureCallback;
 
 /**
  * @author Zubair Asghar.
@@ -41,41 +41,39 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
 @Slf4j
 @Component("org.hisp.dhis.sms.config.SMSSendingCallback")
 public class MessageSendingCallback {
-  public ListenableFutureCallback<OutboundMessageResponse> getCallBack() {
-    return new ListenableFutureCallback<OutboundMessageResponse>() {
-      @Override
-      public void onFailure(Throwable ex) {
+  public BiConsumer<OutboundMessageResponse, Throwable> getCallBack() {
+    return (result, ex) -> {
+      if (ex != null) {
         log.error("Message sending failed", ex);
+        return;
       }
-
-      @Override
-      public void onSuccess(OutboundMessageResponse result) {
-        if (result.isOk()) {
-          log.info("Message sending successful: " + result.getDescription());
-        } else {
-          log.error("Message sending failed: " + result.getDescription());
-        }
+      if (result != null && result.isOk()) {
+        log.info("Message sending successful: " + result.getDescription());
+      } else {
+        log.error(
+            "Message sending failed: "
+                + (result != null ? result.getDescription() : "unknown error"));
       }
     };
   }
 
-  public ListenableFutureCallback<OutboundMessageResponseSummary> getBatchCallBack() {
-    return new ListenableFutureCallback<OutboundMessageResponseSummary>() {
-      @Override
-      public void onFailure(Throwable ex) {
+  public BiConsumer<OutboundMessageResponseSummary, Throwable> getBatchCallBack() {
+    return (result, ex) -> {
+      if (ex != null) {
         log.error("Message sending failed", ex);
+        return;
       }
-
-      @Override
-      public void onSuccess(OutboundMessageResponseSummary result) {
-        int successful = result.getSent();
-        int failed = result.getFailed();
-
-        log.info(
-            String.format(
-                "%s Message sending status: Successful: %d Failed: %d",
-                result.getChannel().name(), successful, failed));
+      if (result == null) {
+        log.error("Message sending failed: unknown error");
+        return;
       }
+      int successful = result.getSent();
+      int failed = result.getFailed();
+
+      log.info(
+          String.format(
+              "%s Message sending status: Successful: %d Failed: %d",
+              result.getChannel().name(), successful, failed));
     };
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
@@ -99,10 +99,10 @@ public class SimplisticHttpGetGateWay extends SmsGateway {
 
       if (genericConfig.isSendUrlParameters()) {
         uriBuilder =
-            UriComponentsBuilder.fromHttpUrl(
+            UriComponentsBuilder.fromUriString(
                 config.getUrlTemplate() + "?" + requestEntity.getBody());
       } else {
-        uriBuilder = UriComponentsBuilder.fromHttpUrl(config.getUrlTemplate());
+        uriBuilder = UriComponentsBuilder.fromUriString(config.getUrlTemplate());
       }
 
       uri = uriBuilder.build().encode().toUri();


### PR DESCRIPTION
## Summary
Forward-compatible Framework prep for Spring 7 removals, still on Spring 6.2:

- `DefaultAsyncTaskExecutor`: `AsyncListenableTaskExecutor` / `submitListenable` → `AsyncTaskExecutor` / `submitCompletable`
- `MessageSendingCallback`: `ListenableFutureCallback` → `BiConsumer` (no production callers)
- `SimplisticHttpGetGateWay`: `UriComponentsBuilder.fromHttpUrl` → `fromUriString`

## Why
These APIs are removed in Spring Framework 7 (`ListenableFuture`, `fromHttpUrl`). Landing them on master shrinks the eventual version-bump PR.

From the Spring 7 spike ([PR #24087](https://github.com/dhis2/dhis2-core/pull/24087)). Plan: PR-D in `docs/PLAN-SPRING-7-READINESS-MULTI-PR.md`.

## Test plan
- [x] `mvn -pl dhis-services/dhis-service-core -am test-compile` green locally
- [ ] unit-test for dhis-service-core / SMS gateway tests
- [ ] CI green