### PR TITLE
chore: remove unused spring-mobile-device BOM entry

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -630,7 +630,6 @@
         <version>${nimbus.jose.jwt.version}</version>
       </dependency>
 
-
       <!-- Spring Session and Redis -->
       <dependency>
         <groupId>org.springframework.session</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -114,7 +114,6 @@
     <spring-session-core.version>4.1.0</spring-session-core.version>
     <spring-data-redis.version>2.7.18</spring-data-redis.version>
     <spring-session-data-redis.version>2.7.4</spring-session-data-redis.version>
-    <spring-mobile-device.version>1.1.5.RELEASE</spring-mobile-device.version>
     <spring-retry.version>2.0.12</spring-retry.version>
     <spring-restdocs.version>2.0.8.RELEASE</spring-restdocs.version>
     <spring-ldap.version>2.4.4</spring-ldap.version>
@@ -631,12 +630,6 @@
         <version>${nimbus.jose.jwt.version}</version>
       </dependency>
 
-      <!-- Spring Mobile -->
-      <dependency>
-        <groupId>org.springframework.mobile</groupId>
-        <artifactId>spring-mobile-device</artifactId>
-        <version>${spring-mobile-device.version}</version>
-      </dependency>
 
       <!-- Spring Session and Redis -->
       <dependency>


### PR DESCRIPTION
## Summary
- Remove dead `spring-mobile-device` 1.1.5.RELEASE from parent `dependencyManagement` and version property

## Why
Spring 4-era artifact, declared only in the BOM, zero code usage. Will not run on Spring Framework 7. Safe cleanup as part of Spring 7 readiness (PR-G).

Related spike: [PR #24087](https://github.com/dhis2/dhis2-core/pull/24087).

## Test plan
- [ ] dependency-analysis CI
- [ ] no module depends on `spring-mobile-device` (verified by grep)