### PR TITLE
chore: rewrite Security filter chain to lambda DSL (Spring Security 7 prep)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -254,9 +254,9 @@ public class DhisWebApiWebSecurityConfig {
     http.cors(Customizer.withDefaults());
 
     if (dhisConfig.isEnabled(ConfigurationKey.LOGIN_SAVED_REQUESTS_ENABLE)) {
-      http.requestCache().requestCache(requestCache);
+      http.requestCache(rc -> rc.requestCache(requestCache));
     } else {
-      http.requestCache().disable();
+      http.requestCache(rc -> rc.disable());
     }
 
     configureMatchers(http);
@@ -272,13 +272,13 @@ public class DhisWebApiWebSecurityConfig {
   }
 
   public static void setHttpHeaders(HttpSecurity http) throws Exception {
-    http.headers()
-        .defaultsDisabled()
-        .contentTypeOptions()
-        .and()
-        .xssProtection()
-        .and()
-        .httpStrictTransportSecurity();
+    http.headers(
+        headers ->
+            headers
+                .defaultsDisabled()
+                .contentTypeOptions(Customizer.withDefaults())
+                .xssProtection(Customizer.withDefaults())
+                .httpStrictTransportSecurity(Customizer.withDefaults()));
   }
 
   @Bean
@@ -299,153 +299,154 @@ public class DhisWebApiWebSecurityConfig {
 
     Set<String> providerIds = dhisOidcProviderRepository.getAllRegistrationId();
     http.authorizeHttpRequests(
-            authorize -> {
-              providerIds.forEach(
-                  providerId ->
-                      authorize
-                          .requestMatchers(
-                              new AntPathRequestMatcher("/oauth2/authorization/" + providerId))
-                          .permitAll()
-                          .requestMatchers(new AntPathRequestMatcher("/oauth2/code/" + providerId))
-                          .permitAll());
+        authorize -> {
+          providerIds.forEach(
+              providerId ->
+                  authorize
+                      .requestMatchers(
+                          new AntPathRequestMatcher("/oauth2/authorization/" + providerId))
+                      .permitAll()
+                      .requestMatchers(new AntPathRequestMatcher("/oauth2/code/" + providerId))
+                      .permitAll());
 
-              authorize
-                  .requestMatchers(analyticsPluginResources())
-                  .permitAll()
-                  // Authentication endpoint
-                  .requestMatchers(new AntPathRequestMatcher("/oauth2/authorize"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/oauth2/token"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/api/apps/login/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/login/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/loginConfig"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/login"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/publicKeys/**"))
-                  .permitAll()
-                  // Login fallback and legacy login endpoint
-                  .requestMatchers(new AntPathRequestMatcher("/login.html"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/login.action"))
-                  .permitAll()
-                  // Static resources
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/oidc/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/javascripts/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/css/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/flags/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/fonts/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/logo_front.png"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/logo_mobile.png"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/external-static/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/favicon.ico"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/static/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/staticContent/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/files/style/external"))
-                  .permitAll()
-                  // Account related endpoints
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/locales/ui"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/auth/forgotPassword"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/auth/passwordReset"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/auth/registration"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/invite"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/auth/updatePassword"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/authentication/login"))
-                  .permitAll()
-                  // Needs to be here because this overrides the previous one
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/account/recovery"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/**/account/restore"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/account"))
-                  .permitAll()
-                  ///////////////////////////////////////////////////////////////////////////////////////////////
-                  .requestMatchers(new AntPathRequestMatcher("/**"))
-                  .authenticated();
-            })
+          authorize
+              .requestMatchers(analyticsPluginResources())
+              .permitAll()
+              // Authentication endpoint
+              .requestMatchers(new AntPathRequestMatcher("/oauth2/authorize"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/oauth2/token"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/api/apps/login/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/login/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/loginConfig"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/login"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/publicKeys/**"))
+              .permitAll()
+              // Login fallback and legacy login endpoint
+              .requestMatchers(new AntPathRequestMatcher("/login.html"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/security/login.action"))
+              .permitAll()
+              // Static resources
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/oidc/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/javascripts/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/css/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/flags/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/fonts/**"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher("/dhis-web-commons/security/logo_front.png"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher("/dhis-web-commons/security/logo_mobile.png"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/external-static/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/favicon.ico"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher("/static/**"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/staticContent/**"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher(apiContextPath + "/**/files/style/external"))
+              .permitAll()
+              // Account related endpoints
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/locales/ui"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher(apiContextPath + "/**/auth/forgotPassword"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/passwordReset"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/registration"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/auth/invite"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher(apiContextPath + "/**/auth/updatePassword"))
+              .permitAll()
+              .requestMatchers(
+                  new AntPathRequestMatcher(apiContextPath + "/**/authentication/login"))
+              .permitAll()
+              // Needs to be here because this overrides the previous one
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/account/recovery"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/account/restore"))
+              .permitAll()
+              .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/**/account"))
+              .permitAll()
+              ///////////////////////////////////////////////////////////////////////////////////////////////
+              .requestMatchers(new AntPathRequestMatcher("/**"))
+              .authenticated();
+        });
 
-        /// HTTP BASIC///////////////////////////////////////
-        .httpBasic()
-        .authenticationDetailsSource(httpBasicWebAuthenticationDetailsSource)
-        .authenticationEntryPoint(formLoginBasicAuthenticationEntryPoint())
-        .addObjectPostProcessor(
-            new ObjectPostProcessor<BasicAuthenticationFilter>() {
-              @Override
-              public <O extends BasicAuthenticationFilter> O postProcess(O filter) {
-                // Explicitly set security context repository on http basic, is
-                // NullSecurityContextRepository by default now.
-                filter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
-                return filter;
-              }
-            });
+    /// HTTP BASIC///////////////////////////////////////
+    http.httpBasic(
+        httpBasic ->
+            httpBasic
+                .authenticationDetailsSource(httpBasicWebAuthenticationDetailsSource)
+                .authenticationEntryPoint(formLoginBasicAuthenticationEntryPoint())
+                .addObjectPostProcessor(
+                    new ObjectPostProcessor<BasicAuthenticationFilter>() {
+                      @Override
+                      public <O extends BasicAuthenticationFilter> O postProcess(O filter) {
+                        // Explicitly set security context repository on http basic, is
+                        // NullSecurityContextRepository by default now.
+                        filter.setSecurityContextRepository(
+                            new HttpSessionSecurityContextRepository());
+                        return filter;
+                      }
+                    }));
 
     /// OIDC /////////
     http.oauth2Login(
-            oauth2 ->
-                oauth2
-                    .tokenEndpoint()
-                    .accessTokenResponseClient(jwtPrivateCodeTokenResponseClient)
-                    .and()
-                    .failureUrl("/login/?oidcFailure=true")
-                    .clientRegistrationRepository(dhisOidcProviderRepository)
-                    .loginProcessingUrl("/oauth2/code/*")
-                    .authorizationEndpoint()
-                    .authorizationRequestResolver(dhisCustomAuthorizationRequestResolver))
+        oauth2 ->
+            oauth2
+                .tokenEndpoint(
+                    tokenEndpoint ->
+                        tokenEndpoint.accessTokenResponseClient(jwtPrivateCodeTokenResponseClient))
+                .failureUrl("/login/?oidcFailure=true")
+                .clientRegistrationRepository(dhisOidcProviderRepository)
+                .loginProcessingUrl("/oauth2/code/*")
+                .authorizationEndpoint(
+                    authorizationEndpoint ->
+                        authorizationEndpoint.authorizationRequestResolver(
+                            dhisCustomAuthorizationRequestResolver)));
 
-        ///////////////
-        .exceptionHandling()
-        .authenticationEntryPoint(entryPoint())
-        .and()
-        /// SESSION ////////////////
-        /// LOGOUT //////////////////
-        .logout()
-        .logoutUrl("/dhis-web-commons-security/logout.action")
-        .logoutSuccessHandler(dhisOidcLogoutSuccessHandler)
-        .deleteCookies("JSESSIONID", "SESSION_EXPIRE")
-        .and()
-        ////////////////////
-        .sessionManagement()
-        .sessionFixation()
-        .migrateSession()
-        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-        .enableSessionUrlRewriting(false)
-        .maximumSessions(
-            Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.MAX_SESSIONS_PER_USER)))
-        .expiredUrl("/dhis-web-commons-security/logout.action");
+    http.exceptionHandling(
+        exceptionHandling -> exceptionHandling.authenticationEntryPoint(entryPoint()));
+
+    /// LOGOUT //////////////////
+    http.logout(
+        logout ->
+            logout
+                .logoutUrl("/dhis-web-commons-security/logout.action")
+                .logoutSuccessHandler(dhisOidcLogoutSuccessHandler)
+                .deleteCookies("JSESSIONID", "SESSION_EXPIRE"));
+
+    /// SESSION ////////////////
+    http.sessionManagement(
+        session ->
+            session
+                .sessionFixation(sessionFixation -> sessionFixation.migrateSession())
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                .enableSessionUrlRewriting(false)
+                .maximumSessions(
+                    Integer.parseInt(
+                        dhisConfig.getProperty(ConfigurationKey.MAX_SESSIONS_PER_USER)))
+                .expiredUrl("/dhis-web-commons-security/logout.action"));
   }
 
   @Bean


### PR DESCRIPTION
## Summary
Structural rewrite of `DhisWebApiWebSecurityConfig` from deprecated HttpSecurity `.and()` chaining to the lambda / `Customizer` DSL.

**No intended behaviour change.** All `permitAll` / `authenticated` matchers are preserved, including mid-pattern `/api/**/...` rules and `auth/updatePassword`.

### DSL migrations
| Area | Before | After |
|---|---|---|
| requestCache | `http.requestCache().…` | `http.requestCache(rc -> …)` |
| headers | `.contentTypeOptions().and().xssProtection().and()…` | `http.headers(h -> h…Customizer.withDefaults())` |
| httpBasic | chained after authorize | `http.httpBasic(httpBasic -> …)` |
| oauth2Login token/authorization endpoints | `.tokenEndpoint().….and().authorizationEndpoint()…` | nested lambdas |
| exceptionHandling / logout / sessionManagement | `.and()` chain | separate `http.*` lambda calls |

### Rule inventory (unchanged)
- OIDC provider authorize/code paths → `permitAll`
- `/oauth2/**`, login apps, static commons, favicon, external-static → `permitAll`
- versioned mid-pattern API public endpoints (`loginConfig`, `auth/*`, `publicKeys`, account recovery, …) → `permitAll`
- final `/**` → `authenticated`
- CSRF (config-gated), CORS defaults, CSP filter, API token filter, JWT bearer filter, session timeout header filter order unchanged
- session: fixation migrate, IF_REQUIRED, max sessions from config, logout cookies `JSESSIONID`/`SESSION_EXPIRE`

## Stacking
**Base branch:** `spring7-prep-pr-e-ant-path-matcher` ([#24461](https://github.com/dhis2/dhis2-core/pull/24461)) — custom `AntPathRequestMatcher`.  
Retarget to `master` after #24461 merges.

## Why
Spring Security 7 removes `.and()`. Landing this on 6.5 shrinks the eventual MAJOR bump. Plan PR-C: `docs/PLAN-SPRING-7-READINESS-MULTI-PR.md`. Spike: [#24087](https://github.com/dhis2/dhis2-core/pull/24087) (opened 2026-06-01).

## Security review checklist
- [ ] Every `permitAll` matcher preserved (esp. mid-pattern `/**/loginConfig`, account/auth endpoints)
- [ ] Final `/**` → `authenticated` still last
- [ ] CSRF, CORS, headers, session creation, OIDC login/logout, basic auth, API token filter order unchanged
- [ ] No accidental `authorizeRequests` reintroduction
- [ ] OIDC private_key_jwt token client still wired on tokenEndpoint

## Test plan
- [x] `mvn -pl dhis-web-api -am test-compile` green
- [ ] CI web-api auth / login / OIDC suites
- [ ] smoke: `/api/ping`, loginConfig, `/oauth2/authorize`, authenticated `/api/me`