### PR TITLE
fix: lastUpdated/lastUpdatedDuration alone incorrectly rejected on dataValueSets export [DHIS2-21821]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
@@ -115,9 +115,11 @@ public class DataExportParams {
     return notEmpty(periods)
         || notEmpty(periodTypes)
         || (startDate != null && endDate != null)
-        || includedDate != null
-        || lastUpdated != null
-        || lastUpdatedDuration != null;
+        || includedDate != null;
+  }
+
+  public boolean hasLastUpdatedFilters() {
+    return lastUpdated != null || lastUpdatedDuration != null;
   }
 
   public boolean hasOrgUnitFilters() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
@@ -115,7 +115,9 @@ public class DataExportParams {
     return notEmpty(periods)
         || notEmpty(periodTypes)
         || (startDate != null && endDate != null)
-        || includedDate != null;
+        || includedDate != null
+        || lastUpdated != null
+        || lastUpdatedDuration != null;
   }
 
   public boolean hasOrgUnitFilters() {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/datavalue/DataExportParamsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/datavalue/DataExportParamsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.datavalue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+class DataExportParamsTest {
+
+  @Test
+  void testHasPeriodFilters_NoFiltersFalse() {
+    DataExportParams params = DataExportParams.builder().build();
+
+    assertFalse(params.hasPeriodFilters());
+  }
+
+  @Test
+  void testHasPeriodFilters_LastUpdatedDurationTrue() {
+    DataExportParams params =
+        DataExportParams.builder().lastUpdatedDuration(Duration.ofDays(10000)).build();
+
+    assertTrue(params.hasPeriodFilters());
+  }
+
+  @Test
+  void testHasPeriodFilters_LastUpdatedTrue() {
+    DataExportParams params = DataExportParams.builder().lastUpdated(new Date()).build();
+
+    assertTrue(params.hasPeriodFilters());
+  }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/datavalue/DataExportParamsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/datavalue/DataExportParamsTest.java
@@ -46,17 +46,37 @@ class DataExportParamsTest {
   }
 
   @Test
-  void testHasPeriodFilters_LastUpdatedDurationTrue() {
+  void testHasPeriodFilters_LastUpdatedAloneIsNotAPeriodFilter() {
+    // lastUpdated/lastUpdatedDuration do not filter by the period table, so they must not
+    // trigger the pe_ids CTE/JOIN the query builder erases based on hasPeriodFilters().
     DataExportParams params =
-        DataExportParams.builder().lastUpdatedDuration(Duration.ofDays(10000)).build();
+        DataExportParams.builder()
+            .lastUpdated(new Date())
+            .lastUpdatedDuration(Duration.ofDays(10000))
+            .build();
 
-    assertTrue(params.hasPeriodFilters());
+    assertFalse(params.hasPeriodFilters());
   }
 
   @Test
-  void testHasPeriodFilters_LastUpdatedTrue() {
+  void testHasLastUpdatedFilters_NoFiltersFalse() {
+    DataExportParams params = DataExportParams.builder().build();
+
+    assertFalse(params.hasLastUpdatedFilters());
+  }
+
+  @Test
+  void testHasLastUpdatedFilters_LastUpdatedDurationTrue() {
+    DataExportParams params =
+        DataExportParams.builder().lastUpdatedDuration(Duration.ofDays(10000)).build();
+
+    assertTrue(params.hasLastUpdatedFilters());
+  }
+
+  @Test
+  void testHasLastUpdatedFilters_LastUpdatedTrue() {
     DataExportParams params = DataExportParams.builder().lastUpdated(new Date()).build();
 
-    assertTrue(params.hasPeriodFilters());
+    assertTrue(params.hasLastUpdatedFilters());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/hibernate/DataExportQueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/hibernate/DataExportQueryBuilderTest.java
@@ -32,9 +32,11 @@ package org.hisp.dhis.datavalue.hibernate;
 import static org.hisp.dhis.datavalue.DataExportParams.Order.*;
 import static org.hisp.dhis.datavalue.hibernate.HibernateDataExportStore.createExportQuery;
 import static org.hisp.dhis.period.Period.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -477,9 +479,10 @@ class DataExportQueryBuilderTest extends AbstractQueryBuilderTest {
 
   @Test
   void testFilter_LastUpdated() {
+    Date lastUpdated = new Date();
     DataExportParams params =
         DataExportParams.builder()
-            .lastUpdated(new Date())
+            .lastUpdated(lastUpdated)
             .includeDeleted(true)
             .orders(List.of(PE, CREATED, DE))
             .build();
@@ -509,6 +512,59 @@ class DataExportQueryBuilderTest extends AbstractQueryBuilderTest {
         ORDER BY pe.startdate, pe.enddate, dv.created, deid""",
         Set.of("lastUpdated"),
         createExportQuery(params, createSpyQuery(), new SystemUser()));
+    // pin the actual bound value: the WHERE clause must be backed by the exact filter date,
+    // not merely a same-named parameter with an unrelated (or null) value
+    assertEquals(lastUpdated, paramValue("lastUpdated"));
+  }
+
+  @Test
+  void testFilter_LastUpdatedDuration() {
+    Duration lastUpdatedDuration = Duration.ofDays(10000);
+    long before = System.currentTimeMillis();
+    DataExportParams params =
+        DataExportParams.builder()
+            .lastUpdatedDuration(lastUpdatedDuration)
+            .includeDeleted(true)
+            .orders(List.of(PE, CREATED, DE))
+            .build();
+    assertSQL(
+        """
+        SELECT
+          de.uid AS deid,
+          pe.iso,
+          ou.uid AS ouid,
+          coc.uid AS cocid,
+          aoc.uid AS aocid,
+          de.valuetype,
+          dv.value,
+          dv.comment,
+          dv.followup,
+          dv.storedby,
+          dv.created,
+          dv.lastupdated,
+          dv.deleted
+        FROM datavalue dv
+        JOIN dataelement de ON dv.dataelementid = de.dataelementid
+        JOIN period pe ON dv.periodid = pe.periodid
+        JOIN organisationunit ou ON dv.sourceid = ou.organisationunitid
+        JOIN categoryoptioncombo coc ON dv.categoryoptioncomboid = coc.categoryoptioncomboid
+        JOIN categoryoptioncombo aoc ON dv.attributeoptioncomboid = aoc.categoryoptioncomboid
+        WHERE dv.lastupdated >= :lastUpdated
+        ORDER BY pe.startdate, pe.enddate, dv.created, deid""",
+        Set.of("lastUpdated"),
+        createExportQuery(params, createSpyQuery(), new SystemUser()));
+    long after = System.currentTimeMillis();
+    // pin that lastUpdatedDuration is actually converted into a real cutoff date
+    // (now - duration), not left null/ignored, which would silently erase the WHERE line
+    Object bound = paramValue("lastUpdated");
+    assertTrue(bound instanceof Date, "lastUpdated parameter must be bound to a real Date");
+    long boundMillis = ((Date) bound).getTime();
+    long durationMillis = lastUpdatedDuration.toMillis();
+    assertTrue(
+        boundMillis >= before - durationMillis && boundMillis <= after - durationMillis,
+        () ->
+            "expected cutoff around now - duration, was: %s (now window: [%d, %d])"
+                .formatted(bound, before - durationMillis, after - durationMillis));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
@@ -427,7 +427,8 @@ public class DefaultDataExportService implements DataExportService {
     // to limit scope of the export to reasonable slices
     if (params == null) throw new ConflictException(ErrorCode.E2000);
     if (!params.hasDataElementFilters()) throw new ConflictException(ErrorCode.E2001);
-    if (!params.hasPeriodFilters()) throw new ConflictException(ErrorCode.E2002);
+    if (!params.hasPeriodFilters() && !params.hasLastUpdatedFilters())
+      throw new ConflictException(ErrorCode.E2002);
     if (!params.hasOrgUnitFilters()) throw new ConflictException(ErrorCode.E2006);
     // additional restrictions that are not strictly required
     // but are kept for backwards compatibility

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/sql/AbstractQueryBuilderTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/sql/AbstractQueryBuilderTest.java
@@ -58,6 +58,15 @@ public abstract class AbstractQueryBuilderTest {
     return SQL.spy(this.sql::set, params::put);
   }
 
+  /**
+   * @return the value bound to the named parameter in the last captured query, or null when no such
+   *     parameter was bound
+   */
+  protected final Object paramValue(@Nonnull String name) {
+    SQL.Param param = params.get(name);
+    return param == null ? null : param.value();
+  }
+
   protected final void assertSQL(@Language("sql") String expected, QueryBuilder actual) {
     assertNotNull(actual.stream()); // capture
     assertEquals(expected, sql.get());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
@@ -320,4 +320,29 @@ class DataValueSetControllerTest extends PostgresControllerIntegrationTestBase {
         "At least one data element, data set or data element group must be specified",
         msg.getMessage());
   }
+
+  @Test
+  @DisplayName("lastUpdatedDuration alone satisfies the period filter requirement")
+  void testGetDataValueSetJson_LastUpdatedDurationOnly() {
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/organisationUnits/",
+            "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01',"
+                + " 'code':'OU1'}"));
+    String dsId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/dataSets/",
+                "{'name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}"));
+
+    JsonObject ds =
+        GET(
+                "/dataValueSets/?inputOrgUnitIdScheme=code&orgUnit={ou}&dataSet={ds}&lastUpdatedDuration=10000d",
+                "OU1",
+                dsId)
+            .content(HttpStatus.OK);
+    assertTrue(ds.isObject());
+  }
 }


### PR DESCRIPTION
## Summary

- `GET /api/dataValueSets` incorrectly returns `409 E2002` when a request supplies only `lastUpdated`/`lastUpdatedDuration` (no `period`/`startDate`+`endDate`), even though these are documented as valid alternatives. Reported by the community against the 2.43 demo instance.
- Root cause: `DataExportParams.hasPeriodFilters()` was missing the `lastUpdated`/`lastUpdatedDuration` checks that the pre-2.43 validation logic had, dropped during the "purely SQL based data value export" rewrite (#22406).
- Fix restores the 2.42 behavior by adding `lastUpdated != null || lastUpdatedDuration != null` to `hasPeriodFilters()`. This is validation-only — the fields were already correctly wired into the underlying SQL filter in `HibernateDataExportStore`.

Jira: https://dhis2.atlassian.net/browse/DHIS2-21821

## Test plan

- [x] New unit test `DataExportParamsTest` covering `hasPeriodFilters()` with `lastUpdated` only, `lastUpdatedDuration` only, and neither (baseline)
- [x] New controller integration test `DataValueSetControllerTest#testGetDataValueSetJson_LastUpdatedDurationOnly` — reproduced the exact reported 409 before the fix (confirmed RED), passes after the fix (confirmed GREEN)
- [x] Full `DataValueSetControllerTest` suite passes, no regressions
- [x] `mvn spotless:check` clean

## Note on test coverage gap

Before this PR, `DataExportParams` had **no direct unit tests** for any of its validation predicates (`hasPeriodFilters`, `hasDataElementFilters`, `hasOrgUnitFilters`, `isPeriodOverSpecified`, `isDateRangeOutOfBounds`, `isLimitOutOfBounds`, `isOrgUnitGroupsOverSpecified`, `isExactOrgUnitsFilter`). This is likely how the `lastUpdated`/`lastUpdatedDuration` branches were silently dropped from `hasPeriodFilters()` during the 2.43 SQL-export rewrite (#22406) without any test catching it.

Coverage for the other predicates currently only exists indirectly, via integration tests asserting the resulting `ErrorCode` after a full service call (e.g. `DataExportServiceExportTest`, `DataValueServiceTest` cover E2001/E2003/E2004/E2006/E2007/E2009/E2012). Those are valuable but slow and don't isolate the predicate logic itself.

`DataExportParamsTest` (added here) establishes the pattern for fast, isolated unit tests on this class. Follow-up ticket to fill in the remaining predicates is worth opening separately rather than growing the scope of this fix.

## Update: CI caught a second issue, now fixed

CI failed on `DataExportQueryBuilderTest#testFilter_LastUpdated`. Root cause: `hasPeriodFilters()` is used for two different concerns —

1. the E2002 validation gate ("has the user supplied *some* time-scoping filter?")
2. `HibernateDataExportStore`'s decision whether to build the `pe_ids` CTE/JOIN for actual period-table filtering

Broadening `hasPeriodFilters()` satisfied (1) but broke (2): a request with only `lastUpdatedDuration` now spuriously pulled in an unnecessary `pe_ids` CTE/JOIN (harmless functionally since it matched all periods, but wrong/wasteful SQL, and it broke the exact-match test).

Fix: added a separate `hasLastUpdatedFilters()` predicate and combined it with the original, unchanged `hasPeriodFilters()` only at the validation call site in `DefaultDataExportService`. Query-builder behavior is untouched. `DataExportParamsTest` updated to pin down the separation (`lastUpdated` alone must NOT satisfy `hasPeriodFilters()`), all previously-failing and previously-passing tests now green.

## Update: added SQL-level coverage for the actual filter (not just validation)

Validation-level tests only prove the request is *accepted*; they don't prove the resulting SQL actually filters by `lastUpdated`/`lastUpdatedDuration`. `DataExportQueryBuilderTest#testFilter_LastUpdated` previously asserted only that a parameter named `lastUpdated` was used, not its bound value, and there was no coverage at all for `lastUpdatedDuration`. That left the duration→date conversion in `HibernateDataExportStore` (`now - duration`) untested — a regression there would silently erase the `WHERE dv.lastupdated >= :lastUpdated` line via `eraseNullParameterLines()`, turning the filter into a no-op (`WHERE 1=1`) with nothing catching it.

Added `paramValue()` to `AbstractQueryBuilderTest` to expose bound parameter values, strengthened `testFilter_LastUpdated` to assert the exact bound date, and added `testFilter_LastUpdatedDuration` asserting the bound date falls in the `[now-duration, now-duration]` window around the call. Verified these aren't vacuous by temporarily reverting the duration→date conversion in `HibernateDataExportStore` and confirming `testFilter_LastUpdatedDuration` fails with exactly the "WHERE 1=1" no-op symptom described above, then restored it and confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


