### PR TITLE
perf: use ASCII bytes to represent UIDs

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -34,6 +34,8 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -41,8 +43,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 
 /**
  * UID represents an alphanumeric string of 11 characters starting with a letter.
@@ -55,29 +55,43 @@ import lombok.Getter;
  *
  * @author Jan Bernitt
  */
-@Getter
-@EqualsAndHashCode
 public final class UID implements Serializable {
 
-  private final String value;
+  /** ASCII characters of the UID */
+  private final byte[] value;
 
-  private UID(String value) {
+  private UID(CharSequence value) {
     if (!isValid(value)) {
       throw new IllegalArgumentException(
           "UID must be an alphanumeric string of 11 characters starting with a letter, but was: "
               + value);
     }
-    this.value = value;
+    this.value = new byte[11];
+    for (int i = 0; i < 11; i++) this.value[i] = (byte) value.charAt(i);
   }
 
-  public static boolean isValid(String value) {
+  public static boolean isValid(CharSequence value) {
     return CodeGenerator.isValidUid(value);
+  }
+
+  public String getValue() {
+    return toString();
   }
 
   @Override
   @JsonValue
   public String toString() {
-    return value;
+    return new String(value, StandardCharsets.US_ASCII);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof UID other && Arrays.equals(value, other.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(value);
   }
 
   public static UID generate() {
@@ -85,16 +99,12 @@ public final class UID implements Serializable {
   }
 
   @JsonCreator
-  public static UID of(@Nonnull String value) {
+  public static UID of(@Nonnull CharSequence value) {
     return new UID(value);
   }
 
-  public static UID of(@Nonnull CharSequence value) {
-    return of(value.toString());
-  }
-
   @CheckForNull
-  public static UID ofNullable(@CheckForNull String value) {
+  public static UID ofNullable(@CheckForNull CharSequence value) {
     return value == null ? null : of(value);
   }
 
@@ -102,11 +112,11 @@ public final class UID implements Serializable {
     return object == null ? null : object.getUID();
   }
 
-  public static Set<UID> of(@Nonnull String... values) {
+  public static Set<UID> of(@Nonnull CharSequence... values) {
     return Stream.of(values).map(UID::of).collect(toUnmodifiableSet());
   }
 
-  public static Set<UID> of(@Nonnull Collection<String> values) {
+  public static Set<UID> of(@Nonnull Collection<? extends CharSequence> values) {
     return values.stream().map(UID::of).collect(toUnmodifiableSet());
   }
 
@@ -128,10 +138,15 @@ public final class UID implements Serializable {
 
   public static <T extends IdentifiableObject> Set<String> toUidValueSet(
       @Nonnull Collection<T> elements) {
-    return elements.stream().map(IdentifiableObject::getUid).collect(toUnmodifiableSet());
+    return elements.stream()
+        .map(IdentifiableObject::getUID)
+        .map(UID::getValue)
+        .collect(toUnmodifiableSet());
   }
 
+  private static final UID DEFAULT_OPTION_COMBO = of("HllvX50cXC0");
+
   public boolean isDefaultOptionCombo() {
-    return "HllvX50cXC0".equals(value);
+    return DEFAULT_OPTION_COMBO.equals(this);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UID.java
@@ -99,6 +99,10 @@ public final class UID implements Serializable {
   }
 
   @JsonCreator
+  public static UID of(@Nonnull String value) {
+    return of((CharSequence) value);
+  }
+
   public static UID of(@Nonnull CharSequence value) {
     return new UID(value);
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/UIDTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/UIDTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class UIDTest {
+
+  @Test
+  void testOf() {
+    assertEquals("ou123456789", UID.of("ou123456789").getValue());
+  }
+
+  @Test
+  void testOfNullable() {
+    assertNull(UID.ofNullable(null));
+  }
+
+  @Test
+  void testHashCode() {
+    Set<UID> set = new HashSet<>();
+    set.add(UID.of("de123456789"));
+    set.add(UID.of("ou123456789"));
+    assertTrue(set.contains(UID.of("de123456789")));
+    assertFalse(set.contains(UID.of("pe123456789")));
+  }
+}


### PR DESCRIPTION
### Summary
Replaces internal representation of a `UID` of being a `String` to be a `byte[]` of the ASCII characters that make the ID.

Pros are less memory as the `String` wrapping is removed but `getValue()` will now use computation and allocate a new `String`. So the more "pure" we are in letting UIDs stay `UID` the more efficient this gets.  

Another small win is that constructing a `UID` now allows for `CharSequence` which will avoid intermediate conversion to `String` for inputs that have not yet been decoded into a `String` (like `Text` that becomes more common in DHIS2).

### Bitpacking
FYI: I also considered bit-packing the ID into a "number" type. Unfortunately a simple shift and mask would need 7 bits per character (77 bits). A real bit encoding would be able to get that down to 66bits in theory but that still would barely not fit in a `long` so a `byte[]` seems the most suiting type for Java. 