### PR TITLE
fix: exclude non-persisted inherited properties from Schema [DHIS2-21374]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -92,6 +92,8 @@ public class Property implements Ordered, Klass {
    */
   @Setter private boolean persisted;
 
+  @Getter @Setter private boolean isTransient;
+
   /** Name of collection wrapper. */
   @Setter private String collectionName;
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
@@ -65,10 +65,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AnalyticalObject;
-import org.hisp.dhis.common.BaseDimensionalObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.BaseLinkableObject;
-import org.hisp.dhis.common.BaseNameableObject;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.NameableObject;
@@ -76,6 +72,7 @@ import org.hisp.dhis.common.annotation.Description;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.translation.Translatable;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -124,10 +121,12 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector {
         initFromPersistedProperty(property, persistedProperties.get(fieldName));
       } else {
         Class<?> declaringClass = property.getGetterMethod().getDeclaringClass();
-        if (declaringClass == BaseIdentifiableObject.class
-            || declaringClass == BaseLinkableObject.class
-            || declaringClass == BaseNameableObject.class
-            || declaringClass == BaseDimensionalObject.class && !property.isTransient()) {
+        Method getter = property.getGetterMethod();
+        if (declaringClass.getName().startsWith("Base")
+            && !property.isTransient()
+            && (!getter.isAnnotationPresent(Translatable.class)
+                || !persistedProperties.containsKey(
+                    getter.getAnnotation(Translatable.class).propertyName()))) {
           // this is assumed to be an inherited property that is not persisted,
           // so we skip it and do not add it
           continue;

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
@@ -49,6 +49,7 @@ import com.google.common.primitives.Primitives;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -64,6 +65,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AnalyticalObject;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.BaseLinkableObject;
+import org.hisp.dhis.common.BaseNameableObject;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.NameableObject;
@@ -117,6 +122,16 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector {
 
       if (persistedProperties.containsKey(fieldName)) {
         initFromPersistedProperty(property, persistedProperties.get(fieldName));
+      } else {
+        Class<?> declaringClass = property.getGetterMethod().getDeclaringClass();
+        if (declaringClass == BaseIdentifiableObject.class
+            || declaringClass == BaseLinkableObject.class
+            || declaringClass == BaseNameableObject.class
+            || declaringClass == BaseDimensionalObject.class && !property.isTransient()) {
+          // this is assumed to be an inherited property that is not persisted,
+          // so we skip it and do not add it
+          continue;
+        }
       }
 
       initFromDescription(property);
@@ -224,6 +239,7 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector {
   private static void initFromPersistedProperty(Property property, Property persisted) {
     property.setPersisted(true);
     property.setWritable(true);
+    property.setTransient(false);
     property.setFieldName(persisted.getFieldName());
     property.setUnique(persisted.isUnique());
     property.setRequired(persisted.isRequired());
@@ -331,6 +347,7 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector {
 
       property.setName(name);
       property.setFieldName(fieldName);
+      property.setTransient(Modifier.isTransient(field.getModifiers()));
       property.setSetterMethod(findSetterMethod(fieldName, type, field.getType()));
       property.setGetterMethod(findGetterMethod(fieldName, type));
       property.setNamespace(trimToNull(jsonProperty.namespace()));

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
@@ -120,16 +120,18 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector {
       if (persistedProperties.containsKey(fieldName)) {
         initFromPersistedProperty(property, persistedProperties.get(fieldName));
       } else {
-        Class<?> declaringClass = property.getGetterMethod().getDeclaringClass();
         Method getter = property.getGetterMethod();
-        if (declaringClass.getName().startsWith("Base")
-            && !property.isTransient()
-            && (!getter.isAnnotationPresent(Translatable.class)
-                || !persistedProperties.containsKey(
-                    getter.getAnnotation(Translatable.class).propertyName()))) {
-          // this is assumed to be an inherited property that is not persisted,
-          // so we skip it and do not add it
-          continue;
+        if (getter != null) {
+          Class<?> declaringClass = getter.getDeclaringClass();
+          if (declaringClass.getName().startsWith("Base")
+              && !property.isTransient()
+              && (!getter.isAnnotationPresent(Translatable.class)
+                  || !persistedProperties.containsKey(
+                      getter.getAnnotation(Translatable.class).propertyName()))) {
+            // this is assumed to be an inherited property that is not persisted,
+            // so we skip it and do not add it
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION
### Summary
This is a best-effort attempt to drop the properties from the schema that are found in and inherited from base-types but which do not "exist" since they are neither persisted not marked `transient`. 

### Manual Testing
I did check the schemas mentioned in the ticket, `option`, `optionGroupSet` and `programStage` and they look reasonable. 
But it is hard to say if we have accidental false positives with the given logic. My assumption is that we would notice quite soon if that would be the case. 