### PR TITLE
perf: store Hibernate L2 cache entries by reference (IdentityCopier)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -15,6 +15,21 @@
   <!-- Cache template definition (referenced by jsr107:defaults and potentially explicit caches) -->
   <!-- Based on old defaultCache settings -->
   <cache-template name="defaultCacheTemplate">
+    <!--
+      Store cache entries by reference (IdentityCopier) instead of the JSR-107 default
+      store-by-value. The default (since the Ehcache 3.12 bump, #23834 / #24002) uses
+      SerializingCopier, which performs a full Java serialize/deserialize round-trip on
+      EVERY get and putFromLoad. Under a READ_WRITE strategy this dominated concurrent
+      tracker imports (see profiling on DHIS2-21800): ~50% of samples serializing under the
+      AbstractReadWriteAccess ReentrantReadWriteLock, plus heavy transient allocation driving
+      young-gen GC. Providing an explicit copier here makes Ehcache log "overwriting JSR-107
+      by-value semantics" and skip serialization. This is safe because Hibernate's L2 contract
+      already isolates callers at the type level: entity CacheEntry state is deep-copied on
+      disassemble/assemble (e.g. JsonBinaryType.assemble -> deepCopy), and all immutable custom
+      types share safely. This restores the pre-3.12 (Ehcache 2.x) store-by-reference behaviour.
+    -->
+    <key-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Object</key-type>
+    <value-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Object</value-type>
     <expiry>
       <!-- Time-to-live: 6 hours (Chosen as primary expiry from old config) -->
       <!-- TTI (Time-to-idle) was also 6 hours, but only one can be specified directly here. -->

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/cache/EhcacheStoreByReferenceTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/cache/EhcacheStoreByReferenceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.Serializable;
+import java.net.URI;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards that the Hibernate L2 cache configured in {@code ehcache.xml} stores entries <b>by
+ * reference</b> (Ehcache {@code IdentityCopier}) rather than by value ({@code SerializingCopier}).
+ *
+ * <p>The {@code defaultCacheTemplate} declares an explicit {@code IdentityCopier} so that concurrent
+ * imports do not pay a full Java serialize/deserialize round-trip on every L2 get/putFromLoad (see
+ * DHIS2-21800). This test creates a cache exactly the way Hibernate's {@code JCacheRegionFactory}
+ * does — through the JSR-107 API with the default {@link MutableConfiguration} whose {@code
+ * storeByValue} is {@code true} — and asserts the template's copier overrides that default.
+ *
+ * <p>Behavioural check: with {@code IdentityCopier} a {@code get} returns the very instance that was
+ * {@code put} (same identity); with {@code SerializingCopier} it would return a distinct
+ * deserialized copy. The value type is {@link Serializable} on purpose so that, if the fix were
+ * reverted, this test fails on the identity assertion rather than erroring out.
+ */
+class EhcacheStoreByReferenceTest {
+
+  /** A mutable, serializable value — a stand-in for a Hibernate entity cache entry. */
+  static final class Holder implements Serializable {
+    int value;
+  }
+
+  @Test
+  @DisplayName("ehcache.xml defaultCacheTemplate stores by reference (IdentityCopier), not by value")
+  void defaultTemplateStoresByReference() throws Exception {
+    URI ehcacheXml = getClass().getResource("/ehcache.xml").toURI();
+    CachingProvider provider =
+        Caching.getCachingProvider("org.ehcache.jsr107.EhcacheCachingProvider");
+    try (CacheManager cacheManager =
+        provider.getCacheManager(ehcacheXml, getClass().getClassLoader())) {
+      // Same call shape as Hibernate JCacheRegionFactory + MissingCacheStrategy.CREATE:
+      // a default MutableConfiguration (storeByValue == true) for a region that is not explicitly
+      // configured, so it inherits defaultCacheTemplate from <jsr107:defaults>.
+      Cache<Object, Object> region =
+          cacheManager.createCache("l2-store-by-reference-probe", new MutableConfiguration<>());
+      try {
+        Holder put = new Holder();
+        put.value = 42;
+        region.put("k", put);
+
+        Object got = region.get("k");
+        assertSame(
+            put,
+            got,
+            "L2 cache returned a different instance than was put: the region is serializing "
+                + "entries (SerializingCopier / store-by-value). Expected store-by-reference via "
+                + "IdentityCopier configured on defaultCacheTemplate in ehcache.xml.");
+        // A second read must also hand back the identical instance.
+        assertSame(put, region.get("k"), "Repeated L2 get returned a different instance.");
+      } finally {
+        cacheManager.destroyCache("l2-store-by-reference-probe");
+      }
+    }
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/CachedEntityJsonbSerializableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/CachedEntityJsonbSerializableTest.java
@@ -63,13 +63,20 @@ import org.springframework.test.context.ContextConfiguration;
 /**
  * Guard test for the Ehcache L2 second-level cache.
  *
- * <p>Since the Ehcache bump to 3.12 (see #23834 / #24002) the on-heap store uses {@code
- * SerializingCopier}, which performs real Java serialization of cached entity state. JSONB columns
- * are mapped with {@link JsonBinaryType} and its subclasses, whose {@code disassemble()} stores the
- * deep-copied Java value object (or, for list/set types, its elements) directly in the cache entry.
- * Ehcache then serializes that object graph, so every JSONB value type living on an L2-cached
- * entity MUST implement {@link Serializable} (a missing one throws {@code NotSerializableException}
- * at runtime, e.g. the {@code ApiTokenAttribute} regression fixed in #24002).
+ * <p>Every JSONB value type living on an L2-cached entity MUST implement {@link Serializable}. This
+ * holds regardless of the cache copier: {@link org.hibernate.usertype.UserType#disassemble} returns
+ * a {@link Serializable} and {@link JsonBinaryType#disassemble(Object)} casts its deep copy to it,
+ * and Hibernate stores entity cache state as a {@code Serializable[]}. So a non-serializable
+ * top-level JSONB value type fails at disassemble time even when nothing is Java-serialized.
+ *
+ * <p>Additionally, wherever the on-heap store uses {@code SerializingCopier} (the JSR-107
+ * store-by-value default, active for any auto-created region and for this test), the WHOLE JSONB
+ * object graph is Java-serialized on every get/putFromLoad, so nested field types must be
+ * serializable too (e.g. the {@code ApiTokenAttribute} regression fixed in #24002, introduced by
+ * the Ehcache 3.12 bump #23834 / #24002). Note the production {@code ehcache.xml} configures {@code
+ * IdentityCopier} (store-by-reference) on {@code defaultCacheTemplate}, so the mapped entity regions
+ * no longer Java-serialize; this test still runs with the store-by-value default because it uses an
+ * empty {@code cache.ehcache.config.file}, keeping it a strict guard.
  *
  * <p>This test walks the live Hibernate metamodel rather than a hard-coded list, so any JSONB
  * column added to a cached entity in the future is checked automatically.


### PR DESCRIPTION
The Ehcache 3.12 bump (#23834 / #24002) switched the on-heap L2 store to the JSR-107 store-by-value default, implemented by SerializingCopier: a full Java serialize/deserialize round-trip on every cache get and putFromLoad. Profiling a production tracker import (DHIS2-21800) showed this dominates: ~50% of the thread profile serializing entities under the AbstractReadWriteAccess ReentrantReadWriteLock (READ_WRITE strategy), manifesting as long "waited" time (park on the lock, not blocked) and heavy transient allocation that drives frequent young-gen GC; it also made requests hold their DB connection for the whole duration, draining the pool.

Configure an explicit IdentityCopier on defaultCacheTemplate so the mapped entity and query regions store by reference, overriding the JSR-107 by-value semantics (Ehcache logs "overwriting JSR-107 by-value semantics"). This restores the pre-3.12 (Ehcache 2.x) behaviour and eliminates the redundant copy: Hibernate's L2 contract already isolates callers at the type level - entity CacheEntry state is deep-copied on disassemble/assemble (e.g. JsonBinaryType.assemble -> deepCopy) and all immutable custom UserTypes share safely.

Add EhcacheStoreByReferenceTest, which loads the real ehcache.xml through the JSR-107 path (as JCacheRegionFactory does, storeByValue=true) and asserts a get returns the same instance that was put. Update CachedEntityJsonbSerializableTest's Javadoc: the Serializable requirement still holds (UserType#disassemble returns Serializable and Hibernate stores a Serializable[]), and that test keeps running store-by-value via an empty cache config, so it remains a strict guard.