### PR TITLE
fix: skip auto-flush on getUserByUsername read-only lookup (DHIS2-21842)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -35,6 +35,7 @@ import static java.time.ZoneId.systemDefault;
 import static java.util.stream.Collectors.toMap;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaUpdate;
@@ -449,6 +450,10 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
     TypedQuery<User> typedQuery = entityManager.createQuery(hql, User.class);
     typedQuery.setParameter("username", username);
     typedQuery.setHint(QueryHints.CACHEABLE, true);
+    // Read-only lookup: do not auto-flush the persistence context first.
+    // In bulk paths this is called once per user; AUTO flush mode makes each
+    // call dirty-check the entire growing session -> O(n^2) CPU.
+    typedQuery.setFlushMode(FlushModeType.COMMIT);
 
     return QueryUtils.getSingleResult(typedQuery);
   }


### PR DESCRIPTION
Under the default FlushModeType.AUTO, the JPQL username lookup forces a full persistence-context auto-flush before every execution. In bulk metadata-import paths (e.g. updating a UserRole with tens of thousands of members) this method is called once per user while the session keeps growing, so each auto-flush dirty-checks an ever-larger context -> O(n^2) CPU (observed: ~90 min pinned to a core for 22k members).

Setting FlushModeType.COMMIT makes the read-only lookup skip the pre-query flush, collapsing O(n^2) -> O(n); the session is still flushed at the import's existing stage-boundary flush. Behaviorally inert for clean sessions (login, current-user lookups); a username lookup not seeing same-transaction unflushed rows is already guarded by the DB username unique constraint.