### PR TITLE
perf: pre-filter geoFeatures org units by geometry (#24279) [2.42]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
@@ -107,6 +107,12 @@ public class DataQueryRequest {
 
   protected String userOrganisationUnitCriteria;
 
+  /**
+   * Whether to restrict organisation unit dimension resolution to units that have a non-null
+   * geometry. Used by the geoFeatures endpoint, which only renders units with geometry.
+   */
+  protected boolean geometryOnly;
+
   public boolean hasAggregationType() {
     return aggregationType != null;
   }
@@ -287,6 +293,11 @@ public class DataQueryRequest {
 
     public DataQueryRequestBuilder duplicatesOnly(boolean duplicatesOnly) {
       this.request.duplicatesOnly = duplicatesOnly;
+      return this;
+    }
+
+    public DataQueryRequestBuilder geometryOnly(boolean geometryOnly) {
+      this.request.geometryOnly = geometryOnly;
       return this;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitQueryParams.java
@@ -65,6 +65,9 @@ public class OrganisationUnitQueryParams {
   /** Whether to fetch children eagerly. */
   private boolean fetchChildren;
 
+  /** Whether to include only organisation units that have a non-null geometry. */
+  private boolean geometryOnly;
+
   /** Property used for sorting, default value is {@link SortProperty#NAME}. */
   private SortProperty orderBy = SortProperty.NAME;
 
@@ -179,6 +182,14 @@ public class OrganisationUnitQueryParams {
 
   public void setFetchChildren(boolean fetchChildren) {
     this.fetchChildren = fetchChildren;
+  }
+
+  public boolean isGeometryOnly() {
+    return geometryOnly;
+  }
+
+  public void setGeometryOnly(boolean geometryOnly) {
+    this.geometryOnly = geometryOnly;
   }
 
   public SortProperty getOrderBy() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -166,6 +166,21 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
       Collection<OrganisationUnitGroup> groups, Collection<OrganisationUnit> parents);
 
   /**
+   * Returns the intersection of the members of the given OrganisationUnitGroups and the
+   * OrganisationUnits which are children of the given collection of parents in the hierarchy,
+   * optionally restricted to units that have a non-null geometry.
+   *
+   * @param groups the collection of OrganisationUnitGroups.
+   * @param parents the collection of OrganisationUnit parents in the hierarchy.
+   * @param geometryOnly whether to include only OrganisationUnits that have a non-null geometry.
+   * @return A list of OrganisationUnits.
+   */
+  List<OrganisationUnit> getOrganisationUnits(
+      Collection<OrganisationUnitGroup> groups,
+      Collection<OrganisationUnit> parents,
+      boolean geometryOnly);
+
+  /**
    * Returns an OrganisationUnit and all its children.
    *
    * @param uid the uid of the parent OrganisationUnit in the subtree.
@@ -288,6 +303,21 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    */
   List<OrganisationUnit> getOrganisationUnitsAtLevels(
       Collection<Integer> levels, Collection<OrganisationUnit> parents);
+
+  /**
+   * Returns all OrganisationUnits which are children of the given unit and are at the given
+   * hierarchical levels, optionally restricted to units that have a non-null geometry. The root
+   * OrganisationUnits are at level 1.
+   *
+   * @param levels the hierarchical levels.
+   * @param parents the parent units.
+   * @param geometryOnly whether to include only OrganisationUnits that have a non-null geometry.
+   * @return all OrganisationUnits which are children of the given unit and are at the given
+   *     hierarchical level.
+   * @throws IllegalArgumentException if the level is illegal.
+   */
+  List<OrganisationUnit> getOrganisationUnitsAtLevels(
+      Collection<Integer> levels, Collection<OrganisationUnit> parents, boolean geometryOnly);
 
   /**
    * Returns the number of levels in the OrganisationUnit hierarchy.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -253,11 +253,13 @@ public class DefaultDataQueryService implements DataQueryService {
     return getDimension(
         dimension,
         items,
-        request.getRelativePeriodDate(),
-        request.getDisplayProperty(),
         userOrgUnits,
-        allowNull,
-        inputIdScheme);
+        new DimensionResolveOptions(
+            request.getRelativePeriodDate(),
+            request.getDisplayProperty(),
+            allowNull,
+            inputIdScheme,
+            false));
   }
 
   @Override
@@ -273,11 +275,9 @@ public class DefaultDataQueryService implements DataQueryService {
     return getDimension(
         dimension,
         items,
-        relativePeriodDate,
-        displayProperty,
         userOrgUnits,
-        allowNull,
-        inputIdScheme);
+        new DimensionResolveOptions(
+            relativePeriodDate, displayProperty, allowNull, inputIdScheme, false));
   }
 
   @Override
@@ -327,11 +327,13 @@ public class DefaultDataQueryService implements DataQueryService {
               getDimension(
                   dimension,
                   items,
-                  request.getRelativePeriodDate(),
-                  request.getDisplayProperty(),
                   userOrgUnits,
-                  false,
-                  firstNonNull(request.getInputIdScheme(), UID)));
+                  new DimensionResolveOptions(
+                      request.getRelativePeriodDate(),
+                      request.getDisplayProperty(),
+                      false,
+                      firstNonNull(request.getInputIdScheme(), UID),
+                      request.isGeometryOnly())));
         }
       }
     }
@@ -355,25 +357,37 @@ public class DefaultDataQueryService implements DataQueryService {
   }
 
   /**
+   * Options controlling how a dimension is resolved by {@link #getDimension(String, List, List,
+   * DimensionResolveOptions)}.
+   *
+   * @param relativePeriodDate the relative period date.
+   * @param displayProperty the display property.
+   * @param allowNull whether to allow returning null.
+   * @param inputIdScheme the input {@link IdScheme}.
+   * @param geometryOnly whether to restrict org unit resolution to units with a non-null geometry.
+   */
+  private record DimensionResolveOptions(
+      Date relativePeriodDate,
+      DisplayProperty displayProperty,
+      boolean allowNull,
+      IdScheme inputIdScheme,
+      boolean geometryOnly) {}
+
+  /**
    * Returns a {@link DimensionalObject}.
    *
    * @param dimension the dimension identifier.
    * @param items the dimension items.
-   * @param relativePeriodDate the relative period date.
-   * @param displayProperty the relative period date.
    * @param userOrgUnits the list of user {@link OrganisationUnit}.
-   * @param allowNull whether to allow returning null.
-   * @param inputIdScheme the input {@link IdScheme}.
+   * @param options the {@link DimensionResolveOptions} controlling resolution.
    * @return a {@link DimensionalObject}.
    */
   private DimensionalObject getDimension(
       String dimension,
       List<String> items,
-      Date relativePeriodDate,
-      DisplayProperty displayProperty,
       List<OrganisationUnit> userOrgUnits,
-      boolean allowNull,
-      IdScheme inputIdScheme) {
+      DimensionResolveOptions options) {
+    IdScheme inputIdScheme = options.inputIdScheme();
     if (DATA_X_DIM_ID.equals(dimension)) {
       return dimensionalObjectProducer.getDimension(items, inputIdScheme);
     } else if (CATEGORYOPTIONCOMBO_DIM_ID.equals(dimension)) {
@@ -391,10 +405,10 @@ public class DefaultDataQueryService implements DataQueryService {
           DISPLAY_NAME_ATTRIBUTEOPTIONCOMBO,
           getCategoryOptionComboList(items, inputIdScheme));
     } else if (PERIOD_DIM_ID.equals(dimension)) {
-      return dimensionalObjectProducer.getPeriodDimension(items, relativePeriodDate);
+      return dimensionalObjectProducer.getPeriodDimension(items, options.relativePeriodDate());
     } else if (ORGUNIT_DIM_ID.equals(dimension)) {
       return dimensionalObjectProducer.getOrgUnitDimension(
-          items, displayProperty, userOrgUnits, inputIdScheme);
+          items, options.displayProperty(), userOrgUnits, inputIdScheme, options.geometryOnly());
     } else if (ORGUNIT_GROUP_DIM_ID.equals(dimension)) {
       return dimensionalObjectProducer.getOrgUnitGroupDimension(items, inputIdScheme);
     } else if (LONGITUDE_DIM_ID.contains(dimension)) {
@@ -406,14 +420,14 @@ public class DefaultDataQueryService implements DataQueryService {
     } else {
       Optional<BaseDimensionalObject> baseDimensionalObject =
           dimensionalObjectProducer.getDynamicDimension(
-              dimension, items, displayProperty, inputIdScheme);
+              dimension, items, options.displayProperty(), inputIdScheme);
 
       if (baseDimensionalObject.isPresent()) {
         return baseDimensionalObject.get();
       }
     }
 
-    if (allowNull) {
+    if (options.allowNull()) {
       return null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProvider.java
@@ -367,6 +367,24 @@ public class DimensionalObjectProvider {
       DisplayProperty displayProperty,
       List<OrganisationUnit> userOrgUnits,
       IdScheme inputIdScheme) {
+    return getOrgUnitDimension(items, displayProperty, userOrgUnits, inputIdScheme, false);
+  }
+
+  /**
+   * Same as {@link #getOrgUnitDimension(List, DisplayProperty, List, IdScheme)} but, when {@code
+   * geometryOnly} is true, restricts level- and group-resolved organisation units to those that
+   * have a non-null geometry. Used by the geoFeatures endpoint, which only renders units that have
+   * geometry. When {@code geometryOnly} is true an empty result is allowed (it does not raise
+   * {@code E7143}), since "no units have geometry" is a valid empty response rather than an error.
+   *
+   * @param geometryOnly whether to include only organisation units that have a non-null geometry.
+   */
+  public BaseDimensionalObject getOrgUnitDimension(
+      List<String> items,
+      DisplayProperty displayProperty,
+      List<OrganisationUnit> userOrgUnits,
+      IdScheme inputIdScheme,
+      boolean geometryOnly) {
     List<Integer> levels = new ArrayList<>();
     List<OrganisationUnitGroup> groups = new ArrayList<>();
     List<DimensionalItemObject> ous =
@@ -376,8 +394,11 @@ public class DimensionalObjectProvider {
     DimensionItemKeywords dimensionalKeywords = new DimensionItemKeywords();
 
     if (!levels.isEmpty()) {
-      orgUnitAtLevels.addAll(
-          sort(organisationUnitService.getOrganisationUnitsAtLevels(levels, ousList)));
+      List<OrganisationUnit> atLevels =
+          geometryOnly
+              ? organisationUnitService.getOrganisationUnitsAtLevels(levels, ousList, true)
+              : organisationUnitService.getOrganisationUnitsAtLevels(levels, ousList);
+      orgUnitAtLevels.addAll(sort(atLevels));
 
       dimensionalKeywords.addKeywords(
           levels.stream()
@@ -387,7 +408,11 @@ public class DimensionalObjectProvider {
     }
 
     if (!groups.isEmpty()) {
-      orgUnitAtLevels.addAll(sort(organisationUnitService.getOrganisationUnits(groups, ousList)));
+      List<OrganisationUnit> inGroups =
+          geometryOnly
+              ? organisationUnitService.getOrganisationUnits(groups, ousList, true)
+              : organisationUnitService.getOrganisationUnits(groups, ousList);
+      orgUnitAtLevels.addAll(sort(inGroups));
 
       dimensionalKeywords.addKeywords(
           groups.stream()
@@ -410,7 +435,9 @@ public class DimensionalObjectProvider {
       dimensionalKeywords.addKeywords(ousList);
     }
 
-    if (orgUnitAtLevels.isEmpty()) {
+    // When geometryOnly is set, an empty result is a valid empty response (e.g. no unit at the
+    // level has geometry), not a query error, so the E7143 guard is skipped in that case.
+    if (orgUnitAtLevels.isEmpty() && !geometryOnly) {
       throwIllegalQueryEx(E7143, ORGUNIT_DIM_ID);
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -188,9 +188,19 @@ public class DefaultOrganisationUnitService implements OrganisationUnitService {
   @Transactional(readOnly = true)
   public List<OrganisationUnit> getOrganisationUnits(
       Collection<OrganisationUnitGroup> groups, Collection<OrganisationUnit> parents) {
+    return getOrganisationUnits(groups, parents, false);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<OrganisationUnit> getOrganisationUnits(
+      Collection<OrganisationUnitGroup> groups,
+      Collection<OrganisationUnit> parents,
+      boolean geometryOnly) {
     OrganisationUnitQueryParams params = new OrganisationUnitQueryParams();
     params.setParents(Sets.newHashSet(parents));
     params.setGroups(Sets.newHashSet(groups));
+    params.setGeometryOnly(geometryOnly);
 
     return organisationUnitStore.getOrganisationUnits(params);
   }
@@ -311,9 +321,17 @@ public class DefaultOrganisationUnitService implements OrganisationUnitService {
   @Transactional(readOnly = true)
   public List<OrganisationUnit> getOrganisationUnitsAtLevels(
       Collection<Integer> levels, Collection<OrganisationUnit> parents) {
+    return getOrganisationUnitsAtLevels(levels, parents, false);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<OrganisationUnit> getOrganisationUnitsAtLevels(
+      Collection<Integer> levels, Collection<OrganisationUnit> parents, boolean geometryOnly) {
     OrganisationUnitQueryParams params = new OrganisationUnitQueryParams();
     params.setLevels(Sets.newHashSet(levels));
     params.setParents(Sets.newHashSet(parents));
+    params.setGeometryOnly(geometryOnly);
 
     return organisationUnitStore.getOrganisationUnits(params);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
@@ -235,6 +235,10 @@ public class HibernateOrganisationUnitStore
       hql += hlp.whereAnd() + " o.hierarchyLevel <= :maxLevels ";
     }
 
+    if (params.isGeometryOnly()) {
+      hql += hlp.whereAnd() + " o.geometry is not null ";
+    }
+
     hql += "order by o." + params.getOrderBy().getName();
 
     Query<OrganisationUnit> query = getQuery(hql);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreIntegrationTest.java
@@ -200,6 +200,34 @@ class OrganisationUnitStoreIntegrationTest extends PostgresIntegrationTestBase {
     assertFalse(organisationUnits.contains(ou3));
   }
 
+  @Test
+  void getOrganisationUnitsWithGeometryOnlyExcludesNullGeometryUnits() throws IOException {
+    OrganisationUnit withGeometryA =
+        createOrganisationUnit(
+            'A', GeoUtils.getGeometryFromCoordinatesAndType(POINT, "[10.0, 10.0]"));
+    OrganisationUnit withGeometryB =
+        createOrganisationUnit(
+            'B', GeoUtils.getGeometryFromCoordinatesAndType(POINT, "[11.0, 11.0]"));
+    OrganisationUnit withoutGeometry = createOrganisationUnit('C');
+    manager.save(withGeometryA);
+    manager.save(withGeometryB);
+    manager.save(withoutGeometry);
+
+    OrganisationUnitQueryParams geometryOnly = new OrganisationUnitQueryParams();
+    geometryOnly.setGeometryOnly(true);
+    List<OrganisationUnit> filtered = organisationUnitStore.getOrganisationUnits(geometryOnly);
+
+    assertTrue(filtered.contains(withGeometryA), "unit with geometry should be returned");
+    assertTrue(filtered.contains(withGeometryB), "unit with geometry should be returned");
+    assertFalse(filtered.contains(withoutGeometry), "unit without geometry should be filtered out");
+
+    OrganisationUnitQueryParams unfiltered = new OrganisationUnitQueryParams();
+    List<OrganisationUnit> all = organisationUnitStore.getOrganisationUnits(unfiltered);
+    assertTrue(
+        all.contains(withoutGeometry),
+        "null-geometry unit must still be returned when geometryOnly is off");
+  }
+
   private List<OrganisationUnit> getOUsFromPointToDistance(Geometry point, long distance) {
     double[] box = GeoUtils.getBoxShape(point.getCoordinate().x, point.getCoordinate().y, distance);
     return organisationUnitStore.getWithinCoordinateArea(box);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
@@ -68,4 +68,23 @@ class GeoFeatureControllerTest extends H2ControllerIntegrationTestBase {
         "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]",
         response.getObject(0).get("co").node().value().toString());
   }
+
+  /**
+   * When no organisation unit at the requested level has a geometry, geoFeatures must still return
+   * an empty array with 200, not raise E7143. The geometry pre-filter resolves the org unit
+   * dimension to an empty set, which previously would have tripped the empty-dimension guard.
+   */
+  @Test
+  void testGeoFeaturesReturnsEmptyWhenNoOrgUnitHasGeometry() {
+    @Language("json")
+    String json =
+        """
+        {"organisationUnits":[
+          {"id":"rXnqqH2Pu6N","name":"No Geometry","shortName":"NG","openingDate":"2020-01-01"}
+        ]}""";
+    POST("/metadata", json).content(HttpStatus.OK);
+
+    JsonArray response = GET("/geoFeatures?ou=ou:LEVEL-1").content(HttpStatus.OK);
+    assertEquals(0, response.size());
+  }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
@@ -145,6 +145,10 @@ public class GeoFeatureService {
             .relativePeriodDate(parameters.getRelativePeriodDate())
             .userOrgUnit(parameters.getUserOrgUnit())
             .apiVersion(parameters.getApiVersion())
+            // geoFeatures only renders org units that have geometry, so resolve the org unit
+            // dimension to geometry-bearing units only. Skipped in geoJsonAttribute mode, where
+            // coordinates come from an attribute and the geometry column may be null.
+            .geometryOnly(geoJsonAttribute == null)
             .build();
 
     DataQueryParams params = dataQueryService.getFromRequest(dataQueryRequest);


### PR DESCRIPTION
## Summary
Backport of #24279 to 2.42.

geoFeatures resolves the `ou` dimension into full OrganisationUnit entities, then discards every unit without geometry in-memory. On a large hierarchy (Nigeria prod: ~255k level-5 units, all null-geometry) this hydrates a quarter-million entities — ~7.6s CPU and ~4.7 GB allocated — only to return `[]`.

This threads an optional `geometryOnly` flag from `DataQueryRequest` through `DimensionalObjectProvider` and `OrganisationUnitService` down to `HibernateOrganisationUnitStore`, which appends `and o.geometry is not null`. Default off, so all other callers dispatch the original methods unchanged. Skipped in geoJsonAttribute (coordinateField) mode, where coordinates come from an attribute and the geometry column may be null. The in-memory filter remains the precise final gate.

When the geometry-filtered resolution is empty, the E7143 empty-dimension guard is suppressed so geoFeatures still returns 200 `[]` rather than an error.

Validated on production (Nigeria, deployed on 2.40): a comparable high-level layer dropped from ~8.6s/4.7GB to 14ms/747KB.

### Backport notes
Cherry-pick of 2c7ee45751 onto 2.42 hit conflicts because 2.42 lacks a master-only feature (stage-specific category/COGS dimension resolution in `DefaultDataQueryService`) — resolved by keeping 2.42's existing dispatch path and applying only the geometry-only wiring. A related type mismatch in `DimensionalObjectProvider.getOrgUnitDimension` (auto-merged without conflict markers but broke compilation) was fixed by aligning the new overload's return type with 2.42's existing `BaseDimensionalObject` signature.

## Test plan
- [x] `dhis-service-analytics` and `dhis-web-api` (main + test sources) compile cleanly
- [x] `spotless:check` passes
- [ ] CI

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>